### PR TITLE
fixing issue with internal face removal not working for SAMRAI

### DIFF
--- a/src/avt/Filters/avtGhostZoneFilter.C
+++ b/src/avt/Filters/avtGhostZoneFilter.C
@@ -164,7 +164,9 @@ ExamineGhostArray(vtkDataSet *in_ds, bool zones, bool haveGhost,
 
         //
         // This nesting of loops looks bad but has plenty of
-        // opportunities to terminate early.
+        // opportunities to terminate early. In addition, the
+        // loop body is written to execute index arithmetic
+        // and data lookup only on the indices of interest.
         //
         for (int k = 0; k < dims[2] && allLogBndGhost; k++)
         {
@@ -300,6 +302,10 @@ avtGhostZoneFilter::ExecuteData(avtDataRepresentation *in_dr)
     bool allLogBndZonesGhost = false;
     ExamineGhostArray(in_ds, zones, haveGhostZones, ghostZoneTypesToRemove,
         &allGhost, &allLogBndZonesGhost);
+    if (allLogBndZonesGhost)
+    {
+        debug5 << "Domain " << domain << " is wholly embedded in at least one layer of ghost zones." << endl;
+    }
     if (allGhost)
     {
         debug5 << "Domain " << domain << " contains only ghost zones.  Removing" << endl;
@@ -310,6 +316,10 @@ avtGhostZoneFilter::ExecuteData(avtDataRepresentation *in_dr)
     bool allLogBndNodesGhost = false;
     ExamineGhostArray(in_ds, !zones, haveGhostNodes, ghostNodeTypesToRemove,
         &allGhost, &allLogBndNodesGhost);
+    if (allLogBndNodesGhost)
+    {
+        debug5 << "Domain " << domain << " is wholly embedded in at least one layer of ghost nodes." << endl;
+    }
     if (allGhost)
     {
         debug5 << "Domain " << domain << " contains only ghost nodes.  Removing" << endl;

--- a/src/visit_vtk/lightweight/vtkUnstructuredGridFacelistFilter.h
+++ b/src/visit_vtk/lightweight/vtkUnstructuredGridFacelistFilter.h
@@ -42,6 +42,27 @@
 
 #include <vtkPolyDataAlgorithm.h>
 
+//
+// MCMiller-11Jan19: My understanding of what this class does, from a cursory
+// review of the code, is that it iterates over all cells in the mesh (grid)
+// adding the faces from each cell to various hashes. However, the face-adding
+// logic is designed to add a face only if it has never been seen before
+// and otherwise remove the face. For topological reasons, faces are shared by
+// at most two cells. So a face will only ever be encountered once or twice.
+// Once all faces from all cells have been iterated what remains are those
+// faces that were only ever encountered once. Those are the *external* faces
+// of the input mesh (grid). There is no logic here to address whether the
+// cells involved (or their corresonding nodes) are associated with any
+// ghosting.
+//
+// Note 1: a similar operation is performed in the Silo plugin to handle
+// painting of enumerated scalar nodal values for annotation int zonelists
+// except that multi-layer STL maps are used for the hashing.
+//
+// Note 2: This kind of algorithm is exactly the kind of thing something
+// like Big Data Apache Spark filters handle very well.
+//
+
 class VISIT_VTK_LIGHT_API vtkUnstructuredGridFacelistFilter :
     public vtkPolyDataAlgorithm
 {


### PR DESCRIPTION
SAMRAI can output ghosts and can output per-patch information which indicates which boundaries of a patch are external to whole problem or not. 

Nonetheless, transparent PC plots looked bad for single level SAMRAI files due to internal surfaces still being present. This was the result of missing "avtRealDims" functionality from the SAMRAI plugin. However, it took a day and a half of debugging to determine this.

I also discovered the ``GenericExecute`` method of ``visit_vtk/full/vtkDataSetRemoveGhostCells.C`` was not filtering on ``GhostZoneTypeToRemove`` and fixed (and tested) that as well. If this latter bit of code had been working, I might not have ever realized the *shortcut* via "avtRealDims" accelerator info.