### PR TITLE
Modify regression test to delete .git/index.lock before doing git pull.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_surface
+++ b/src/tools/dev/scripts/regressiontest_surface
@@ -234,6 +234,7 @@ fi
 
 # Update the repository.
 cd visit
+rm -f .git/index.lock >> ../buildlog 2>&1
 git pull >> ../buildlog 2>&1
 
 if test "$branch" = "trunk" ; then


### PR DESCRIPTION
I modified the regression test to delete the ".git/index.lock file before doing a git pull. The existence
of that file indicates another git operation is in progress and prevents the git pull from operating. I
don't know why this is happening, but there aren't any changes happening in the test repository, so
removing it is safe and allows the git pull to happen and the test suite to pick up the day's changes.