### PR TITLE
Replaced call to SVNVersion with GITVersion.

### DIFF
--- a/src/common/misc/VisItInit.C
+++ b/src/common/misc/VisItInit.C
@@ -244,6 +244,10 @@ NewHandler(void)
 //    Added logic to manage decoration of level 1 debug logs with __FILE__
 //    and __LINE__; an extra 'd' in debug level arg will turn on these log
 //    decorations.
+//
+//    Eric Brugger, Tue Jan 29 09:09:44 PST 2019
+//    I modified the method to work with Git.
+//
 // ****************************************************************************
 
 void
@@ -369,12 +373,12 @@ VisItInit::Initialize(int &argc, char *argv[], int r, int n, bool strip, bool si
         {
             SetIsDevelopmentVersion(true);
         }
-        else if (strcmp("-svn_revision",  argv[i]) == 0)
+        else if (strcmp("-git_revision",  argv[i]) == 0)
         {
-            if(visitcommon::SVNVersion() == "")
-                cerr << "SVN revision is unknown!" << endl;
+            if(visitcommon::GITVersion() == "")
+                cerr << "GIT version is unknown!" << endl;
             else
-                cerr << "Built from revision " << visitcommon::SVNVersion() << endl;
+                cerr << "Built from version " << visitcommon::GITVersion() << endl;
             exit(0); // HOOKS_IGNORE
         }
     }

--- a/src/doc/StartupOptions/index.rst
+++ b/src/doc/StartupOptions/index.rst
@@ -80,8 +80,8 @@ USAGE: visit [options]::
     Version options
     ---------------------------------------------------------------------------
         -version             Do NOT run VisIt. Just print the current version.
-        -svn_revision        Do NOT run VisIt. Just print the Subversion 
-                             revision it was built from.
+        -git_version         Do NOT run VisIt. Just print the Git version it
+                             was built from.
         -beta                Run the current beta version.
         -v <version>         Run a specified version. Specifying 2 digits,
                              such as X.Y, will run the latest patch release

--- a/src/resources/usage/visitusage.txt
+++ b/src/resources/usage/visitusage.txt
@@ -64,8 +64,8 @@
     Version options
     ---------------------------------------------------------------------------
         -version             Do NOT run VisIt. Just print the current version.
-        -svn_revision        Do NOT run VisIt. Just print the Subversion 
-                             revision it was built from.
+        -git_version         Do NOT run VisIt. Just print the Git version it
+                             was built from.
         -beta                Run the current beta version.
         -v <version>         Run a specified version. Specifying 2 digits,
                              such as X.Y, will run the latest patch release


### PR DESCRIPTION
I replaced a call to SVNVersion with GITVersion, since SVNVersion no longer exists. While I was at
it I replaced the command line option "-svn_revision" with "-git_version". I also updated the
documentation.