### PR TITLE
Modify build visit to disable osmesa if mesagl is already built.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -231,6 +231,11 @@ function bv_osmesa_build
         check_if_installed "osmesa" $OSMESA_VERSION
         if [[ $? == 0 ]] ; then
             info "Skipping OSMesa build.  OSMesa is already installed."
+            return 0
+        fi
+        check_if_installed "mesagl" $MESAGL_VERSION
+        if [[ $? == 0 ]] ; then
+            info "Skipping OSMesa build.  MesaGL is already installed."
         else
             info "Building OSMesa (~20 minutes)"
             build_osmesa


### PR DESCRIPTION
Building osmesa is unnecessary after building mesagl, since it is the same thing. I added a check
in build_visit to skip building osmesa if mesagl is already built.