### PR TITLE
Change mesa libraries built with -optional in build visit.

### DIFF
--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -86,7 +86,6 @@
             <lib name="icet"/>
             <lib name="ispc"/>
             <lib name="llvm"/>
-            <lib name="mesagl"/>
             <lib name="mfem"/>
             <lib name="mili"/>
             <lib name="moab"/>
@@ -95,6 +94,7 @@
             <lib name="netcdf"/>
             <lib name="openexr"/>
             <lib name="openssl"/>
+            <lib name="osmesa"/>
             <lib name="ospray"/>
             <lib name="pidx"/>
             <lib name="p7zip"/>


### PR DESCRIPTION
I changed the libraries that get built with build visit with the -optional flag to remove mesagl and add
osmesa. Mesagl is used when the GL installed on a system is insufficient for VTK so it should only be
built if explicitly specified. Osmesa on the other hand is used for off screen rendering and should be
part of the optional build.