### PR TITLE
updating the baseline for chgcar in parallel

### DIFF
--- a/test/baseline/databases/chgcar/parallel/chgcar_05.png
+++ b/test/baseline/databases/chgcar/parallel/chgcar_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3fccd616edafbe6e552fa7502a93f4b2b605895e79fd6be635c4e7a21302645
-size 29718
+oid sha256:f498f26bc9c184ccdd34c405b5db8dc95a87493862c717636ffd6651a132a043
+size 44446

--- a/test/baseline/databases/chgcar/parallel/chgcar_07.png
+++ b/test/baseline/databases/chgcar/parallel/chgcar_07.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52765b4073c9533a92f36a5f849338b1e1609e348c485ddb3bd4ccd2a35fd5fc
-size 34846
+oid sha256:ea9ee300833555183aac1131ce236d51faaeb0f14a3a4c9f9aab41e4454e9698
+size 46456


### PR DESCRIPTION
Updating to reflect changes made to the default volume renderer. 