### PR TITLE
Modify build visit to create GIT_VERSION when building from git clone.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -289,16 +289,16 @@ function build_visit
         rm -rf $VISIT_BUILD_DIR/* || error "Can't clean VisIt build dir."
     fi
 
+    info "Building VisIt in ${VISIT_BUILD_DIR} . . ."
+    
+    cd $VISIT_BUILD_DIR
+
     #
     # Create the GIT_VERSION file.
     #
     if [[ "$DO_GIT" == "yes" && "$USE_VISIT_FILE" == "no" ]] ; then
-        git log -1 | grep "^commit" | cut -d' ' -f2 | head -c 7 > ./visit/src/GIT_VERSION
+        git log -1 | grep "^commit" | cut -d' ' -f2 | head -c 7 > ../src/GIT_VERSION
     fi
-
-    info "Building VisIt in ${VISIT_BUILD_DIR} . . ."
-    
-    cd $VISIT_BUILD_DIR
 
     #
     # Set up the config-site file, which gives configure the information it

--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -293,7 +293,7 @@ function build_visit
     # Create the GIT_VERSION file.
     #
     if [[ "$DO_GIT" == "yes" && "$USE_VISIT_FILE" == "no" ]] ; then
-        git log -1 | grep \"^commit\" | cut -d' ' -f2 | head -c 7 > ./visit/src/GIT_VERSION");
+        git log -1 | grep "^commit" | cut -d' ' -f2 | head -c 7 > ./visit/src/GIT_VERSION
     fi
 
     info "Building VisIt in ${VISIT_BUILD_DIR} . . ."

--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -278,7 +278,6 @@ function build_visit
     # Set up the VisIt build dir which is a sibling to the VisIt src dir
     #
     if [[ "$DO_GIT" == "yes" && "$USE_VISIT_FILE" == "no" ]] ; then
-        #remove the src from the destination path and replace it with build.
         VISIT_BUILD_DIR="visit/build"
     else
         VISIT_BUILD_DIR="${VISIT_FILE%.tar*}/build"
@@ -288,6 +287,13 @@ function build_visit
         mkdir $VISIT_BUILD_DIR || error "Can't make VisIt build dir."
     else
         rm -rf $VISIT_BUILD_DIR/* || error "Can't clean VisIt build dir."
+    fi
+
+    #
+    # Create the GIT_VERSION file.
+    #
+    if [[ "$DO_GIT" == "yes" && "$USE_VISIT_FILE" == "no" ]] ; then
+        git log -1 | grep \"^commit\" | cut -d' ' -f2 | head -c 7 > ./visit/src/GIT_VERSION");
     fi
 
     info "Building VisIt in ${VISIT_BUILD_DIR} . . ."


### PR DESCRIPTION
I modified build visit to create the file src/GIT_VERSION when building visit from a git clone. The file is used to populate the git version string in the splash screen.