### PR TITLE
Change the default third party path in build visit to ./third_party.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -509,7 +509,7 @@ function initialize_build_visit()
     fi
 
     export MAKE=${MAKE:-"make"}
-    export THIRD_PARTY_PATH=${THIRD_PARTY_PATH:-"./visit"}
+    export THIRD_PARTY_PATH=${THIRD_PARTY_PATH:-"./third_party"}
     export GROUP=${GROUP:-"visit"}
     #export LOG_FILE=${LOG_FILE:-"${0##*/}_log"}
     export GITREVISION=${GITREVISION:-"HEAD"}


### PR DESCRIPTION
I changed the default third path path in build visit from ./visit to ./third_party. This is to avoid a conflict with the name of the git checkout, which is ./visit.