### PR TITLE
Correct a bug with OSPRAY mode state tracking.

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -212,6 +212,13 @@ VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
     curRenderTimes[0] = curRenderTimes[1] = curRenderTimes[2] = 0.0;
 
 #ifdef VISIT_OSPRAY
+    osprayRendering = false;
+    ospraySPP = 1;
+    osprayAO = 0;
+    osprayShadows = false;
+    modeIsPerspective = true;
+    canvas->SetPass(0);
+
     osprayPass = vtkOSPRayPass::New();
     vtkViewNodeFactory* factory = osprayPass->GetViewNodeFactory();
     factory->RegisterOverride("vtkDataSetMapper",
@@ -616,7 +623,7 @@ VisWinRendering::Start2DMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(true);
+    SetModePerspective(false);
 #endif
 }
 
@@ -655,7 +662,7 @@ VisWinRendering::Stop2DMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(false);
+    SetModePerspective(true);
 #endif
 }
 
@@ -687,7 +694,7 @@ VisWinRendering::StartCurveMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(true);
+    SetModePerspective(false);
 #endif
 }
 
@@ -720,7 +727,7 @@ VisWinRendering::StopCurveMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY
-    SetModePerspective(false);
+    SetModePerspective(true);
 #endif
 }
      
@@ -752,7 +759,7 @@ VisWinRendering::StartAxisArrayMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(true);
+    SetModePerspective(false);
 #endif
 }
 
@@ -785,7 +792,7 @@ VisWinRendering::StopAxisArrayMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(false);
+    SetModePerspective(true);
 #endif
 }
 
@@ -817,7 +824,7 @@ VisWinRendering::StartParallelAxesMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(true);
+    SetModePerspective(false);
 #endif
 }
 
@@ -850,7 +857,7 @@ VisWinRendering::StopParallelAxesMode(void)
     canvas->ComputeAspect();
 
 #ifdef VISIT_OSPRAY 
-    SetModePerspective(false);
+    SetModePerspective(true);
 #endif
 }
 
@@ -1129,14 +1136,14 @@ void
 VisWinRendering::RenderRenderWindow(void)
 {
 #ifdef VISIT_OSPRAY
-    if (!GetOsprayRendering())
+    if (GetOsprayRendering() && modeIsPerspective)
     {
-        canvas->SetPass(0);
-        canvas->SetUseShadows(false);
+        canvas->SetPass(osprayPass);
     }
     else
     {
-        canvas->SetPass(osprayPass);
+        canvas->SetUseShadows(false);
+        canvas->SetPass(0);
     }
 #endif
 
@@ -2803,11 +2810,7 @@ VisWinRendering::UpdateMouseActions(std::string action, double start_dx, double 
 void
 VisWinRendering::SetModePerspective(bool modePerspective)
 {
-    if (modePerspective != modeIsPerspective)
-    {
-        modeIsPerspective = modePerspective;
-        SetOsprayRendering(modeIsPerspective);
-    }
+    modeIsPerspective = modePerspective;
 }
 
 
@@ -2833,12 +2836,9 @@ VisWinRendering::SetModePerspective(bool modePerspective)
 void
 VisWinRendering::SetOsprayRendering(bool enabled)
 {
-    if (enabled != GetOsprayRendering())
-    {
-        osprayRendering = enabled;
-    }
+    osprayRendering = enabled;
 
-    if (GetOsprayRendering() && !modeIsPerspective)
+    if (GetOsprayRendering() && modeIsPerspective)
     {
         canvas->SetPass(osprayPass);
     }
@@ -2923,12 +2923,9 @@ VisWinRendering::SetOsprayAO(int val)
 void
 VisWinRendering::SetOsprayShadows(bool enabled)
 {
-    if(enabled != osprayShadows)
-    {
-        osprayShadows = enabled;
-    }
+    osprayShadows = enabled;
     
-    if(osprayShadows && !modeIsPerspective)
+    if(osprayShadows && modeIsPerspective)
     {
         canvas->SetUseShadows(true);
     }


### PR DESCRIPTION
I corrected a bug with the tracking of the OSPRAY mode. If you ran with the GUI and created a plot from 2D data it would render it with OSPRAY, even though the OSPRAY mode was off and 2D data should never be rendered with OSPRAY. I believe I have all the state tracking correct now.