### PR TITLE
Corrected a crash with compositing transparent geometry on cooley.alcf.anl.gov.

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.h
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.h
@@ -526,7 +526,7 @@ private:
 };
 
 #include <cstdlib>
-#ifndef HAVE_ALIGNED_ALLOC
+#if ! defined HAVE_ALIGNED_ALLOC || ! defined USE_ALIGNED_ALLOC
 #define aligned_alloc(_a, _n) \
     malloc(_n)
 #endif

--- a/src/engine/main/ProgrammableCompositer.h
+++ b/src/engine/main/ProgrammableCompositer.h
@@ -202,7 +202,7 @@ private:
 
 #include <iostream>
 #include <cstdlib>
-#ifndef HAVE_ALIGNED_ALLOC
+#if ! defined HAVE_ALIGNED_ALLOC || ! defined USE_ALIGNED_ALLOC
 #define aligned_alloc(_a, _n) \
     malloc(_n)
 #endif

--- a/src/resources/help/en_US/relnotes3.0.0.html
+++ b/src/resources/help/en_US/relnotes3.0.0.html
@@ -109,6 +109,7 @@ SetBackendType("VTKm")
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Other bugs fixed in version 3.0</font></b></p>
 <ul>
+  <li>Corrected a bug where VisIt would crash rendering transparent geometry on the Cooley system at the Argonne Leadership Computing Facility.</li>
   <li><i>ANNOTATION_INT</i> facelists with faces appearing in more than one sublist are now handled correctly.</li>
   <li>Corrected a bug that caused empty plots when using the <i>OnionPeel</i> operator with data containing enumerated subsets.</li>
   <li>Corrected a few usability issues for the <i>Save Movie Wizard</i> including: 

--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -470,7 +470,7 @@ if test "$post" = "true" ; then
 
     # Copy the results to nersc
     cd src/test
-    scp html.tar.gz $userNersc@$nerscHost:${branch}_html.tar.gz
+    scp -i ~/.ssh/nersc html.tar.gz $userNersc@$nerscHost:${branch}_html.tar.gz
     if test "$debug" = "true" ; then
         echo "Results copied to $nerscHost at: `date`" | mail -s "Results copied" $userEmail
     fi
@@ -479,8 +479,8 @@ if test "$post" = "true" ; then
 
     # Post the results.
     cd ../..
-    scp src/tools/dev/scripts/visit-copy-test-results $userNersc@$nerscHost:
-    ssh $userNersc@$nerscHost "./visit-copy-test-results ${branch}_html.tar.gz"
+    scp -i ~/.ssh/nersc src/tools/dev/scripts/visit-copy-test-results $userNersc@$nerscHost:
+    ssh -i ~/.ssh/nersc $userNersc@$nerscHost "./visit-copy-test-results ${branch}_html.tar.gz"
     if test "$debug" = "true" ; then
         echo "Results posted at: `date`" | mail -s "Results posted" $userEmail
     fi
@@ -496,13 +496,13 @@ if test "$post" = "true" ; then
 
     # If its a sunday, purge old test results
     if test "$(date +%A)" = "Sunday" ; then
-        scp src/tools/dev/scripts/purge_old_test_results.sh $userNersc@$nerscHost:
-        ssh $userNersc@$nerscHost "./purge_old_test_results.sh"
+        scp -i ~/.ssh/nersc src/tools/dev/scripts/purge_old_test_results.sh $userNersc@$nerscHost:
+        ssh -i ~/.ssh/nersc $userNersc@$nerscHost "./purge_old_test_results.sh"
     fi
 
     # Copy the update script to nersc and execute it.
-    scp src/tools/dev/scripts/visit-update-test-website $userNersc@$nerscHost:
-    ssh $userNersc@$nerscHost "./visit-update-test-website"
+    scp -i ~/.ssh/nersc src/tools/dev/scripts/visit-update-test-website $userNersc@$nerscHost:
+    ssh -i ~/.ssh/nersc $userNersc@$nerscHost "./visit-update-test-website"
 
     # Set the permissions so that others may access the test directory.
     cd ../..


### PR DESCRIPTION
I corrected a bug that caused a crash compositing transparent geometry on cooley.alcf.anl.gov. The crash occurred whenever any memory that was allocated by aligned_alloc was freed. I made the use of aligned_alloc dependent on USE_ALIGNED_ALLOC being defined, which it won't be unless someone sets it as a preprocessor flag.