### PR TITLE
Changes to build visit for compiling on a Power 9 system.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -129,6 +129,11 @@ function build_mesagl
     if [[ "$VISIT_BUILD_MODE" == "Debug" ]]; then
         MESAGL_DEBUG_BUILD="--enable-debug"
     fi
+    if [[ "$(uname -m)" == "x86_64" ]] ; then
+        MESAGL_GALLIUM_DRIVERS="swrast,swr"
+    else
+        MESAGL_GALLIUM_DRIVERS="swrast"
+    fi
 
     info "Configuring MesaGL . . ."
     echo CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
@@ -149,7 +154,7 @@ function build_mesagl
         --disable-va \
         --enable-glx \
         --enable-llvm \
-        --with-gallium-drivers=swrast,swr \
+        --with-gallium-drivers=${MESAGL_GALLIUM_DRIVERS} \
         --enable-gallium-osmesa $MESAGL_STATIC_DYNAMIC $MESAGL_DEBUG_BUILD \
         --with-llvm-prefix=${VISIT_LLVM_DIR}
     env CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
@@ -170,7 +175,7 @@ function build_mesagl
         --disable-va \
         --enable-glx \
         --enable-llvm \
-        --with-gallium-drivers=swrast,swr \
+        --with-gallium-drivers=${MESAGL_GALLIUM_DRIVERS} \
         --enable-gallium-osmesa $MESAGL_STATIC_DYNAMIC $MESAGL_DEBUG_BUILD \
         --with-llvm-prefix=${VISIT_LLVM_DIR}
 

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -237,7 +237,7 @@ function apply_qt_5101_linux_mesagl_patch
   
   
       QMAKE_LIBDIR_X11        = /usr/X11R6/lib64
-    ! QMAKE_LIBDIR_OPENGL=$MESAGL_LIB_DIR
+    ! QMAKE_LIBDIR_OPENGL=$MESAGL_LIB_DIR $LLVM_LIB_DIR
     ! QMAKE_INCDIR_OPENGL=$MESAGL_INCLUDE_DIR
   
       load(qt_config)
@@ -312,20 +312,20 @@ function build_qt
             QT_PLATFORM="aix-solaris-64"
         fi
     elif [[ "$OPSYS" == "Linux" ]] ; then
-	if [[ "$C_COMPILER" == "clang" ]]; then
+        if [[ "$C_COMPILER" == "clang" ]]; then
             QT_PLATFORM="linux-clang"
-	elif [[ "$C_COMPILER" == "llvm" ]]; then
+        elif [[ "$C_COMPILER" == "llvm" ]]; then
             QT_PLATFORM="linux-llvm"
-
         elif [[ "$(uname -m)" == "ia64" ]]; then
-                QT_PLATFORM="linux-g++-64"
-
+            QT_PLATFORM="linux-g++-64"
         elif [[ "$(uname -m)" == "x86_64" ]] ; then
             if [[ "$C_COMPILER" == "icc" || "$CXX_COMPILER" == "icpc" ]]; then
                 QT_PLATFORM="linux-icc-64"
             else
                 QT_PLATFORM="linux-g++-64"
             fi
+        elif [[ "$(uname -m)" == "ppc64" || "$(uname -m)" == "ppc64le" ]]; then
+            QT_PLATFORM="linux-g++-64"
         else
             if [[ "$C_COMPILER" == "icc" || "$CXX_COMPILER" == "icpc" ]]; then
                 QT_PLATFORM="linux-icc-32"
@@ -412,6 +412,14 @@ function build_qt
     if [[ $? != 0 ]] ; then
         warn "${QT_VER_MSG} configure failed. Giving up."
         return 1
+    fi
+
+    if [[ "$DO_MESAGL" == "yes" ]] ; then
+        if [[ ${QT_VERSION} == 5.10.1 ]] ; then
+            if [[ "$OPSYS" == "Linux" ]]; then
+                sed -i 's/-o Makefile/-o Makefile -after "QMAKE_LIBS_OPENGL+=-lLLVM"/' Makefile
+            fi
+        fi
     fi
 
     #


### PR DESCRIPTION
I modified the build of mesagl to remove SWR as one of the GALLIUM_DRIVERS. SWR requires AVX2, which isn't present on Power 9 processors.
I modified the Qt build to include the path to LLVM and add LLVM to the list of libraries to link. Qt's build system qmake is pretty complex so the fix involved modifying the linux-g++-64 configuration file as well as patching the top level makefile that is generated by configure.