### PR TITLE
2.13 rccp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2491,9 +2491,9 @@ ENDIF (NOT WIN32)
 
 #todo: replace add_subdirectory with the lines above
 SET(FIXUP_OSX TRUE CACHE BOOL "Whether to fix up osx.")
-IF(APPLE AND FIXUP_OSX)
+IF (APPLE AND FIXUP_OSX)
     ADD_SUBDIRECTORY(osxfixup)
-ENDIF(APPLE)
+ENDIF ()
 
 IF (NOT WIN32)
     MESSAGE(STATUS "\n\nUse recmake_visit.sh or search for `CMAKE_INVOKE' in CMakeCache.txt to re-run CMake with the same arguments\n\n")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -943,6 +943,27 @@ ELSE(WIN32)
         SET(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
         SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     ENDIF(VISIT_RPATH_RELATIVE_TO_EXECUTABLE_PATH)
+
+    if (APPLE)
+# Follow convention that libraries are installed with full path
+      set(CMAKE_MACOSX_RPATH FALSE)
+      if (NOT DEFINED CMAKE_INSTALL_NAME_DIR)
+# Set library directory as needed by package managers
+        set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/${VISIT_VERSION}/${VISIT_INSTALL_PLATFORM}/lib)
+      endif ()
+    elseif (LINUX)
+      set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,\$ORIGIN ${CMAKE_EXE_LINKER_FLAGS}")
+      set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath,\$ORIGIN ${CMAKE_SHARED_LINKER_FLAGS}")
+    endif ()
+# Add the automatically determined parts of the RPATH that
+# point to directories outside the build tree to the install RPATH
+# See: http://www.itk.org/Wiki/CMake_RPATH_handling
+    if (NOT DEFINED CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+# Add the automatically determined parts of the RPATH that
+# point to directories outside the build tree to the install RPATH
+      set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    endif ()
+
     #
     # Note that the last line in the EXECUTE_PROCESS command below should
     # have a "\" before the ${CMAKE_INSTALL_PREFIX} to be truely correct.
@@ -1839,6 +1860,17 @@ if(HAVE_ZLIB_H)
     list(APPEND VISIT_COMMON_INCLUDES ${ZLIB_INCLUDE_DIR})
 endif()
 
+if(WIN32)
+  if(EXISTS ${VISIT_ZLIB_DIR}/bin/zlib1.dll)
+    INSTALL(FILES ${VISIT_ZLIB_DIR}/bin/zlib1.dll
+        DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
+        PERMISSIONS OWNER_READ OWNER_WRITE
+                    GROUP_READ GROUP_WRITE
+                    WORLD_READ
+    )
+  endif()
+endif()
+
 # macros/defines needed by CMake/VisItMacros.cmake
 if (NOT DEFINED VISIT_REPLACE_DEBUG_FLAGS)
   set(VISIT_REPLACE_DEBUG_FLAGS TRUE)
@@ -2458,9 +2490,9 @@ ENDIF (NOT WIN32)
 #ADD_DEPENDENCIES(osxfixup install)
 
 #todo: replace add_subdirectory with the lines above
-IF(APPLE)
-    ADD_SUBDIRECTORY(osxfixup)
-ENDIF(APPLE)
+#IF(APPLE)
+#    ADD_SUBDIRECTORY(osxfixup)
+#ENDIF(APPLE)
 
 IF (NOT WIN32)
     MESSAGE(STATUS "\n\nUse recmake_visit.sh or search for `CMAKE_INVOKE' in CMakeCache.txt to re-run CMake with the same arguments\n\n")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2490,9 +2490,9 @@ ENDIF (NOT WIN32)
 #ADD_DEPENDENCIES(osxfixup install)
 
 #todo: replace add_subdirectory with the lines above
-#IF(APPLE)
-#    ADD_SUBDIRECTORY(osxfixup)
-#ENDIF(APPLE)
+IF(APPLE)
+    ADD_SUBDIRECTORY(osxfixup)
+ENDIF(APPLE)
 
 IF (NOT WIN32)
     MESSAGE(STATUS "\n\nUse recmake_visit.sh or search for `CMAKE_INVOKE' in CMakeCache.txt to re-run CMake with the same arguments\n\n")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2490,7 +2490,8 @@ ENDIF (NOT WIN32)
 #ADD_DEPENDENCIES(osxfixup install)
 
 #todo: replace add_subdirectory with the lines above
-IF(APPLE)
+SET(FIXUP_OSX TRUE CACHE BOOL "Whether to fix up osx.")
+IF(APPLE AND FIXUP_OSX)
     ADD_SUBDIRECTORY(osxfixup)
 ENDIF(APPLE)
 

--- a/src/config-site/windows-bilder.cmake
+++ b/src/config-site/windows-bilder.cmake
@@ -38,5 +38,13 @@ IF (CMAKE_CL_64)
 ENDIF ()
 
 # To find the resources
-GET_FILENAME_COMPONENT(VISIT_WINDOWS_DIR ${VISIT_SOURCE_DIR}/../visitwindows REALPATH)
+if (EXISTS ${VISIT_SOURCE_DIR}/../visitwindows)
+  set(VISIT_WINDOWS_DIR ${VISIT_SOURCE_DIR}/../visitwindows)
+elseif (EXISTS ${VISIT_SOURCE_DIR}/../../visitwindows)
+  set(VISIT_WINDOWS_DIR ${VISIT_SOURCE_DIR}/../../visitwindows)
+else ()
+  message(FATAL_ERROR "visitwindows not found.")
+endif ()
+GET_FILENAME_COMPONENT(VISIT_WINDOWS_DIR ${VISIT_WINDOWS_DIR} REALPATH)
+message(STATUS "VISIT_WINDOWS_DIR = ${VISIT_WINDOWS_DIR}.")
 

--- a/src/databases/Vs/VsFilter.C
+++ b/src/databases/Vs/VsFilter.C
@@ -27,6 +27,9 @@
 #include "VsAttribute.h"
 #include "VsRegistry.h"
 
+// To make sure that other h5 plugins do not interfer
+#include <visit-hdf5.h>
+
 struct RECURSION_DATA {
   VsRegistry* registry;
   VsObject* parent;

--- a/src/databases/Vs/VsRectilinearMesh.C
+++ b/src/databases/Vs/VsRectilinearMesh.C
@@ -23,22 +23,20 @@ VsRectilinearMesh::VsRectilinearMesh(VsGroup* group):VsMesh(group) {
     numTopologicalDims = -1;
 }
 
-
-VsRectilinearMesh::~VsRectilinearMesh() {
-}
+VsRectilinearMesh::~VsRectilinearMesh() {}
 
 
 VsRectilinearMesh* VsRectilinearMesh::buildRectilinearMesh(VsGroup* group) {
 
   VsRectilinearMesh* newMesh = new VsRectilinearMesh(group);
   bool success = newMesh->initialize();
-  
+
   if (success) {
     VsLog::debugLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
                       << "Returning success." << std::endl;
     return newMesh;
   }
-  
+
   delete (newMesh);
   newMesh = NULL;
 
@@ -46,7 +44,6 @@ VsRectilinearMesh* VsRectilinearMesh::buildRectilinearMesh(VsGroup* group) {
                     << "Returning NULL." << std::endl;
   return NULL;
 }
-
 
 bool VsRectilinearMesh::initialize() {
 
@@ -63,7 +60,7 @@ bool VsRectilinearMesh::initialize() {
         << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
         << "Can't determine spatial dimensionality - no axis "
         << 0 << " '" << getAxisDatasetName(0) << "' dataset?" << std::endl;
-      
+
       return false;
   }
 
@@ -73,61 +70,52 @@ bool VsRectilinearMesh::initialize() {
         << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
         << "Can't determine spatial dimensionality - no axis "
         << 1 << " '" << getAxisDatasetName(1) << "' dataset?" << std::endl;
-      
+
       return false;
   }
-  
+
   numTopologicalDims = 0;
 
   // Get each axis that contributes to the spatial and topological dim.
   for( int i=0; i<3; ++i ) {
 
     VsDataset* axis = getAxisDataset(i);
-  
+
     if (axis) {
       std::vector<int> axisDims = axis->getDims();
 
       if (axisDims.size() != 1) {
-        // 
-        if( axisDims.size() == 2 && axisDims[1] == 1 )
-        {
-          VsLog::debugLog()
+        if( axisDims.size() == 2 && axisDims[1] == 1 ) {
+          VsLog::errorLog()
             << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
             << "Expected 1-d dataset for Axis "
             << i << " '" << getAxisDatasetName(i) << "', "
-            << "actually have " << axisDims.size() << ".  "
-            << "Ignoring because the second dimension is 1." << std::endl;
-        }
-        else
-        {
+            << "actually have " << axisDims.size() << "  "
+            << "ignoring because the second dimension is 1." << std::endl;
+        } else {
           VsLog::errorLog()
             << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
             << "Expected 1-d dataset for Axis "
             << i << " '" << getAxisDatasetName(i) << "', "
             << "actually have " << axisDims.size() << "." << std::endl;
-          
           return false;
         }
       }
-      
       if (axisDims[0] == 0) {
-        VsLog::errorLog()
+        VsLog::debugLog()
           << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
           << "Expected data in dataset for Axis "
           << i << " '" << getAxisDatasetName(i) << "', "
           << "actually have none." << std::endl;
-
-        return false;
       }
-      
       numSpatialDims = i + 1;
 
-      // ARS - Becasue of the way the data structures are used to hold
+      // ARS - Because of the way the data structures are used to hold
       // structured data in VTK and VisIt the topological dimension has to
       // equal the spatial dimension unless the last dim(s) are 1.
 
       // i.e. 1, 1, 2 = topological dims == 3
-      // i.e. 2, 1, 1 = topological dims == 1 
+      // i.e. 2, 1, 1 = topological dims == 1
 
       // Check for the last axis for a dimension greater than 1
       if ( axisDims[0] > 1 ) {
@@ -144,7 +132,7 @@ bool VsRectilinearMesh::initialize() {
       break;
     }
   }
-  
+
   VsLog::debugLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
                     << "Rectilinear Mesh " << getShortName() << " "
                     << "has num spatial dims = "
@@ -163,7 +151,6 @@ hid_t VsRectilinearMesh::getDataType() const{
       << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
       << "Can't determine data type - no axis "
       << 0 << " '" << getAxisDatasetName(0) << "' dataset?" << std::endl;
-    
     return H5T_NATIVE_DOUBLE; //?
   }
 
@@ -174,7 +161,7 @@ hid_t VsRectilinearMesh::getDataType() const{
     if (axis && axis->getType() == H5T_NATIVE_DOUBLE)
       return H5T_NATIVE_DOUBLE;
   }
-  
+
   return H5T_NATIVE_FLOAT;
 }
 
@@ -183,7 +170,7 @@ std::string VsRectilinearMesh::getAxisDatasetName(int axisNumber) const {
   if ((axisNumber < 0) || (axisNumber > 2)) {
     return "";
   }
-  
+
   std::string axisKey;
   switch (axisNumber) {
     case 0: axisKey = VsSchema::Rectilinear::axis0Key;
@@ -196,9 +183,9 @@ std::string VsRectilinearMesh::getAxisDatasetName(int axisNumber) const {
        return "";
        break;
   }
-  
+
   std::string axisName;
-    
+
   //First see if the user has specified a name for the dataset
   VsAttribute* axisNameAtt = getAttribute(axisKey);
   if (axisNameAtt) {
@@ -207,7 +194,7 @@ std::string VsRectilinearMesh::getAxisDatasetName(int axisNumber) const {
       return makeCanonicalName(getFullName(), axisName);
     }
   }
-  
+
   //if we didn't find a user supplied name, try the default name
   switch (axisNumber) {
     case 0: axisName = VsSchema::Rectilinear::axis0DefaultName;
@@ -221,7 +208,7 @@ std::string VsRectilinearMesh::getAxisDatasetName(int axisNumber) const {
        break;
   }
 
-  //axisName 
+  //axisName
   return makeCanonicalName(getFullName(), axisName);
 }
 
@@ -247,10 +234,10 @@ void VsRectilinearMesh::getNodeDims(std::vector<int>& dims) const
 {
   VsLog::debugLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
                     << "Entering." <<  std::endl;
-  
+
   // The size of rectilinear mesh depends on the numSpatialDims
   dims.resize(numSpatialDims);
-  
+
   for( int i=0; i<numSpatialDims; ++i )
   {
     dims[i] = getAxisDataset(i)->getDims()[0];
@@ -262,7 +249,7 @@ void VsRectilinearMesh::getCellDims(std::vector<int>& dims) const
 {
   // Determine the number of cells which is the number of nodes less 1.
   getNodeDims( dims );
-  
+
   for( int i=0; i<dims.size(); ++i )
     dims[i] -= 1;
 }

--- a/src/databases/Vs/VsUniformMesh.C
+++ b/src/databases/Vs/VsUniformMesh.C
@@ -285,7 +285,8 @@ bool VsUniformMesh::initialize()
                         << std::endl;
       return false;
     }
-
+// SS: These restrictions are commented out because we have cases that have mismatched dimensions but they should work anyway.
+/*
     if( iNumCells.size() != iStartCell.size() )
     {
       VsLog::errorLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
@@ -309,7 +310,7 @@ bool VsUniformMesh::initialize()
                         << std::endl;
       return false;
     }
-
+*/
     VsLog::errorLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
                       << "Found a start cell for this mesh, "
                       << "but not sure how it should be used, "

--- a/src/databases/Vs/avtVsFileFormat.C
+++ b/src/databases/Vs/avtVsFileFormat.C
@@ -244,8 +244,8 @@ avtVsFileFormat::CreateCacheNameIncludingSelections(std::string s)
 //  Method: avtVsFileFormat::RegisterDataSelections
 //
 //  Purpose:
-//      The Vs format can exploit some data selections so get them. 
-//      
+//      The Vs format can exploit some data selections so get them.
+//
 //  Programmer: Allen Sanderson
 //  Creation:   March 4, 2011
 //
@@ -263,8 +263,8 @@ avtVsFileFormat::RegisterDataSelections(const std::vector<avtDataSelection_p> &s
 //  Method: avtVsFileFormat::ProcessDataSelections
 //
 //  Purpose:
-//      The Vs format can exploit some data selections so process them. 
-//      
+//      The Vs format can exploit some data selections so process them.
+//
 //  Programmer: Allen Sanderson
 //  Creation:   March 4, 2011
 //
@@ -516,7 +516,7 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
                                          haveDataSelections, mins, maxs, strides);
             }
         }
-        
+
         // At this point we don't know what kind of mesh it is.
         else {
           VsLog::debugLog() << CLASSFUNCLINE
@@ -585,7 +585,7 @@ vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // ARS - Becasue of the way the data structures are used to hold
@@ -604,7 +604,7 @@ vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
 
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Getting bounds for mesh." << std::endl;
-    
+
     std::vector<float> lowerBounds;
     uniformMesh->getLowerBounds(&lowerBounds);
 
@@ -629,10 +629,10 @@ vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
     // ARS _ CURRENTLY THE START CELL IS IGNORED AS HOW IT IS TO USED IS
     // NOT FULLY DEFINED.
 
-    // startCell - 
+    // startCell -
     // VsLog::debugLog() << CLASSFUNCLINE
     //                << "Loading optional startCells attribute." << std::endl;
-    
+
     // std::vector<int> startCell;
     // herr_t err = uniformMesh->getStartCell(&startCell);
     // if (err < 0) {
@@ -753,7 +753,7 @@ avtVsFileFormat::getRectilinearMesh(VsRectilinearMesh* rectilinearMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // ARS - Becasue of the way the data structures are used to hold
@@ -858,12 +858,12 @@ avtVsFileFormat::getRectilinearMesh(VsRectilinearMesh* rectilinearMesh,
             VsLog::debugLog() << CLASSFUNCLINE
                               << "GetDataSet returned error: " << err << "  "
                               << "Returning NULL." << std::endl;
-            
+
             if( isDoubleType( axisDataType ) )
               delete [] dblDataPtr;
             else if( isFloatType( axisDataType ) )
               delete [] fltDataPtr;
-            
+
             return NULL;
         }
 
@@ -894,7 +894,7 @@ avtVsFileFormat::getRectilinearMesh(VsRectilinearMesh* rectilinearMesh,
                   temp = dblDataPtr[j];
                 else if( isFloatType( axisDataType ) )
                   temp = fltDataPtr[j];
-                
+
                 coords[i]->InsertTuple(cc, &temp);
                 ++cc;
                 j += strides[i];
@@ -1052,7 +1052,7 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsStructuredMesh* structuredMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Find points: Structured meshes are datasets, and the data is
@@ -1361,7 +1361,7 @@ avtVsFileFormat::getHighOrderUnstructuredMesh(VsUnstructuredMesh* unstructuredMe
                                               bool haveDataSelections,
                                               int* mins, int* maxs, int* strides) {
     VsLog::debugLog() << CLASSFUNCLINE << "Entering." << std::endl;
-    
+
     LoadData();
 
     thisData.setReader(reader);
@@ -1393,7 +1393,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Check for points type
@@ -1464,7 +1464,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
     VsLog::debugLog() << CLASSFUNCLINE
                       << "VPoints array will have " << numNodes << " points."
                       << std::endl;
-    
+
     vpoints->SetNumberOfPoints(numNodes);
     void* dataPtr = vpoints->GetVoidPointer(0);
 
@@ -1472,12 +1472,12 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Unable to allocate the points.  Cleaning up."
                           << std::endl;
-        
+
         ugridPtr->Delete();
-        
+
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Returning NULL." << std::endl;
-        
+
         return NULL;
     }
 
@@ -1531,7 +1531,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Call to getDataSet returned error: "
                                   << err << "Returning NULL." << std::endl;
-                
+
                 return NULL;
             }
         }
@@ -1641,7 +1641,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
                           << std::endl;
 
         vtkIdType vertex;
-        
+
         for (size_t i=0; i<numNodes; ++i) {
             vertex = i;
             ugridPtr->InsertNextCell(VTK_VERTEX, 1, &vertex);
@@ -1745,7 +1745,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
 
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Returning NULL." << std::endl;
-        
+
         return NULL;
     }
 
@@ -1866,7 +1866,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
                           << "Allocating " << numCells << " cells.  "
                           << "If old VTK and this fails, it will just abort."
                           << std::endl;
-        
+
         ugridPtr->Allocate(numCells);
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Allocation succeeded." << std::endl;
@@ -1894,7 +1894,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
     }
 
     // Tweak for Nautilus
-    
+
     // Prepare to fix up the connectivity list if node correction data
     // is available
     int* correctionList = NULL;
@@ -1934,7 +1934,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
 
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Inserting cells into grid." << std::endl;
-    
+
     int warningCount = 0;
     int cellCount = 0;
     unsigned int cellVerts = 0; // total verts (for VTK_POLYHEDRON this value is not topologically meaningful - see below)
@@ -2029,7 +2029,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
                                     << "Error messages disabled for remaining cells."
                                     << std::endl;
                 }
-                
+
                 ++warningCount;
                 cellType = VTK_EMPTY_CELL;
             }
@@ -2075,7 +2075,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
             // VTK_POLYHEDRON type takes face count, not vertex count
             vtkIdType cellOrFaceCount =
               (cellType == VTK_POLYHEDRON) ? cellFaces : cellVerts;
-            
+
             ugridPtr->InsertNextCell(cellType, cellOrFaceCount, &verts[0]);
         }
         else {
@@ -2129,7 +2129,7 @@ vtkDataSet* avtVsFileFormat::getPointMesh(VsVariableWithMesh* variableWithMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     hid_t meshDataType = variableWithMesh->getType();
@@ -2152,7 +2152,7 @@ vtkDataSet* avtVsFileFormat::getPointMesh(VsVariableWithMesh* variableWithMesh,
     size_t numSpatialDims     = variableWithMesh->getNumSpatialDims();
     size_t numTopologicalDims = variableWithMesh->getNumTopologicalDims();
     size_t numLogicalDims     = 1;
-    
+
     std::vector<int> numNodes(numLogicalDims);
     numNodes[0] = (int)variableWithMesh->getNumPoints();
 
@@ -2392,7 +2392,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Save the original name in a temporary variable
@@ -2437,8 +2437,8 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
 
           VsLog::debugLog() << CLASSFUNCLINE
                             << "Found a component, which refers to variable "
-                            << name << " and index " << componentIndex 
-                            << std::endl;         
+                            << name << " and index " << componentIndex
+                            << std::endl;
         }
     }
 
@@ -2517,7 +2517,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
 
     // Get the number of points on the curve.
     int nPts;
-    
+
     if (varMeta->isCompMinor()) {
       nPts = varMeta->getDims()[0];
     } else {
@@ -2531,7 +2531,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
     int nPtsInMesh;
     if (varMeta->isZonal())
       nPtsInMesh = meshDims[0];      // Get the number of cells.
-    else 
+    else
       nPtsInMesh = meshDims[0] + 1;  // Get the number of nodes.
 
     int nPtsInOutput;
@@ -2542,7 +2542,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
       VsLog::debugLog() << CLASSFUNCLINE
                         << "ERROR - mesh and var dimensionas don't match."
                         << std::endl;
-        
+
       // Use the lower of the two values
       if (nPts < nPtsInMesh)
         nPtsInOutput = nPts;
@@ -2561,7 +2561,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
     // Create 1D RectilinearGrid
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Building Rectilinear grid." << std::endl;
-    
+
     vtkFloatArray* vals = vtkFloatArray::New();
     vals->SetNumberOfComponents(1);
     vals->SetNumberOfTuples(nPtsInOutput);
@@ -2651,7 +2651,7 @@ bool avtVsFileFormat::nameIsComponent(std::string& name, int& componentIndex) {
                           << name << " and index " << componentIndex
                           << std::endl;
     }
-    
+
     return isAComponent;
 }
 
@@ -2671,14 +2671,14 @@ bool avtVsFileFormat::isTransformedName(std::string& name) {
 
     bool transform = false;
     std::string origVarName = registry->getOriginalVarName(name);
-    
+
     if (!origVarName.empty()) {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Original var for the transformed var "
                           << name << " is " << origVarName << std::endl;
         transform = true;
         name = origVarName;
-        
+
     } else {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Unable to find an original var for the possible transform name "
@@ -2703,7 +2703,7 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
                                            const char* requestedName)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Save the original name in a temporary variable so that we can
@@ -2717,7 +2717,7 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
     if( (haveDataSelections = ProcessDataSelections(mins, maxs, strides)) )
     {
         ///TODO: check on fix for assignment
-      
+
         VsLog::debugLog()
           << CLASSFUNCLINE
           << "Have a data selection for variable " << name << "  "
@@ -2749,7 +2749,7 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Found MD metadata for this name: "
                           << name << std::endl;
-        
+
         if (0 <= domain && (size_t)domain < mdMeta->getNumBlocks()) {
             meta = mdMeta->getBlock(domain);
             name = meta->getFullName();
@@ -2770,7 +2770,7 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Looking for regular (non-md) variable." << std::endl;
         meta = registry->getVariable(name);
-        
+
         if( meta )
           variableDataset = registry->getDataset(meta->getFullName());
     }
@@ -2892,7 +2892,7 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
         // varDims.size() will always be one more than the logical
         // dims because it has an extra dim regardless if the vaiarble
         // is a component or not.
-        
+
         // For a Structured Mesh the VarDims.size() will match the
         // numLogicalDims (numTopologicalDims) plus 1.
 
@@ -2936,13 +2936,13 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
       VsLog::debugLog() << " " << varDims[i];
 
     VsLog::debugLog() << ")" << std::endl;
-    
+
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Variable " << name << " has dimensions =";
 
     for (size_t i=0; i<numLogicalDims; ++i)
       VsLog::debugLog() << " " << varDims[i+isCompMajor];
-    
+
     VsLog::debugLog() << ", numLogicalDims = " << numLogicalDims
                       << ", isComponent = " << isAComponent << "." << std::endl;
 
@@ -3090,7 +3090,7 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Finished dumping data. " << std::endl;
     END DEBUG */
-    
+
     vtkDataArray* rv = 0;
 
     if (isDouble) {
@@ -3324,7 +3324,7 @@ VsVariable* avtVsFileFormat::getVariableMeta(int domain,
     // replace "name" with the name of that variable.
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Checking for possible MD var." << std::endl;
-    
+
     VsMDVariable* mdMeta = registry->getMDVariable(name);
     if (mdMeta) {
         VsLog::debugLog() << CLASSFUNCLINE
@@ -3394,7 +3394,7 @@ vtkDataArray* avtVsFileFormat::NodalVar(VsVariable* meta,
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
     LoadData();
-    
+
     thisData.setReader(reader);
     thisData.setRegistry(registry);
 
@@ -3421,7 +3421,7 @@ vtkDataArray* avtVsFileFormat::GetVar(int domain, const char* requestedName)
 
     int component;
     VsVariable* meta = getVariableMeta(domain, requestedName, component);
-    
+
     if( meta != NULL) {
         if(meta->getMesh()->isHighOrder()) {
             VsLog::debugLog() << CLASSFUNCLINE
@@ -3481,7 +3481,7 @@ void avtVsFileFormat::FreeUpResources(void)
 void avtVsFileFormat::RegisterExpressions(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     //get list of expressions from reader
@@ -3514,7 +3514,7 @@ void avtVsFileFormat::RegisterExpressions(avtDatabaseMetaData* md)
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Adding expression " << iv->first << " = "
                           << iv->second << std::endl;
-        
+
         Expression e;
         e.SetName (iv->first);
 
@@ -3552,7 +3552,7 @@ void avtVsFileFormat::RegisterExpressions(avtDatabaseMetaData* md)
                                       << *it << "  was found." << std::endl;
 
                     e.SetType(Expression::CurveMeshVar);
-                    
+
                     break;  // No need to stay in the loop
                 }
             }
@@ -3586,7 +3586,7 @@ void avtVsFileFormat::RegisterExpressions(avtDatabaseMetaData* md)
 void avtVsFileFormat::RegisterVars(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Get var names
@@ -3765,7 +3765,7 @@ void avtVsFileFormat::RegisterVars(avtDatabaseMetaData* md)
             if (vMeta->hasTransform()) {
                 std::string transformVarName = vMeta->getFullTransformedName();
                 VsLog::debugLog() << CLASSFUNCLINE
-                                  << "Registering transformed variable: " 
+                                  << "Registering transformed variable: "
                                   << transformVarName <<std::endl;
 
                 avtScalarMetaData* smd_transformed =
@@ -3803,7 +3803,7 @@ void avtVsFileFormat::RegisterVars(avtDatabaseMetaData* md)
 void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // All meshes names
@@ -3879,7 +3879,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
         std::vector<int> dims;
         int bounds[3] = {1,1,1};
         size_t numCells = 1;
-        
+
         //std::cout << "isDgMesh is " << meta->isDgMesh() << "\n";
 
         // Uniform Mesh
@@ -3942,7 +3942,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
                   new avtMeshMetaData(transformedMeshName, 1, 1, 1, 0,
                                       (int) numSpatialDims,
                                       (int) numTopologicalDims, meshType);
-                
+
                 vmd->SetBounds( bounds );
                 vmd->SetNumberCells( (int)numCells );
                 setAxisLabels(vmd, rectMesh->hasTransform());
@@ -3978,7 +3978,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Registering mesh " << it->c_str()
                                   << " as AVT_POINT_MESH" << std::endl;
-                
+
                 meshType = AVT_POINT_MESH;
             }
             else {
@@ -3991,7 +3991,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
 
             // Add in the logical bounds of the mesh.
             numCells = unstructuredMesh->getNumCells();
-            
+
             bounds[0] = (int) numCells;
             bounds[1] = bounds[2] = 0;
         }
@@ -4012,7 +4012,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
          // Add in the logical bounds of the mesh.  Number of cells
          // before each cell is triangulated
          numCells = dgMesh->getNumCells();
-         
+
          bounds[0] = numCells;
          bounds[1] = bounds[2] = 0;
         }
@@ -4034,7 +4034,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
               new avtMeshMetaData(it->c_str(), 1, 1, 1, 0,
                                   (int) numSpatialDims,
                                   (int) numTopologicalDims, meshType);
-            
+
             vmd->SetBounds( bounds );
             vmd->SetNumberCells( (int) numCells );
             setAxisLabels(vmd);
@@ -4061,7 +4061,7 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
 void avtVsFileFormat::RegisterMdVars(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Get vars names
@@ -4113,7 +4113,7 @@ void avtVsFileFormat::RegisterMdVars(avtDatabaseMetaData* md)
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Variable has " << numComps
                           << " components." << std::endl;
-        
+
         if (numComps > 1) {
             for (size_t i = 0; i<numComps; ++i) {
                 //first, get a unique name for this component
@@ -4167,7 +4167,7 @@ void avtVsFileFormat::RegisterMdVars(avtDatabaseMetaData* md)
 void avtVsFileFormat::RegisterMdMeshes(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     std::vector<std::string> names;
@@ -4187,7 +4187,7 @@ void avtVsFileFormat::RegisterMdMeshes(avtDatabaseMetaData* md)
         VsLog::debugLog() << CLASSFUNCLINE
                           << " Adding md mesh '"
                           << *it << "'." << std::endl;
-        
+
         VsMDMesh* meta = registry->getMDMesh(*it);
         if (!meta) {
             VsLog::debugLog() << CLASSFUNCLINE
@@ -4241,7 +4241,7 @@ void avtVsFileFormat::RegisterMdMeshes(avtDatabaseMetaData* md)
 void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     std::vector<std::string> names;
@@ -4284,7 +4284,7 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
                 avtScalarMetaData* smd =
                   new avtScalarMetaData(compName.c_str(), it->c_str(),
                                         AVT_NODECENT);
-                
+
                 smd->hasUnits = false;
                 md->Add(smd);
 
@@ -4306,7 +4306,7 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
                       new avtScalarMetaData(transformComponentName.c_str(),
                                             transformMeshName.c_str(),
                                             AVT_NODECENT);
-                    
+
                     smd_transformed->hasUnits = false;
                     md->Add(smd_transformed);
                 }
@@ -4332,16 +4332,16 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
                               << std::endl;
             numSpatialDims = 2;
         }
-        
+
         VsLog::debugLog()
           << CLASSFUNCLINE
           << "Adding point mesh for this variable." << std::endl;
-        
+
         avtMeshMetaData* vmd =
           new avtMeshMetaData(it->c_str(), 1, 1, 1, 0,
                               numSpatialDims, numTopologicalDims,
                               AVT_POINT_MESH);
-        
+
         vmd->SetBounds(bounds);
         vmd->SetNumberCells(numCells);
         setAxisLabels(vmd);
@@ -4354,12 +4354,12 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
             VsLog::debugLog() << CLASSFUNCLINE
                               << "Variable lives on a mesh with a transform: "
                               << transformMeshName << std::endl;
-            
+
             avtMeshMetaData* vmd_transform =
               new avtMeshMetaData(transformMeshName.c_str(), 1, 1, 1, 0,
                                   numSpatialDims, numTopologicalDims,
                                   AVT_POINT_MESH);
-            
+
             vmd_transform->SetBounds(bounds);
 
             // This is the change for ticket 3340: the transformed
@@ -4394,6 +4394,138 @@ void avtVsFileFormat::ActivateTimestep()
 }
 
 // *****************************************************************************
+//  Method: avtVsFileFormat::UpdateCyclesAndTimes
+//
+//  Purpose:
+//      How do you do the voododo that you do
+//
+//  Programmer: Marc Durant
+//  Creation:   June, 2010
+//
+//  Modifications:
+//
+/*
+void avtVsFileFormat::UpdateCyclesAndTimes(avtDatabaseMetaData* md)
+{
+    VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
+
+    LoadData();
+
+    if (!md) {
+      VsLog::debugLog() << CLASSFUNCLINE
+                        << "md was NULL, returning." <<std::endl;
+        return;
+    }
+
+    int timeStep = 0;
+
+    // Extract timestep from filename
+    // First, get file name from full path
+    std::string fileName(dataFileName);
+    std::string::size_type lastSlash = fileName.find_last_of('/');
+    if (lastSlash == std::string::npos) {
+        lastSlash = fileName.find_last_of('\\');
+    }
+    VsLog::debugLog() << CLASSFUNCLINE
+    <<"Last slash is " <<lastSlash << std::endl;
+    if (lastSlash != std::string::npos) {
+        std::string::size_type nameLength = fileName.length() - (lastSlash + 1);
+        fileName = fileName.substr(lastSlash + 1, nameLength);
+    }
+    VsLog::debugLog() << CLASSFUNCLINE
+                      <<"Extracted filename is \"" <<fileName <<"\"" << std::endl;
+
+    // Timestep = the number between the last underscore and the first dot
+    std::string::size_type lastUnderscore = fileName.find_last_of('_');
+    VsLog::debugLog() << CLASSFUNCLINE
+                      <<"lastUnderscore is " <<lastUnderscore << std::endl;
+
+    std::string::size_type firstDot = fileName.find_first_of('.');
+    VsLog::debugLog() << CLASSFUNCLINE
+                      <<"firstDot is " <<firstDot << std::endl;
+
+    if ((lastUnderscore != std::string::npos) &&
+            (firstDot != std::string::npos) &&
+            (firstDot > lastUnderscore + 1)) {
+        std::string step =
+        fileName.substr(lastUnderscore + 1, firstDot - (lastUnderscore + 1));
+
+        VsLog::debugLog() << CLASSFUNCLINE
+                          << "Step is \"" << step << "\""
+                          << std::endl;
+
+        timeStep = atoi(step.c_str());
+
+        VsLog::debugLog() << CLASSFUNCLINE
+                          <<"Converted to integer is \"" << timeStep << "\""
+                          << std::endl;
+    }
+
+    // If time data is present, tell VisIt
+    if (registry->hasTime()) {
+        VsLog::debugLog() << CLASSFUNCLINE
+        << "This file supplies time: "
+        << registry->getTime() << std::endl;
+
+        md->SetTime(timeStep, registry->getTime());
+        md->SetTimeIsAccurate(true, registry->getTime());
+    }
+
+    // If time cycle is present, tell VisIt
+    if (registry->hasCycle()) {
+        VsLog::debugLog() << CLASSFUNCLINE
+        << "This file supplies cycle: "
+        << registry->getCycle() << std::endl;
+
+        md->SetCycle(timeStep, registry->getCycle());
+        md->SetCycleIsAccurate(true, registry->getCycle());
+    }
+
+    // If time data is present, tell VisIt
+    // if (registry->hasTime()) {
+    //     VsLog::debugLog() << CLASSFUNCLINE
+    //                       << "This file supplies time: "
+    //                       << registry->getTime() << std::endl;
+
+    //     std::vector<double> times;
+    //     times.resize( 1 );
+    //     times[0] = registry->getTime();
+
+    //     md->SetTimesAreAccurate(true);
+    //     md->SetTimes( times );
+    // }
+
+    // If cycle data is present, tell VisIt
+    // if (registry->hasCycle()) {
+    //     VsLog::debugLog() << CLASSFUNCLINE
+    //                       << "This file supplies cycle: "
+    //                       << registry->getCycle() << std::endl;
+
+    //     std::vector<int> cycles;
+    //     cycles.resize( 1 );
+    //     cycles[0] = registry->getCycle();
+
+    //     md->SetCyclesAreAccurate(true);
+    //     md->SetCycles( cycles );
+    // }
+
+    if (registry->hasLowerBounds() && registry->hasUpperBounds()) {
+
+      VsLog::debugLog() << CLASSFUNCLINE
+                        << "Getting bounds for mesh." << std::endl;
+
+      std::vector<float> lowerBounds;
+      registry->getLowerBounds(&lowerBounds);
+
+      std::vector<float> upperBounds;
+      registry->getUpperBounds(&upperBounds);
+    }
+
+    VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
+}
+*/
+
+// *****************************************************************************
 //  Method: avtVsFileFormat::LoadData
 //
 //  Purpose:
@@ -4419,7 +4551,7 @@ void avtVsFileFormat::LoadData()
 
         if (!registry)
           registry = new VsRegistry();
-        
+
         reader = new VsReader(dataFileName, registry);
     }
     catch (std::invalid_argument& ex) {
@@ -4450,7 +4582,7 @@ void avtVsFileFormat::LoadData()
 void avtVsFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-    
+
     LoadData();
 
     // Tell visit that we can split meshes into subparts when running
@@ -4501,26 +4633,6 @@ void avtVsFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md)
         setAxisLabels(mmd);
         setGlobalExtents(mmd);
         md->Add(mmd);
-    }
-
-    // If time data is present, tell VisIt
-    if (registry->hasTime()) {
-        VsLog::debugLog() << CLASSFUNCLINE
-        << "This file supplies time: "
-        << registry->getTime() << std::endl;
-
-        md->SetTime(timestep, registry->getTime());
-        md->SetTimeIsAccurate(true, timestep);
-    }
-
-    // If time cycle is present, tell VisIt
-    if (registry->hasCycle()) {
-        VsLog::debugLog() << CLASSFUNCLINE
-        << "This file supplies cycle: "
-        << registry->getCycle() << std::endl;
-
-        md->SetCycle(timestep, registry->getCycle());
-        md->SetCycleIsAccurate(true, timestep);
     }
 
     VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
@@ -4598,7 +4710,7 @@ void avtVsFileFormat::setGlobalExtents(avtMeshMetaData* mmd)
 
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Getting bounds for mesh." << std::endl;
-          
+
     std::vector<float> lowerBounds;
     registry->getLowerBounds(&lowerBounds);
 
@@ -4617,7 +4729,7 @@ void avtVsFileFormat::setGlobalExtents(avtMeshMetaData* mmd)
 //  Method: avtVsFileFormat::GetCycle
 //
 //  Purpose:
-//      How do you do the voododo that you do
+//       This function gets called when VisIt tries "harder", otherwise "_i" in the file names is used.
 //
 //  Programmer: Marc Durant
 //  Creation:   June, 2010
@@ -4625,22 +4737,18 @@ void avtVsFileFormat::setGlobalExtents(avtMeshMetaData* mmd)
 //  Modifications:
 //
 
-int avtVsFileFormat::GetCycle()
-{
+int avtVsFileFormat::GetCycle() {
     VsLog::debugLog() << CLASSFUNCLINE << "entering" << std::endl;
 
     LoadData();
 
-    if (registry->hasCycle())
-    {
+    if (registry->hasCycle()) {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "The file " << dataFileName << " has cycle: "
                           << registry->getCycle() << std::endl;
-
         return registry->getCycle();
     }
-    else
-    {
+    else {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "The file " << dataFileName << " has no cycle.  "
                           << "Returning INVALID_CYCLE." << std::endl;
@@ -4654,7 +4762,7 @@ int avtVsFileFormat::GetCycle()
 //  Method: avtVsFileFormat::GetTime
 //
 //  Purpose:
-//      How do you do the voododo that you do
+//        This function gets called when VisIt tries "harder".  Otherwise is not used."
 //
 //  Programmer: Marc Durant
 //  Creation:   June, 2010
@@ -4662,22 +4770,19 @@ int avtVsFileFormat::GetCycle()
 //  Modifications:
 //
 
-double avtVsFileFormat::GetTime()
-{
+double avtVsFileFormat::GetTime() {
     VsLog::debugLog() << CLASSFUNCLINE << "entering" << std::endl;
-    
+
     LoadData();
 
-    if (registry->hasTime())
-    {
+    if (registry->hasTime()) {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "The file " << dataFileName << " has time: "
                           <<registry->getTime() << std::endl;
-        
+
         return registry->getTime();
     }
-    else
-    {
+    else {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "The file " << dataFileName << " has no time.  "
                           << "Returning INVALID_TIME." << std::endl;
@@ -4954,7 +5059,7 @@ bool avtVsFileFormat::GetParallelDecomp( int numLogicalDims,
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Parallel & Decompose_Domains are defined, "
                       << "exiting parallel code." << std::endl;
-    
+
     // If not on processor 0 and if the porcessor has only one node
     // skip it as it is slice which will have been drawn by the previous
     // processor.

--- a/src/databases/Vs/avtVsFileFormat.h
+++ b/src/databases/Vs/avtVsFileFormat.h
@@ -183,6 +183,13 @@ class avtVsFileFormat: public avtSTMDFileFormat {
    */
   HighOrderUnstructuredData thisData;
 
+  /**
+   * Change the default behavior so that the plugin does not populate spatial extent information.
+   */
+  bool HasInvariantMetaData(void) const { 
+    return false; 
+  }
+
   private:
 
   /**

--- a/src/databases/Vs/avtVsFileFormat.h
+++ b/src/databases/Vs/avtVsFileFormat.h
@@ -1,12 +1,12 @@
 /**
  *
- * @file        avtVsFileFormat.h
+ * @file    avtVsFileFormat.h
  *
- * @brief       Base class for VizSchema visit plugins
+ * @brief   Base class for VizSchema visit plugins
  *
  * @version $Id: avtVsFileFormat.h 27 2008-03-26 22:04:41Z sveta $
  *
- * Copyright &copy; 2007, Tech-X Corporation
+ * Copyright &copy; 2007-2019, Tech-X Corporation
  * See LICENSE file for conditions of use.
  *
  */
@@ -54,241 +54,252 @@ class avtVsFileFormat: public avtSTMDFileFormat {
 #if HDF5_VERSION_GE(1, 8, 1)
   public:
 
-  /**
-   * Construct a file reader from a data file.
-   *
-   * @param dfnm the name of the data file
-   */
-  avtVsFileFormat(const char*, DBOptionsAttributes *);
+/**
+ * Construct a file reader from a data file.
+ *
+ * @param dfnm the name of the data file
+ */
+    avtVsFileFormat(const char*, DBOptionsAttributes *);
 
-  /**
-   * Destructor
-   */
-  virtual ~avtVsFileFormat();
+/**
+ * Destructor
+ */
+    virtual ~avtVsFileFormat();
 
-  /**
-   * Get plugin type
-   *
-   * @return plugin type name
-   */
-  virtual const char* GetType(void) {
-    return "Vs";
-  };
+/**
+ * Get plugin type
+ *
+ * @return plugin type name
+ */
+    virtual const char* GetType(void) {
+      return "Vs";
+    };
 
-  virtual std::string CreateCacheNameIncludingSelections(std::string s);
+    virtual std::string CreateCacheNameIncludingSelections(std::string s);
 
-  /**
-   * Get the data selections
-   *
-   */
-  virtual void RegisterDataSelections( const std::vector<avtDataSelection_p> &sels,
-                                       std::vector<bool> *selectionsApplied );
+/**
+ * Get the data selections
+ *
+ */
+    virtual void RegisterDataSelections(
+        const std::vector<avtDataSelection_p> &sels,
+        std::vector<bool> *selectionsApplied);
 
-  /**
-   * Process the data selections
-   *
-   */
-  bool ProcessDataSelections(int *mins, int *maxs, int *strides);
+/**
+ * Process the data selections
+ *
+ */
+    bool ProcessDataSelections(int *mins, int *maxs, int *strides);
 
-  /**
-   * Get a mesh by name
-   *
-   * @param domain the number of the domain in this mesh
-   * @param meshname the name of the mesh
-   *
-   * @return a pointer to the mesh. Caller assumes ownership (must delete when done)
-   */
-  virtual vtkDataSet* GetMesh(int domain, const char* meshname);
+/**
+ * Get a mesh by name
+ *
+ * @param domain the number of the domain in this mesh
+ * @param meshname the name of the mesh
+ *
+ * @return a pointer to the mesh. Caller assumes ownership
+ *         (must delete when done)
+ */
+    virtual vtkDataSet* GetMesh(int domain, const char* meshname);
 
-  /**
-   * get a scalar variable by name
-   *
-   * @param domain the number of the domain in this mesh
-   * @param varname the name of the variable
-   *
-   * @return a pointer to the variable. Caller assumes ownership (must delete when done)
-   */
-  virtual vtkDataArray* GetVar(int domain, const char* varname);
+/**
+ * get a scalar variable by name
+ *
+ * @param domain the number of the domain in this mesh
+ * @param varname the name of the variable
+ *
+ * @return a pointer to the variable. Caller assumes ownership
+ *         (must delete when done)
+ */
+    virtual vtkDataArray* GetVar(int domain, const char* varname);
 
-  /**
-   * Get variable in the case when it is stored on a node by node basis per cell.  This
-   * is needed for discontinuous Galerkin data.
-   * @param meta is the variable of interest
-   * @param component is the component of interest
-   */
-  virtual vtkDataArray* NodalVar(VsVariable* meta, std::string requestedName, int component);
+/**
+ * Get variable in the case when it is stored on a node by node basis per cell.
+ * This is needed for discontinuous Galerkin data.
+ * @param meta is the variable of interest
+ * @param component is the component of interest
+ */
+    virtual vtkDataArray* NodalVar(VsVariable* meta,
+        std::string requestedName, int component);
 
-  /**
-   * Get a variable that is "standard".  A standard variable is a variable that
-   * is stored on cell centers, cell vertices or edges.  It does not include
-   * discontinuous Galerkin type data (or likely other high order data).
-   */
-  virtual vtkDataArray* StandardVar(int domain, const char* requestedName);
+/**
+ * Get a variable that is "standard".  A standard variable is a variable that
+ * is stored on cell centers, cell vertices or edges.  It does not include
+ * discontinuous Galerkin type data (or likely other high order data).
+ */
+    virtual vtkDataArray* StandardVar(int domain, const char* requestedName);
 
-  /**
-   * Determine if the name is a component of a larger vector
-   * @param name is the name of the variable
-   * @param componentIndex is the index of that variable (returned).
-   */
-  virtual bool nameIsComponent(std::string& name, int& componentIndex);
+/**
+ * Determine if the name is a component of a larger vector
+ * @param name is the name of the variable
+ * @param componentIndex is the index of that variable (returned).
+ */
+    virtual bool nameIsComponent(std::string& name, int& componentIndex);
 
-  /**
-   * Check to see if the name has been transformed to a different name for
-   * display
-   * @param name is the name of the variable
-   */
-  virtual bool isTransformedName(std::string& name);
+/**
+ * Check to see if the name has been transformed to a different name for
+ * display
+ * @param name is the name of the variable
+ */
+    virtual bool isTransformedName(std::string& name);
 
-  /**
-   * Free up any resources created by this object.
-   */
-  virtual void FreeUpResources(void);
+/**
+ * Free up any resources created by this object.
+ */
+    virtual void FreeUpResources(void);
 
-  /**
-   * Called to alert the database reader that VisIt is about to ask for data
-   * at this timestep.  Since this reader is single-time, this is 
-   * only provided for reference and does nothing.
-   */
-  virtual void ActivateTimestep(void);
-  
+/**
+ * Called to alert the database reader that VisIt is about to ask for data
+ * at this timestep.  Since this reader is single-time, this is
+ * only provided for reference and does nothing.
+ */
+    virtual void ActivateTimestep(void);
+
   protected:
-  /**
-   * Get the cycle for the associated file
-   * @return the cycle, or INVALID_CYCLE if none is available
-   */
-  virtual int GetCycle();
 
-  /**
-   * Get the time for the associated file
-   * @return the time, or INVALID_TIME if none is available
-   */
-  virtual double GetTime();
+/**
+ * Get the cycle for the associated file
+ * @return the cycle, or INVALID_CYCLE if none is available
+ */
+    virtual int GetCycle();
 
-  /** Populate the meta data */
-  virtual void PopulateDatabaseMetaData(avtDatabaseMetaData* md);
+/**
+ * Get the time for the associated file
+ * @return the time, or INVALID_TIME if none is available
+ */
+    virtual double GetTime();
 
-  /** The file containing the data */
-  std::string dataFileName;
+/** Populate the meta data */
+    virtual void PopulateDatabaseMetaData(avtDatabaseMetaData* md);
 
-  /** Pointer to the reader */
-  VsReader* reader;
+/** The file containing the data */
+    std::string dataFileName;
 
-  /** Ensure data has been read **/
-  void LoadData();
+/** Pointer to the reader */
+    VsReader* reader;
 
-  /**
-   * This is not the best way to do this.  In fact every type of mesh should
-   * have a separate class and then there would be a pointer to the type selected.
-   * Since I only have one class that uses this approach I'm doing it this way.
-   */
-  HighOrderUnstructuredData thisData;
+/** Ensure data has been read */
+    void LoadData();
 
-  /**
-   * Change the default behavior so that the plugin does not populate spatial extent information.
-   */
-  bool HasInvariantMetaData(void) const { 
-    return false; 
-  }
+/**
+ * This is not the best way to do this.  In fact every type of mesh should
+ * have a separate class and then there would be a pointer to the type selected.
+ * Since I only have one class that uses this approach I'm doing it this way.
+ */
+    HighOrderUnstructuredData thisData;
+
+/**
+ * Change the default behavior so that the plugin does not populate
+ * spatial extent information.
+ */
+    bool HasInvariantMetaData(void) const {
+      return false;
+    }
 
   private:
 
-  /**
-   * Get the meta data for a variable given a name.
-   * @domain is the domain of interest
-   * @requestedName is the full name of the variable
-   * @componentIndex is the component we are requesting
-   */
-  VsVariable* getVariableMeta(int domain, std::string requestedName, int &componentIndex);
+/**
+ * Get the meta data for a variable given a name.
+ * @domain is the domain of interest
+ * @requestedName is the full name of the variable
+ * @componentIndex is the component we are requesting
+ */
+    VsVariable* getVariableMeta(int domain, std::string requestedName,
+        int &componentIndex);
 
-  /**
-   * A counter to track the number of avtVsFileFormat objects in existence
-   */
-  static int instanceCounter;
+/**
+ * A counter to track the number of avtVsFileFormat objects in existence
+ */
+    static int instanceCounter;
 
-  /**
-   * A registry of all objects found in the data file
-   */
-  VsRegistry* registry;
+/**
+ * A registry of all objects found in the data file
+ */
+    VsRegistry* registry;
 
-  /** Some stuff to keep track of data selections */
-  std::vector<avtDataSelection_p> selList;
-  std::vector<bool>              *selsApplied;
+/** Some stuff to keep track of data selections */
+    std::vector<avtDataSelection_p> selList;
+    std::vector<bool>              *selsApplied;
 
-  bool processDataSelections;
+    bool processDataSelections;
 
-  /**
-   * Maintain a list of curve names so we can classify expressions better
-   */
-  std::vector<std::string> curveNames;
+/**
+ * Maintain a list of curve names so we can classify expressions better
+ */
+    std::vector<std::string> curveNames;
 
-  /**
-   * Set the axis labels for a mesh.
-   *
-   * @param mmd a pointer to the object that needs the axis labels.
-   */
-  void setAxisLabels(avtMeshMetaData* mmd, bool transform = false);
+/**
+ * Set the axis labels for a mesh.
+ *
+ * @param mmd a pointer to the object that needs the axis labels.
+ */
+    void setAxisLabels(avtMeshMetaData* mmd, bool transform = false);
 
-  /**
-   * Set the global extents for a mesh.
-   *
-   * @param mmd a pointer to the object that needs the axis labels.
-   */
-  void setGlobalExtents(avtMeshMetaData* mmd);
-  
-  /**
-   * Create various meshes.
-   */
-  vtkDataSet* getUniformMesh(VsUniformMesh*, bool, int*, int*, int*);
-  vtkDataSet* getRectilinearMesh(VsRectilinearMesh*, bool, int*, int*, int*, bool);
-  vtkDataSet* getStructuredMesh(VsStructuredMesh*, bool, int*, int*, int*);
-  vtkDataSet* getUnstructuredMesh(VsUnstructuredMesh*, bool, int*, int*, int*);
-  vtkDataSet* getPointMesh(VsVariableWithMesh*, bool, int*, int*, int*, bool);
-  vtkDataSet* getHighOrderUnstructuredMesh(VsUnstructuredMesh*, bool, int*, int*, int*);
-  vtkDataSet* getCurve(int domain, const std::string& name);
+/**
+ * Set the global extents for a mesh.
+ *
+ * @param mmd a pointer to the object that needs the axis labels.
+ */
+    void setGlobalExtents(avtMeshMetaData* mmd);
+
+/**
+ * Create various meshes.
+ */
+    vtkDataSet* getUniformMesh(VsUniformMesh*, bool, int*, int*, int*);
+    vtkDataSet* getRectilinearMesh(VsRectilinearMesh*, bool, int*, int*, int*,
+        bool);
+    vtkDataSet* getStructuredMesh(VsStructuredMesh*, bool, int*, int*, int*);
+    vtkDataSet* getUnstructuredMesh(VsUnstructuredMesh*, bool, int*, int*,
+        int*);
+    vtkDataSet* getPointMesh(VsVariableWithMesh*, bool, int*, int*, int*, bool);
+    vtkDataSet* getHighOrderUnstructuredMesh(VsUnstructuredMesh*, bool, int*,
+        int*, int*);
+    vtkDataSet* getCurve(int domain, const std::string& name);
 
 
-  /**
-   * Each type of object is added to the database with a separate method
-   * for neatness.
-   */
-  void RegisterMeshes(avtDatabaseMetaData* md);
-  void RegisterMdMeshes(avtDatabaseMetaData* md);
-  void RegisterVarsWithMesh(avtDatabaseMetaData* md);
-  void RegisterVars(avtDatabaseMetaData* md);
-  void RegisterMdVars(avtDatabaseMetaData* md);
-  void RegisterExpressions(avtDatabaseMetaData* md);
+/**
+ * Each type of object is added to the database with a separate method
+ * for neatness.
+ */
+    void RegisterMeshes(avtDatabaseMetaData* md);
+    void RegisterMdMeshes(avtDatabaseMetaData* md);
+    void RegisterVarsWithMesh(avtDatabaseMetaData* md);
+    void RegisterVars(avtDatabaseMetaData* md);
+    void RegisterMdVars(avtDatabaseMetaData* md);
+    void RegisterExpressions(avtDatabaseMetaData* md);
 
-  void GetSelectionBounds( size_t numTopologicalDims,
-                           std::vector<int> &numCells,
-                           std::vector<int> &gdims,
-                           int *mins,
-                           int *maxs,
-                           int *strides,
-                           bool haveDataSelections,
-                           bool isNodal = true );
+    void GetSelectionBounds(size_t numTopologicalDims,
+        std::vector<int> &numCells,
+        std::vector<int> &gdims,
+        int *mins,
+        int *maxs,
+        int *strides,
+        bool haveDataSelections,
+        bool isNodal = true);
 
-  bool GetParallelDecomp( int numTopologicalDims,
-                          std::vector<int> &dims,
-                          int *mins,
-                          int *maxs,
-                          int *strides,
-                          bool isNodal = true );
-  
-  template <typename TYPE>
-  void fillInMaskNodeArray(const std::vector<int>& gdims,
-                           VsDataset *mask, bool maskIsFortranOrder,
-                           vtkUnsignedCharArray *maskedNodes);
+    bool GetParallelDecomp(int numTopologicalDims,
+        std::vector<int> &dims,
+        int *mins,
+        int *maxs,
+        int *strides,
+        bool isNodal = true);
 
-  template <typename TYPE>
+    template <typename TYPE>
+    void fillInMaskNodeArray(const std::vector<int>& gdims,
+        VsDataset *mask, bool maskIsFortranOrder,
+        vtkUnsignedCharArray *maskedNodes);
+
+    template <typename TYPE>
     void setStructuredMeshCoords(const std::vector<int>& gdims,
-                                 const TYPE* dataPtr,
-                                 bool isFortranOrder,
-                                 vtkPoints* vpoints);
-
+        const TYPE* dataPtr,
+        bool isFortranOrder,
+        vtkPoints* vpoints);
 
 #else
-  avtVsFileFormat(const char* dfnm) : avtSTMDFileFormat(&dfnm, 1) {;};
+    avtVsFileFormat(const char* dfnm) : avtSTMDFileFormat(&dfnm, 1) {};
 #endif
+
 };
 
 #endif
+

--- a/src/sim/V2/swig/python/simV2_wrap.cxx
+++ b/src/sim/V2/swig/python/simV2_wrap.cxx
@@ -3692,6 +3692,7 @@ SWIG_AsVal_unsigned_SS_char (PyObject * obj, unsigned char *val)
 # if defined(isfinite)
 #  define SWIG_isfinite(X) (isfinite(X))
 # elif defined __cplusplus && __cplusplus >= 201103L
+#  include <cmath>
 #  define SWIG_isfinite(X) (std::isfinite(X))
 # elif defined(_MSC_VER)
 #  define SWIG_isfinite(X) (_finite(X))


### PR DESCRIPTION
This pull request modifies the top level CMakeLists.txt so that 

On Mac: CMAKE_INSTALL_NAME_DIR is set to the directory into which libraries are installed (consisten with homebrew conventions)
On Linux: add \$ORIGIN to the rpath.
Set CMAKE_INSTALL_RPATH_USE_LINK_PATH to true.
On Windows, install zlib1.dll
Ability to disable osxfixup, which is needed only for packaging.

It modifies src/sim/V2/swig/python/simV2_wrap.cxx to be compatible with C++11 by including cmath.

It then has various fixes in the Vs directory to allow different kinds of meshes to coexist.  The commit message explains all that.