### PR TITLE
fixing issue with 64 bit integers from netcdf

### DIFF
--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -58,10 +58,7 @@
 #include <vtkShortArray.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnsignedIntArray.h>
-#ifdef HAVE_VTK_SIZEOF___INT64
-#include <vtk__Int64Array.h>
-#include <vtkUnsigned__Int64Array.h>
-#endif
+#include <vtkUnsignedLongLongArray.h>
 #include <vtkUnsignedShortArray.h>
 #include <vtkInformation.h>
 #include <vtkMultiBlockDataSet.h>
@@ -583,10 +580,10 @@ static int SizeOfNCType(int type)
         case NC_UINT:
 #endif
             return sizeof(int);
-#if defined(NC_NETCDF4) && defined(HAVE_VTK_SIZEOF___INT64)
+#if defined(NC_NETCDF4)
         case NC_INT64:
         case NC_UINT64:
-            return sizeof(__int64);
+            return sizeof(long long);
 #endif
         case NC_FLOAT:
             return sizeof(float);
@@ -1099,31 +1096,31 @@ MakeVTKDataArrayByTakingOwnershipOfNCVarData(nc_type type,
             arr->SetArray((unsigned int*)buf, num_comps * num_vals, SAVE_ARRAY, VTK_DA_FREE);
             return arr;
         }
-#if defined(NC_NETCDF4) && defined(HAVE_VTK_SIZEOF___INT64)
+#if defined(NC_NETCDF4)
         case NC_INT64:
         {
             if (num_comps > 1)
             {
-                void *newbuf = (void*) Interleave<__int64>((__int64*) buf, num_comps, num_vals);
+                void *newbuf = (void*) Interleave<long long>((long long*) buf, num_comps, num_vals);
                 free(buf);
                 buf = newbuf;
             }
-            vtk__Int64Array *arr = vtk__Int64Array::New();
+            vtkLongLongArray *arr = vtkLongLongArray::New();
             arr->SetNumberOfComponents(num_comps);
-            arr->SetArray((__int64*)buf, num_comps * num_vals, SAVE_ARRAY, VTK_DA_FREE);
+            arr->SetArray((long long*)buf, num_comps * num_vals, SAVE_ARRAY, VTK_DA_FREE);
             return arr;
         }
         case NC_UINT64:
         {
             if (num_comps > 1)
             {
-                void *newbuf = (void*) Interleave<unsigned __int64>((unsigned __int64*) buf, num_comps, num_vals);
+                void *newbuf = (void*) Interleave<unsigned long long>((unsigned long long*) buf, num_comps, num_vals);
                 free(buf);
                 buf = newbuf;
             }
-            vtkUnsigned__Int64Array *arr = vtkUnsigned__Int64Array::New();
+            vtkUnsignedLongLongArray *arr = vtkUnsignedLongLongArray::New();
             arr->SetNumberOfComponents(num_comps);
-            arr->SetArray((unsigned __int64*)buf, num_comps * num_vals, SAVE_ARRAY, VTK_DA_FREE);
+            arr->SetArray((uint64_t*)buf, num_comps * num_vals, SAVE_ARRAY, VTK_DA_FREE);
             return arr;
         }
 #endif
@@ -1335,7 +1332,7 @@ GetExodusSetsVar(int exncfid, int ts, char const *var, int numNodes, int numElem
 // ****************************************************************************
 
 template <class T>
-static void ReadBlockIds(int fid, int vid, int numBlocks, vector<int>& blockId, int (*NcRdFunc)(int,int,int*))
+static void ReadBlockIds(int fid, int vid, int numBlocks, vector<int>& blockId, int (*NcRdFunc)(int,int,T*))
 {
     int ncerr;
     T *buf = new T [numBlocks];
@@ -1355,7 +1352,7 @@ static void ReadBlockIds(int fid, int vid, int numBlocks, vector<int>& blockId, 
 // Convenient shorter name for instancing a block id read
 // ****************************************************************************
 
-#define READ_BLOCK_IDS(F,V,N,BIDS,TYPE) ReadBlockIds<TYPE>(F,V,N,BIDS,nc_get_var_ ## TYPE);
+#define READ_BLOCK_IDS(F,V,N,BIDS,TYPE,NCTNAME) ReadBlockIds<TYPE>(F,V,N,BIDS,nc_get_var_ ## NCTNAME);
 
 // ****************************************************************************
 // Reads a string-valued variables and attributes from the netcdf file known
@@ -1421,9 +1418,9 @@ GetElementBlockNamesAndIds(int ncExIIId, int numBlocks,
     nc_inq_vartype(ncExIIId, eb_blockid_varid, &vtype);
     switch (vtype)
     {
-        case NC_INT:   READ_BLOCK_IDS(ncExIIId, eb_blockid_varid, numBlocks, blockId, int); break;
-#if defined(NC_NETCDF4) && defined(HAVE_VTK_SIZEOF___INT64)
-        case NC_INT64: READ_BLOCK_IDS(ncExIIId, eb_blockid_varid, numBlocks, blockId, __int64); break;
+        case NC_INT:   READ_BLOCK_IDS(ncExIIId, eb_blockid_varid, numBlocks, blockId, int, int); break;
+#if defined(NC_NETCDF4)
+        case NC_INT64: READ_BLOCK_IDS(ncExIIId, eb_blockid_varid, numBlocks, blockId, long long, longlong); break;
 #endif
     }
 }
@@ -2817,7 +2814,7 @@ avtExodusFileFormat::GetMesh(int ts, const char *mesh)
                 delete [] conn_buf;
                 break;
             }
-#if defined(NC_NETCDF4) && defined(HAVE_VTK_SIZEOF___INT64)
+#if defined(NC_NETCDF4)
             case NC_INT64:
             {
                 long long *conn_buf = new long long[connect_varlen];


### PR DESCRIPTION
A recent change in Alegra and/or Exodus meant that data previously written as ``int`` was now being written as ``int64`` to netCDF files.

We weren't able to read these files due to conditional compilation logic that failed to compile code blocks designed to handle 64 bit integers. However, even after activation, those code blocks were found to the be problematic and required some modification. 

I adjusted the conditional compilation triggers for these blocks and fixed the blocks to use appropriate VTK 8 data array types.

A source of confusion is the fact that netCDF captures 64 bit integer type information in confusingly named ways. The run-time symbol names indicating type are ``NC_INT64`` or ``NC_UINT64`` but the actual function type signatures are typed as ``nc_get_var_longlong(int,int,long long*)`` and ``nc_get_var_ulonglong(int,int,unsigned long long*)``. So, in reality, netCDF handles ``long long`` and ``unsigned long long`` types in the interface and does not handle ``int64_t`` or ``uint64_t``. 