### PR TITLE
Update visit-install-closed for several systems.

### DIFF
--- a/src/tools/dev/scripts/visit-install-closed
+++ b/src/tools/dev/scripts/visit-install-closed
@@ -63,7 +63,10 @@
 #   that made this unnecessary.
 #
 #   Eric Brugger, Mon Nov 19 15:54:23 PST 2018
-#   Added shark.
+#   I added shark.
+#
+#   Eric Brugger, Wed Mar 20 10:31:35 PDT 2019
+#   I deleted zin. I added sierra. I updated jade for 3.0.0b.
 #
 #-----------------------------------------------------------------------
 
@@ -75,9 +78,9 @@ user=`whoami`
 # Parse the execute line, providing default values for error checking.
 #
 winnipeg=true
-zin=true
 jade=true
 shark=true
+sierra=true
 trinity=true
 
 ver=undefined
@@ -92,9 +95,9 @@ do
    case $1 in
       -none)
          winnipeg=false
-         zin=false
          jade=false
          shark=false
+         sierra=false
          trinity=false
          shift
          ;;
@@ -104,14 +107,6 @@ do
          ;;
       +winnipeg)
          winnipeg=true
-         shift
-         ;;
-      -zin)
-         zin=false
-         shift
-         ;;
-      +zin)
-         zin=true
          shift
          ;;
       -jade)
@@ -128,6 +123,14 @@ do
          ;;
       +shark)
          shark=true
+         shift
+         ;;
+      -sierra)
+         sierra=false
+         shift
+         ;;
+      +sierra)
+         sierra=true
          shift
          ;;
       -trinity)
@@ -204,62 +207,14 @@ then
 fi
 
 #
-# Install on zin.
-#
-rm -f zin
-cat <<EOF > zin
-#!/bin/sh
-./visit-install -private -c llnl_closed -g visit -b wbronze -gw -l $ver linux-x86_64-zin /usr/gapps/visit > installlog 2>&1
-cp /usr/gapps/visit/nvidia304-libs/*.304.54 /usr/gapps/visit/$ver+/linux-x86_64/lib
-ln -s libGL.so.304.54 /usr/gapps/visit/$ver+/linux-x86_64/lib/libGL.so
-ln -s libGL.so.304.54 /usr/gapps/visit/$ver+/linux-x86_64/lib/libGL.so.1
-chmod 775 /usr/gapps/visit/$ver+/linux-x86_64/lib/*.304.54
-chgrp visit /usr/gapps/visit/$ver+/linux-x86_64/lib/*.304.54
-rm -f resultlog
-echo ""                                            > resultlog 2>&1
-echo "        install of visit on zin"             >> resultlog 2>&1
-echo "       -------------------------"            >> resultlog 2>&1
-echo ""                                            >> resultlog 2>&1
-df -k /usr/gapps/visit                             >> resultlog 2>&1
-echo ""                                            >> resultlog 2>&1
-ls -l /usr/gapps/visit/$ver+/linux-x86_64/bin      >> resultlog 2>&1
-echo ""                                            >> resultlog 2>&1
-echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
-echo ""                                            >> resultlog 2>&1
-echo "The database plugins:"                       >> resultlog 2>&1
-ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-x86_64\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-mv resultlog resultlog.zin
-EOF
-
-if [ $zin = true ]
-then
-   if [ $test = no ]
-   then
-      scp zin497:/usr/tmp/$user/zin/visitbuild/visit$ver2.linux-x86_64.tar.gz visit$ver2.linux-x86_64-zin.tar.gz
-      scp visit$ver2.linux-x86_64-zin.tar.gz zin497:
-      scp visit-install zin497:
-      scp zin zin497:zin_install
-      ssh zin497 "chmod 750 zin_install;./zin_install"
-   fi
-fi
-
-#
 # Install on jade.
 #
 rm -f jade
 cat <<EOF > jade
 #!/bin/sh
 rm -rf /usr/gapps/visit/toss3
-./visit-install -private -c llnl_closed -g visit -b wbronze -gw -l $ver linux-x86_64-jade /usr/gapps/visit/toss3 > installlog 2>&1
-mv /usr/gapps/visit/toss3/$ver+/linux-x86_64 /usr/gapps/visit/$ver+/linux-x86_64-toss3
-rm -rf /usr/gapps/visit/toss3
-cp /usr/gapps/visit/nvidia304-libs/*.304.54 /usr/gapps/visit/$ver+/linux-x86_64-toss3/lib
-ln -s libGL.so.304.54 /usr/gapps/visit/$ver+/linux-x86_64-toss3/lib/libGL.so
-ln -s libGL.so.304.54 /usr/gapps/visit/$ver+/linux-x86_64-toss3/lib/libGL.so.1
-chmod 775 /usr/gapps/visit/$ver+/linux-x86_64-toss3/lib/*.304.54
-chgrp visit /usr/gapps/visit/$ver+/linux-x86_64-toss3/lib/*.304.54
+./visit-install -private -c llnl_closed -g visit -b wbronze -gw -l $ver linux-x86_64-jade /usr/gapps/visit > installlog 2>&1
+mv /usr/gapps/visit/$ver+/linux-x86_64 /usr/gapps/visit/$ver+/linux-x86_64-toss3
 rm -f resultlog
 echo ""                                              > resultlog 2>&1
 echo "        install of visit on jade"              >> resultlog 2>&1
@@ -328,6 +283,43 @@ then
 fi
 
 #
+# Install on sierra
+#
+rm -f sierra
+cat <<EOF > sierra
+#!/bin/sh
+./visit-install -private -c llnl_closed -g visit -b wbronze -gw -l $ver linux-intel-sierra /usr/gapps/visit > installlog 2>&1
+rm -f resultlog
+echo ""                                              > resultlog 2>&1
+echo "        install of visit on sierra"            >> resultlog 2>&1
+echo "       ----------------------------"           >> resultlog 2>&1
+echo ""                                              >> resultlog 2>&1
+df -k /usr/gapps/visit                               >> resultlog 2>&1
+echo ""                                              >> resultlog 2>&1
+ls -l /usr/gapps/visit/$ver+/linux-intel/bin         >> resultlog 2>&1
+echo ""                                              >> resultlog 2>&1
+echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-intel/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
+echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-intel/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
+echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-intel/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
+echo ""                                              >> resultlog 2>&1
+echo "The database plugins:"                         >> resultlog 2>&1
+ls /usr/gapps/visit/$ver+/linux-intel/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-intel\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
+mv resultlog resultlog.sierra
+EOF
+
+if [ $sierra = true ]
+then
+   if [ $test = no ]
+   then
+      scp sierra4358:/usr/tmp/$user/sierra/visitbuild/visit$ver2.linux-intel.tar.gz visit$ver2.linux-intel-sierra
+      scp visit$ver2.linux-intel-sierra.tar.gz sierra:
+      scp visit-install sierra:
+      scp sierra sierra:sierra_install
+      ssh sierra "chmod 750 sierra_install;./sierra_install"
+   fi
+fi
+
+#
 # Install on trinity.
 #
 rm -f trinity
@@ -367,5 +359,5 @@ fi
 #
 if [ $test = no ]
 then
-   rm -f winnipeg zin jade shark trinity
+   rm -f winnipeg jade shark sierra trinity
 fi

--- a/src/tools/dev/scripts/visit-install-closed
+++ b/src/tools/dev/scripts/visit-install-closed
@@ -311,7 +311,7 @@ if [ $sierra = true ]
 then
    if [ $test = no ]
    then
-      scp sierra4358:/usr/tmp/$user/sierra/visitbuild/visit$ver2.linux-intel.tar.gz visit$ver2.linux-intel-sierra
+      scp sierra4358:/usr/tmp/$user/sierra/visitbuild/visit$ver2.linux-intel.tar.gz visit$ver2.linux-intel-sierra.tar.gz
       scp visit$ver2.linux-intel-sierra.tar.gz sierra:
       scp visit-install sierra:
       scp sierra sierra:sierra_install


### PR DESCRIPTION
I removed the code to install visit on zin, since it is now the same as jade and no longer necessary. I added code to install on sierra. I updated the code to install on jade for 3.0.0b.