### PR TITLE
Updated tests with elevate to use the correct ScalingMode. Tests pass…

### DIFF
--- a/src/test/tests/databases/netcdf.py
+++ b/src/test/tests/databases/netcdf.py
@@ -219,7 +219,7 @@ def test3():
     ClearWindow()
     AddOperator("Elevate")
     e = ElevateAttributes()
-    e.useXYLimits = 1
+    e.useXYLimits = e.Always
     SetOperatorOptions(e)
     AddOperator("Transform")
     t = TransformAttributes()

--- a/src/test/tests/rendering/legends.py
+++ b/src/test/tests/rendering/legends.py
@@ -134,6 +134,10 @@ def TestSizeAndPosition(a):
     AddOperator("Elevate")
     AddPlot("Pseudocolor", "p")
     AddOperator("Elevate")
+    elevate_atts = ElevateAttributes()
+    elevate_atts.useXYLimits = elevate_atts.Never
+    SetOperatorOptions(elevate_atts)
+    
     DrawPlots()
     Test("legends_06")
     DeleteAllPlots()


### PR DESCRIPTION
… locally.

### Description

Resolves #3341 

Two tests failed due to the changes from the referenced pull request.

The first failed because the default has been changed to Auto and the test did not expect scaling. I explicitly set the scaling to never.

The second failed because it set the scaling to 1, which used to point to true, but now it points to Auto. I explicitly set the scaling to always.


### Type of change

Please select one below

- [ ] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

The tests in question are rendering/legends.py and databases/netcdf.py. I've made changes

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo


*Don't forget to squash merge when this pull request is approved*
