### PR TITLE
rebasing parallel volume test

### DIFF
--- a/test/baseline/databases/chgcar/parallel/chgcar_05.png
+++ b/test/baseline/databases/chgcar/parallel/chgcar_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f498f26bc9c184ccdd34c405b5db8dc95a87493862c717636ffd6651a132a043
-size 44446
+oid sha256:55aa6f379ded5f68241fb63410bdbbf8f96002b053d323e9ba03602bbdf13bb1
+size 44419

--- a/test/baseline/databases/chgcar/parallel/chgcar_07.png
+++ b/test/baseline/databases/chgcar/parallel/chgcar_07.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea9ee300833555183aac1131ce236d51faaeb0f14a3a4c9f9aab41e4454e9698
-size 46456
+oid sha256:c439867ebcc107c110482817f978170ca252314db885546e28ccd6d2964c60bf
+size 46458


### PR DESCRIPTION
Just rebasing the chgcar parallel tests. I had forgotten to rebase these after updating the volume renderer. 