### PR TITLE
Corrected a memory overwrite with transparency rendering with scalable rendering.

### DIFF
--- a/src/avt/Plotter/avtTransparencyActor.C
+++ b/src/avt/Plotter/avtTransparencyActor.C
@@ -1461,6 +1461,11 @@ void avtTransparencyActor::SyncProps()
 //    MPI_MAX is not defined for MPI_UNSIGNED_LONG_LONG in the MSMPI we use on
 //    Windows, and the actual type returned by GetMTime is 'unsigned long'.
 //
+//    Eric Brugger, Thu Apr  4 08:26:51 PDT 2019
+//    I corrected a memory overwrite where an MPI broadcast was being done
+//    with 22 doubles but the buffer was only 20 doubles long. I changed
+//    the broadcast to only send 20 doubles.
+//
 // ****************************************************************************
 
 int avtTransparencyActor::SyncProps(vtkProperty *dest, vtkProperty *source)
@@ -1553,7 +1558,7 @@ int avtTransparencyActor::SyncProps(vtkProperty *dest, vtkProperty *source)
 #ifdef PARALLEL
     // if any processes don't have valid props send
     if (n_have != size)
-        MPI_Bcast(buf, 22, MPI_DOUBLE, root, VISIT_MPI_COMM);
+        MPI_Bcast(buf, 20, MPI_DOUBLE, root, VISIT_MPI_COMM);
 #endif
 
     // deserialize
@@ -2188,7 +2193,7 @@ avtTransparencyActor::TransparenciesExist()
     {
         DetermineTransparencies();
 
-        // since we are already doing ommunication here, and this only
+        // since we are already doing communication here, and this only
         // occurs once per frame, this is as good a place as any to ensure
         // that the props are in sync TODO -- this is needed when some ranks
         // don't have data, there should be a way to pass down the props

--- a/src/engine/main/NetworkManager.C
+++ b/src/engine/main/NetworkManager.C
@@ -6760,7 +6760,7 @@ NetworkManager::RenderSetup(avtImageType imgT, int windowID, intVector& plotIds,
         }
     }
 
-    // farce transparency actor recalulate it's transparency
+    // force transparency actor recalulate it's transparency
     avtTransparencyActor* tact = viswin->GetTransparencyActor();
     tact->InvalidateTransparencyCache();
 

--- a/src/resources/help/en_US/relnotes3.0.0.html
+++ b/src/resources/help/en_US/relnotes3.0.0.html
@@ -118,6 +118,7 @@ SetBackendType("VTKm")
 <p><b><font size="4">Other bugs fixed in version 3.0</font></b></p>
 <ul>
   <li>Corrected a bug where VisIt would crash rendering transparent geometry on the Cooley system at the Argonne Leadership Computing Facility.</li>
+  <li>Corrected a bug where VisIt would randomly crash rendering transparent geometry due to memory corruption.</li>
   <li><i>ANNOTATION_INT</i> facelists with faces appearing in more than one sublist are now handled correctly.</li>
   <li>Corrected a bug that caused empty plots when using the <i>OnionPeel</i> operator with data containing enumerated subsets.</li>
   <li>Corrected a few usability issues for the <i>Save Movie Wizard</i> including: 


### PR DESCRIPTION
### Description

I corrected a bug with scalable rendering of transparent geometry. An MPI broadcast was being performed of 22 doubles, unfortunately the buffer only had 20 doubles causing a memory overwrite. The memory overwrite sometimes caused the MPI communications between the processors to get out of sync resulting in either hangs or crashes. I changed the broadcast to only send 20 doubles.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I tested this in parallel with some customer data on quartz. The data consists of a vtk file with a single domain. I ran VisIt on 2 processors and created a contour plot of 10 levels with the first one transparent. The code would crash before the change and didn't after the change. The code was clearly wrong and the fix seemed straightforward. The difficulty was in finding it.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo