### PR TITLE
Enhanced conn cmfe to handle mapping between point and polygonal meshes.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.0.html
+++ b/src/resources/help/en_US/relnotes3.0.0.html
@@ -102,7 +102,7 @@ SetBackendType("VTKm")
 <a name="Expression_changes"></a>
 <p><b><font size="4">Changes to VisIt's expression language in version 3.0</font></b></p>
 <ul>
-  <li>The <i>conn_cmfe</i> expression was enhanced to handle mapping cell data between point meshes and polyhedral meshes where the number of points and polyhedra match. This didn't work previously because polyhedra are split into zoo elements, which results in the number of cells not matching. Now the splitting is taken into account.</li>
+  <li>The <i>conn_cmfe</i> expression was enhanced to handle mapping cell data between point meshes and polygonal or polyhedral meshes where the number of points and polygons or polyhedra match. This didn't work previously in the case of polygons because while the number of cells matched the number of points didn't. Now the number of points is ignored. It didn't work in the case of polyhedral meshes because polyhedra are split into zoo elements, which results in the number of cells not matching. Now the splitting is taken into account.</li>
 </ul>
 
 <a name="Query_changes"></a>


### PR DESCRIPTION
### Description

About a month ago I enhanced conn cmfe to handle mapping between point and polyhedral meshes. I tested it on the users 3D data and it worked great. Today he tried it on 2D, since that was where he starts because that is simpler. Well, I didn't handle that case because in 2D polyhedra are polygons and we handle polygons fine. I added logic to detect this case and then allow it to proceed using the normal logic.

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] New Documentation

### How Has This Been Tested?

I tested it with the users 2D polygonal mesh.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo