### PR TITLE
Update label plot's font scale for consistency with other uses of FontAttributes

### DIFF
--- a/src/plots/Label/LabelAttributes.C
+++ b/src/plots/Label/LabelAttributes.C
@@ -295,9 +295,9 @@ void LabelAttributes::Init()
     labelDisplayFormat = Natural;
     numberOfLabels = 200;
     textFont1.GetColor().SetRgb(255, 0, 0);
-    textFont1.SetScale(0.04);
+    textFont1.SetScale(4);
     textFont2.GetColor().SetRgb(0, 0, 255);
-    textFont2.SetScale(0.04);
+    textFont2.SetScale(4);
     horizontalJustification = HCenter;
     verticalJustification = VCenter;
     depthTestMode = LABEL_DT_AUTO;
@@ -1449,13 +1449,13 @@ LabelAttributes::ProcessOldVersions(DataNode *parentNode,
         {
             float height = k->AsFloat();
             searchNode->RemoveNode(k, true);
-            textFont1.SetScale((double) height);
+            textFont1.SetScale((double) (height+0.02)*100);
         }
         if ((k = searchNode->GetNode("textHeight2")) != 0)
         {
             float height = k->AsFloat();
             searchNode->RemoveNode(k, true);
-            textFont2.SetScale((double) height);
+            textFont2.SetScale((double) (height+0.02)*100);
         }
         if ((k = searchNode->GetNode("textColor1")) != 0)
         {

--- a/src/plots/Label/LabelAttributes.code
+++ b/src/plots/Label/LabelAttributes.code
@@ -138,12 +138,12 @@ Postfix:
 Target: xml2atts
 Initialization: textFont1
     textFont1.GetColor().SetRgb(255, 0, 0);
-    textFont1.SetScale(0.04);
+    textFont1.SetScale(4);
 
 
 Initialization: textFont2
     textFont2.GetColor().SetRgb(0, 0, 255);
-    textFont2.SetScale(0.04);
+    textFont2.SetScale(4);
 
 
 Function: ChangesRequireRecalculation

--- a/src/plots/Label/LabelAttributes.code
+++ b/src/plots/Label/LabelAttributes.code
@@ -62,7 +62,7 @@ Postfix:
             }
             // Increase the value, new labels are smaller, we want
             // a better approximation of the original size
-            font1.SetScale(val+0.02);
+            font1.SetScale((val+0.02)*100);
             Py_INCREF(Py_None);
             obj = Py_None;
         }
@@ -76,7 +76,7 @@ Postfix:
             }
             // Increase the value, new labels are smaller, we want
             // a better approximation of the original size
-            font2.SetScale(val+0.02);
+            font2.SetScale((val+0.02)*100);
             Py_INCREF(Py_None);
             obj = Py_None;
         }
@@ -211,13 +211,13 @@ LabelAttributes::ProcessOldVersions(DataNode *parentNode,
         {
             float height = k->AsFloat();
             searchNode->RemoveNode(k, true);
-            textFont1.SetScale((double) height);
+            textFont1.SetScale((double) (height+0.02)*100);
         }
         if ((k = searchNode->GetNode("textHeight2")) != 0)
         {
             float height = k->AsFloat();
             searchNode->RemoveNode(k, true);
-            textFont2.SetScale((double) height);
+            textFont2.SetScale((double) (height+0.02)*100);
         }
         if ((k = searchNode->GetNode("textColor1")) != 0)
         {

--- a/src/plots/Label/PyLabelAttributes.C
+++ b/src/plots/Label/PyLabelAttributes.C
@@ -821,7 +821,7 @@ PyLabelAttributes_setattr(PyObject *self, char *name, PyObject *args)
             }
             // Increase the value, new labels are smaller, we want
             // a better approximation of the original size
-            font1.SetScale(val+0.02);
+            font1.SetScale((val+0.02)*100);
             Py_INCREF(Py_None);
             obj = Py_None;
         }
@@ -835,7 +835,7 @@ PyLabelAttributes_setattr(PyObject *self, char *name, PyObject *args)
             }
             // Increase the value, new labels are smaller, we want
             // a better approximation of the original size
-            font2.SetScale(val+0.02);
+            font2.SetScale((val+0.02)*100);
             Py_INCREF(Py_None);
             obj = Py_None;
         }

--- a/src/plots/Label/QvisLabelPlotWindow.C
+++ b/src/plots/Label/QvisLabelPlotWindow.C
@@ -426,16 +426,12 @@ QvisLabelPlotWindow::UpdateWindow(bool doAll)
             break;
         case LabelAttributes::ID_textFont1:
              {
-             FontAttributes f = labelAtts->GetTextFont1();
-             f.SetScale(f.GetScale() *100.);
-             textFont1->setFontAttributes(f);
+             textFont1->setFontAttributes(labelAtts->GetTextFont1());
              }
             break;
         case LabelAttributes::ID_textFont2:
              {
-             FontAttributes f = labelAtts->GetTextFont2();
-             f.SetScale(f.GetScale() *100.);
-             textFont2->setFontAttributes(f);
+             textFont2->setFontAttributes(labelAtts->GetTextFont2());
              }
             break;
         case LabelAttributes::ID_horizontalJustification:
@@ -525,17 +521,13 @@ QvisLabelPlotWindow::GetCurrentValues(int which_widget)
     // Do textFont1
     if(which_widget == LabelAttributes::ID_textFont1  || doAll)
     {
-        FontAttributes f = textFont1->getFontAttributes();
-        f.SetScale(f.GetScale() *0.01);
-        labelAtts->SetTextFont1(f);
+        labelAtts->SetTextFont1(textFont1->getFontAttributes());
     }
 
     // Do textFont2
     if(which_widget == LabelAttributes::ID_textFont2  || doAll)
     {
-        FontAttributes f = textFont2->getFontAttributes();
-        f.SetScale(f.GetScale() *0.01);
-        labelAtts->SetTextFont2(f);
+        labelAtts->SetTextFont2(textFont2->getFontAttributes());
     }
 
     // Do formatTemplate
@@ -737,9 +729,7 @@ QvisLabelPlotWindow::labelDisplayFormatChanged(int val)
 void
 QvisLabelPlotWindow::textFont1Changed(const FontAttributes &f)
 {
-    FontAttributes f2 = const_cast<FontAttributes &>(f);
-    f2.SetScale(f2.GetScale() *0.01);
-    labelAtts->SetTextFont1(f2);
+    labelAtts->SetTextFont1(f);
     SetUpdate(false);
     Apply();
 }
@@ -747,9 +737,7 @@ QvisLabelPlotWindow::textFont1Changed(const FontAttributes &f)
 void
 QvisLabelPlotWindow::textFont2Changed(const FontAttributes &f)
 {
-    FontAttributes f2 = const_cast<FontAttributes &>(f);
-    f2.SetScale(f2.GetScale() *0.01);
-    labelAtts->SetTextFont2(f2);
+    labelAtts->SetTextFont2(f);
     SetUpdate(false);
     Apply();
 }

--- a/src/plots/Label/vtkLabelMapper.C
+++ b/src/plots/Label/vtkLabelMapper.C
@@ -459,7 +459,7 @@ vtkLabelMapper::DrawDynamicallySelectedLabels2D(vtkDataSet *input,
     //
     const double base = 2.;
     double bin_x_size, bin_y_size;
-    double textScale = atts.GetTextFont1().GetScale() / 0.04;
+    double textScale = atts.GetTextFont1().GetScale() * 0.25;
     if (win_aspect >= 1.0)
     {
         // The X axis is the long axis of the view window.

--- a/src/plots/Label/vtkLabelMapperBase.C
+++ b/src/plots/Label/vtkLabelMapperBase.C
@@ -373,7 +373,7 @@ vtkLabelMapperBase::SetTextAtts(vtkViewport *vp)
             this->NodeLabelProperty->SetColor(rgb);
         }
 
-        this->NodeLabelProperty->SetFontSize(nodeFA.GetScale()*sz[1]);
+        this->NodeLabelProperty->SetFontSize(nodeFA.GetScale()*0.01*sz[1]);
         this->NodeLabelProperty->SetFontFamily((int)nodeFA.GetFont());
         this->NodeLabelProperty->SetBold(nodeFA.GetBold());
         this->NodeLabelProperty->SetItalic(nodeFA.GetItalic());
@@ -389,7 +389,7 @@ vtkLabelMapperBase::SetTextAtts(vtkViewport *vp)
             cellFA.GetColor().GetRgb(rgb);
             this->CellLabelProperty->SetColor(rgb);
         }
-        this->CellLabelProperty->SetFontSize(cellFA.GetScale()*sz[1]);
+        this->CellLabelProperty->SetFontSize(cellFA.GetScale()*0.01*sz[1]);
         this->CellLabelProperty->SetFontFamily((int)cellFA.GetFont());
         this->CellLabelProperty->SetBold(cellFA.GetBold());
         this->CellLabelProperty->SetItalic(cellFA.GetItalic());
@@ -410,11 +410,11 @@ vtkLabelMapperBase::SetTextAtts(vtkViewport *vp)
             this->NodeLabelProperty->SetColor(rgb);
             this->CellLabelProperty->SetColor(rgb);
         }
-        this->NodeLabelProperty->SetFontSize(labelFA.GetScale()*sz[1]);
+        this->NodeLabelProperty->SetFontSize(labelFA.GetScale()*0.01*sz[1]);
         this->NodeLabelProperty->SetFontFamily((int)labelFA.GetFont());
         this->NodeLabelProperty->SetBold(labelFA.GetBold());
         this->NodeLabelProperty->SetItalic(labelFA.GetItalic());
-        this->CellLabelProperty->SetFontSize(labelFA.GetScale()*sz[1]);
+        this->CellLabelProperty->SetFontSize(labelFA.GetScale()*0.01*sz[1]);
         this->CellLabelProperty->SetFontFamily((int)labelFA.GetFont());
         this->CellLabelProperty->SetBold(labelFA.GetBold());
         this->CellLabelProperty->SetItalic(labelFA.GetItalic());

--- a/src/resources/help/en_US/relnotes3.0.0.html
+++ b/src/resources/help/en_US/relnotes3.0.0.html
@@ -91,6 +91,7 @@ SetBackendType("VTKm")
   <li>The Vector plot supports plot animation. The vector glyphs alternate between 50% and 100% of their glyph length while the plot animates, helping to see features in the vector field.</li>
   <li>The Curve plot supports plot animation. The line and time cue features in the plot can respond to plot animation and they advance from left to right while the plot animates.</li>
   <li>When Min or Max is chosen for Pseudocolor plot, a color can now be chosen for those values below the minimum or above the maximum.</li>
+  <li>The setting for Label Plot's textHeight has been replaced with a Font Scale.  Other options affecting font were added: Font name, Bold, Italic. Attempts were made to ensure old settings from python script, session file snd configuration files would be replicated as closely as possible, however the new label size may not exactly match how things looked in previous versions of VisIt.</li>
 </ul>
 
 <a name="Operator_changes"></a>


### PR DESCRIPTION
I believe this addresses the concern over the change in gui text as discussed in #3102.
At the very least, it introduces consistency in how FontAttributes::Font size is used between label plot and other places in VisIt, and consistency between gui and python script for Label Plot.

There is now no translation in gui before setting in atts or vice-versa.
Scaling is only done in mapper when setting vtkTextProperty's FontSize.
Translation from pre 3.0 settings (textHeight) are now consistent between
session/config files and python scripts.
Release notes have been updated to reflect changes.

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I reran all tests that utilize the LabelPlot and there were no failures.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
