### PR TITLE
set scientific notation and precision to 8

### DIFF
--- a/src/databases/XYZ/avtXYZWriter.C
+++ b/src/databases/XYZ/avtXYZWriter.C
@@ -148,6 +148,8 @@ avtXYZWriter::WriteChunk(vtkDataSet *ds, int chunk)
 
     std::ofstream  out;
     out.open(filename.c_str());
+    out << std::scientific << std::setprecision(8);
+    
 
     // Collect up the data arrays, and find the atomic number one
 #define MAX_XYZ_VARS 6
@@ -193,7 +195,7 @@ avtXYZWriter::WriteChunk(vtkDataSet *ds, int chunk)
         double *coord = ds->GetPoint((vtkIdType)a);
 
         // Get a viable atomic number
-        int atomicNumber = 0;
+        int atomicNumber = -1;
         if (element)
             atomicNumber = element->GetTuple1((vtkIdType)a);
         if (atomicNumber < 0 || atomicNumber > MAX_ELEMENT_NUMBER)


### PR DESCRIPTION
### Description

User reported XYZ format outputing many lines of exact same numerical values. Turns out it was using default precision, 6, and notation which is neither fixed nor scientific. For large spatial extents, there aren't enough significant digits and each line of output can appear identical to the last.

I changed to precision of 8 and notation to scientific. This should probably be either settable via options or perhaps automated by getting spatial extents.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

No.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo


*Don't forget to squash merge when this pull request is approved*
