### PR TITLE
Ensure userInfoFont is updated correctly in GetCurrentValues.

### DIFF
--- a/src/gui/QvisAnnotationWindow.C
+++ b/src/gui/QvisAnnotationWindow.C
@@ -2104,6 +2104,9 @@ QvisAnnotationWindow::UpdateAnnotationObjectControls(bool doAll)
 //   Kathleen Biagas, Wed Jun  8 17:10:30 PDT 2016
 //   Ensure spinbox values are retrieved.
 //
+//   Kathleen Biagas, Mon Apr  8 15:43:24 PDT 2019
+//   Set userInfoFont, not databaseInfoFont when processing userInfoFont.
+//
 // ****************************************************************************
 
 void
@@ -2141,7 +2144,7 @@ QvisAnnotationWindow::GetCurrentValues(int which_widget)
 
     if(which_widget == AnnotationAttributes::ID_userInfoFont || doAll)
     {
-        annotationAtts->SetDatabaseInfoFont(userInfoFont->getFontAttributes());
+        annotationAtts->SetUserInfoFont(userInfoFont->getFontAttributes());
     }
 
     if(which_widget == AnnotationAttributes::ID_databaseInfoFont || doAll)


### PR DESCRIPTION
### Description

Resolves #3384

Ensure userInfoFont is updated correctly in GetCurrentValues.

Previously, userInfoFont was being used to set databaseInfoFont in this
method, causing the userInfo font scale to have no effect when 'Apply'
was clicked, unless 'Enter' had been pressed in the fontScale text box.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I ran through the 'how to replicate' steps of the bug ticket.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
