### PR TITLE
Fixed "GUI Too Wide" issue on OSX

### DIFF
--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -2636,6 +2636,10 @@ QvisGUIApplication::CustomizeAppearance(bool notify)
 //   Brad Whitlock, Wed Oct  6 12:14:21 PDT 2010
 //   I made it call SetWindowArea for this class.
 //
+//   Kevin Griffin, Tue Apr  9 17:23:47 PDT 2019
+//   Invoked MoveAndResizeMainWindow using QTimer::singleShot to make sure the
+//   resize operation is performed after this widget is laid out.
+//
 // ****************************************************************************
 
 void
@@ -2647,7 +2651,7 @@ QvisGUIApplication::SetOrientation(int orientation)
     // Tell the main window to set its orientation.
     //
     mainWin->SetOrientation(orientation);
-    MoveAndResizeMainWindow(orientation);
+    QTimer::singleShot(0, this, SLOT(MoveAndResizeMainWindow(orientation)));
 
     //
     // Tell the viewer to move its vis windows.
@@ -3086,6 +3090,10 @@ QvisGUIApplication::AddViewerSpaceArguments()
 //   Brad Whitlock, Thu Sep 14 13:10:36 PDT 2017
 //   Cinema support.
 //
+//   Kevin Griffin, Tue Apr  9 17:23:47 PDT 2019
+//   Invoked MoveAndResizeMainWindow using QTimer::singleShot to make sure the
+//   resize operation is performed after this widget is laid out.
+//
 // ****************************************************************************
 
 void
@@ -3150,7 +3158,7 @@ QvisGUIApplication::CreateMainWindow()
     // Move and resize the GUI so that we can get accurate size and
     // position information from it.
     mainWin->SetOrientation(orientation);
-    MoveAndResizeMainWindow(orientation);
+    QTimer::singleShot(0, this, SLOT(MoveAndResizeMainWindow(orientation)));
 }
 
 // ****************************************************************************

--- a/src/vtkqt/vtkQtRenderWindow.C
+++ b/src/vtkqt/vtkQtRenderWindow.C
@@ -123,10 +123,8 @@ vtkQtRenderWindow::vtkQtRenderWindow(QWidget *parent, Qt::WindowFlags f) : QMain
     setIconSize(QSize(20,20));
     setUnifiedTitleAndToolBarOnMac(false);
     setAnimated(false);
-
-#ifndef Q_OS_OSX
     setWindowFlags(f);
-#endif
+
     // With the call to setCentralWidget() vtkQtRenderWindow takes
     // ownership of the gl widget pointer and deletes it at the
     // appropriate time.
@@ -139,10 +137,8 @@ vtkQtRenderWindow::vtkQtRenderWindow(bool stereo, QWidget *parent, Qt::WindowFla
     setIconSize(QSize(20,20));
     setUnifiedTitleAndToolBarOnMac(false);
     setAnimated(false);
-
-#ifndef Q_OS_OSX
     setWindowFlags(f);
-#endif
+    
     // With the call to setCentralWidget() vtkQtRenderWindow takes
     // ownership of the gl widget pointer and deletes it at the
     // appropriate time.


### PR DESCRIPTION
### Description

Invoked MoveAndResizeMainWindow using QTimer::singleShot to make sure the resize operation is performed after the widget is laid out.

Resolves #3300  (*If this PR is unrelated to a ticket, please erase this line*)

Please include a summary of the change


### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

Built and ran VisIt and confirmed that the GUI size is correct.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo


*Don't forget to squash merge when this pull request is approved*