### PR TITLE
Modified build_visit to check for non blank checksums before using.

### DIFF
--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -276,11 +276,21 @@ function uncompress_untar
 # *************************************************************************** #
 # Function: verify_checksum                                                   #
 #                                                                             #
-# Purpose: Verify the checksum of given file                                  #
+# Purpose: Verify the checksum of the given file                              #
 #                                                                             #
-# verify_md5_checksum: checks md5                                             #
-# verify_sha_checksum: checks sha (256,512)                                   #
+#          verify_md5_checksum: checks md5                                    #
+#          verify_sha_checksum: checks sha (256,512)                          #
+#          verfiy_checksum_by_lookup: pick which checksum method to use       #
+#                                     based on if they are defined giving     #
+#                                     preference to the strongest checksums.  #
+#                                                                             #
 # Programmer: Hari Krishnan                                                   #
+#                                                                             #
+# Modifications:                                                              #
+#   Eric Brugger, Thu Apr 11 15:51:25 PDT 2019                                #
+#   Modified verify_checksum_by_lookup to also check that the checksum is     #
+#   not blank in addition to being defined before using it.                   #
+#                                                                             #
 # *************************************************************************** #
 
 function verify_md5_checksum
@@ -379,20 +389,20 @@ function verify_checksum_by_lookup
             md5sum_varname=${varbase}_MD5_CHECKSUM
             sha256_varname=${varbase}_SHA256_CHECKSUM
             sha512_varname=${varbase}_SHA512_CHECKSUM
-            if [ ! -z ${!sha512_varname+x} ]; then
+            if [ ! -z ${!sha512_varname+x} && ! -z "${sha512_varname}" ]; then
                 verify_checksum SHA512 ${!sha512_varname} $dlfile
                 return $?
-            elif [ ! -z ${!sha256_varname+x} ]; then
+            elif [ ! -z ${!sha256_varname+x} && ! -z "${sha256_varname}" ]; then
                 verify_checksum SHA256 ${!sha256_varname} $dlfile
                 return $?
-            elif [ ! -z ${!md5sum_varname+x} ]; then
+            elif [ ! -z ${!md5sum_varname+x} && ! -z "${md5sum_varname}" ]; then
                 verify_checksum MD5 ${!md5sum_varname} $dlfile
                 return $?
             fi
         fi
     done
 
-    #since this is an optional check, all cases should pass if it gets here..
+    # since this is an optional check, all cases should pass if it gets here.
     info "unable to find a MD5, SHA256, or SHA512, checksum associated with $dlfile; check disabled"
     return 0
 }

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -389,13 +389,13 @@ function verify_checksum_by_lookup
             md5sum_varname=${varbase}_MD5_CHECKSUM
             sha256_varname=${varbase}_SHA256_CHECKSUM
             sha512_varname=${varbase}_SHA512_CHECKSUM
-            if [ ! -z ${!sha512_varname+x} && ! -z "${sha512_varname}" ]; then
+            if [[ ! -z ${!sha512_varname+x} && ! -z "${!sha512_varname}" ]]; then
                 verify_checksum SHA512 ${!sha512_varname} $dlfile
                 return $?
-            elif [ ! -z ${!sha256_varname+x} && ! -z "${sha256_varname}" ]; then
+            elif [[ ! -z ${!sha256_varname+x} && ! -z "${!sha256_varname}" ]]; then
                 verify_checksum SHA256 ${!sha256_varname} $dlfile
                 return $?
-            elif [ ! -z ${!md5sum_varname+x} && ! -z "${md5sum_varname}" ]; then
+            elif [[ ! -z ${!md5sum_varname+x} && ! -z "${!md5sum_varname}" ]]; then
                 verify_checksum MD5 ${!md5sum_varname} $dlfile
                 return $?
             fi

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -389,13 +389,13 @@ function verify_checksum_by_lookup
             md5sum_varname=${varbase}_MD5_CHECKSUM
             sha256_varname=${varbase}_SHA256_CHECKSUM
             sha512_varname=${varbase}_SHA512_CHECKSUM
-            if [[ ! -z ${!sha512_varname+x} && ! -z "${!sha512_varname}" ]]; then
+            if [ ! -z ${!sha512_varname} ]; then
                 verify_checksum SHA512 ${!sha512_varname} $dlfile
                 return $?
-            elif [[ ! -z ${!sha256_varname+x} && ! -z "${!sha256_varname}" ]]; then
+            elif [ ! -z ${!sha256_varname} ]; then
                 verify_checksum SHA256 ${!sha256_varname} $dlfile
                 return $?
-            elif [[ ! -z ${!md5sum_varname+x} && ! -z "${!md5sum_varname}" ]]; then
+            elif [ ! -z ${!md5sum_varname} ]; then
                 verify_checksum MD5 ${!md5sum_varname} $dlfile
                 return $?
             fi

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -353,7 +353,7 @@ function verify_checksum
     checksum=$2
     dfile=$3
 
-    info "verifying type $checksum_type, checksum $checksum for $dfile . . ."
+    info "verifying $checksum_type checksum $checksum for $dfile . . ."
 
     if [[ "$checksum_type" == "MD5" ]]; then
         verify_md5_checksum $checksum $dfile


### PR DESCRIPTION
### Description

Modified build_visit so that it also checked that the checksum wasn't blank before using it. If a checksum was blank, then the checksum command didn't get enough arguments and it would try to read from stdin, causing the script to hang.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I set the checksums for PIDX to blank and then forced build_visit to try to build PIDX. The scripts successfully skipped doing any checksums for PIDX and proceeded to build PIDX.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas