### PR TITLE
Fix QMetaObject::invokeMethod error message re MoveAndResizeMainWindow.

### DIFF
--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -2702,7 +2702,7 @@ QvisGUIApplication::SetOrientation(int _orientation)
 //   being drawn partly offscreen when running VisIt remotely.
 // 
 //   Kathleen Biagas, Fri Apr 12 15:05:18 PDT 2019
-//   Remove orienation from args, it is now an ivar.
+//   Remove orientation from args, it is now an ivar.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -2645,7 +2645,7 @@ QvisGUIApplication::CustomizeAppearance(bool notify)
 //   resize operation is performed after this widget is laid out.
 //
 //   Kathleen Biagas, Fri Apr 12 15:05:18 PDT 2019
-//   Saved the orienation arg. Remove orienation from MoveAndResizeMainWindow.
+//   Saved the orientation arg. Remove orientation from MoveAndResizeMainWindow.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -636,6 +636,9 @@ GUI_LogQtMessages(QtMsgType type, const QMessageLogContext &context, const QStri
 //   Brad Whitlock, Tue Jan 15 10:30:20 PST 2013
 //   Give the file server list a pointer to the host profiles.
 //
+//   Kathleen Biagas, Fri Apr 12 15:04:39 PDT 2019
+//   Initialize orientation (used same init value as AppearanceAtts).
+//
 // ****************************************************************************
 
 QvisGUIApplication::QvisGUIApplication(int &argc, char **argv, ViewerProxy *proxy) :
@@ -720,6 +723,7 @@ QvisGUIApplication::QvisGUIApplication(int &argc, char **argv, ViewerProxy *prox
     savedGUISize[1] = 0;
     savedGUILocation[0] = 0;
     savedGUILocation[1] = 0;
+    orientation = 0;
 
     // Create the viewer, statusSubject, and fileServer for GUIBase.
     SetViewerProxy( proxy ? proxy : new ViewerProxy());
@@ -2640,18 +2644,22 @@ QvisGUIApplication::CustomizeAppearance(bool notify)
 //   Invoked MoveAndResizeMainWindow using QTimer::singleShot to make sure the
 //   resize operation is performed after this widget is laid out.
 //
+//   Kathleen Biagas, Fri Apr 12 15:05:18 PDT 2019
+//   Saved the orienation arg. Remove orienation from MoveAndResizeMainWindow.
+//
 // ****************************************************************************
 
 void
-QvisGUIApplication::SetOrientation(int orientation)
+QvisGUIApplication::SetOrientation(int _orientation)
 {
     if(mainWin == 0)
         return;
+    orientation = _orientation;
     //
     // Tell the main window to set its orientation.
     //
     mainWin->SetOrientation(orientation);
-    QTimer::singleShot(0, this, SLOT(MoveAndResizeMainWindow(orientation)));
+    QTimer::singleShot(0, this, SLOT(MoveAndResizeMainWindow()));
 
     //
     // Tell the viewer to move its vis windows.
@@ -2693,10 +2701,13 @@ QvisGUIApplication::SetOrientation(int orientation)
 //   Added logic specific to restoring session, to prevent window from
 //   being drawn partly offscreen when running VisIt remotely.
 // 
+//   Kathleen Biagas, Fri Apr 12 15:05:18 PDT 2019
+//   Remove orienation from args, it is now an ivar.
+//
 // ****************************************************************************
 
 void
-QvisGUIApplication::MoveAndResizeMainWindow(int orientation)
+QvisGUIApplication::MoveAndResizeMainWindow()
 {
     const char *mName = "QvisGUIApplication::MoveAndResizeMainWindow: ";
     int x, y, w, h;
@@ -3094,6 +3105,9 @@ QvisGUIApplication::AddViewerSpaceArguments()
 //   Invoked MoveAndResizeMainWindow using QTimer::singleShot to make sure the
 //   resize operation is performed after this widget is laid out.
 //
+//   Kathleen Biagas, Fri Apr 12 15:06:48 PDT 2019
+//   Removed orienation from MoveAndResizeMainWindow args.
+//
 // ****************************************************************************
 
 void
@@ -3158,7 +3172,7 @@ QvisGUIApplication::CreateMainWindow()
     // Move and resize the GUI so that we can get accurate size and
     // position information from it.
     mainWin->SetOrientation(orientation);
-    QTimer::singleShot(0, this, SLOT(MoveAndResizeMainWindow(orientation)));
+    QTimer::singleShot(0, this, SLOT(MoveAndResizeMainWindow()));
 }
 
 // ****************************************************************************

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -3106,7 +3106,7 @@ QvisGUIApplication::AddViewerSpaceArguments()
 //   resize operation is performed after this widget is laid out.
 //
 //   Kathleen Biagas, Fri Apr 12 15:06:48 PDT 2019
-//   Removed orienation from MoveAndResizeMainWindow args.
+//   Removed orientation from MoveAndResizeMainWindow args.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisGUIApplication.h
+++ b/src/gui/QvisGUIApplication.h
@@ -352,6 +352,10 @@ class SplashScreen;
 //    Brad Whitlock, Thu Sep 14 13:18:12 PDT 2017
 //    Cinema support.
 //
+//    Kathleen Biagas, Fri Apr 12 14:39:58 PDT 2019
+//    Made MoveAndResizeMainWindow a slot function without arguments so it
+//    can be called from QTimer::singleShot. Added orientation ivar.
+//
 // ****************************************************************************
 
 class GUI_API QvisGUIApplication : public QObject, public ConfigManager, public GUIBase
@@ -390,7 +394,6 @@ protected:
     void LoadFile(QualifiedFilename &f, bool addDefaultPlots);
     void LoadSessionFile();
     void LoadSessionRemoteFile(const std::string& filename, const std::string& host, std::istringstream& sessionGUI);
-    void MoveAndResizeMainWindow(int orientation);
     void ProcessArguments(int &argc, char **argv);
     virtual DataNode *ReadConfigFile(const char *filename);
     virtual DataNode *ReadConfigFile(std::istream& in);
@@ -490,6 +493,7 @@ protected slots:
     void sessionFileHelper_LoadSessionWithDifferentSources(const QString &,
              const stringVector &);
     void UpdateSavedConfigFile();
+    void MoveAndResizeMainWindow();
 
     // Plot, operator related slots.
     void AddPlot(int, const QString &);
@@ -668,6 +672,7 @@ protected:
     
     // VisIt Process ID
     std::string                 visitPIDStr;
+    int                         orientation;
 };
 
 #endif


### PR DESCRIPTION
Made the method a SLOT and removed the arg in favor of an ivar.

### Description
QvisGUIApplication::MoveAndResizeMainWindow being called by QTimer::singleShot.
singleShot requires the methods it invokes to be SLOT functions, and have no arguments.


### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

Compiled and ran the gui on Linux. No more message in the terminal window, and the main
gui window is the correct size again.  This needs to be tested on MAC, because the original
change to add MoveAndResizeMainWindow  to the singleShot timer was to fix an issue on OSX.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo


*Don't forget to squash merge when this pull request is approved*
