### PR TITLE
Fix pluginVsInstall test suite failure with mfem db plugin.

### DIFF
--- a/src/CMake/PluginVsInstall.cmake.in
+++ b/src/CMake/PluginVsInstall.cmake.in
@@ -103,6 +103,10 @@
 #   Kathleen Biagas, Thu Nov  8 10:10:06 PST 2018
 #   Added VTKh_INCLUDE_DIRS and VTKM_DIR.
 #
+#   Kathleen Biagas, Wed Apr 17 12:54:40 PDT 2019
+#   MFEM has an include dependency on conduit, move it below conduit in the
+#   list and add conduit include to it's include.
+#
 #****************************************************************************/
 
 ##
@@ -325,9 +329,6 @@ set(XDMF_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/xdmf/include)
 set(XDMF_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
 set(XDMF_LIB @XDMF_LIB@)
 
-set(MFEM_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/mfem/include)
-set(MFEM_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
-set(MFEM_LIB @MFEM_LIB@)
 
 set(CONDUIT_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/conduit/conduit)
 set(CONDUIT_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
@@ -337,6 +338,10 @@ if(VISIT_PARALLEL)
     set(CONDUIT_MPI_LIBRARY_DIR ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
     set(CONDUIT_MPI_LIB @CONDUIT_MPI_LIB@)
 endif()
+
+set(MFEM_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/mfem/include;${CONDUIT_INCLUDE_DIR})
+set(MFEM_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
+set(MFEM_LIB @MFEM_LIB@)
 
 set(OPENEXR_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/openexr/OpenEXR)
 set(OPENEXR_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})


### PR DESCRIPTION
PluginVsInstall.cmake.in needed to add mfem's include dependency on conduit.

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I ran the databasesVsInstall.py test.  It succeeds.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo

