### PR TITLE
Bug/markcmiller86/all build visus failure 16 apr19

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -105,8 +105,10 @@
 #   Add 'PATHS' and 'PATH_SUFFIXES' when finding 7zip on non-windows.
 #   Beefed up error message if 7-zip not found.
 #
+#   Mark C. Miller, Tue Apr 16 13:11:15 PDT 2019
+#   Reduced min cmake vesion required to 3.7
 #****************************************************************************/
-CMAKE_MINIMUM_REQUIRED(VERSION 3.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7)
 CMAKE_POLICY(PUSH)
 CMAKE_POLICY(SET CMP0037 OLD) # allow defining help target
 


### PR DESCRIPTION
Ran into a problem with ViSUS using `build_visit` with `--all-io` on my OSX system. It tried to download a Darwin architecture tarball and failed because that tarball was missing from the NERSC hosted download dir. After I added it there, the download succeeded but the checksum verify failed because the only and only checksum set for ViSUS was for the Linux architecture download. 

I upgraded `bv_visus.sh` to

* select the correct architecture for download
* set correct checksums for the associated architecture download
* disable itself if it is unable to find a supported architecture to download and issue a warning message.

I tested by manually overriding (e.g. hacking `bv_visus.sh`) VisIt's `uname` query to force it to download and verify all architecture downloads. I also manually set it to a non-supported architecture and confirmed it correctly disables itself.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes