### PR TITLE
I added checks to prevent using VTKm on unsupported data.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.0.html
+++ b/src/resources/help/en_US/relnotes3.0.0.html
@@ -64,6 +64,7 @@ SetBackendType("VTKm")
     <li>Slice operator: Restrictions - Only works when <i>Project to 2D</i> is disabled.</li>
   </ul>
   <p>VTK-m functionality is currently enabled for 3D rectilinear, curvilinear and unstructured grids with only hexahedral elements. VTK-m supports both single block and multi-block grids.</p>
+  <p>In order for VTK-m filters to perform better than VTK filters the number of cells in a block must be fairly large, typically at least 1 million cells. Furthermore, there is some overhead in converting between VTK and VTK-m representations that will impact performance. Lastly, checks have been put in to make sure that the data sets being operated on are supported by VTK-m and these can impact performance as well. Checking if a variable is node centered or 3D is inexpensive, whereas checking if an unstructured grid contains only hexahedra is expensive.</p>
   </li>
   <li>Due to lack of availability of C++11 compliant compilers, support for OSX 10.8 has been dropped.</li>
   <li>The <i>Remote Profiles</i> tab in the <i>Host profiles</i> will now allow importing profiles from the currently running release as well as from the trunk.</li>

--- a/src/test/tests/hybrid/vtkm.py
+++ b/src/test/tests/hybrid/vtkm.py
@@ -20,8 +20,27 @@
 SetBackendType("vtkm")
 
 #
-# Test a rectilinear mesh.
+# Test a 2d rectilinear mesh.
 #
+OpenDatabase(silo_data_path("rect2d.silo"))
+
+AddPlot("Contour", "u")
+DrawPlots()
+
+Test("vtkm_rect2d_01")
+
+DeleteAllPlots()
+
+AddPlot("Contour", "d")
+DrawPlots()
+
+Test("vtkm_rect2d_02")
+
+#
+# Test a 3d rectilinear mesh.
+#
+DeleteAllPlots()
+
 OpenDatabase(silo_data_path("rect3d.silo"))
 
 AddPlot("Contour", "u")
@@ -37,6 +56,13 @@ v.farPlane = 1.7321
 SetView3D(v)
 
 Test("vtkm_rect3d_01")
+
+DeleteAllPlots()
+
+AddPlot("Contour", "d")
+DrawPlots()
+
+Test("vtkm_rect3d_01a")
 
 DeleteAllPlots()
 
@@ -97,7 +123,26 @@ DrawPlots()
 Test("vtkm_rect3d_05")
 
 #
-# Test an curvilinear mesh.
+# Test a 2d curvilinear mesh.
+#
+DeleteAllPlots()
+
+OpenDatabase(silo_data_path("curv3d.silo"))
+
+AddPlot("Contour", "u")
+DrawPlots()
+
+Test("vtkm_curv2d_01")
+
+DeleteAllPlots()
+
+AddPlot("Contour", "d")
+DrawPlots()
+
+Test("vtkm_curv2d_02")
+
+#
+# Test a 3d curvilinear mesh.
 #
 DeleteAllPlots()
 
@@ -116,6 +161,13 @@ v.farPlane = 32.0156
 SetView3D(v)
 
 Test("vtkm_curv3d_01")
+
+DeleteAllPlots()
+
+AddPlot("Contour", "d")
+DrawPlots()
+
+Test("vtkm_curv3d_01a")
 
 DeleteAllPlots()
 
@@ -176,7 +228,26 @@ DrawPlots()
 Test("vtkm_curv3d_05")
 
 #
-# Test an unstructured mesh.
+# Test a 2d unstructured mesh.
+#
+DeleteAllPlots()
+
+OpenDatabase(silo_data_path("ucd2d.silo"))
+
+AddPlot("Contour", "u")
+DrawPlots()
+
+Test("vtkm_ucd2d_01")
+
+DeleteAllPlots()
+
+AddPlot("Contour", "d")
+DrawPlots()
+
+Test("vtkm_ucd2d_02")
+
+#
+# Test a 3d unstructured mesh.
 #
 DeleteAllPlots()
 
@@ -195,6 +266,13 @@ v.farPlane = 22.9129
 SetView3D(v)
 
 Test("vtkm_ucd3d_01")
+
+DeleteAllPlots()
+
+AddPlot("Contour", "d")
+DrawPlots()
+
+Test("vtkm_ucd3d_01a")
 
 DeleteAllPlots()
 

--- a/test/baseline/hybrid/vtkm/vtkm_curv2d_01.png
+++ b/test/baseline/hybrid/vtkm/vtkm_curv2d_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a87d3fff6f599dc8d9bf32575747c68e1d23ce23b77a1276f89e7344eb0c359
+size 11260

--- a/test/baseline/hybrid/vtkm/vtkm_curv2d_02.png
+++ b/test/baseline/hybrid/vtkm/vtkm_curv2d_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65a9832835d4c78282e79e5d15a4fc055e73ab36440fd116241ca99d988ce26a
+size 10433

--- a/test/baseline/hybrid/vtkm/vtkm_curv3d_01a.png
+++ b/test/baseline/hybrid/vtkm/vtkm_curv3d_01a.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eaad4701c61c5b33f4ccac8fadd00e4700a437f8e9868e903ac3ea8aac2558c
+size 10432

--- a/test/baseline/hybrid/vtkm/vtkm_rect2d_01.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect2d_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e401a3d6f9d4afb3c96e9b50cea5252b6a3ca6a72827f91644e5f1a9dd70c4e7
+size 4119

--- a/test/baseline/hybrid/vtkm/vtkm_rect2d_02.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect2d_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f24dd33477151de303a88b0df94c1a2e325342e7aec518178c1c1d202a440f8f
+size 4676

--- a/test/baseline/hybrid/vtkm/vtkm_rect3d_01a.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect3d_01a.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ebc882776eb56fbeb8aa35b667579b36d50919e9a3e851511424242549c1020
+size 42351

--- a/test/baseline/hybrid/vtkm/vtkm_ucd2d_01.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd2d_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5b029577d23a169f91f27cc9b90210bfb42686a08c70b24ecfbad7978f58ad2
+size 1032

--- a/test/baseline/hybrid/vtkm/vtkm_ucd2d_02.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd2d_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f172c7fd6bf851571eb44cd7086080efd40880e24c9c60c4e23b44f472a5d57
+size 2965

--- a/test/baseline/hybrid/vtkm/vtkm_ucd3d_01a.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd3d_01a.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:085d07deac7c01a775bda4cb08719601a67ce4c422f0dfb005180be1e630d198
+size 12738


### PR DESCRIPTION
### Description

Resolves #3269

I added several checks to make sure that we weren't using the VTKm contour filter in cases where the filter didn't support the data. Specifically, I added checks to make sure it was contouring point data, that the data was 3D and in the case of an unstructured mesh that it only included hexahedra.

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I ran the hybrid/vtkm.py test suite with my changes. I also added tests for 2D rectilinear, 2D curvilinear, 2D unstructured, and cell centered data on 3D meshes. All these cases would have crashed previously, now they are detected and the normal VTK filter is used instead.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added any new baselines to the repo