### PR TITLE
Changed an OSPRay exception from ospray::Exception to EXCEPTION1

### DIFF
--- a/src/avt/Filters/avtOSPRaySamplePointExtractor.C
+++ b/src/avt/Filters/avtOSPRaySamplePointExtractor.C
@@ -339,6 +339,10 @@ avtOSPRaySamplePointExtractor::DoSampling(vtkDataSet *ds, int idx)
 //    Kevin Griffin, Fri Apr 22 16:31:57 PDT 2016
 //    Added support for polygons.
 //
+//    Eric Brugger, Thu Apr 18 14:15:53 PDT 2019
+//    Converted the generation of the exception from ospray::Exception
+//    to EXCEPTION1.
+//
 // ****************************************************************************
 
 void
@@ -420,13 +424,9 @@ avtOSPRaySamplePointExtractor::RasterBasedSample(vtkDataSet *ds, int num)
         //---------------------------------------------------------
         if (num == 0) {
             const std::string msg = 
-                "Dataset type " + std::to_string((int)(ds->GetDataObjectType())) + " "
-                "is not a VTK_RECTILINEAR_GRID. "
-                "Currently the RayCasting:OSPRay renderer "
-                "only supports rectilinear grid, " 
-                "thus the volume cannot be rendered\n";
-            //ospray::Warning(msg);
-            ospray::Exception(msg);
+                "The data wasn't rendered because OSPRay currently only "
+                "supports volume rendering rectilinear grids.";
+            EXCEPTION1(ImproperUseException, msg);
         }
     }
 }


### PR DESCRIPTION
### Description

Resolves #3291

I converted the generation of an exception from ospray::Exception to EXCEPTION1. The message shows up in the engine debug log, but unfortunately doesn't make it to the user. This is a basic failure in VisIt not being able to propagate errors from the engine back to the gui. If we fix that, then the message will get back to the user.

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation

### How Has This Been Tested?

I ran visit with debug logs enabled and created a volume from of u from globe.silo. The image appeared as it should. I then changed the volume plot "Rendering Method" to "Ray casting: OSPRay", hit Apply and noted that the everything showed up in the plot except the volume rendering. I checked the level 1 debug log and the Exception message showed up.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code