### PR TITLE
Correct a bug with build_visit building pidx when mpich is used for mpi.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_pidx.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pidx.sh
@@ -211,16 +211,17 @@ function build_pidx
 #        ntopts="${ntopts} -DCMAKE_INSTALL_NAME_DIR:PATH=${pidx_inst_path}/lib"
 #    fi
 
-#    if test "x${DO_MPICH}" = "xyes"; then
-#        info "mpich requested.  Configuring PIDX with mpich support."
-#        ntopts="${ntopts} -DMPI_ROOT:PATH=${VISITDIR}/mpich/${MPICH_VERSION}/${VISITARCH}"
+    if test "x${DO_MPICH}" = "xyes"; then
+        info "mpich requested.  Configuring PIDX with mpich support."
+        ntopts="${ntopts} -DMPI_C_COMPILER:PATH=${VISITDIR}/mpich/${MPICH_VERSION}/${VISITARCH}/bin/mpicc"
+        ntopts="${ntopts} -DMPI_CXX_COMPILER:PATH=${VISITDIR}/mpich/${MPICH_VERSION}/${VISITARCH}/bin/mpicxx"
 
 #        if [[ "$OPSYS" == "Darwin" ]]; then
 #            export DYLD_LIBRARY_PATH="$VISITDIR/mpich/$MPICH_VERSION/$VISITARCH/lib":$DYLD_LIBRARY_PATH
 #        else
 #            export LD_LIBRARY_PATH="$VISITDIR/mpich/$MPICH_VERSION/$VISITARCH/lib":$LD_LIBRARY_PATH
 #        fi
-#    fi
+    fi
 
     cd "$START_DIR"
 


### PR DESCRIPTION
### Description

I corrected a bug in build_visit when building pidx and using our mpich for the mpi. When using our mpich the standard cmake find module can't find it and cmake fails. I added logic to specify the cmake C and C++ compilers when using our build of mpich.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I used build_visit to build pidx on kickit using this fix.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code