### PR TITLE
Fix explode operator crash on Windows.

### DIFF
--- a/src/operators/Explode/avtExplodeFilter.C
+++ b/src/operators/Explode/avtExplodeFilter.C
@@ -2236,7 +2236,7 @@ PlaneExplosion::CalcDisplacement(double *dataCenter, double expFactor,
         // on the plane. If it does, use a new data point that
         // isn't the cell center but still should be in the cell. 
         //
-        double planeDist;
+        double planeDist = 0.0;
         for (int i = 0; i < 3; ++i)
         {
             planeDist += (dataPt[i] - planePoint[i]) * planeNorm[i];


### PR DESCRIPTION
Initialize planeDist. It was being used uninitialized and caused the crash.

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I ran the explode operator test on windows. It now passes.
