### PR TITLE
Fix bug determining whether scalable rendering should be used.

### DIFF
--- a/src/engine/main/Engine.C
+++ b/src/engine/main/Engine.C
@@ -2947,6 +2947,9 @@ ParallelMergeClonedWriterOutputs(avtDataObject_p dob,
 //    triggered, some thinking it had -- which lead to a cascade mistmatched
 //    MPI calls. 
 //
+//    Eric Brugger, Mon May  6 12:17:21 PDT 2019
+//    I converted several integers to long longs to avoid arithmetic overflow
+//    in determining if we should use scalable rendering.
 //
 // ****************************************************************************
 
@@ -2995,7 +2998,7 @@ Engine::GatherData(avtDataObjectWriter_p &writer,
     //
     bool sendDataAnyway = respondWithNull || scalableThreshold==-1;
     bool thresholdExceeded = false;
-    int  currentCellCount = 0;
+    long long currentCellCount = 0;
 
     if (PAR_UIProcess())
     {
@@ -3011,7 +3014,7 @@ Engine::GatherData(avtDataObjectWriter_p &writer,
         if (cellCountMultiplier > INT_MAX/2.)
             currentCellCount = INT_MAX;
         else
-            currentCellCount = (int) 
+            currentCellCount =
               (ui_dob->GetNumberOfCells(polysOnly) * cellCountMultiplier);
 
         // test if we've exceeded the scalable threshold already with proc 0's
@@ -3039,7 +3042,7 @@ Engine::GatherData(avtDataObjectWriter_p &writer,
             long long cellCountTotal;
             netmgr->CalculateCellCountTotal(cellCounts, cellCountMultipliers,
                 globalCellCounts, cellCountTotal);
-            int reducedCurrentCellCount = (int) cellCountTotal;
+            long long reducedCurrentCellCount = cellCountTotal;
 
             if (currentTotalGlobalCellCount == INT_MAX ||
                 currentCellCount == INT_MAX ||
@@ -3144,7 +3147,7 @@ Engine::GatherData(avtDataObjectWriter_p &writer,
             if (cellCountMultiplier > INT_MAX/2.)
                 currentCellCount = INT_MAX;
             else
-                currentCellCount = (int) 
+                currentCellCount =
                   (dob->GetNumberOfCells(polysOnly) * cellCountMultiplier);
 
             // Determine the cell counts.
@@ -3158,7 +3161,7 @@ Engine::GatherData(avtDataObjectWriter_p &writer,
             long long cellCountTotal;
             netmgr->CalculateCellCountTotal(cellCounts, cellCountMultipliers,
                 globalCellCounts, cellCountTotal);
-            int reducedCurrentCellCount = (int) cellCountTotal;
+            long long reducedCurrentCellCount = cellCountTotal;
 
             if (currentTotalGlobalCellCount == INT_MAX ||
                 currentCellCount == INT_MAX ||

--- a/src/resources/help/en_US/relnotes3.0.1.html
+++ b/src/resources/help/en_US/relnotes3.0.1.html
@@ -25,7 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.0.1</font></b></p>
 <ul>
   <li>Corrected a bug where VisIt would crash rendering transparent geometry when processor 0 didn't have any geometry.</li>
-  <li></li>
+  <li>Corrected a bug where VisIt would not switch into scalable rendering mode when it should have when the total number of primitives to render was greater than 2 billion. This typically resulted in VisIt crashing because it ran out of memory.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

I ran into a crash rendering a pseudocolor plot of a really large particle data set. I did some exploring and found that even though scalable rendering was set to always, it was still trying to collect all the geometry at processor 0 and running out of memory. The problem was caused by overflowing a couple of integer variables in determining whether or not to use scalable rendering or not. I converted several integers to long longs and that fixed the problem. I did the minimal fix to get it working. To completely fix it quite a few more integers would need to be changed to long long and it would probably involve a protocol change between the components, so it could only be done for 3.1. I will submit a ticket for that.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I tested it with the users data.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have updated the release notes
- [X] I have assigned reviewers