### PR TITLE
Bugfix/biagas/update windows platform info downloads page

### DIFF
--- a/docs/WebSite/pages/visit/executables.xml
+++ b/docs/WebSite/pages/visit/executables.xml
@@ -100,8 +100,8 @@
           <th width="138">Executable</th>
         </tr>
         <tr>
-          <td>Windows (Vista / 7 / 8) 64 bit<br />
-          Visual Studio 2012</td>
+          <td>Windows (10 / 8 / 7) 64 bit<br />
+          Visual Studio 2017</td>
           <td><a href="http://portal.nersc.gov/project/visit/releases/3.0.0b/visit3.0.0b_x64.exe">Download</a></td>
         </tr>
         <tr>
@@ -144,8 +144,8 @@
           <th width="138">Executable</th>
         </tr>
         <tr>
-          <td>Windows (Vista / 7 / 8) 64 bit<br />
-          Visual Studio 2012</td>
+          <td>Windows (10 / 8 / 7) 64 bit<br />
+          Visual Studio 2013</td>
           <td><a href="http://portal.nersc.gov/project/visit/releases/2.13.3/visit2.13.3_x64.exe">Download</a></td>
         </tr>
         <tr>
@@ -210,8 +210,8 @@
           <th width="138">Executable</th>
         </tr>
         <tr>
-          <td>Windows (Vista / 7 / 8) 64 bit<br />
-          Visual Studio 2012</td>
+          <td>Windows (10 / 8 / 7) 64 bit<br />
+          Visual Studio 2013</td>
           <td><a href="http://portal.nersc.gov/project/visit/releases/2.13.2/visit2.13.2_x64.exe">Download</a></td>
         </tr>
         <tr>
@@ -294,8 +294,8 @@
           <th width="138">Executable</th>
         </tr>
         <tr>
-          <td>Windows (Vista / 7 / 8) 64 bit<br />
-          Visual Studio 2012</td>
+          <td>Windows (10 / 8 / 7) 64 bit<br />
+          Visual Studio 2013</td>
           <td><a href="http://portal.nersc.gov/project/visit/releases/2.13.1/visit2.13.1_x64.exe">Download</a></td>
         </tr>
         <tr>
@@ -378,8 +378,8 @@
           <th width="138">Executable</th>
         </tr>
         <tr>
-          <td>Windows (Vista / 7 / 8) 64 bit<br />
-          Visual Studio 2012</td>
+          <td>Windows (10 / 8 / 7) 64 bit<br />
+          Visual Studio 2013</td>
           <td><a href="http://portal.nersc.gov/project/visit/releases/2.13.0/visit2.13.0_x64.exe">Download</a></td>
         </tr>
         <tr>

--- a/docs/WebSite/pages/visit/executables.xml
+++ b/docs/WebSite/pages/visit/executables.xml
@@ -56,8 +56,8 @@
           <th width="138">Executable</th>
         </tr>
         <tr>
-          <td>Windows (Vista / 7 / 8) 64 bit<br />
-          Visual Studio 2012</td>
+          <td>Windows (10 / 8 / 7) 64 bit<br />
+          Visual Studio 2017</td>
           <td><a href="http://portal.nersc.gov/project/visit/releases/3.0.0/visit3.0.0_x64.exe">Download</a></td>
         </tr>
         <tr>


### PR DESCRIPTION
Update platform information for Windows executables on our downloads page for version 3.x and 2.13x to correct Windows versions and Visual Studio version used to compile.

