### PR TITLE
Compile time version comparison

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -898,7 +898,8 @@ VISIT_3RDPARTY_VAR(TBB_ROOT      "Path containing the TBB library's include and 
 #-----------------------------------------------------------------------------
 FILE(STRINGS VERSION VERSION)
 IF(NOT VERSION)
-    SET(VERSION "3.0.0")
+    MESSAGE(FATAL_ERROR
+        "File \"VERSION\" with ascii string of VisIt version does not exist")
 ENDIF(NOT VERSION)
 SET(VISIT_VERSION ${VERSION})
 
@@ -914,6 +915,10 @@ list(GET v_list 0 VISIT_VERSION_MAJOR)
 list(GET v_list 1 VISIT_VERSION_MINOR)
 list(GET v_list 2 VISIT_VERSION_PATCH)
 unset(v_list)
+
+# Further decompose PATCH string into number and, when present, letter
+string(REGEX REPLACE "^([0-9]+)([a-z]*)$" \\1 VISIT_VERSION_PATCH_NUMBER ${VISIT_VERSION_PATCH})
+string(REGEX REPLACE "^([0-9]+)([a-z]*)$" \\2 VISIT_VERSION_PATCH_LETTER ${VISIT_VERSION_PATCH})
 
 #-----------------------------------------------------------------------------
 # Set up some installation related value and macros (needs version).

--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -3186,6 +3186,10 @@ ConvertGlobalElementIdsToInt(vtkDataArray *da)
 static vtkDataArray *
 EnsureGlobalElementIdsAreInt(vtkDataArray *da)
 {
+#if VISIT_VERSION_HEX > 0x0300000F
+#error EITHER FIX GLOBAL ELEMENT ID BASED GHOST-ZONE COMM OR UPDATE THIS VERSION TRIGGER
+#endif
+
     if (!da) return 0;
 
     if (da->IsA("vtkIntArray")) return da;

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -271,8 +271,88 @@
 /* Define if we want to use VisIt's no-spin BCast. */
 #cmakedefine VISIT_USE_NOSPIN_BCAST
 
-/* VisIt version */
+/* VisIt version as string */
 #cmakedefine VISIT_VERSION "@VISIT_VERSION@"
+
+/*
+         Compile time VisIt version number support
+
+VISIT_VERSION is a string. It does not support == or >< comparisons
+at compile time. The logic below does. It constructs an integer using
+each of the major, minor, patch and optional letter (a)alpha (b)eta
+by using each digit as a one byte hex field of a 4-byte integer. This
+number, VISIT_VERSION_HEX, can then be used in conditional compilation
+blocks like so...
+
+#if VISIT_VERSION_HEX > 0x0301020f // compare to 3.1.2
+...
+#endif
+
+#if VISIT_VERSION_HEX > 0x0400000b // compare to 4.0.0b
+...
+#endif
+
+In CMakeLists.txt VISIT_VERSION_PATCH gets either just a number or a
+number/letter combo. So, this is further broken down in CMakeLists.txt
+to VISIT_VERSION_PATCH_NUMBER and VISIT_VERSION_PATCH_LETTER. Because
+the patch letter isn't always present, the compile-time variant is always
+constructed by pre-catenation with 0x0 so that when the letter is not
+present, the compile time value is 0
+
+When the compile time letter evaluates to 0, it's field in the hex
+version integer is assigned a value of 0xf. Otherwise, its field is
+assigned whatever the letter is. This supports letters that are valid
+hex digits only [a-e]. It will not support any other letters. This
+construction ensures that the hex integers for versions such as
+3.0.0a < 3.0.0b < 3.0.0 are correctly ordered numerically. But, it
+also means VisIt version 3.0.0 is encoded properly as the hex integer
+as 0x0300000f.
+
+The two-level indirection in the macros, V_V_HEX->_V_V_HEX->__V_V_HEX
+is necessary to ensure the correct substitutions occur for the CPP token
+pasting involved.
+
+Finally, there are four sanity checks on the resulting version number
+here to cause compilation failure if this logic somehow fails.
+*/
+
+/* VisIt version as broken out integer values */
+/* Don't use #cmakedefine because 0 values will get undef'd */
+#define VISIT_VERSION_MAJOR @VISIT_VERSION_MAJOR@
+#define VISIT_VERSION_MINOR @VISIT_VERSION_MINOR@
+#define VISIT_VERSION_PATCH @VISIT_VERSION_PATCH@
+
+/* Since PATCH can contain letters, break it down further */
+/* Don't use #cmakedefine because 0 values will get undef'd */
+#define VISIT_VERSION_PATCH_NUMBER @VISIT_VERSION_PATCH_NUMBER@
+#define VISIT_VERSION_PATCH_LETTER 0x0@VISIT_VERSION_PATCH_LETTER@
+
+/* The VISIT_VERSION_HEX constant 
+Examples:
+#if VISIT_VERSION_HEX < 0x0212030b for VisIt versions older than 2.12.3b
+#if VISIT_VERSION_HEX > 0x0212020f for VisIt versions newer than 2.12.2
+*/
+#if VISIT_VERSION_PATCH_LETTER == 0
+#define __VISIT_VERSION_HEX(A,B,C,D) ((((0x0 ## A)<<24)|((0x0 ## B)<<16)|((0x0 ## C)<<8)|0xF))
+#else
+#define __VISIT_VERSION_HEX(A,B,C,D) ((((0x0 ## A)<<24)|((0x0 ## B)<<16)|((0x0 ## C)<<8)|D))
+#endif
+#define _VISIT_VERSION_HEX(A,B,C,D) __VISIT_VERSION_HEX(A,B,C,D)
+#define VISIT_VERSION_HEX _VISIT_VERSION_HEX(VISIT_VERSION_MAJOR,VISIT_VERSION_MINOR,VISIT_VERSION_PATCH_NUMBER,VISIT_VERSION_PATCH_LETTER)
+
+/* Sanity checks on the VISIT_VERSION_HEX */
+#if _VISIT_VERSION_HEX(2,13,3,0xb) < _VISIT_VERSION_HEX(2,13,3,0xa)
+#error PROBLEM WITH _VISIT_VERSION_HEX
+#endif
+#if _VISIT_VERSION_HEX(2,13,3,0xa) > _VISIT_VERSION_HEX(2,13,3,0)
+#error PROBLEM WITH _VISIT_VERSION_HEX
+#endif
+#if VISIT_VERSION_HEX > 0x7521320c /* insanely high version number */
+#error PROBLEM WITH VISIT_VERSION_HEX
+#endif
+#if VISIT_VERSION_HEX < 0x03000000 /* version this was introduced */
+#error PROBLEM WITH VISIT_VERSION_HEX
+#endif
 
 /* Plugin version macro */
 #define VISIT_PLUGIN_VERSION_NAME(A,B) A##B


### PR DESCRIPTION
Resolves #3444 

### Description
This adds to `visit-cmake.h.in` (`visit-config.h`) a new symbol, `VISIT_VERSION_HEX` which is designed to behave like the other hex-based version comparison logic defined there for TPLs so you can do something like

```
#ifdef VISIT_VERSION_HEX < 0x0213030F
    // code you only want compiled for versions of VisIt older than with 2.13.3
#endif
````

The trailing `0F` is a bit funky. It means zero. Encoding VisIt's version number as a hex integer in this fashion is complicated by the possibility of having trailing *letter* for (a)lpha or (b)eta, etc. That requries 4 fields (bytes) of the hex encoded version number and requires some funkiness to get numerical ordering correct so that 3.0.0 > 3.0.0b > 3.0.0a. To do this, the trailing letter, if present, maps to itself as a hex digit (which supports letters `a`,`b`,`c`,`d`,`e`) or to `f` if there is no trailing letter. This ensures zero is greater than numerically, lettered variants.

**Note:** I also adjusted `CMakeLists.txt` logic that sets `VISIT_VERSION` to fail if it cannot find the file `VISIT_VERSION` instead of encoding into `CMakeLists.txt` the current VisIt version also. If we're going to do the one, why do we need the other?


### Type of change

This is a new feature to support code blocks that are needed only for certain versions of VisIt.

### How Has This Been Tested?

I tested a lot of the code in a small `.C` file as unit test and then re-compiled all of VisIt and the Exodus plugin (where I actually use the version check for good reason). I also added sanity checks to `visit-cmake.h.in` to ensure 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [x] I have added debugging support to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
