### PR TITLE
VISIT_VERSION_GE() Macro

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -898,7 +898,8 @@ VISIT_3RDPARTY_VAR(TBB_ROOT      "Path containing the TBB library's include and 
 #-----------------------------------------------------------------------------
 FILE(STRINGS VERSION VERSION)
 IF(NOT VERSION)
-    SET(VERSION "3.0.0")
+    MESSAGE(FATAL_ERROR
+        "File \"VERSION\" with ascii string of VisIt version does not exist")
 ENDIF(NOT VERSION)
 SET(VISIT_VERSION ${VERSION})
 
@@ -914,6 +915,10 @@ list(GET v_list 0 VISIT_VERSION_MAJOR)
 list(GET v_list 1 VISIT_VERSION_MINOR)
 list(GET v_list 2 VISIT_VERSION_PATCH)
 unset(v_list)
+
+# Further decompose PATCH string into number and, when present, letter
+string(REGEX REPLACE "^([0-9]+)([a-z]*)$" \\1 VISIT_VERSION_PATCH_NUMBER ${VISIT_VERSION_PATCH})
+string(REGEX REPLACE "^([0-9]+)([a-z]*)$" \\2 VISIT_VERSION_PATCH_LETTER ${VISIT_VERSION_PATCH})
 
 #-----------------------------------------------------------------------------
 # Set up some installation related value and macros (needs version).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -916,10 +916,6 @@ list(GET v_list 1 VISIT_VERSION_MINOR)
 list(GET v_list 2 VISIT_VERSION_PATCH)
 unset(v_list)
 
-# Further decompose PATCH string into number and, when present, letter
-string(REGEX REPLACE "^([0-9]+)([a-z]*)$" \\1 VISIT_VERSION_PATCH_NUMBER ${VISIT_VERSION_PATCH})
-string(REGEX REPLACE "^([0-9]+)([a-z]*)$" \\2 VISIT_VERSION_PATCH_LETTER ${VISIT_VERSION_PATCH})
-
 #-----------------------------------------------------------------------------
 # Set up some installation related value and macros (needs version).
 #-----------------------------------------------------------------------------

--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -3186,7 +3186,7 @@ ConvertGlobalElementIdsToInt(vtkDataArray *da)
 static vtkDataArray *
 EnsureGlobalElementIdsAreInt(vtkDataArray *da)
 {
-#if VISIT_VERSION_HEX > 0x0300000F
+#if VISIT_VERSION_GE(3,0,1)
 #error EITHER FIX GLOBAL ELEMENT ID BASED GHOST-ZONE COMM OR UPDATE THIS VERSION TRIGGER
 #endif
 

--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -3186,6 +3186,10 @@ ConvertGlobalElementIdsToInt(vtkDataArray *da)
 static vtkDataArray *
 EnsureGlobalElementIdsAreInt(vtkDataArray *da)
 {
+#if VISIT_VERSION_HEX > 0x0300000F
+#error EITHER FIX GLOBAL ELEMENT ID BASED GHOST-ZONE COMM OR UPDATE THIS VERSION TRIGGER
+#endif
+
     if (!da) return 0;
 
     if (da->IsA("vtkIntArray")) return da;

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -278,80 +278,53 @@
          Compile time VisIt version number support
 
 VISIT_VERSION is a string. It does not support == or >< comparisons
-at compile time. The logic below does. It constructs an integer using
-each of the major, minor, patch and optional letter (a)alpha (b)eta
-by using each digit as a one byte hex field of a 4-byte integer. This
-number, VISIT_VERSION_HEX, can then be used in conditional compilation
-blocks like so...
+at compile time. The logic below does. It works by carefully
+constructing an integer from the major, minor and patch fields of the
+version number taking care that the patch field can include a single
+trailing letter for (a)lpha, (b)eta. This number is used internally
+to define a greater-than-or-equal macro for testing VisIt version
+numbers like so...
 
-#if VISIT_VERSION_HEX > 0x0301020f // compare to 3.1.2
-...
+#if VISIT_VERSION_GE(3,0,0b)
+    code for versions of VisIt the same or newer than 3.0.0b
 #endif
-
-#if VISIT_VERSION_HEX > 0x0400000b // compare to 4.0.0b
-...
-#endif
-
-In CMakeLists.txt VISIT_VERSION_PATCH gets either just a number or a
-number/letter combo. So, this is further broken down in CMakeLists.txt
-to VISIT_VERSION_PATCH_NUMBER and VISIT_VERSION_PATCH_LETTER. Because
-the patch letter isn't always present, the compile-time variant is always
-constructed by pre-catenation with 0x0 so that when the letter is not
-present, the compile time value is 0
-
-When the compile time letter evaluates to 0, it's field in the hex
-version integer is assigned a value of 0xf. Otherwise, its field is
-assigned whatever the letter is. This supports letters that are valid
-hex digits only [a-e]. It will not support any other letters. This
-construction ensures that the hex integers for versions such as
-3.0.0a < 3.0.0b < 3.0.0 are correctly ordered numerically. But, it
-also means VisIt version 3.0.0 is encoded properly as the hex integer
-as 0x0300000f.
 
 The two-level indirection in the macros, V_V_HEX->_V_V_HEX->__V_V_HEX
 is necessary to ensure the correct substitutions occur for the CPP token
 pasting involved.
 
-Finally, there are four sanity checks on the resulting version number
-here to cause compilation failure if this logic somehow fails.
+Finally, there are some sanity checks on the resulting version number
+logic here to cause compilation failure if this logic seems to be failing.
 */
 
-/* VisIt version as broken out integer values */
+/* VisIt version as broken out integer values. */
 /* Don't use #cmakedefine because 0 values will get undef'd */
 #define VISIT_VERSION_MAJOR @VISIT_VERSION_MAJOR@
 #define VISIT_VERSION_MINOR @VISIT_VERSION_MINOR@
 #define VISIT_VERSION_PATCH @VISIT_VERSION_PATCH@
 
-/* Since PATCH can contain letters, break it down further */
-/* Don't use #cmakedefine because 0 values will get undef'd */
-#define VISIT_VERSION_PATCH_NUMBER @VISIT_VERSION_PATCH_NUMBER@
-#define VISIT_VERSION_PATCH_LETTER 0x0@VISIT_VERSION_PATCH_LETTER@
+#define __VISIT_VERSION_HEX(A,B,C) (((A)<<24)|((B)<<16)|(((C)<=0x9)*(((C)<<8)|0xF))|(((C)>0x9)*((((C)&0xF0)<<4)|(C)&0x0F)))
+#define _VISIT_VERSION_HEX(A,B,C) __VISIT_VERSION_HEX(A,B,(0x##C))
+#define VISIT_VERSION_HEX(A,B,C) _VISIT_VERSION_HEX(A,B,C)
 
-/* The VISIT_VERSION_HEX constant 
-Examples:
-#if VISIT_VERSION_HEX < 0x0212030b for VisIt versions older than 2.12.3b
-#if VISIT_VERSION_HEX > 0x0212020f for VisIt versions newer than 2.12.2
-*/
-#if VISIT_VERSION_PATCH_LETTER == 0
-#define __VISIT_VERSION_HEX(A,B,C,D) ((((0x0 ## A)<<24)|((0x0 ## B)<<16)|((0x0 ## C)<<8)|0xF))
-#else
-#define __VISIT_VERSION_HEX(A,B,C,D) ((((0x0 ## A)<<24)|((0x0 ## B)<<16)|((0x0 ## C)<<8)|D))
-#endif
-#define _VISIT_VERSION_HEX(A,B,C,D) __VISIT_VERSION_HEX(A,B,C,D)
-#define VISIT_VERSION_HEX _VISIT_VERSION_HEX(VISIT_VERSION_MAJOR,VISIT_VERSION_MINOR,VISIT_VERSION_PATCH_NUMBER,VISIT_VERSION_PATCH_LETTER)
+/* GE version macro defined in terms of the HEX version number */
+#define VISIT_VERSION_GE(A,B,C) (VISIT_VERSION_HEX(VISIT_VERSION_MAJOR,VISIT_VERSION_MINOR,VISIT_VERSION_PATCH)>=VISIT_VERSION_HEX(A,B,C))
 
-/* Sanity checks on the VISIT_VERSION_HEX */
-#if _VISIT_VERSION_HEX(2,13,3,0xb) < _VISIT_VERSION_HEX(2,13,3,0xa)
-#error PROBLEM WITH _VISIT_VERSION_HEX
+/* Sanity checks for VISIT_VERSION_HEX Utility */
+#if VISIT_VERSION_HEX(2,13,3) < VISIT_VERSION_HEX(2,13,3a)
+#error Problem with VISIT_VERSION_HEX() macro function
 #endif
-#if _VISIT_VERSION_HEX(2,13,3,0xa) > _VISIT_VERSION_HEX(2,13,3,0)
-#error PROBLEM WITH _VISIT_VERSION_HEX
+#if VISIT_VERSION_HEX(3,0,0b) < VISIT_VERSION_HEX(3,0,0a)
+#error Problem with VISIT_VERSION_HEX() macro function
 #endif
-#if VISIT_VERSION_HEX > 0x7521320c /* insanely high version number */
-#error PROBLEM WITH VISIT_VERSION_HEX
+#if VISIT_VERSION_HEX(3,0,0) < VISIT_VERSION_HEX(2,13,3)
+#error Problem with VISIT_VERSION_HEX() macro function
 #endif
-#if VISIT_VERSION_HEX < 0x03000000 /* version this was introduced */
-#error PROBLEM WITH VISIT_VERSION_HEX
+#if VISIT_VERSION_HEX(3,0,0) < VISIT_VERSION_HEX(3,0,0b)
+#error Problem with VISIT_VERSION_HEX() macro function
+#endif
+#if VISIT_VERSION_HEX(3,0,1) < VISIT_VERSION_HEX(3,0,0b)
+#error Problem with VISIT_VERSION_HEX() macro function
 #endif
 
 /* Plugin version macro */

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -271,8 +271,88 @@
 /* Define if we want to use VisIt's no-spin BCast. */
 #cmakedefine VISIT_USE_NOSPIN_BCAST
 
-/* VisIt version */
+/* VisIt version as string */
 #cmakedefine VISIT_VERSION "@VISIT_VERSION@"
+
+/*
+         Compile time VisIt version number support
+
+VISIT_VERSION is a string. It does not support == or >< comparisons
+at compile time. The logic below does. It constructs an integer using
+each of the major, minor, patch and optional letter (a)alpha (b)eta
+by using each digit as a one byte hex field of a 4-byte integer. This
+number, VISIT_VERSION_HEX, can then be used in conditional compilation
+blocks like so...
+
+#if VISIT_VERSION_HEX > 0x0301020f // compare to 3.1.2
+...
+#endif
+
+#if VISIT_VERSION_HEX > 0x0400000b // compare to 4.0.0b
+...
+#endif
+
+In CMakeLists.txt VISIT_VERSION_PATCH gets either just a number or a
+number/letter combo. So, this is further broken down in CMakeLists.txt
+to VISIT_VERSION_PATCH_NUMBER and VISIT_VERSION_PATCH_LETTER. Because
+the patch letter isn't always present, the compile-time variant is always
+constructed by pre-catenation with 0x0 so that when the letter is not
+present, the compile time value is 0
+
+When the compile time letter evaluates to 0, it's field in the hex
+version integer is assigned a value of 0xf. Otherwise, its field is
+assigned whatever the letter is. This supports letters that are valid
+hex digits only [a-e]. It will not support any other letters. This
+construction ensures that the hex integers for versions such as
+3.0.0a < 3.0.0b < 3.0.0 are correctly ordered numerically. But, it
+also means VisIt version 3.0.0 is encoded properly as the hex integer
+as 0x0300000f.
+
+The two-level indirection in the macros, V_V_HEX->_V_V_HEX->__V_V_HEX
+is necessary to ensure the correct substitutions occur for the CPP token
+pasting involved.
+
+Finally, there are four sanity checks on the resulting version number
+here to cause compilation failure if this logic somehow fails.
+*/
+
+/* VisIt version as broken out integer values */
+/* Don't use #cmakedefine because 0 values will get undef'd */
+#define VISIT_VERSION_MAJOR @VISIT_VERSION_MAJOR@
+#define VISIT_VERSION_MINOR @VISIT_VERSION_MINOR@
+#define VISIT_VERSION_PATCH @VISIT_VERSION_PATCH@
+
+/* Since PATCH can contain letters, break it down further */
+/* Don't use #cmakedefine because 0 values will get undef'd */
+#define VISIT_VERSION_PATCH_NUMBER @VISIT_VERSION_PATCH_NUMBER@
+#define VISIT_VERSION_PATCH_LETTER 0x0@VISIT_VERSION_PATCH_LETTER@
+
+/* The VISIT_VERSION_HEX constant 
+Examples:
+#if VISIT_VERSION_HEX < 0x0212030b for VisIt versions older than 2.12.3b
+#if VISIT_VERSION_HEX > 0x0212020f for VisIt versions newer than 2.12.2
+*/
+#if VISIT_VERSION_PATCH_LETTER == 0
+#define __VISIT_VERSION_HEX(A,B,C,D) ((((0x0 ## A)<<24)|((0x0 ## B)<<16)|((0x0 ## C)<<8)|0xF))
+#else
+#define __VISIT_VERSION_HEX(A,B,C,D) ((((0x0 ## A)<<24)|((0x0 ## B)<<16)|((0x0 ## C)<<8)|D))
+#endif
+#define _VISIT_VERSION_HEX(A,B,C,D) __VISIT_VERSION_HEX(A,B,C,D)
+#define VISIT_VERSION_HEX _VISIT_VERSION_HEX(VISIT_VERSION_MAJOR,VISIT_VERSION_MINOR,VISIT_VERSION_PATCH_NUMBER,VISIT_VERSION_PATCH_LETTER)
+
+/* Sanity checks on the VISIT_VERSION_HEX */
+#if _VISIT_VERSION_HEX(2,13,3,0xb) < _VISIT_VERSION_HEX(2,13,3,0xa)
+#error PROBLEM WITH _VISIT_VERSION_HEX
+#endif
+#if _VISIT_VERSION_HEX(2,13,3,0xa) > _VISIT_VERSION_HEX(2,13,3,0)
+#error PROBLEM WITH _VISIT_VERSION_HEX
+#endif
+#if VISIT_VERSION_HEX > 0x7521320c /* insanely high version number */
+#error PROBLEM WITH VISIT_VERSION_HEX
+#endif
+#if VISIT_VERSION_HEX < 0x03000000 /* version this was introduced */
+#error PROBLEM WITH VISIT_VERSION_HEX
+#endif
 
 /* Plugin version macro */
 #define VISIT_PLUGIN_VERSION_NAME(A,B) A##B


### PR DESCRIPTION
### Description
Resolves #3444 

Adds `VISIT_VERSION_GE()` macro to `visit-cmake.h.in` (`visit-config.h`)

1. Removes setting a default version number in `CMakeLists.txt`
1. Defines a compile time macro, `VISIT_VERSION_GE(A,B,C)` which can be used like so...

```
#if VISIT_VERSION_GE(3,0,0a)
    // code for version 3.0.0a and newer
#endif 
```

The approach still uses careful construction of an integer value from the major, minor and patch digits of the VisIt version number being careful to handle possible letters in the patch digit. But, these details are hidden *behind* the `VISIT_VERSION_GE()` macro. The `_VISIT_VERSION_HEX()` macro **is not intended** for developer use directly. The arguments to `VISIT_VERSION_GE()` are major, minor and patch fields (which can include a trailing letter of a,b,c,d,e). See example above. The logic is such that the version numbers 3.0.0a < 3.0.0b < 3.0.0 are properly numerically ordered by the magic in `_VISIT_VERSION_HEX()` macro.

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Sanity checks are included in `visit-cmake.h.in`


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [x] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
