### PR TITLE
Fix type of avgdiff CL arg in runtest

### DIFF
--- a/src/test/visit_test_suite.py
+++ b/src/test/visit_test_suite.py
@@ -492,7 +492,7 @@ def default_suite_options():
                       "data_host":"localhost",
                       "interactive":False,
                       "pixdiff":0.0,
-                      "avgdiff":0,
+                      "avgdiff":0.0,
                       "numdiff":0.0,
                       "vargs": "",
                       "host_profile_dir": "",
@@ -694,7 +694,7 @@ def parse_args():
                       default=defs["pixdiff"],
                       help="allowed % of pixels different [default = 0.0%]")
     parser.add_option("--avgdiff",
-                      type="int",
+                      type="float",
                       default=defs["avgdiff"],
                       help="if pixdiff exceeded, allowed mean grayscale diff "
                            "[default = 0]")


### PR DESCRIPTION
### Description
The `--avgdiff` CL arg for `runtest` is intended to indicate the threshold of average gray-scale (e.g. intensity) diff of pixels above which, the result should be flagged as an error. This is as sum of the intensity diffs divided by the number of different pixels and, for normal testing purposes, is usually always a small number, less than one.

For some reason, it was treated as type `int` which does not allow values less than one. I have fixed this.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I ran the `tensor.py` test on my mac. Because its a mac, it generates subtle diffs. For the `avgdiff` metric, I get data like...

```
tensor_01.html:      0.003900
tensor_02.html:      0.006400
tensor_03.html:      0.000444
tensor_04.html:      0.005611
tensor_05.html:      0.021733
tensor_06.html:      0.005633
tensor_07.html:      0.048811
tensor_08.html:      0.006078
```
After switching the python code to use `float` rather than `int` for `avgdiff` CL argument and then doing following...

```
./runtest --avgdiff=0.03 -e ../../build2/bin/visit -d ../../data/ -b ../../test/baseline -v tests/plots/tensor.py
```
and I got failure only for `tensor_07` case and then ran...
```
./runtest --avgdiff=0.01 -e ../../build2/bin/visit -d ../../data/ -b ../../test/baseline -v tests/plots/tensor.py
```
and I got failures for `tensor_07` and `tensor_05` cases proving just changing the type ensured proper behavior.
