### PR TITLE
Fix _GNU_SOURCE multiple definitions warning.

### DIFF
--- a/src/databases/paraDIS/RC_cpp_lib/RC_c_lib/gprof-helper.c
+++ b/src/databases/paraDIS/RC_cpp_lib/RC_c_lib/gprof-helper.c
@@ -30,7 +30,9 @@ It wouldn~t be too hard to put a call to setitimer in each function spawned by a
 Daniel Jönsson enhanced my code so that it could be used in a preload library without having to modify the program. It can also be very useful for libraries that spawn threads without warning, such as libSDL. The result code is shown below and can be downloaded (gprof-helper.c):
 */
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 #include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/databases/paraDIS_tecplot/RC_c_lib/gprof-helper.c
+++ b/src/databases/paraDIS_tecplot/RC_c_lib/gprof-helper.c
@@ -30,7 +30,9 @@ It wouldn~t be too hard to put a call to setitimer in each function spawned by a
 Daniel Jönsson enhanced my code so that it could be used in a preload library without having to modify the program. It can also be very useful for libraries that spawn threads without warning, such as libSDL. The result code is shown below and can be downloaded (gprof-helper.c):
 */
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 #include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/mdserver/main/MDServerConnection.C
+++ b/src/mdserver/main/MDServerConnection.C
@@ -42,7 +42,9 @@
 #include <string.h>
 #else
 #include <pwd.h>
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 #include <dirent.h>
 #include <unistd.h>
 #include <sys/stat.h>

--- a/src/tools/third_party/qtssh/unix/uxpeer.c
+++ b/src/tools/third_party/qtssh/unix/uxpeer.c
@@ -8,7 +8,9 @@
 #endif
 
 #ifdef HAVE_SO_PEERCRED
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 #include <features.h>
 #endif
 


### PR DESCRIPTION
I chose to wrap in #ifndef, so we don't interfere with the compiler definition.

### Description

Resolves #3467
 
- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Ensure no more warnings with compiler that defines _GNU_SOURCE.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
