### PR TITLE
Conditionally compile deprecated MPI functions

### DIFF
--- a/src/avt/Filters/avtValueImageCompositer.C
+++ b/src/avt/Filters/avtValueImageCompositer.C
@@ -156,8 +156,13 @@ avtValueImageCompositer::InitializeMPIStuff(void)
 #undef FLT
 
    // create the MPI data type for ZFPixel
+#if MPI_VERSION >= 2
+   MPI_Get_address(&onePixel.z, &displacements[0]);
+   MPI_Get_address(&onePixel.value, &displacements[1]);
+#else
    MPI_Address(&onePixel.z, &displacements[0]);
    MPI_Address(&onePixel.value, &displacements[1]);
+#endif
 
    for (int i = 1; i >= 0; --i)
       displacements[i] -= displacements[0];
@@ -167,7 +172,12 @@ avtValueImageCompositer::InitializeMPIStuff(void)
 
    // check that the datatype has the correct extent
    MPI_Aint ext;
+#if MPI_VERSION >= 2
+   MPI_Aint lb;
+   MPI_Type_get_extent(avtValueImageCompositer::mpiTypeZFPixel, &lb, &ext);
+#else
    MPI_Type_extent(avtValueImageCompositer::mpiTypeZFPixel, &ext);
+#endif
    if (ext != sizeof(onePixel))
    {
        MPI_Datatype tmp = avtValueImageCompositer::mpiTypeZFPixel;

--- a/src/avt/Filters/avtWholeImageCompositerWithZ.C
+++ b/src/avt/Filters/avtWholeImageCompositerWithZ.C
@@ -180,10 +180,17 @@ avtWholeImageCompositerWithZ::InitializeMPIStuff(void)
 #undef FLT
 
    // create the MPI data type for ZFPixel
+#if MPI_VERSION >= 2
+   MPI_Get_address(&onePixel.z, &displacements[0]);
+   MPI_Get_address(&onePixel.r, &displacements[1]);
+   MPI_Get_address(&onePixel.g, &displacements[2]);
+   MPI_Get_address(&onePixel.b, &displacements[3]);
+#else
    MPI_Address(&onePixel.z, &displacements[0]);
    MPI_Address(&onePixel.r, &displacements[1]);
    MPI_Address(&onePixel.g, &displacements[2]);
    MPI_Address(&onePixel.b, &displacements[3]);
+#endif
 
    for (int i = 3; i >= 0; --i)
       displacements[i] -= displacements[0];
@@ -193,7 +200,12 @@ avtWholeImageCompositerWithZ::InitializeMPIStuff(void)
 
    // check that the datatype has the correct extent
    MPI_Aint ext;
+#if MPI_VERSION >= 2
+   MPI_Aint lb;
+   MPI_Type_get_extent(avtWholeImageCompositerWithZ::mpiTypeZFPixel, &lb, &ext);
+#else
    MPI_Type_extent(avtWholeImageCompositerWithZ::mpiTypeZFPixel, &ext);
+#endif
    if (ext != sizeof(onePixel))
    {
        MPI_Datatype tmp = avtWholeImageCompositerWithZ::mpiTypeZFPixel;


### PR DESCRIPTION
### Description

Resolves #3410 

Turns out there were many places in VisIt where MPI functions deprecated in MPI2 were already being conditionally compiled. This issue found one in `avtWholeImageCompositorWithZ.C` and `avtValueImageCompositer.C`

I used this kind of conditional compilation logic...

```
#if MPI_VERSION >= 2
// new MPI functions here
#else 
// old MPI functions here
#endif 
```

As is the pattern in other sources where this is already handled, for example `avt/Pipeline/Pipeline/avtParallelContext.C`

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [x] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I've compiled on OSX, with MPI-2

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).