### PR TITLE
Fix #3531; change default color table name from hot to Default

### DIFF
--- a/src/plots/Pseudocolor/Pseudocolor.xml
+++ b/src/plots/Pseudocolor/Pseudocolor.xml
@@ -81,7 +81,7 @@
         Natural
       </Field>
       <Field name="colorTableName" label="Color table" type="colortable">
-        hot
+        Default
       </Field>
       <Field name="invertColorTable" label="Invert Color table" type="bool">
         false

--- a/src/plots/Pseudocolor/PseudocolorAttributes.C
+++ b/src/plots/Pseudocolor/PseudocolorAttributes.C
@@ -465,7 +465,7 @@ const AttributeGroup::private_tmfs_t PseudocolorAttributes::TmfsStruct = {PSEUDO
 PseudocolorAttributes::PseudocolorAttributes() : 
     AttributeSubject(PseudocolorAttributes::TypeMapFormatString),
     belowMinColor(), aboveMaxColor(), 
-    colorTableName("hot"), pointSizeVar("default"), 
+    colorTableName("Default"), pointSizeVar("default"), 
     wireframeColor(0, 0, 0, 0), pointColor(0, 0, 0, 0)
 {
     PseudocolorAttributes::Init();
@@ -489,7 +489,7 @@ PseudocolorAttributes::PseudocolorAttributes() :
 PseudocolorAttributes::PseudocolorAttributes(private_tmfs_t tmfs) : 
     AttributeSubject(tmfs.tmfs),
     belowMinColor(), aboveMaxColor(), 
-    colorTableName("hot"), pointSizeVar("default"), 
+    colorTableName("Default"), pointSizeVar("default"), 
     wireframeColor(0, 0, 0, 0), pointColor(0, 0, 0, 0)
 {
     PseudocolorAttributes::Init();

--- a/src/plots/Surface/Surface.xml
+++ b/src/plots/Surface/Surface.xml
@@ -72,7 +72,7 @@
         1.000000
       </Field>
       <Field name="colorTableName" label="Color table" type="colortable">
-        hot
+        Default
       </Field>
       <Field name="invertColorTable" label="Invert Color table" type="bool">
         false

--- a/src/plots/Surface/SurfaceAttributes.C
+++ b/src/plots/Surface/SurfaceAttributes.C
@@ -247,7 +247,7 @@ const AttributeGroup::private_tmfs_t SurfaceAttributes::TmfsStruct = {SURFACEATT
 SurfaceAttributes::SurfaceAttributes() : 
     AttributeSubject(SurfaceAttributes::TypeMapFormatString),
     surfaceColor(0, 0, 0), wireframeColor(0, 0, 0), 
-    colorTableName("hot")
+    colorTableName("Default")
 {
     SurfaceAttributes::Init();
 }
@@ -270,7 +270,7 @@ SurfaceAttributes::SurfaceAttributes() :
 SurfaceAttributes::SurfaceAttributes(private_tmfs_t tmfs) : 
     AttributeSubject(tmfs.tmfs),
     surfaceColor(0, 0, 0), wireframeColor(0, 0, 0), 
-    colorTableName("hot")
+    colorTableName("Default")
 {
     SurfaceAttributes::Init();
 }

--- a/src/resources/help/en_US/relnotes3.0.1.html
+++ b/src/resources/help/en_US/relnotes3.0.1.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Corrected a bug where VisIt would crash rendering transparent geometry when processor 0 didn't have any geometry.</li>
   <li>Corrected a bug where VisIt would not switch into scalable rendering mode when it should have when the total number of primitives to render was greater than 2 billion. This typically resulted in VisIt crashing because it ran out of memory.</li>
+  <li>Corrected color table named in Pseudocolor and Surface plots from hot to Default making those plots use whatever the default color map is set to.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #3531 

1. Changed `.xml` files for `colorTableName` member to use *Default* instead of *hot*.
1. Re-generated the plot classes.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I just ran my build and confirmed that when I open the associated plot attribute objects, they come up showing *Default* for the color table name.

There *is* a chance the test suite could fail. If so, will fix it.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
