### PR TITLE
Allow cell-centered data for coloring/scaling glyphs.

### DIFF
--- a/src/visit_vtk/full/vtkVisItGlyph3D.C
+++ b/src/visit_vtk/full/vtkVisItGlyph3D.C
@@ -140,6 +140,9 @@ vtkVisItGlyph3D::~vtkVisItGlyph3D()
 //    Jeremy Meredith, Fri Aug 23 12:01:38 EDT 2013
 //    Added back the original full frame correction for non-vector glyphs.
 //
+//    Kathleen Biagas, Thu May 30 12:15:07 PDT 2019
+//    Allow cell-centered data for coloring/scaling.
+//
 // ****************************************************************************
 
 int
@@ -163,6 +166,7 @@ vtkVisItGlyph3D::RequestData(
     outInfo->Get(vtkDataObject::DATA_OBJECT()));
 
   vtkPointData *pd;
+  vtkCellData  *cd;
   vtkDataArray *inScalars = NULL;
   vtkDataArray *inScalars_forColoring = NULL;
   vtkDataArray *inScalars_forScaling = NULL;
@@ -217,15 +221,26 @@ vtkVisItGlyph3D::RequestData(
     }
 
   pd = input->GetPointData();
+  cd = input->GetCellData();
   inScalars = pd->GetScalars(this->InputScalarsSelection);
   inVectors = pd->GetVectors(this->InputVectorsSelection);
   inNormals = pd->GetNormals(this->InputNormalsSelection);
 
   inScalars_forColoring = pd->GetArray(this->ScalarsForColoring);
+  if (inScalars_forColoring == NULL)
+      inScalars_forColoring = cd->GetArray(this->ScalarsForColoring);
   inScalars_forScaling  = pd->GetArray(this->ScalarsForScaling);
+  if (inScalars_forScaling == NULL)
+      inScalars_forScaling = cd->GetArray(this->ScalarsForScaling);
   inVectors_forColoring = pd->GetArray(this->VectorsForColoring);
+  if (inVectors_forColoring == NULL)
+      inVectors_forColoring = cd->GetArray(this->VectorsForColoring);
   inVectors_forScaling  = pd->GetArray(this->VectorsForScaling);
+  if (inVectors_forScaling == NULL)
+      inVectors_forScaling = cd->GetArray(this->VectorsForScaling);
   inTensors_forScaling  = pd->GetArray(this->TensorsForScaling);
+  if (inTensors_forScaling == NULL)
+      inTensors_forScaling = cd->GetArray(this->TensorsForScaling);
 
   inOrigNodes = pd->GetArray("avtOriginalNodeNumbers");
   inOrigCells = pd->GetArray("avtOriginalCellNumbers");


### PR DESCRIPTION
Glyph generator was only looking for point-centered data for scaling/coloring.
Modified code to also look for cell-centered data.

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I used Allen's cell-centered point data to verify the glyphs are being colored correctly with the fix.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
