### PR TITLE
Update Expression::GetTypeString returned string.

### DIFF
--- a/src/common/state/Expression.C
+++ b/src/common/state/Expression.C
@@ -1046,6 +1046,10 @@ Expression::GetNumTypes()
 //    Kathlen Bonnell, Tue Aug  1 08:26:14 PDT 2006 
 //    Added CurveMeshVar. 
 // 
+//    Kathleen Biagas, Thu Jun  6 16:14:45 PDT 2019
+//    Change returned strings to match case-changes in QvisExpressionWindow,
+//    the only other place this method is used.
+//
 // ****************************************************************************
 
 const char *
@@ -1054,17 +1058,17 @@ Expression::GetTypeString(const Expression::ExprType t)
     switch(t)
     {
     case ScalarMeshVar:
-        return "Scalar Mesh Variable";
+        return "Scalar mesh variable";
     case VectorMeshVar:
-        return "Vector Mesh Variable";
+        return "Vector mesh variable";
     case TensorMeshVar:
-        return "Tensor Mesh Variable";
+        return "Tensor mesh variable";
     case SymmetricTensorMeshVar:
-        return "Symmetric Tensor Mesh Variable";
+        return "Symmetric tensor mesh variable";
     case ArrayMeshVar:
-        return "Array Mesh Variable";
+        return "Array mesh variable";
     case CurveMeshVar:
-        return "Curve Mesh Variable";
+        return "Curve mesh variable";
     case Mesh:
         return "Mesh";
     case Material:

--- a/src/common/state/Expression.code
+++ b/src/common/state/Expression.code
@@ -40,6 +40,10 @@ Definition:
 //    Kathlen Bonnell, Tue Aug  1 08:26:14 PDT 2006 
 //    Added CurveMeshVar. 
 // 
+//    Kathleen Biagas, Thu Jun  6 16:14:45 PDT 2019
+//    Change returned strings to match case-changes in QvisExpressionWindow,
+//    the only other place this method is used.
+//
 // ****************************************************************************
 
 const char *
@@ -48,17 +52,17 @@ Expression::GetTypeString(const Expression::ExprType t)
     switch(t)
     {
     case ScalarMeshVar:
-        return "Scalar Mesh Variable";
+        return "Scalar mesh variable";
     case VectorMeshVar:
-        return "Vector Mesh Variable";
+        return "Vector mesh variable";
     case TensorMeshVar:
-        return "Tensor Mesh Variable";
+        return "Tensor mesh variable";
     case SymmetricTensorMeshVar:
-        return "Symmetric Tensor Mesh Variable";
+        return "Symmetric tensor mesh variable";
     case ArrayMeshVar:
-        return "Array Mesh Variable";
+        return "Array mesh variable";
     case CurveMeshVar:
-        return "Curve Mesh Variable";
+        return "Curve mesh variable";
     case Mesh:
         return "Mesh";
     case Material:

--- a/src/resources/help/en_US/relnotes3.0.1.html
+++ b/src/resources/help/en_US/relnotes3.0.1.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where VisIt would not switch into scalable rendering mode when it should have when the total number of primitives to render was greater than 2 billion. This typically resulted in VisIt crashing because it ran out of memory.</li>
   <li>Corrected color table named in Pseudocolor and Surface plots from hot to Default making those plots use whatever the default color map is set to.</li>
   <li>Corrected the batch launching on Sierra type systems at Lawrence Livermore National Laboratory.</li>
+  <li>Fixed type widget in the Expressions window losing the type name when 'Apply' clicked.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.0.1.html
+++ b/src/resources/help/en_US/relnotes3.0.1.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where VisIt would not switch into scalable rendering mode when it should have when the total number of primitives to render was greater than 2 billion. This typically resulted in VisIt crashing because it ran out of memory.</li>
   <li>Corrected color table named in Pseudocolor and Surface plots from hot to Default making those plots use whatever the default color map is set to.</li>
   <li>Corrected the batch launching on Sierra type systems at Lawrence Livermore National Laboratory.</li>
+  <li>Fixed glyphed points color being wrong when transparency turned on.</li>
   <li>Fixed type widget in the Expressions window losing the type name when 'Apply' clicked.</li>
 </ul>
 


### PR DESCRIPTION
Changed case of returned strings to match what is used in
QvisExpressionWindow.C.  Fixes a bug where the Expression type
widget would be empty after clicking 'Apply'.

