### PR TITLE
Fixed glyphed points getting wrong color when transparency turned on.

### DIFF
--- a/src/avt/Plotter/vtk/vtkPointGlyphMapper.C
+++ b/src/avt/Plotter/vtk/vtkPointGlyphMapper.C
@@ -476,16 +476,29 @@ void vtkPointGlyphMapper::ReleaseGraphicsResources(vtkWindow *w)
 
 
 //----------------------------------------------------------------------------
+// Modifications:
+//  
+//    Kathleen Biagas, Fri Jun  7 11:06:14 PDT 2019
+//    Tell superclass the scalar range, too. Needed by transparency actor.
+//----------------------------------------------------------------------------
+
 void vtkPointGlyphMapper::SetScalarRange(double min, double max)
 {
+  this->Superclass::SetScalarRange(min, max);
   this->GlyphMapper->SetScalarRange(min, max);
   this->PointMapper->SetScalarRange(min, max);
 }
 
 
 //----------------------------------------------------------------------------
+// Modifications:
+//  
+//    Kathleen Biagas, Fri Jun  7 11:06:14 PDT 2019
+//    Tell superclass the lut, too. Needed by transparency actor.
+//----------------------------------------------------------------------------
 void vtkPointGlyphMapper::SetLookupTable(vtkLookupTable *lut)
 {
+  this->Superclass::SetLookupTable(lut);
   this->GlyphMapper->SetLookupTable(lut);
   this->PointMapper->SetLookupTable(lut);
 }
@@ -582,8 +595,14 @@ void vtkPointGlyphMapper::DataScalingOn(const string &sname, int varDim)
 }
 
 //----------------------------------------------------------------------------
+// Modifications:
+//  
+//    Kathleen Biagas, Fri Jun  7 11:06:14 PDT 2019
+//    Tell superclass too. Needed by transparency actor.
+//----------------------------------------------------------------------------
 void vtkPointGlyphMapper::ColorByScalarOn(const string &sn)
 {
+  this->Superclass::ScalarVisibilityOn();
   this->GlyphFilter->SetColorModeToColorByScalar();
   this->GlyphFilter->SelectScalarsForColoring(sn.c_str());
   this->GlyphMapper->ScalarVisibilityOn();
@@ -591,8 +610,14 @@ void vtkPointGlyphMapper::ColorByScalarOn(const string &sn)
 }
 
 //----------------------------------------------------------------------------
+// Modifications:
+//  
+//    Kathleen Biagas, Fri Jun  7 11:06:14 PDT 2019
+//    Tell superclass too. Needed by transparency actor.
+//----------------------------------------------------------------------------
 void vtkPointGlyphMapper::ColorByScalarOff()
 {
+  this->Superclass::ScalarVisibilityOff();
   this->GlyphFilter->SetColorMode(0);
   this->GlyphMapper->ScalarVisibilityOff();
   this->PointMapper->ScalarVisibilityOff();

--- a/src/resources/help/en_US/relnotes3.0.1.html
+++ b/src/resources/help/en_US/relnotes3.0.1.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where VisIt would not switch into scalable rendering mode when it should have when the total number of primitives to render was greater than 2 billion. This typically resulted in VisIt crashing because it ran out of memory.</li>
   <li>Corrected color table named in Pseudocolor and Surface plots from hot to Default making those plots use whatever the default color map is set to.</li>
   <li>Corrected the batch launching on Sierra type systems at Lawrence Livermore National Laboratory.</li>
+  <li>Fixed glyphed points color being wrong when transparency turned on.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Scalar color/visibility information wasn't being sent to the superclass,
so avtTransparencyActor queries for the information were wrong.
This is a merge of changes already made to 3.0RC