### PR TITLE
Add "-noconfig" to generated command line in GenerateCinema in cinema tests.

### DIFF
--- a/src/test/tests/hybrid/cinema-a.py
+++ b/src/test/tests/hybrid/cinema-a.py
@@ -16,14 +16,17 @@
 #    use 'repr(db)' when writing script file to preserve '\' escapes.
 #    Replace forward-slash with back-slash in pattern.
 #
+#    Kathleen Biagas, Tue Jun 11 11:44:14 PDT 2019
+#    Pass '-noconfig' to generated command line in GenerateCinema.
+#
 # ----------------------------------------------------------------------------
 import os, string, subprocess
 
 def GenerateCinema(cinemaArgs):
     if TestEnv.params["parallel"]:
-        args = [TestEnv.params["visit_bin"], "-cinema", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + cinemaArgs
+        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + cinemaArgs
     else:
-        args = [TestEnv.params["visit_bin"], "-cinema"] + cinemaArgs
+        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema"] + cinemaArgs
     p = subprocess.check_output(args)
     return p
 

--- a/src/test/tests/hybrid/cinema-c.py
+++ b/src/test/tests/hybrid/cinema-c.py
@@ -11,15 +11,17 @@
 #  Date:       Thu Feb 15 16:37:20 PST 2018
 #
 #  Modifications:
+#    Kathleen Biagas, Tue Jun 11 11:44:14 PDT 2019
+#    Pass '-noconfig' to generated command line in GenerateCinema.
 #
 # ----------------------------------------------------------------------------
 import math, os, string, subprocess, zlib
 
 def GenerateCinema(cinemaArgs):
     if TestEnv.params["parallel"]:
-        args = [TestEnv.params["visit_bin"], "-cinema", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + cinemaArgs
+        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + cinemaArgs
     else:
-        args = [TestEnv.params["visit_bin"], "-cinema"] + cinemaArgs
+        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema"] + cinemaArgs
     p = subprocess.check_output(args)
     return p
 


### PR DESCRIPTION
Resolves #3584.

Though the bug ticket only mentions cinema-a.py, I updated cinema-c.py as well.

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Before the change, running cinema-a.py test on my local linux box would fail, because it used
the default continuous color table from my saved config settings, which is different than the 
standard default.  After the change, the test uses the correct color table and passes.
