### PR TITLE
Add support for cell-scalars in the filters used by Pseudocolor plot's line geometry features.

### DIFF
--- a/src/avt/Filters/avtLineoutFilter.h
+++ b/src/avt/Filters/avtLineoutFilter.h
@@ -44,7 +44,7 @@
 #define AVT_LINEOUT_FILTER_H
 #include <filters_exports.h>
 
-#include <avtPluginDataTreeIterator.h>
+#include <avtDataTreeIterator.h>
 
 class vtkDataSet;
 class vtkIdList;

--- a/src/avt/Filters/avtPolylineCleanupFilter.C
+++ b/src/avt/Filters/avtPolylineCleanupFilter.C
@@ -42,10 +42,7 @@
 
 #include <avtPolylineCleanupFilter.h>
 
-#include <vtkTubeFilter.h>
-#include <vtkAppendPolyData.h>
 #include <vtkCleanPolyData.h>
-#include <vtkDataSet.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 
@@ -95,10 +92,13 @@ avtPolylineCleanupFilter::~avtPolylineCleanupFilter()
 //
 //  Note: The cell data copying is untested.
 //
-//  Programmer:  Cyrus Harrison 
+//  Programmer:  Cyrus Harrison
 //  Creation:    Mon Nov  7 11:21:19 PST 2016
 //
 //  Modifications:
+//    Kathleen Biagas, Thu Jun 20 11:17:52 PDT 2019
+//    Remove unnecessary handling of active scalars, vtkCleanPolyData
+//    doesn't modify them.
 //
 // ****************************************************************************
 
@@ -115,26 +115,15 @@ avtPolylineCleanupFilter::ExecuteData(avtDataRepresentation *inDR)
         return inDR;
     }
 
-    vtkDataArray *activeScalars = inDS->GetPointData()->GetScalars();
-
-    vtkPolyData *data = vtkPolyData::SafeDownCast(inDS);
-
     // Clean duplicate points from the polydata.
     vtkCleanPolyData *cleanFilter = vtkCleanPolyData::New();
 
-    cleanFilter->SetInputData(data);
+    cleanFilter->SetInputData(vtkPolyData::SafeDownCast(inDS));
     cleanFilter->Update();
 
     // Get the output.
     vtkPolyData *outPD = cleanFilter->GetOutput();
     outPD->Register(NULL);
-
-    // Restore the active scalars.
-    if (activeScalars)
-    {
-        data->GetPointData()->SetActiveScalars(activeScalars->GetName());
-        outPD->GetPointData()->SetActiveScalars(activeScalars->GetName());
-    }
 
     // Create the output data rep.
     avtDataRepresentation *outDR =
@@ -150,7 +139,7 @@ avtPolylineCleanupFilter::ExecuteData(avtDataRepresentation *inDR)
 //  Purpose:
 //      Indicate that this invalidates the zone numberings.
 //
-//  Programmer:  Cyrus Harrison 
+//  Programmer:  Cyrus Harrison
 //  Creation:    Mon Nov  7 11:21:19 PST 2016
 //
 // ****************************************************************************

--- a/src/avt/Filters/avtPolylineToRibbonFilter.C
+++ b/src/avt/Filters/avtPolylineToRibbonFilter.C
@@ -44,7 +44,7 @@
 
 #include <vtkRibbonFilter.h>
 #include <vtkAppendPolyData.h>
-#include <vtkDataSet.h>
+#include <vtkCellData.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 
@@ -96,8 +96,17 @@ avtPolylineToRibbonFilter::~avtPolylineToRibbonFilter()
 //
 //  Modifications:
 //    Eric Brugger, Thu Oct 20 14:51:51 PDT 2016
-//    I added code to remove duplicate points from the lines since the 
+//    I added code to remove duplicate points from the lines since the
 //    vtkRibbonFilter exits on any lines that have duplicate points.
+//
+//    Kathleen Biagas, Thu Jun 20 11:37:25 PDT 2019
+//    1) Handle cell-centered data.
+//    2) Only use the append filter if input contained more than just lines,
+//       and remove the lines before adding to append.
+//    3) Change how widthVar is sent to the vtk filter to avoid mucking with
+//       ActiveScalars.
+//    4) Removed CleanFilter as the input has already been cleaned before this
+//       filter is called.
 //
 // ****************************************************************************
 
@@ -121,13 +130,11 @@ avtPolylineToRibbonFilter::ExecuteData(avtDataRepresentation *inDR)
         return inDR;
     }
 
-    vtkDataArray *activeScalars = inDS->GetPointData()->GetScalars();
-
     vtkPolyData *data = vtkPolyData::SafeDownCast(inDS);
 
     // Create the ribbon polydata.
     vtkRibbonFilter *ribbonFilter = vtkRibbonFilter::New();
-
+    ribbonFilter->SetInputData(data);
     ribbonFilter->SetWidth( width );
     ribbonFilter->ReleaseDataFlagOn();
     ribbonFilter->SetVaryWidth( varyWidth );
@@ -136,38 +143,49 @@ avtPolylineToRibbonFilter::ExecuteData(avtDataRepresentation *inDR)
     if (varyWidth && widthVar != "" && widthVar != "\0")
     {
         if (widthVar != "default")
-            data->GetPointData()->SetActiveScalars(widthVar.c_str());
+        {
+            int fieldAssociation = vtkDataObject::FIELD_ASSOCIATION_POINTS;
+            if (data->GetCellData()->HasArray(widthVar.c_str()))
+            {
+                fieldAssociation = vtkDataObject::FIELD_ASSOCIATION_CELLS;
+            }
+            ribbonFilter->SetInputArrayToProcess(0, 0,0, fieldAssociation,
+                                                 widthVar.c_str());
+        }
+    }
+    ribbonFilter->Update();
+    vtkPolyData *outPD = NULL;
+
+    // Append the original data and ribbon polydata if needed
+    if (data->GetNumberOfLines() < data->GetNumberOfCells())
+    {
+        // seems to work better removing the lines before the append
+        // especially if avtPolylineAddEndPointsFilter has been used
+        // prior to this filter. The cell-data arrays get mixed up
+        // when lines are still in the data.
+        vtkPolyData *noLines = data->NewInstance();
+        noLines->ShallowCopy(data);
+        noLines->SetLines(NULL);
+        noLines->RemoveDeletedCells();
+
+        vtkAppendPolyData *append = vtkAppendPolyData::New();
+        append->AddInputData(noLines);
+        append->AddInputData(ribbonFilter->GetOutput());
+        append->Update();
+
+        outPD = append->GetOutput();
+        outPD->Register(NULL);
+        append->Delete();
+        noLines->Delete();
+    }
+    else
+    {
+        outPD = ribbonFilter->GetOutput();
+        outPD->Register(NULL);
     }
 
-    ribbonFilter->SetInputData(data);
-
-    ribbonFilter->Update();
-
-    // Append the original data and ribbon polydata
-    vtkAppendPolyData *append = vtkAppendPolyData::New();
-
-    append->AddInputData(data);
-    append->AddInputData(ribbonFilter->GetOutput());
-    
     ribbonFilter->Delete();
 
-    append->Update();
-
-    // Get the output.
-    vtkPolyData *outPD = append->GetOutput();
-    outPD->Register(NULL);
-    append->Delete();
-    
-    // Remove the lines.
-    outPD->SetLines(NULL);
-    outPD->RemoveDeletedCells();
-
-    // Restore the active scalars.
-    if (activeScalars)
-    {
-        data->GetPointData()->SetActiveScalars(activeScalars->GetName());
-        outPD->GetPointData()->SetActiveScalars(activeScalars->GetName());
-    }
 
     // Create the output data rep.
     avtDataRepresentation *outDR =

--- a/src/avt/Filters/avtPolylineToTubeFilter.C
+++ b/src/avt/Filters/avtPolylineToTubeFilter.C
@@ -42,12 +42,13 @@
 
 #include <avtPolylineToTubeFilter.h>
 
-#include <vtkTubeFilter.h>
 #include <vtkAppendPolyData.h>
+#include <vtkCellData.h>
 #include <vtkCleanPolyData.h>
-#include <vtkDataSet.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
+#include <vtkTubeFilter.h>
+
 
 // ****************************************************************************
 //  Method: avtPolylineToTubeFilter constructor
@@ -99,8 +100,17 @@ avtPolylineToTubeFilter::~avtPolylineToTubeFilter()
 //
 //  Modifications:
 //    Eric Brugger, Thu Oct 20 14:15:30 PDT 2016
-//    I added code to remove duplicate points from the lines since the 
+//    I added code to remove duplicate points from the lines since the
 //    vtkTubeFilter exits on any lines that have duplicate points.
+//
+//    Kathleen Biagas, Thu Jun 20 11:37:25 PDT 2019
+//    1) Handle cell-centered data.
+//    2) Only use the append filter if input contained more than just lines,
+//       and remove the lines before adding to append.
+//    3) Change how radiusVar is sent to the vtk filter to avoid mucking with
+//       ActiveScalars.
+//    4) Removed CleanFilter as the input has already been cleaned before this
+//       filter is called.
 //
 // ****************************************************************************
 
@@ -124,65 +134,64 @@ avtPolylineToTubeFilter::ExecuteData(avtDataRepresentation *inDR)
         return inDR;
     }
 
-    vtkDataArray *activeScalars = inDS->GetPointData()->GetScalars();
-
     vtkPolyData *data = vtkPolyData::SafeDownCast(inDS);
+    vtkPolyData *output = NULL;
 
-    // Clean duplicate points from the polydata.
-    vtkCleanPolyData *cleanFilter = vtkCleanPolyData::New();
-
-    cleanFilter->SetInputData(data);
-
-    cleanFilter->Update();
 
     // Create the tube polydata.
     vtkTubeFilter *tubeFilter = vtkTubeFilter::New();
-
+    tubeFilter->SetInputData(data);
     tubeFilter->SetRadius(radius);
     tubeFilter->SetNumberOfSides(numberOfSides);
     tubeFilter->SetCapping(1);
     tubeFilter->ReleaseDataFlagOn();
 
-    if (varyRadius && radiusVar != "" && radiusVar != "\0")
+    if (varyRadius)
     {
-        if (radiusVar != "default")
-            data->GetPointData()->SetActiveScalars(radiusVar.c_str());
-        
+        if (!radiusVar.empty() && radiusVar != "default")
+        {
+            int fieldAssociation = vtkDataObject::FIELD_ASSOCIATION_POINTS;
+            if (data->GetCellData()->HasArray(radiusVar.c_str()))
+            {
+                fieldAssociation = vtkDataObject::FIELD_ASSOCIATION_CELLS;
+            }
+            tubeFilter->SetInputArrayToProcess(0, 0,0, fieldAssociation,
+                                               radiusVar.c_str());
+        }
         tubeFilter->SetVaryRadiusToVaryRadiusByScalar();
         tubeFilter->SetRadiusFactor(radiusFactor);
     }
-
-    tubeFilter->SetInputData(cleanFilter->GetOutput());
-
-    cleanFilter->Delete();
-
     tubeFilter->Update();
 
-    // Append the original data and tube polydata
-    vtkAppendPolyData *append = vtkAppendPolyData::New();
+    vtkPolyData *outPD = NULL;
 
-    append->AddInputData(data);
-    append->AddInputData(tubeFilter->GetOutput());
-    
-    tubeFilter->Delete();
-
-    append->Update();
-
-    // Get the output.
-    vtkPolyData *outPD = append->GetOutput();
-    outPD->Register(NULL);
-    append->Delete();
-    
-    // Remove the lines.
-    outPD->SetLines(NULL);
-    outPD->RemoveDeletedCells();
-
-    // Restore the active scalars.
-    if (activeScalars)
+    if (data->GetNumberOfLines() < data->GetNumberOfCells())
     {
-        data->GetPointData()->SetActiveScalars(activeScalars->GetName());
-        outPD->GetPointData()->SetActiveScalars(activeScalars->GetName());
+        // seems to work better removing the lines before the append
+        // especially if avtPolylineAddEndPointsFilter has been used
+        // prior to this filter. The cell-data arrays get mixed up
+        // when lines are still in the data.
+        vtkPolyData *noLines = data->NewInstance();
+        noLines->ShallowCopy(data);
+        noLines->SetLines(NULL);
+        noLines->RemoveDeletedCells();
+
+        vtkAppendPolyData *append = vtkAppendPolyData::New();
+        append->AddInputData(data);
+        append->AddInputData(tubeFilter->GetOutput());
+        append->ReleaseDataFlagOn();
+        append->Update();
+        outPD = append->GetOutput();
+        outPD->Register(NULL);
+        append->Delete();
+        noLines->Delete(); 
     }
+    else
+    {
+        outPD = tubeFilter->GetOutput();
+        outPD->Register(NULL);
+    }
+    tubeFilter->Delete();
 
     // Create the output data rep.
     avtDataRepresentation *outDR =

--- a/src/plots/Pseudocolor/avtPseudocolorPlot.C
+++ b/src/plots/Pseudocolor/avtPseudocolorPlot.C
@@ -500,6 +500,13 @@ avtPseudocolorPlot::ApplyRenderingTransformation(avtDataObject_p input)
       polylineToTubeFilter = NULL;
     }
 
+    // PolylineToRibbon Filter
+    if (polylineToRibbonFilter != NULL)
+    {
+      delete polylineToRibbonFilter;
+      polylineToRibbonFilter = NULL;
+    }
+
     if( atts.GetLineType() == PseudocolorAttributes::Tube )
     {
       double bbox[6] = {0.,1.,0.,1.,0.,1.};
@@ -522,15 +529,7 @@ avtPseudocolorPlot::ApplyRenderingTransformation(avtDataObject_p input)
 
       dob = polylineToTubeFilter->GetOutput();
     }
-
-    // PolylineToRibbon Filter
-    if (polylineToRibbonFilter != NULL)
-    {
-      delete polylineToRibbonFilter;
-      polylineToRibbonFilter = NULL;
-    }
-
-    if( atts.GetLineType() == PseudocolorAttributes::Ribbon )
+    else if( atts.GetLineType() == PseudocolorAttributes::Ribbon )
     {
       double bbox[6] = {0.,1.,0.,1.,0.,1.};
       dob->GetInfo().GetAttributes().GetOriginalSpatialExtents()->CopyTo(bbox);

--- a/src/resources/help/en_US/relnotes3.0.1.html
+++ b/src/resources/help/en_US/relnotes3.0.1.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed inability to change opacity attenuation when ray casting.</li>
   <li>Updated the language translations in the graphical user interface.</li>
   <li>Increased the maximum number of characters allowed in file and dataset names from 1023 to 2047 in the XDMF reader.</li>
+  <li>Pseudocololor plot's line geometry options (tube, ribbon, endpoints) have been fixed to support cell-centered data.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
eg (tube, ribbons, endpoints).
Also changed how 'line' cells are removed after tube or ribbon
filters applied, the append filter seems to do strange things
with cell-data, but removing the lines before appending fixes
the problem.  Resolves #3581.

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

I verified the data in question renders correctly with tubes applied.
Locally ran test suite, no issues.

