### PR TITLE
Rebaseline databaseVsInstall result from removing CCM.

### DIFF
--- a/test/baseline/plugins/databasesVsInstall/databasesVsInstall.txt
+++ b/test/baseline/plugins/databasesVsInstall/databasesVsInstall.txt
@@ -13,7 +13,6 @@
     'Blueprint': 'success',
     'Boxlib2D': 'success',
     'Boxlib3D': 'success',
-    'CCM': 'skipped',
     'CEAucd': 'success',
     'CGNS': 'success',
     'CMAT': 'success',


### PR DESCRIPTION
### Description

Rebaselined the databaseVsInstall test result because the CCM reader was removed.

### Type of change

- [X] New feature

### How Has This Been Tested?

This wasn't tested.

### Checklist:

- [X] I have performed a self-review of my own code