### PR TITLE
Rebaseline databaseVsInstall result from removing CCM. (#3643)

### DIFF
--- a/test/baseline/plugins/databasesVsInstall/databasesVsInstall.txt
+++ b/test/baseline/plugins/databasesVsInstall/databasesVsInstall.txt
@@ -13,7 +13,6 @@
     'Blueprint': 'success',
     'Boxlib2D': 'success',
     'Boxlib3D': 'success',
-    'CCM': 'skipped',
     'CEAucd': 'success',
     'CGNS': 'success',
     'CMAT': 'success',


### PR DESCRIPTION
Merge from the 3.0RC to develop.