### PR TITLE
resolving repeat shared vars

### DIFF
--- a/src/databases/Mili/avtMiliMetaData.C
+++ b/src/databases/Mili/avtMiliMetaData.C
@@ -3057,6 +3057,9 @@ avtMiliMetaData::GetSharedVariableInfo(const char *shortName)
 //
 //  Modifications:
 //
+//      Alister Maguire, Fri Jun 28 15:01:24 PDT 2019
+//      Set isLive to false.
+//
 // ****************************************************************************
 
 void
@@ -3097,6 +3100,7 @@ avtMiliMetaData::AddSharedVariableInfo(string shortName,
         SharedVariableInfo *newShared = new SharedVariableInfo();
         newShared->shortName = shortName;
         newShared->isAllES   = false;
+        newShared->isLive    = false;
         newShared->variableIndicies.push_back(varIdx);
         sharedVariables.push_back(newShared);
     }

--- a/src/databases/Mili/avtMiliMetaData.h
+++ b/src/databases/Mili/avtMiliMetaData.h
@@ -78,6 +78,7 @@ typedef struct SharedVariableInfo
     string       shortName;
     intVector    variableIndicies;
     bool         isAllES;
+    bool         isLive;
 } SharedVariableInfo;
 
 


### PR DESCRIPTION
### Description
This fixes the issue with cause and sand appearing multiple times in the visit menu when opening mili datasets. 
Resolves #3650 

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?
I re-ran the test suite to make sure that none of my changes caused issues. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
