### PR TITLE
Correct a typo spelling Fortran in bv_adios2.sh.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -208,7 +208,7 @@ function build_adios2
         cfg_opts="${cfg_opts} -DADIOS2_BUILD_EXAMPLES:BOOL=OFF"
         cfg_opts="${cfg_opts} -DADIOS2_BUILD_TESTING:BOOL=OFF"
         cfg_opts="${cfg_opts} -DADIOS2_USE_ZeroMQ:BOOL=OFF"
-        cfg_opts="${cfg_opts} -DADIOS2_USE_Fortan:BOOL=OFF"
+        cfg_opts="${cfg_opts} -DADIOS2_USE_Fortran:BOOL=OFF"
 
         if test "x${DO_STATIC_BUILD}" = "xyes" ; then
             cfg_opts="${cfg_opts} -DBUILD_SHARED_LIBS:BOOL=OFF"


### PR DESCRIPTION
### Description

Fix a typo in bv_adios2.sh where I misspelled Fortran, causing Fortran support not getting disabled from the ADIOS2 build.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran build_visit from scratch on kickit and it built the third party libraries fine including ADIOS2 and Fortran support was indeed turned off.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code