### PR TITLE
Correct a typo spelling Fortran in bv_adios2.sh. (#3663)

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -208,7 +208,7 @@ function build_adios2
         cfg_opts="${cfg_opts} -DADIOS2_BUILD_EXAMPLES:BOOL=OFF"
         cfg_opts="${cfg_opts} -DADIOS2_BUILD_TESTING:BOOL=OFF"
         cfg_opts="${cfg_opts} -DADIOS2_USE_ZeroMQ:BOOL=OFF"
-        cfg_opts="${cfg_opts} -DADIOS2_USE_Fortan:BOOL=OFF"
+        cfg_opts="${cfg_opts} -DADIOS2_USE_Fortran:BOOL=OFF"
 
         if test "x${DO_STATIC_BUILD}" = "xyes" ; then
             cfg_opts="${cfg_opts} -DBUILD_SHARED_LIBS:BOOL=OFF"


### PR DESCRIPTION
Merge from the 3.0RC to develop.