### PR TITLE
Correct a compile error with ADIOS2 reader on Sierra type systems.

### DIFF
--- a/src/databases/ADIOS2/avtADIOS2BaseFileFormat.C
+++ b/src/databases/ADIOS2/avtADIOS2BaseFileFormat.C
@@ -130,7 +130,7 @@ avtADIOS2BaseFileFormat::CreateInterface(const char *const *list,
 
 
 avtADIOS2BaseFileFormat::avtADIOS2BaseFileFormat(const char *filename)
-    : adios(std::make_shared<adios2::ADIOS>(adios2::DebugON)),
+    : adios(std::make_shared<adios2::ADIOS>()),
       numTimeSteps(1),
       isClosed(false),
       supportMultiDom(false),

--- a/src/databases/ADIOS2/avtADIOS2SSTFileFormat.C
+++ b/src/databases/ADIOS2/avtADIOS2SSTFileFormat.C
@@ -120,7 +120,7 @@ avtADIOS2SSTFileFormat::CreateInterface(const char *const *list,
 // ****************************************************************************
 
 avtADIOS2SSTFileFormat::avtADIOS2SSTFileFormat(const char *filename)
-    : adios(std::make_shared<adios2::ADIOS>(adios2::DebugON)),
+    : adios(std::make_shared<adios2::ADIOS>()),
       io(adios->DeclareIO("sstIO")),
       numTimeSteps(1),
       avtMTSDFileFormat(&filename, 1)

--- a/src/databases/ADIOS2/avtLAMMPSFileFormat.C
+++ b/src/databases/ADIOS2/avtLAMMPSFileFormat.C
@@ -121,7 +121,7 @@ avtLAMMPSFileFormat::CreateInterface(const char *const *list,
 // ****************************************************************************
 
 avtLAMMPSFileFormat::avtLAMMPSFileFormat(const char *filename)
-    : adios(std::make_shared<adios2::ADIOS>(adios2::DebugON)),
+    : adios(std::make_shared<adios2::ADIOS>()),
       numTimeSteps(1),
       currentTimestep(-1),
       numAtoms(-1),

--- a/src/databases/ADIOS2/avtMEUMMAPSFileFormat.C
+++ b/src/databases/ADIOS2/avtMEUMMAPSFileFormat.C
@@ -122,7 +122,7 @@ avtMEUMMAPSFileFormat::CreateInterface(const char *const *list,
 // ****************************************************************************
 
 avtMEUMMAPSFileFormat::avtMEUMMAPSFileFormat(const char *filename)
-    :  adios(std::make_shared<adios2::ADIOS>(adios2::DebugON)),
+    :  adios(std::make_shared<adios2::ADIOS>()),
        io(adios->DeclareIO("ReadBP")),
        numTimeSteps(1),
        avtMTMDFileFormat(filename)


### PR DESCRIPTION
### Description

This fixes some compile errors with the ADIOS2 reader on Sierra type systems.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I made the change and it fixed compiling the ADIOS2 reader on rzansel. I'll test on other operating systems when I build visit 3.0.1 on several different systems.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have assigned reviewers