### PR TITLE
Update several config site files for 3.0.1.

### DIFF
--- a/src/config-site/jade188.cmake
+++ b/src/config-site/jade188.cmake
@@ -1,14 +1,14 @@
-#/usr/workspace/visit/visit/thirdparty_shared/3.0.0/toss3/cmake/3.9.3/linux-x86_64_gcc-4.9/bin/cmake
+#/usr/workspace/visit/visit/thirdparty_shared/3.0.1/toss3/cmake/3.9.3/linux-x86_64_gcc-4.9/bin/cmake
 ##
-## ./build_visit3_0_0 generated host.cmake
-## created: Tue Apr 30 10:26:33 PDT 2019
-## system: Linux jade770 3.10.0-957.5.1.3chaos.ch6.x86_64 #1 SMP Tue Feb 26 14:19:40 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+## ./build_visit3_0_1 generated host.cmake
+## created: Wed Jul 11 15:47:02 PDT 2019
+## system: Linux jade764 3.10.0-957.12.2.1chaos.ch6.x86_64 #1 SMP Tue May 14 18:38:00 PDT 2019 x86_64 x86_64 x86_64 GNU/Linux
 ## by: brugger
 
 ##
 ## Setup VISITHOME & VISITARCH variables.
 ##
-SET(VISITHOME /usr/workspace/visit/visit/thirdparty_shared/3.0.0/toss3)
+SET(VISITHOME /usr/workspace/visit/visit/thirdparty_shared/3.0.1/toss3)
 SET(VISITARCH linux-x86_64_gcc-4.9)
 VISIT_OPTION_DEFAULT(VISIT_SLIVR TRUE TYPE BOOL)
 

--- a/src/config-site/sierra4358.cmake
+++ b/src/config-site/sierra4358.cmake
@@ -1,14 +1,14 @@
-#/usr/workspace/visit/visit/thirdparty_shared/3.0.0/blueos/cmake/3.9.3/linux-ppc64le_gcc-4.9/bin/cmake
+#/usr/workspace/visit/visit/thirdparty_shared/3.0.1/blueos/cmake/3.9.3/linux-ppc64le_gcc-4.9/bin/cmake
 ##
-## ./build_visit3_0_0 generated host.cmake
-## created: Tue Apr 30 12:22:55 PDT 2019
-## system: Linux sierra4359 4.14.0-49.18.1.bl6.ppc64le #1 SMP Tue Dec 11 16:29:11 PST 2018 ppc64le ppc64le ppc64le GNU/Linux
+## ./build_visit3_0_1 generated host.cmake
+## created: Fri Jul 12 09:50:03 PDT 2019
+## system: Linux sierra4361 4.14.0-49.18.1.bl6.ppc64le #1 SMP Tue Dec 11 16:29:11 PST 2018 ppc64le ppc64le ppc64le GNU/Linux
 ## by: brugger
 
 ##
 ## Setup VISITHOME & VISITARCH variables.
 ##
-SET(VISITHOME /usr/workspace/visit/visit/thirdparty_shared/3.0.0/blueos)
+SET(VISITHOME /usr/workspace/visit/visit/thirdparty_shared/3.0.1/blueos)
 SET(VISITARCH linux-ppc64le_gcc-4.9)
 VISIT_OPTION_DEFAULT(VISIT_SLIVR TRUE TYPE BOOL)
 

--- a/src/config-site/winnipeg.llnl.gov.cmake
+++ b/src/config-site/winnipeg.llnl.gov.cmake
@@ -1,14 +1,14 @@
-#/usr/gapps/visit/thirdparty_shared/3.0.0/cmake/3.9.3/linux-x86_64_gcc-4.8/bin/cmake
+#/usr/gapps/visit/thirdparty_shared/3.0.1/cmake/3.9.3/linux-x86_64_gcc-4.8/bin/cmake
 ##
-## ./build_visit3_0_0 generated host.cmake
-## created: Wed May  1 11:39:29 PDT 2019
-## system: Linux winnipeg.llnl.gov 5.0.3-1.el7.elrepo.x86_64 #1 SMP Tue Mar 19 09:51:25 EDT 2019 x86_64 x86_64 x86_64 GNU/Linux
+## ./build_visit3_0_1 generated host.cmake
+## created: Thu Jul 11 16:05:27 PDT 2019
+## system: Linux winnipeg.llnl.gov 5.0.8-1.el7.elrepo.x86_64 #1 SMP Wed Apr 17 10:11:44 EDT 2019 x86_64 x86_64 x86_64 GNU/Linux
 ## by: brugger1
 
 ##
 ## Setup VISITHOME & VISITARCH variables.
 ##
-SET(VISITHOME /usr/gapps/visit/thirdparty_shared/3.0.0)
+SET(VISITHOME /usr/gapps/visit/thirdparty_shared/3.0.1)
 SET(VISITARCH linux-x86_64_gcc-4.8)
 VISIT_OPTION_DEFAULT(VISIT_SLIVR TRUE TYPE BOOL)
 
@@ -25,7 +25,7 @@ VISIT_OPTION_DEFAULT(VISIT_CXX_FLAGS " -m64 -fPIC -fvisibility=hidden" TYPE STRI
 ##
 VISIT_OPTION_DEFAULT(VISIT_PARALLEL ON TYPE BOOL)
 ## (configured w/ mpi compiler wrapper)
-VISIT_OPTION_DEFAULT(VISIT_MPI_COMPILER /usr/gapps/visit/thirdparty_shared/3.0.0/mpich/3.0.4/linux-x86_64_gcc-4.8/bin/mpicc TYPE FILEPATH)
+VISIT_OPTION_DEFAULT(VISIT_MPI_COMPILER /usr/gapps/visit/thirdparty_shared/3.0.1/mpich/3.0.4/linux-x86_64_gcc-4.8/bin/mpicc TYPE FILEPATH)
 
 ##
 ## VisIt Thread Option

--- a/src/tools/dev/scripts/visit-create-chksums
+++ b/src/tools/dev/scripts/visit-create-chksums
@@ -110,15 +110,15 @@ do
    echo "The VisIt executable $property"                  >> $output
    echo ""                                                >> $output
    $cmd INSTALL_NOTES                                     >> $output
-   $cmd VisIt-$version.dmg                                >> $output
+#  $cmd VisIt-$version.dmg                                >> $output
    $cmd VisIt-$version-10.13.dmg                          >> $output
    $cmd jvisit$version.tar.gz                             >> $output
    $cmd visit-install$version2                            >> $output
    $cmd visit${version}_x64.exe                           >> $output
-   $cmd visit$version2.darwin-x86_64.tar.gz               >> $output
+#  $cmd visit$version2.darwin-x86_64.tar.gz               >> $output
    $cmd visit${version2}-10.13.darwin-x86_64.tar.gz       >> $output
-   $cmd visit$version2.linux-x86_64-ubuntu18.tar.gz       >> $output
-   $cmd visit$version2.linux-x86_64-ubuntu18-wmesa.tar.gz >> $output
+#  $cmd visit$version2.linux-x86_64-ubuntu18.tar.gz       >> $output
+#  $cmd visit$version2.linux-x86_64-ubuntu18-wmesa.tar.gz >> $output
    $cmd visit$version2.linux-x86_64-rhel7.tar.gz          >> $output
    $cmd visit$version2.linux-x86_64-rhel7-wmesa.tar.gz    >> $output
 
@@ -128,14 +128,12 @@ do
    $cmd build_visit$version2                              >> $output
    $cmd $dist.tar.gz                                      >> $output
    $cmd visitdev$version.exe                              >> $output
-   cd third_party
-   files=`ls`
+   files=`ls third_party`
    for file in $files
    do
-      $cmd $file >> ../$output
+      $cmd third_party/$file | sed "s/third_party\///" >> $output
       shift
    done
-   cd ..
 
    shift
 done


### PR DESCRIPTION
### Description

Rebuilt the third party libraries for 3.0.1 on winnipeg, jade and sierra and updated the config site files.

Corrected a few bugs in the visit-create-chksums script.

### Type of change

- [X] Bug fix
- [X] New feature

### How Has This Been Tested?

I will test the new config site files when I build and install VisIt 3.0.1 on the affected systems. I tested the corrected visit-create-chksums generating the checksums for 3.0.1.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code