### PR TITLE
Change path to CMake in regressiontest_pascal to one for 3.0.1.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -196,7 +196,7 @@ done
 
 if test "$branch" = "trunk" ; then
     workingDir="test_trunk"
-    cmakeCmd="/usr/workspace/wsa/visit/visit/thirdparty_shared/3.0.0b/toss3/cmake/3.9.3/linux-x86_64_gcc-4.9/bin/cmake"
+    cmakeCmd="/usr/workspace/wsa/visit/visit/thirdparty_shared/3.0.1/toss3/cmake/3.9.3/linux-x86_64_gcc-4.9/bin/cmake"
 else
     workingDir="test_branch"
     cmakeCmd="/usr/gapps/visit/thirdparty_shared/2.12.0/cmake/3.0.2/linux-x86_64_gcc-4.4/bin/cmake"


### PR DESCRIPTION
### Description

Change the path to CMake in regressiontest_pascal to point to the one built for 3.0.1. I deleted the one it previously pointed to.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I checked that the new path points to a file by cutting and pasting the path into an "ls" command.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code