### PR TITLE
Fix duplicate explicit links

### DIFF
--- a/src/doc/tutorials/Aneurysm.rst
+++ b/src/doc/tutorials/Aneurysm.rst
@@ -419,10 +419,10 @@ Sharing automation script
 In this section we will render and save pathline trace in 20 steps. Then
 upload and share the rendered 20 images as a sequence and instuct SeedMe to
 encode a video from these set of images at 2 frames per second. A sample
-video can be seen `here <https://www.seedme.org/node/49054#videos>`_.
+video can be seen `here <https://www.seedme.org/node/49054#videos>`__.
 
 A detailed example with a brief explanation in the comments can be seen
-`here <https://bitbucket.org/seedme/seedme-python-client/src/master/demo.py?at=master&fileviewer=file-view-default>`_.
+`here <https://bitbucket.org/seedme/seedme-python-client/src/master/demo.py?at=master&fileviewer=file-view-default>`__.
 
 1. Go to *Controls->Command*.
 2. Find an empty tab.


### PR DESCRIPTION
### Description

This file had multiple cases of this kind of reST syntax...

```
video can be seen `here <https://www.seedme.org/node/49054#videos>`_.
A detailed example with a brief explanation in the comments can be seen
`here <https://bitbucket.org/seedme/seedme-python-client/src/master/demo.py?at=master&fileviewer=file-view-default>`_.
```
Because the link text, `here`, is same in both cases, Sphinx complains...
```
Running Sphinx v1.5.3
loading pickled environment... done
building [mo]: all of 0 po files
building [html]: all source files
updating environment: 1 added, 7 changed, 0 removed
reading sources... [100%] tutorials/index                                                                                           
/Users/miller86/visit/visit/src/doc/tutorials/Aneurysm.rst:4: WARNING: Duplicate explicit target name: "here".
looking for now-outdated files... none found
.
.
.
```
The solution is to switch to [*anonymous* links](https://github.com/sphinx-doc/sphinx/issues/3921) by adding underscores.

This update does that.