### PR TITLE
Update the launcher baselines because of a change in the MPI version.

### DIFF
--- a/test/baseline/unit/launcher/msub_aprun.txt
+++ b/test/baseline/unit/launcher/msub_aprun.txt
@@ -4,7 +4,7 @@ CASE: msub/aprun
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/aprun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/aprun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/aprun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_ibrun.txt
+++ b/test/baseline/unit/launcher/msub_ibrun.txt
@@ -4,7 +4,7 @@ CASE: msub/ibrun
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/ibrun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/ibrun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/ibrun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_mpiexec.txt
+++ b/test/baseline/unit/launcher/msub_mpiexec.txt
@@ -4,7 +4,7 @@ CASE: msub/mpiexec
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -23,7 +23,7 @@ CASE: msub/mpiexec -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -42,7 +42,7 @@ CASE: msub/mpiexec -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -61,7 +61,7 @@ CASE: msub/mpiexec -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_mpirun.txt
+++ b/test/baseline/unit/launcher/msub_mpirun.txt
@@ -4,7 +4,7 @@ CASE: msub/mpirun
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/mpirun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/mpirun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/mpirun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_srun.txt
+++ b/test/baseline/unit/launcher/msub_srun.txt
@@ -4,7 +4,7 @@ CASE: msub/srun
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/srun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/srun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/srun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/sbatch.txt
+++ b/test/baseline/unit/launcher/sbatch.txt
@@ -4,7 +4,7 @@ CASE: sbatch
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -19,7 +19,7 @@ CASE: sbatch -totalview engine_par
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -34,7 +34,7 @@ CASE: sbatch -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -49,7 +49,7 @@ CASE: sbatch -strace engine_par
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/sbatch_aprun.txt
+++ b/test/baseline/unit/launcher/sbatch_aprun.txt
@@ -4,7 +4,7 @@ CASE: sbatch/aprun
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -19,7 +19,7 @@ CASE: sbatch/aprun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -34,7 +34,7 @@ CASE: sbatch/aprun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -49,7 +49,7 @@ CASE: sbatch/aprun -strace engine_par
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/lib:/usr/tce/packages/intel/intel-18.0.1/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/osmesa:$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/cuda/cuda-8.0/lib64:/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4/lib:/usr/tce/packages/intel/intel-19.0.4/lib/intel64,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh


### PR DESCRIPTION
### Description

Updates several launcher unit test baseline results because the version of MPI changed on quartz.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

Haven't tested it. We'll know if the tests pass when the test suite runs tonight.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code