### PR TITLE
Remove shortname (8dot3name) reliance.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -24,7 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.0.2</font></b></p>
 <ul>
-  <li></li>
+  <li>Fixed launch failure on Windows when 8dot3name (shortnames) is disabled on the system.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Fixes launch failure on windows system when 8dot3name is disabled.
Resolves #3684.

### Type of change
- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I created an installer, installed to a clean windows 10 machine with 8dot3name disabled.
I tried launching from the default icon, from 'visit parallel' shortcut, 'visit cli' shortcut, 'visit with debug logging shortcut'. All work.
I also tried launching cli from within the gui and that worked as well.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [X] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
