### PR TITLE
Resolves #3751. Updated masonry to build adios2 for OSX distribution.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -39,7 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.0.2</font></b></p>
 <ul>
-  <li></li>
+  <li>Updated masonry to build adios2 for OSX.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/masonry/opts/mb-3.0.2-darwin-10.13-x86_64-release.json
+++ b/src/tools/dev/masonry/opts/mb-3.0.2-darwin-10.13-x86_64-release.json
@@ -26,6 +26,7 @@
                        "mxml",
                        "mpich",
                        "adios",
+                       "adios2",
                        "advio",
                        "boxlib",
                        "cfitsio",


### PR DESCRIPTION
Resolves #3751. Updated masonry to build adios2 for OSX distribution.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [x] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Build 3.0RC with masonry and verified that adios2 was downloaded and built.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
