### PR TITLE
Work to resolve #3074 plugin_vs_install for OSX.

### DIFF
--- a/src/CMake/FilterDependencies.cmake.in
+++ b/src/CMake/FilterDependencies.cmake.in
@@ -163,10 +163,24 @@ function(FILTER_VISIT_LIB_DEPENDENCIES filename)
                        rem_quote ${replace_quote})
                 string(REPLACE "@@@@@" "\"" newtoken ${rem_quote})
             elseif(token MATCHES "Qt5::")
-                # replace Qt5::libname with Qt5libname
-                string(REGEX REPLACE "Qt5::([a-zA-Z]+)"
-                       "Qt5\\1"
-                       newtoken ${token})
+                if(APPLE)
+                    if(token MATCHES "Qt5::Concurrent|Qt5::Core|Qt5::Gui|Qt5::Network|Qt5::OpenGL|Qt5::PrintSupport|Qt5::Qml|Qt5::Svg|Qt5::Widgets|Qt5::Xml")
+                        # replace Qt5::libname with Qtlibname.framework
+                        string(REGEX REPLACE "Qt5::([a-zA-Z]+)"
+                                             "\${VISIT_LIBRARY_DIR}/Qt\\1.framework"
+                                             newtoken ${token})
+                    else()
+                        # replace Qt5::libname with Qt5libname
+                        string(REGEX REPLACE "Qt5::([a-zA-Z]+)"
+                                             "Qt5\\1"
+                                             newtoken ${token})
+                    endif()
+                else()
+                    # replace Qt5::libname with Qt5libname
+                    string(REGEX REPLACE "Qt5::([a-zA-Z]+)"
+                                         "Qt5\\1"
+                                         newtoken ${token})
+                endif()
             elseif(${token} IN_LIST VTK_TARGETS)
                 # append VTK version to vtk lib names
                 if(token MATCHES "WrappingPythonCore")
@@ -224,6 +238,11 @@ function(FILTER_VISIT_LIB_DEPENDENCIES filename)
             endif()
             list(APPEND filteredline ${newtoken})
         endforeach()
+        # Sometimes the last tokens get filtered so the corresponding ';")' is missing
+        # causing syntax errors. Need to check if filteredline ends with '")' if not add it
+        if(NOT "${filteredline}" MATCHES "\\)")
+            list(APPEND filteredline "\")")
+        endif()
         file(APPEND ${filename} "${filteredline}\n")
         unset(filteredline)
     endforeach()

--- a/src/CMake/PluginVsInstall.cmake.in
+++ b/src/CMake/PluginVsInstall.cmake.in
@@ -110,6 +110,9 @@
 #   Eric Brugger, Wed Jun 26 10:01:32 PDT 2019
 #   Removed the CCM reader.
 #
+#   Kevin Griffin, Thu Aug 8 18:30:27 PDT 2019
+#   Added the correct paths for the QT_QT*_INCLUDE_DIR variables for OSX.
+#
 #****************************************************************************/
 
 ##
@@ -213,12 +216,21 @@ set(TESSELLATION_LIBRARY @TESSELLATION_LIBRARY@)
 set(BOOST_INCLUDE_DIR ${VISIT_INCLUDE_DIR}/boost/include/boost)
 
 # Set up Qt
-set(QT_INCLUDE_DIR           ${VISIT_INCLUDE_DIR}/qt/include)
-set(QT_QTCORE_INCLUDE_DIR    ${VISIT_INCLUDE_DIR}/qt/include/QtCore)
-set(QT_QTGUI_INCLUDE_DIR     ${VISIT_INCLUDE_DIR}/qt/include/QtGui)
-set(QT_QTOPENGL_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/qt/include/QtOpenGL)
-set(QT_QTWIDGETS_INCLUDE_DIR ${VISIT_INCLUDE_DIR}/qt/include/QtWidgets)
-set(QT_QTXML_INCLUDE_DIR     ${VISIT_INCLUDE_DIR}/qt/include/QtXml)
+if(APPLE)
+    set(QT_INCLUDE_DIR           ${VISIT_INCLUDE_DIR}/qt/include)
+    set(QT_QTCORE_INCLUDE_DIR    ${VISIT_LIBRARY_DIR}/QtCore.framework/Versions/Current/Headers)
+    set(QT_QTGUI_INCLUDE_DIR     ${VISIT_LIBRARY_DIR}/QtGui.framework/Versions/Current/Headers)
+    set(QT_QTOPENGL_INCLUDE_DIR  ${VISIT_LIBRARY_DIR}/QtOpenGL.framework/Versions/Current/Headers)
+    set(QT_QTWIDGETS_INCLUDE_DIR ${VISIT_LIBRARY_DIR}/QtWidgets.framework/Versions/Current/Headers)
+    set(QT_QTXML_INCLUDE_DIR     ${VISIT_LIBRARY_DIR}/QtXml.framework/Versions/Current/Headers)
+else()
+    set(QT_INCLUDE_DIR           ${VISIT_INCLUDE_DIR}/qt/include)
+    set(QT_QTCORE_INCLUDE_DIR    ${VISIT_INCLUDE_DIR}/qt/include/QtCore)
+    set(QT_QTGUI_INCLUDE_DIR     ${VISIT_INCLUDE_DIR}/qt/include/QtGui)
+    set(QT_QTOPENGL_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/qt/include/QtOpenGL)
+    set(QT_QTWIDGETS_INCLUDE_DIR ${VISIT_INCLUDE_DIR}/qt/include/QtWidgets)
+    set(QT_QTXML_INCLUDE_DIR     ${VISIT_INCLUDE_DIR}/qt/include/QtXml)
+endif()
 
 set(QT_LIBRARY_DIR           ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
 set(QT_BIN                   ${VISIT_BINARY_DIR})


### PR DESCRIPTION
Currently plugin_vs_install doesn't work for OSX. This work fixes some of the major issues. Still need to do full testing once @biagas commits her changes that are on devlop to the 3.0RC branch. In the meantime I will be working on other tickets and didn't want this work to get stale. 

### Type of change
* Fixed the syntax errors when generating the VisItLibraryDependencies.cmake file
* Added the correct paths for the qt frameworks
* Added the correct QT include directory 

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I've done initial tests building plots on the develop branch. Waiting for @biagas  to add the changes she made on develop to the 3.0RC so I can finish testing. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).