### PR TITLE
remove update visit gui logic, since it has atrophied

### DIFF
--- a/src/gui/QvisGUIApplication.h
+++ b/src/gui/QvisGUIApplication.h
@@ -356,6 +356,9 @@ class SplashScreen;
 //    Made MoveAndResizeMainWindow a slot function without arguments so it
 //    can be called from QTimer::singleShot. Added orientation ivar.
 //
+//    Cyrus Harrison, Tue Aug 13 15:46:52 PDT 2019
+//    Removed updateVisIt related logic.
+//
 // ****************************************************************************
 
 class GUI_API QvisGUIApplication : public QObject, public ConfigManager, public GUIBase
@@ -535,8 +538,6 @@ protected slots:
     void setupHostProfilesAndConfig();
     void showSeedMeWindow();
 
-    void updateVisIt();
-    void updateVisItCompleted(const QString &);
 private:
     void DestructorHelper(bool fastExit = false);
     void GetCrashFilePIDs(const QFileInfoList &, intVector &);

--- a/src/gui/QvisMainWindow.C
+++ b/src/gui/QvisMainWindow.C
@@ -992,6 +992,8 @@ QvisMainWindow::SetDefaultSplitterSizes(int h)
 // Creation:   Wed Dec 31 11:28:51 EST 2008
 //
 // Modifications:
+//   Cyrus Harrison, Tue Aug 13 15:40:11 PDT 2019
+//   Remove update visit entry.
 //
 // ****************************************************************************
 
@@ -1015,9 +1017,6 @@ QvisMainWindow::AddHelpMenu(void)
                          this, SIGNAL(activateReleaseNotesWindow()));
 
     helpPopup->addSeparator();
-
-    updateVisItAct = helpPopup->addAction(tr("Check for new version . . ."),
-                                          this, SIGNAL(updateVisIt()));
 }
 
 // ****************************************************************************
@@ -2519,27 +2518,6 @@ QvisMainWindow::unreadOutput(bool val)
         outputButton->setIcon(*outputRed);
     else
         outputButton->setIcon(*outputBlue);
-}
-
-// ****************************************************************************
-// Method: QvisMainWindow::updateNotAllowed
-//
-// Purpose: 
-//   This is a Qt slot function that disables the "update visit" help option.
-//
-// Programmer: Brad Whitlock
-// Creation:   Tue Feb 15 14:16:28 PST 2005
-//
-// Modifications:
-//    Cyrus Harrison, Mon Jun 30 14:14:59 PDT 2008
-//    Initial Qt4 Port.
-//
-// ****************************************************************************
-
-void
-QvisMainWindow::updateNotAllowed()
-{
-    updateVisItAct->setEnabled(false);
 }
 
 // ****************************************************************************

--- a/src/gui/QvisMainWindow.h
+++ b/src/gui/QvisMainWindow.h
@@ -240,6 +240,9 @@ class WindowInformation;
 //   Jonathan Byrd (Allinea Software), Sun 18 Dec, 2011
 //   Added an Action and a Qt slot to attempt a connection to DDT
 //
+//   Cyrus Harrison, Tue Aug 13 15:46:52 PDT 2019
+//   Removed updateVisIt related logic.
+//
 // ****************************************************************************
 
 class GUI_API QvisMainWindow : public QvisWindowBase, public SimpleObserver
@@ -315,7 +318,6 @@ signals:
     void activateInteractorWindow();
     void activateMeshManagementWindow();
     void activateSelectionsWindow();
-    void updateVisIt();
     void activateSetupHostProfilesAndConfig();
     void activateSeedMeWindow();
 
@@ -339,7 +341,6 @@ public slots:
     virtual void show();
 
     void unreadOutput(bool);
-    void updateNotAllowed();
     void SetTimeStateFormat(const TimeFormat &fmt);
     void SetShowSelectedFiles(bool);
     void SetAllowFileSelectionChange(bool);
@@ -450,7 +451,6 @@ private:
     QAction                  *spinModeAct;
     QAction                  *fullFrameModeAct;
     QMenu                    *helpPopup;
-    QAction                  *updateVisItAct;
 
     QTimer                    *recoveryFileTimer;
     bool                       okayToSaveRecoveryFile;


### PR DESCRIPTION
Resolves #3767 

Removes UI logic for trying to update visit in place with a new version.

It has atrophied and we don't plan to support, given new complexity with macOS deployment
