### PR TITLE
Resolves Bug #3074. Fixed the plugin build against install for OSX.

### DIFF
--- a/src/CMake/FilterDependencies.cmake.in
+++ b/src/CMake/FilterDependencies.cmake.in
@@ -47,6 +47,10 @@
 #    non-windows. Remove slivr libraries from the suppression list as they
 #    are no longer part of VisIt.
 #
+#    Kevin Griffin, Thu Aug 8 18:20:01 PDT 2019
+#    Fixed the Qt and qwt frameworks path for OSX and the syntax error produced from
+#    filtering the right parenthesis in certain cases.
+#
 #****************************************************************************/
 cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0057 NEW)
@@ -116,9 +120,16 @@ function(FILTER_VISIT_LIB_DEPENDENCIES filename)
                                line "${line}")
             endif()
             if(VISIT_QWT_DIR AND "${line}" MATCHES "qwt")
-                string(REPLACE "${VISIT_QWT_DIR}/lib/"
-                               ""
-                               line "${line}")
+                if(APPLE)
+                    string(REPLACE "${VISIT_QWT_DIR}/lib/"
+                                   "\${VISIT_LIBRARY_DIR}/"
+                                   line "${line}")
+                    
+                else()
+                    string(REPLACE "${VISIT_QWT_DIR}/lib/"
+                                   ""
+                                   line "${line}")
+                endif()
             endif()
         endif()
         if(VISIT_OPENEXR_DIR)

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -40,6 +40,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.0.2</font></b></p>
 <ul>
   <li>Updated masonry to build adios2 for OSX.</li>
+  <li>Fixed building plugins against a VisIt install for OSX.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
Resolves #3074. Fixed the plugin build against install for OSX.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Tested building a database (Miranda), plot (Pseudocolor), and an operator (RadialResample) against an installed version of VisIt.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
