### PR TITLE
Add openssl to list of required libraries in build_visit. (#3788)

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Host profiles were added for the Oak Ridge National Laboratory's Summit system.</li>
   <li>Tables in the GUI doc that ran off the edge of the page have been converted to definition lists.</li>
   <li>Modified the batch launching at NERSC to work on Cori after the major operating system upgrade."</li>
+  <li>Openssl was added to the list of reuquired libriaries in build_visit.</li> 
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -3,6 +3,7 @@
         <!-- required libraries -->
         <required>
             <lib name="cmake"/> <!-- cmake is here -->
+            <lib name="openssl"/>
             <lib name="python"/>
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
             <lib name="qt"/>
@@ -41,7 +42,6 @@
             <lib name="nektarpp"/>
             <lib name="netcdf"/>
             <lib name="openexr"/>
-            <lib name="openssl"/>
             <lib name="osmesa"/>
             <lib name="ospray"/>
             <lib name="p7zip"/>
@@ -60,6 +60,7 @@
         <!-- thirdparty flag -->
         <group name="required" comment="All required libraries" enabled="yes">
             <lib name="cmake"/> <!-- cmake is here -->
+            <lib name="openssl"/>
             <lib name="python"/>
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
             <lib name="qt"/>
@@ -91,7 +92,6 @@
             <lib name="mxml"/>
             <lib name="netcdf"/>
             <lib name="openexr"/>
-            <lib name="openssl"/>
             <lib name="ospray"/>
             <lib name="p7zip"/>
             <lib name="pidx"/>


### PR DESCRIPTION
Merge from the 3.0RC to develop.

Resolves #3730 