### PR TITLE
Resolves #3807. Copied the Qt platforms and styles directories

### DIFF
--- a/src/CMake/FindVisItQt.cmake
+++ b/src/CMake/FindVisItQt.cmake
@@ -258,12 +258,24 @@ if(NOT VISIT_QT_SKIP_INSTALL)
 
       install(DIRECTORY ${VISIT_QT_DIR}/plugins/platforms
               DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/viewer.app/Contents/MacOS)
+      
+      install(DIRECTORY ${VISIT_QT_DIR}/plugins/platforms
+              DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/xmledit.app/Contents/MacOS)
+
+      install(DIRECTORY ${VISIT_QT_DIR}/plugins/platforms
+              DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/mcurvit.app/Contents/MacOS)
 
       install(DIRECTORY ${VISIT_QT_DIR}/plugins/styles
               DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/gui.app/Contents/MacOS)
 
       install(DIRECTORY ${VISIT_QT_DIR}/plugins/styles
               DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/viewer.app/Contents/MacOS)
+
+      install(DIRECTORY ${VISIT_QT_DIR}/plugins/styles
+              DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/xmledit.app/Contents/MacOS)
+
+      install(DIRECTORY ${VISIT_QT_DIR}/plugins/styles
+              DESTINATION ${VISIT_INSTALLED_VERSION_BIN}/mcurvit.app/Contents/MacOS)
   else()
       install(DIRECTORY ${VISIT_QT_DIR}/plugins/platforms
               DESTINATION ${VISIT_INSTALLED_VERSION_LIB}/qtplugins)

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -44,6 +44,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Updated masonry to build adios2 for OSX.</li>
   <li>Fixed building plugins against a VisIt install for OSX.</li>
+  <li>Fixed xmledit failure due to missing QT cocoa plugin.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
Resolves #3807. Copied the Qt platforms and styles directories xmledit.app and mcurvit.app.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Copied directories and verified that xmledit worked correctly.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
