### PR TITLE
Remove pyside as an option from build_visit

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -46,6 +46,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated masonry to build adios2 for OSX.</li>
   <li>Fixed building plugins against a VisIt install for OSX.</li>
   <li>Fixed xmledit failure due to missing QT cocoa plugin.</li>
+  <li>PySide was removed from build_visit until we get a newer version working with VisIt.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -45,7 +45,6 @@
             <lib name="ospray"/>
             <lib name="p7zip"/>
             <lib name="pidx"/>
-            <lib name="pyside"/>
             <lib name="silo"/>
             <lib name="szip"/>
             <lib name="tbb"/>
@@ -106,7 +105,6 @@
         <group name="no-thirdparty" comment="Do not build required 3rd party libraries" enabled="no">
             <lib name="no-cmake"/>
             <lib name="no-python"/>
-            <lib name="no-pyside"/>
             <lib name="no-qt" />
             <lib name="no-qwt" />
             <lib name="no-vtk"/>


### PR DESCRIPTION
Remove pyside as an option from build_visit until we can get a newer version working with Visit.

Resolves #3815
