### PR TITLE
Resolves #3794. Added the --with-libxml2 option when configuring uintah.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -46,6 +46,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated masonry to build adios2 for OSX.</li>
   <li>Fixed building plugins against a VisIt install for OSX.</li>
   <li>Fixed xmledit failure due to missing QT cocoa plugin.</li>
+  <li>Fixed the libxml2 image not found error when loading the uintah database..</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -132,6 +132,9 @@ function bv_uintah_dry_run
 # Kevin Griffin, Mon Nov 24 12:33:02 PST 2014                                  #
 # Changed the -showme:compile to -show for OS X Mavericks. The -showme:compile #
 # was being reported as an invalid option.                                     #
+#                                                                              #
+# Kevin Griffin, Wed Aug 28 10:25:30 PDT 2019                                  #
+# Added the --with-libxml2 option to ensure that the /usr/lib/ version is used #
 # **************************************************************************** #
 
 function build_uintah
@@ -273,7 +276,8 @@ function build_uintah
 	--enable-minimal --enable-optimize \
 	--with-fortran=no --with-petsc=no --with-hypre=no \
 	--with-lapack=no --with-blas=no \
-        --with-mpi=\"$PAR_INCLUDE_DIR/..\" "
+        --with-mpi=\"$PAR_INCLUDE_DIR/..\" \
+        --with-libxml2=\"/usr\" "
 
         #        --with-mpi-include="${PAR_INCLUDE_DIR}/" \
         #        --with-mpi-lib="${PAR_INCLUDE_DIR}/../lib" "
@@ -288,7 +292,8 @@ function build_uintah
         --enable-minimal --enable-optimize \
 	--with-fortran=no --with-petsc=no --with-hypre=no \
 	--with-lapack=no --with-blas=no \
-        --with-mpi=\"$PAR_INCLUDE_DIR/..\" "
+        --with-mpi=\"$PAR_INCLUDE_DIR/..\" \
+        --with-libxml2=\"/usr\" "
 
         #        --with-mpi-include="${PAR_INCLUDE_DIR}/" \
         #        --with-mpi-lib="${PAR_INCLUDE_DIR}/../lib" "


### PR DESCRIPTION
Resolves #3794. Added the --with-libxml2 option when configuring uintah to ensure that the libxml2 library is used from the /usr/lib directory.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

1. built the uintah third party library with the --with-libxml2 option set
2. Rebuilt 3.0RC and verified that the correct libxm2 is being used and the error no longer exists

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
