### PR TITLE
Modify visit-notify-test-failure to convert known noreply addresses to real addresses.

### DIFF
--- a/src/tools/dev/scripts/visit-notify-test-failure
+++ b/src/tools/dev/scripts/visit-notify-test-failure
@@ -97,6 +97,12 @@ if test "$lastpass" != "0" ; then
 fi
 
 #
+# Convert any known email addresses with noreply in them.
+#
+sed -i "s/mclarsen@users.noreply.github.com/larsen30@llnl.gov/" modifiers
+sed -i "s/jameskress@users.noreply.github.com/kressjm@ornl.gov/" modifiers
+
+#
 # Build the email list of modifiers.
 #
 modifiersEmails=


### PR DESCRIPTION
### Description

Modified visit-notify-test-failure to convert e-mail addresses associated with a commit that had noreply in them to their real e-mail address for known authors.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I manually executed the added code and checked the results.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas