### PR TITLE
Resolves #3728. Fixed issue with GUI plot list going blank on macOS.

### DIFF
--- a/src/gui/QvisPlotManagerWidget.C
+++ b/src/gui/QvisPlotManagerWidget.C
@@ -823,6 +823,11 @@ QvisPlotManagerWidget::DestroyVariableMenu()
 //   Mark C. Miller, Thu Jun  8 14:56:07 PDT 2017
 //   Adjust calls to UpdateVariableMenu/UpdatePlotVariableMenu to include
 //   bools indicating whether to destroy or simply clear menu items
+//
+//   Kevin Griffin, Fri Sep  6 18:46:24 PDT 2019
+//   Added calls to plotListBox and this widget to update and repaint
+//   themselves after an update for OSX.
+//
 // ****************************************************************************
 
 void
@@ -996,6 +1001,14 @@ QvisPlotManagerWidget::Update(Subject *TheChangedSubject)
 
     // Update the enabled state for plot/operator menus
     UpdatePlotAndOperatorMenuEnabledState();
+    
+#ifdef Q_OS_MAC
+    plotListBox->update();
+    plotListBox->repaint();
+    
+    this->update();
+    this->repaint();
+#endif
 }
 
 // ****************************************************************************
@@ -1085,6 +1098,7 @@ QvisPlotManagerWidget::UpdatePlotList()
 
         prefixes.push_back(prefix);
     }
+    
 
     //
     // Create a vector of selection names for the new plot list.
@@ -1175,7 +1189,7 @@ QvisPlotManagerWidget::UpdatePlotList()
 
     // Set the enabled states for the hide, delete, and draw buttons.
     UpdateHideDeleteDrawButtonsEnabledState();
-
+    
     blockSignals(false);
 }
 
@@ -2421,6 +2435,10 @@ QvisPlotManagerWidget::drawPlots()
 //   Cyrus Harrison, Thu Jul  3 09:16:15 PDT 2008
 //   Initial Qt4 Port.
 //
+//   Kevin Griffin, Fri Sep  6 18:46:24 PDT 2019
+//   Added calls to plotListBox and this widget to update and repaint
+//   themselves after an update for OSX.
+//
 // ****************************************************************************
 
 void
@@ -2480,6 +2498,14 @@ QvisPlotManagerWidget::setActivePlots()
                 newOperatorSelection, newExpandedPlots);
         }
     }
+    
+#ifdef Q_OS_MAC
+    plotListBox->update();
+    plotListBox->repaint();
+    
+    this->update();
+    this->repaint();
+#endif
 }
 
 // ****************************************************************************

--- a/src/gui/QvisPlotManagerWidget.C
+++ b/src/gui/QvisPlotManagerWidget.C
@@ -1098,7 +1098,6 @@ QvisPlotManagerWidget::UpdatePlotList()
 
         prefixes.push_back(prefix);
     }
-    
 
     //
     // Create a vector of selection names for the new plot list.

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug with importing remote profiles, where it looked at the old Subversion repository for remote profiles. Now it looks at the new Git repository.</li>
   <li>Corrected a bug where bringing up the Elevate attributes window would crash the graphical user interface on OSX.</li>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
+  <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #3728. Fixed issue with GUI plot list going blank on macOS.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Did a local build of visit and verified that the plot list doesn't disappear.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
