### PR TITLE
Fix VTK Reader erroneous setting of topodim to 0.

### DIFF
--- a/src/databases/VTK/avtVTKFileReader.C
+++ b/src/databases/VTK/avtVTKFileReader.C
@@ -693,13 +693,12 @@ avtVTKFileReader::ReadInDataset(int domain)
         // returned.
         //
         if(pieceExtents[domain] == NULL  &&
-           dataset->GetDataObjectType() == VTK_IMAGE_DATA) 
+           dataset->GetDataObjectType() == VTK_IMAGE_DATA)
         {
-        
-          vtkImageData *img = vtkImageData::SafeDownCast(dataset); 
+          vtkImageData *img = vtkImageData::SafeDownCast(dataset);
           if(img)
           {
-            int *ext  = img->GetExtent(); 
+            int *ext  = img->GetExtent();
             dataset = ConvertStructuredPointsToRGrid((vtkStructuredPoints*)dataset,
                                                       ext);
           }
@@ -722,18 +721,20 @@ avtVTKFileReader::ReadInDataset(int domain)
             CreateCurves(rgrid);
         }
     }
-    
+
     // Convert vtkGhostType to avtGhostDataType
     // Rename the arrays stored in dataset->GetCellData() and dataset->GetPointData()
-    
+
     vtkDataArray *zoneArray = dataset->GetCellData()->GetArray("vtkGhostType");
-    if (zoneArray) {
+    if (zoneArray)
+    {
         zoneArray->SetName("avtGhostZones");
         dataset->GetCellData()->AddArray(zoneArray);
     }
-    
+
     vtkDataArray *nodeArray = dataset->GetPointData()->GetArray("vtkGhostType");
-    if (nodeArray) {
+    if (nodeArray)
+    {
         nodeArray->SetName("avtGhostNodes");
         dataset->GetPointData()->AddArray(nodeArray);
     }
@@ -1278,13 +1279,16 @@ avtVTKFileReader::GetVectorVar(int domain, const char *var)
 //    If unstructured grid has declared no cells (valid in xml verisons),
 //    assume it is a point mesh and set topodim to 0.
 //
+//    Kathleen Biagas, Tue Sep 10 12:11:23 PDT 2019
+//    Test UnstructedGrids and vtkPolyData for existence of Points before
+//    determining if the topological dimension should be lowered. Lack of
+//    points indicates an empty dataset.
+//
 // ****************************************************************************
 
 void
 avtVTKFileReader::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
 {
-    int  i;
-
     if (!readInDataset)
     {
         ReadInFile();
@@ -1333,33 +1337,41 @@ avtVTKFileReader::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
     if (vtkType == VTK_UNSTRUCTURED_GRID)
     {
         vtkUnstructuredGrid *ugrid = (vtkUnstructuredGrid *) dataset;
-        vtkUnsignedCharArray *types = vtkUnsignedCharArray::New();
-        GetListOfUniqueCellTypes(ugrid, types);
 
-        if (types->GetNumberOfTuples() == 1)
+        if(ugrid->GetNumberOfPoints() > 0)
         {
-            int myType = (int) types->GetValue(0);
-            if (myType == VTK_VERTEX)
+            if (ugrid->GetNumberOfCells() == 0)
             {
+                // no cells declared, assume  point mesh.
                 debug5 << "The VTK file format contains all points -- "
                        << "declaring this a point mesh." << endl;
+                type = AVT_POINT_MESH;
                 topo = 0;
             }
-            else if(myType == VTK_LINE)
+            else
             {
-                debug5 << "The mesh contains all lines, set topo=1" << endl;
-                topo = 1;
+                vtkUnsignedCharArray *types = vtkUnsignedCharArray::New();
+                GetListOfUniqueCellTypes(ugrid, types);
+
+                if (types->GetNumberOfTuples() == 1)
+                {
+                    int myType = (int) types->GetValue(0);
+                    if (myType == VTK_VERTEX)
+                    {
+                        debug5 << "The VTK file format contains all points -- "
+                               << "declaring this a point mesh." << endl;
+                        type = AVT_POINT_MESH;
+                        topo = 0;
+                    }
+                    else if(myType == VTK_LINE)
+                    {
+                        debug5 << "The mesh contains all lines, set topo=1" << endl;
+                        topo = 1;
+                    }
+                }
+                types->Delete();
             }
         }
-        else if (types->GetNumberOfTuples() == 0)
-        {
-            // no cells declared, assume  point mesh.
-            debug5 << "The VTK file format contains all points -- "
-                   << "declaring this a point mesh." << endl;
-            topo = 0;
-        }
-
-        types->Delete();
     }
     else if (vtkType == VTK_STRUCTURED_GRID)
     {
@@ -1380,15 +1392,14 @@ avtVTKFileReader::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
     else if (vtkType == VTK_POLY_DATA)
     {
         vtkPolyData *pd = (vtkPolyData *) dataset;
-        if (pd->GetNumberOfPolys() == 0 && pd->GetNumberOfStrips() == 0)
+        if (pd->GetNumberOfPoints() > 0)
         {
-            if (pd->GetNumberOfLines() > 0)
+            if (pd->GetNumberOfPolys() == 0 && pd->GetNumberOfStrips() == 0)
             {
-                topo = 1;
-            }
-            else
-            {
-                topo = 0;
+                if (pd->GetNumberOfLines() > 0)
+                    topo = 1;
+                else
+                    topo = 0;
             }
         }
     }
@@ -1492,7 +1503,7 @@ avtVTKFileReader::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
 
     int nvars = 0;
 
-    for (i = 0 ; i < dataset->GetPointData()->GetNumberOfArrays() ; i++)
+    for (int i = 0 ; i < dataset->GetPointData()->GetNumberOfArrays() ; i++)
     {
         vtkDataArray *arr = dataset->GetPointData()->GetArray(i);
         int ncomp = arr->GetNumberOfComponents();
@@ -1551,7 +1562,7 @@ avtVTKFileReader::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
         }
         nvars++;
     }
-    for (i = 0 ; i < dataset->GetCellData()->GetNumberOfArrays() ; i++)
+    for (int i = 0 ; i < dataset->GetCellData()->GetNumberOfArrays() ; i++)
     {
         vtkDataArray *arr = dataset->GetCellData()->GetArray(i);
         int ncomp = arr->GetNumberOfComponents();

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where bringing up the Elevate attributes window would crash the graphical user interface on OSX.</li>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
+  <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Since in a multiblock setting it is feasible to have  empty datasets, test if
vtkUnstructuredGrid or vtkPolyData contains points (eg is non empty) before further testing
for lower topodim.
Minor code style and whitespace cleanup.

Resolves #3877.

I verified Greg's data can be read correctly.
I verified data from #3089 still reads correctly.

@brugger1, can this still make it into 3.0.2? I will update the appropriate release notes based on your response.

