### PR TITLE
Fix VTK reader erroneously setting topological dim to 0.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where bringing up the Elevate attributes window would crash the graphical user interface on OSX.</li>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
+  <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #3877

* Fix VTK Reader erroneous setting of topodim to 0.
Since in a multiblock setting it is feasible to have  empty datasets, test if vtkUnstructuredGrid or vtkPolyData contains points (eg is non empty) before further testing for lower topodim.
* Minor code style and whitespace cleanup.
* Update release notes.

Merge from 3.0RC

