### PR TITLE
Corrected a bug with build_visit that prevented Uintah from being built with MPICH on Linux. (#3895)

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -56,6 +56,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected the building of plugins against a VisIt install for OSX.</li>
   <li>Corrected an xmledit failure due to missing a Qt cocoa plugin.</li>
   <li>PySide was removed from build_visit until we get a newer version working with VisIt.</li>
+  <li>Corrected a bug with build_visit that prevented Uintah from being built with MPICH on Linux. This occured when specifying "--mpich --uintah" on the command line.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -946,9 +946,11 @@ function check_parallel
             export VISIT_MPI_COMPILER_CXX="$MPICH_COMPILER_CXX"
             export PAR_COMPILER="$MPICH_COMPILER"
             export PAR_COMPILER_CXX="$MPICH_COMPILER_CXX"
+            export PAR_INCLUDE="-I${VISITDIR}/mpich/$MPICH_VERSION/${VISITARCH}/include"
             info  "Configuring parallel with mpich build: "
-            info  "  PAR_COMPILER: $MPICH_COMPILER "
-            info  "  PAR_COMPILER_CXX: $MPICH_COMPILER_CXX"
+            info  "  PAR_COMPILER: $PAR_COMPILER"
+            info  "  PAR_COMPILER_CXX: $PAR_COMPILER_CXX"
+            info  "  PAR_INCLUDE: $PAR_INCLUDE"
             return 0
         fi
 


### PR DESCRIPTION
Resolves #3888 
Merge from the 3.0RC to develop.