### PR TITLE
resolving global id highlight issue

### DIFF
--- a/src/avt/Queries/Pick/avtPickByZoneQuery.C
+++ b/src/avt/Queries/Pick/avtPickByZoneQuery.C
@@ -147,6 +147,10 @@ avtPickByZoneQuery::~avtPickByZoneQuery()
 //    Matt Larsen, July 19 08:29:l2 PDT 2017
 //    Added support for picking by label
 //
+//    Alister Maguire, Thu Sep 12 15:34:02 PDT 2019
+//    Make sure that the highlight extractor gets the local id, not the
+//    global one. 
+//
 // ****************************************************************************
 
 void
@@ -357,7 +361,7 @@ avtPickByZoneQuery::Execute(vtkDataSet *ds, const int dom)
         pickAtts.SetPickPoint(center);
     }
     
-    this->ExtractZonePickHighlights(origPick, ds, dom);
+    this->ExtractZonePickHighlights(zoneid, ds, dom);
 }
 
 

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -34,8 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
   <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
   <li>Corrected a bug with highlighting zones picked by their global ids. The highlighted cells were incorrect or non-existent before.</li>
-  <li>Corrected a bug where the OriginalZoneLabels and OriginalNodeLabels appeared twice in the menu when opening mili datasets.</li>
-  <li>Fixed viewer crash when glyphed points size scaled by tensor.</li>
+  <li>Corrected a bug where the OriginalZoneLabels and OriginalNodeLabels variables appeared twice in the menu for Mili files.</li>
   <li>Corrected a viewer crash when glyphed points were scaled by a tensor.</li>
 </ul>
 

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
   <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
+  <li>Fixed bug with highlighting zones picked by their global ids.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -33,7 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
   <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
-  <li>Fixed bug with highlighting zones picked by their global ids.</li>
+  <li>Corrected a bug with highlighting zones picked by their global ids. The highlighted cells were incorrect or non-existent before.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -24,7 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.0.3</font></b></p>
 <ul>
-  <li>Fixed bug with highlighting zones picked by their global ids.</li>
+  <li></li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -24,7 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.0.3</font></b></p>
 <ul>
-  <li></li>
+  <li>Fixed bug with highlighting zones picked by their global ids.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/queries/pick.py
+++ b/src/test/tests/queries/pick.py
@@ -225,6 +225,9 @@
 #    Alister Maguire, Tue May 21 13:10:05 PDT 2019
 #    Updated tests that use mili to adhere to the plugin changes. 
 #
+#    Alister Maguire, Thu Sep 12 15:54:36 PDT 2019
+#    Add test for highlighting a zone picked by global id. 
+#
 # ----------------------------------------------------------------------------
 RequiredDatabasePlugin(("Boxlib2D","SAMRAI","Mili"))
 defaultAtts = GetPickAttributes()
@@ -2808,6 +2811,25 @@ def PickHighlight():
     Test("PickHighlight_01")
     DeleteAllPlots()
     ResetPickLetter()
+
+    OpenDatabase(silo_data_path("global_node.silo"))
+    AddPlot("Pseudocolor", "p")
+    DrawPlots()
+
+    # bug '3880 -- global id highlights incorrect cell. 
+    origAtts = GetPickAttributes()
+    pickAtts = origAtts
+    pickAtts.showPickHighlight = 1
+    pickAtts.showPickLetter = 1
+    SetPickAttributes(pickAtts)
+
+    PickByGlobalZone(236919)
+    Test("GlobalHighlight_00")
+
+    SetPickAttributes(origAtts)
+    DeleteAllPlots()
+    ResetPickLetter()
+
     #restore the attributes
     annotAtts  = GetAnnotationAttributes() 
     annotAtts.userInfoFlag = 1

--- a/test/baseline/queries/pick/GlobalHighlight_00.png
+++ b/test/baseline/queries/pick/GlobalHighlight_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d64239c2002513338e6e7f4427ff7256f752c497b4caa8001e618c325be4d10d
+size 1096


### PR DESCRIPTION
### Description
Fixing issue with pick highlight using global zone ids. The highlight extraction needs the local zone id to apply the correct highlight, but it was receiving the global id when PickByGlobalZone was used. 

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?
I ran all tests that include the pick operator, and they passed. I also added a test that specifically makes sure that the global zone highlight works correctly. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
