### PR TITLE
Fix viewer crash when glyphed points scaled by tensor.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
   <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
+  <li>Fixed viewer crash when glyphed points size scaled by tensor.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/visit_vtk/full/vtkVisItGlyph3D.C
+++ b/src/visit_vtk/full/vtkVisItGlyph3D.C
@@ -143,6 +143,10 @@ vtkVisItGlyph3D::~vtkVisItGlyph3D()
 //    Kathleen Biagas, Thu May 30 12:15:07 PDT 2019
 //    Allow cell-centered data for coloring/scaling.
 //
+//    Kathleen Biagas, Fri Sep 13 09:36:22 PDT 2019
+//    When scaling by a tensor use inTensors_forScaling,
+//    not inScalars_forScaling.
+//
 // ****************************************************************************
 
 int

--- a/src/visit_vtk/full/vtkVisItGlyph3D.C
+++ b/src/visit_vtk/full/vtkVisItGlyph3D.C
@@ -518,7 +518,7 @@ vtkVisItGlyph3D::RequestData(
         if (this->ScaleMode == VTK_SCALE_BY_TENSOR) 
           {
           // def_mat is Identity at its creation, only change needed elements.
-          double* tensor = inScalars_forScaling->GetTuple9(inPtId);
+          double* tensor = inTensors_forScaling->GetTuple9(inPtId);
           def_mat->SetElement(0,0,tensor[0]);
           def_mat->SetElement(0,1,tensor[1]);
           def_mat->SetElement(0,2,tensor[2]);


### PR DESCRIPTION
### Description

Resolves #3899

The glyph filter attempted to use the wrong data array (which was NULL) for scaling by the tensor.


### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I used the customer's data and plotted a Pseudocolor plot of a point var,
changed the glyph type to Box, and requested it be scaled by a Tensor var defined on the same mesh as the point var.  The viewer no longer crashes, and the results were as expected.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
