### PR TITLE
Removing label duplicates in mili menu

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2614,6 +2614,10 @@ avtMiliFileFormat::AddMiliVariableToMetaData(avtDatabaseMetaData *avtMD,
 //      Added checks to determine if shared variables have been added
 //      or not.  
 //
+//      Alister Maguire, Fri Sep 13 08:37:45 MST 2019
+//      We don't need to add the OriginalZone/NodeLabels for the 
+//      sand mesh. 
+//
 // ****************************************************************************
 
 void
@@ -2711,20 +2715,6 @@ avtMiliFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md,
                                   numMats, 
                                   matNames, 
                                   matColors);
-
-            AddLabelVarToMetaData(md, 
-                                  "OriginalZoneLabels", 
-                                  sandMeshName, 
-                                  AVT_ZONECENT, 
-                                  dims);
-
-            bool hideFromGui = false;
-            AddLabelVarToMetaData(md, 
-                                  "OriginalNodeLabels", 
-                                  sandMeshName, 
-                                  AVT_NODECENT, 
-                                  dims, 
-                                  hideFromGui);
         }
 
         //

--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
   <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
+  <li>Corrected a bug where the OriginalZoneLabels and OriginalNodeLabels appeared twice in the menu when opening mili datasets.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description
OriginalZoneLabels and OriginalNodeLabels appeared twice in the GUI menu when opening mili datasets. These changes resolve that issue. 


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?
I've re-run the mili tests, and everything passes. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
