### PR TITLE
Fix viewer crash when using a tensor var to scale glyphed points.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.2.html
+++ b/src/resources/help/en_US/relnotes3.0.2.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug with the Uintah reader where it would not load because the libxml2 could not be found.</li>
   <li>Corrected a bug where the GUI plot list goes blank on macOS.</li>
   <li>Corrected a bug where the VTK reader incorrectly set topological dimension of a dataset to 0, making the dataset undrawable by VisIt. This occured in a multiblock case where the first block contained neither points nor cells.</li>
+  <li>Fixed viewer crash when glyphed points size scaled by tensor.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/visit_vtk/full/vtkVisItGlyph3D.C
+++ b/src/visit_vtk/full/vtkVisItGlyph3D.C
@@ -143,6 +143,10 @@ vtkVisItGlyph3D::~vtkVisItGlyph3D()
 //    Kathleen Biagas, Thu May 30 12:15:07 PDT 2019
 //    Allow cell-centered data for coloring/scaling.
 //
+//    Kathleen Biagas, Fri Sep 13 09:36:22 PDT 2019
+//    When scaling by a tensor use inTensors_forScaling,
+//    not inScalars_forScaling.
+//
 // ****************************************************************************
 
 int
@@ -518,7 +522,7 @@ vtkVisItGlyph3D::RequestData(
         if (this->ScaleMode == VTK_SCALE_BY_TENSOR) 
           {
           // def_mat is Identity at its creation, only change needed elements.
-          double* tensor = inScalars_forScaling->GetTuple9(inPtId);
+          double* tensor = inTensors_forScaling->GetTuple9(inPtId);
           def_mat->SetElement(0,0,tensor[0]);
           def_mat->SetElement(0,1,tensor[1]);
           def_mat->SetElement(0,2,tensor[2]);


### PR DESCRIPTION
Was using the incorrect data array.
Merge from 3.0RC
Resolves #3899 

