### PR TITLE
Fix a couple of bugs in the regression test script.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -225,7 +225,7 @@ fi
 
 cd $testDir/$workingDir
 
-rm -f buildlog
+rm -f buildlog installlog
 
 # Clone the repository if necessary.
 if test ! -e $testDir/$workingDir/visit; then
@@ -356,7 +356,7 @@ echo "Starting install:\`date\`"
 
 # Install the package
 cd ../
-version=`cat $testDir/$workingDir/visit/src/VERSION`
+version=\`cat $testDir/$workingDir/visit/src/VERSION\`
 
 ../src/tools/dev/scripts/visit-install -c llnl_open \$version linux-x86_64 ./_install >> ../../installlog 2>&1
 


### PR DESCRIPTION
### Description

I modified the regression suite script to delete installlog at the beginning of each invokation. Previously it was always appending to it and the log file had gotten to a huge size. There is no reason to continuously append to the file. I modified the command that get the version of VisIt so that it executed when the script was run and not when the script was generated. This only caused a problem when the version was updated or there wasn't an existing checkout of the test source code.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

It can't really be tested ahead of time so I am testing it immediately after checking in the change.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code