### PR TITLE
Disable remote profile import on Windows OS

### DIFF
--- a/src/gui/QvisHostProfileWindow.C
+++ b/src/gui/QvisHostProfileWindow.C
@@ -427,9 +427,10 @@ QvisHostProfileWindow::CreateWindowContents()
 
     launchProfilesGroup = CreateLaunchProfilesGroup();
     machineTabs->addTab(launchProfilesGroup, tr("Launch Profiles"));
-
+#ifndef WIN32
     remoteProfilesGroup = CreateRemoteProfilesGroup();
     masterWidget->addTab(remoteProfilesGroup, tr("Remote Profiles"));
+#endif
 
     ((DropListWidget*)hostList)->window = this;
 }


### PR DESCRIPTION
Disable remote profile import until #3918 can be addressed.
