### PR TITLE
Disable remote-profile import on Windows OS.

### DIFF
--- a/src/gui/QvisHostProfileWindow.C
+++ b/src/gui/QvisHostProfileWindow.C
@@ -391,9 +391,10 @@ QvisHostProfileWindow::CreateWindowContents()
 
     launchProfilesGroup = CreateLaunchProfilesGroup();
     machineTabs->addTab(launchProfilesGroup, tr("Launch Profiles"));
-
+#ifndef WIN32
     remoteProfilesGroup = CreateRemoteProfilesGroup();
     masterWidget->addTab(remoteProfilesGroup, tr("Remote Profiles"));
+#endif
 
     ((DropListWidget*)hostList)->window = this;
 }


### PR DESCRIPTION
Until #3918 can be addressed.
This is a merge from 3.0RC.
