### PR TITLE
Fix bug with VTK reader while parsing .vtm files 

### DIFF
--- a/src/databases/VTK/VTMParser.C
+++ b/src/databases/VTK/VTMParser.C
@@ -55,8 +55,8 @@ using std::vector;
 // ****************************************************************************
 //  Method: VTMParser constructor
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
 //
 // ****************************************************************************
 
@@ -72,12 +72,12 @@ VTMParser::VTMParser() : fileName(), baseDir(), blockExtension(),
 // ****************************************************************************
 //  Method: VTMParser destructor
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
 //
 // ****************************************************************************
 
-VTMParser::~VTMParser() 
+VTMParser::~VTMParser()
 {
     groupIds.clear();
     blockNames.clear();
@@ -100,8 +100,8 @@ VTMParser::~VTMParser()
 //  Arguments:
 //    fn        The file name.
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
 //
 // ****************************************************************************
 
@@ -122,8 +122,8 @@ VTMParser::SetFileName(const char *fn)
 //  Arguments:
 //      index   The block index.
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
 //
 // ****************************************************************************
 
@@ -144,8 +144,8 @@ VTMParser::GetBlockFileName(int index)
 //
 //  Return:  The number of blocks.
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
 //
 // ****************************************************************************
 
@@ -161,13 +161,13 @@ VTMParser::GetNumberOfBlocks()
 //
 //  Purpose:
 //    Parses the 'vtm' file for DataSet file names, and other information
-//    that VisIt might want like block and group names. 
+//    that VisIt might want like block and group names.
 //
 //  Note:
 //     A lot of error checking here, perhaps more than is truly needed.
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
 //
 // ****************************************************************************
 
@@ -200,7 +200,7 @@ VTMParser::Parse()
     string dsType = root->GetAttribute("type");
     if (dsType != "vtkMultiBlockDataSet")
     {
-        errorMessage = string("VTKFile type: ") + 
+        errorMessage = string("VTKFile type: ") +
                       dsType + string(" currently not supported.");
         return false;
     }
@@ -215,7 +215,7 @@ VTMParser::Parse()
     int n = mbdsNode->GetNumberOfNestedElements();
 
     // Loop over nested attributes, assuming each represents a 'group'.
-    // Only top-level groups are accounted for with this code, sub-groups 
+    // Only top-level groups are accounted for with this code, sub-groups
     // are ignored.  (VTK's many_blocks.vtm example has sub-groups).
     vector<int> nBlocksPerGroup;
     for (int i = 0; i < n; ++i)
@@ -231,7 +231,7 @@ VTMParser::Parse()
         // associate each block with this group, via groupIds.
         for (int j = 0; j < nb; ++j)
             groupIds.push_back(i);
-        string elName(el->GetName()); 
+        string elName(el->GetName());
 
         if (elName  != "DataSet")
             groupPieceName = elName;
@@ -239,7 +239,7 @@ VTMParser::Parse()
     }
     nGroups = (int)nBlocksPerGroup.size();
 
-    // Sanity checks in case some blocks or datasets didn't have a 'name' 
+    // Sanity checks in case some blocks or datasets didn't have a 'name'
     // attribute
     if (nGroups == 1 || (int)groupNames.size() != nGroups)
         groupNames.clear();
@@ -249,9 +249,9 @@ VTMParser::Parse()
 
     // No guarantee that there is a separate name (or Title) for groups,
     // or blocks for that matter. If group and piece name are the same,
-    // give groupPieceName a generic name. 
-    if (!groupPieceName.empty() && 
-        !blockPieceName.empty() && 
+    // give groupPieceName a generic name.
+    if (!groupPieceName.empty() &&
+        !blockPieceName.empty() &&
         groupPieceName == blockPieceName)
     {
         groupPieceName = "Group";
@@ -264,11 +264,15 @@ VTMParser::Parse()
 //  Method: VTMParser::ParseForDS
 //
 //  Purpose:
-//    Recursively checks the passed vtkXMLDataElement for 'DataSet' tag. 
+//    Recursively checks the passed vtkXMLDataElement for 'DataSet' tag.
 //    Retrieves and stores 'file' and 'name' attributes.
 //
-//  Programmer: Kathleen Biagas 
-//  Creation:   August 12, 2015 
+//  Programmer: Kathleen Biagas
+//  Creation:   August 12, 2015
+//
+//  Modifications:
+//    Kathleen Biagas, Thu Sep 19 14:11:28 PDT 2019
+//    Don't process the 'DataSet' tag if it doesn't have a 'file' attribute.
 //
 // ****************************************************************************
 
@@ -278,33 +282,36 @@ VTMParser::ParseForDS(vtkXMLDataElement *de, int &n)
     string name(de->GetName());
     if (name == "DataSet")
     {
-        n++;
-        string bfn(de->GetAttribute("file"));
-        if (blockExtension.empty())
+        if (de->GetAttribute("file"))
         {
-            size_t pos = bfn.find_last_of('.');
-            if (pos == std::string::npos)
-                blockExtension = "none";
-            else
-                blockExtension = bfn.substr(pos+1);
-        }
-        blockFileNames.push_back(bfn);
-        if (de->GetAttribute("name") != NULL) 
-        {
-            blockNames.push_back(string(de->GetAttribute("name")));
-        }
-        if (blockPieceName.empty())
-        {
-            vtkXMLDataElement *parent = de->GetParent();
-            if(parent)
-{
-                blockPieceName = parent->GetName();
-}
+            n++;
+            string bfn(de->GetAttribute("file"));
+            if (blockExtension.empty())
+            {
+                size_t pos = bfn.find_last_of('.');
+                if (pos == std::string::npos)
+                    blockExtension = "none";
+                else
+                    blockExtension = bfn.substr(pos+1);
+            }
+            blockFileNames.push_back(bfn);
+            if (de->GetAttribute("name") != NULL)
+            {
+                blockNames.push_back(string(de->GetAttribute("name")));
+            }
+            if (blockPieceName.empty())
+            {
+                vtkXMLDataElement *parent = de->GetParent();
+                if(parent)
+                {
+                    blockPieceName = parent->GetName();
+                }
+            }
         }
     }
     else
     {
         for (int i = 0; i < de->GetNumberOfNestedElements(); ++i)
             ParseForDS(de->GetNestedElement(i), n);
-    } 
+    }
 }

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -24,7 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.0.3</font></b></p>
 <ul>
-  <li></li>
+  <li>Fixed bug with VTK reader parsing .vtm files when 'DataSet' tag doesn't have a 'file' attribute.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Customer reported inability to read .vtm files.
The vtm file had a DataSet tag without a 'file' attribute, but the reader assumed it had one.
Fixed the assumption.