### PR TITLE
Disable VCR play/reverse play if no plots.

### DIFF
--- a/src/gui/QvisMainWindow.C
+++ b/src/gui/QvisMainWindow.C
@@ -44,7 +44,6 @@
 #include <QPixmap>
 #include <QMenuBar>
 #include <QMenu>
-//#include <QMenuItem>
 #include <QComboBox>
 #include <QSplitter>
 #include <QStatusBar>
@@ -120,7 +119,7 @@
 // ****************************************************************************
 // Method: QvisMainWindow::QvisMainWindow
 //
-// Purpose: 
+// Purpose:
 //    Constructor for the QvisMainWindow class. It creates the widgets
 //    that are part of the main window.
 //
@@ -220,8 +219,8 @@
 //    I fixed a widget parenting bug with some menus that caused
 //    VisIt to crash on exit.
 //
-//    Kathleen Bonnell, Wed Feb 19 13:13:24 PST 2003  
-//    I added activateGlobalLineoutWindow. 
+//    Kathleen Bonnell, Wed Feb 19 13:13:24 PST 2003
+//    I added activateGlobalLineoutWindow.
 //
 //    Eric Brugger, Thu Mar 13 12:00:12 PST 2003
 //    I added the preferences window.
@@ -247,25 +246,25 @@
 //    Brad Whitlock, Fri Aug 15 15:05:24 PST 2003
 //    I passed a pointer to the menu bar to the plot manager widget.
 //
-//    Kathleen Bonnell, Tue Aug 26 13:47:34 PDT 2003 
+//    Kathleen Bonnell, Tue Aug 26 13:47:34 PDT 2003
 //    Changed 'Material' to 'Material options'.
 //
 //    Brad Whitlock, Sat Jan 24 23:51:40 PST 2004
 //    I added support for next generation file handling, including close
 //    and reopen menus.
 //
-//    Kathleen Bonnell, Wed Mar 31 10:13:43 PST 2004 
+//    Kathleen Bonnell, Wed Mar 31 10:13:43 PST 2004
 //    I added query over time window.
 //
 //    Brad Whitlock, Mon Apr 5 15:28:04 PST 2004
 //    I added support for putting reopen and close in an "Advanced"
 //    pullright menu.
 //
-//    Kathleen Bonnell, Thu Jun 17 13:50:58 PDT 2004 
+//    Kathleen Bonnell, Thu Jun 17 13:50:58 PDT 2004
 //    Changed QueryOverTime's accelerator key from CTL-T to CTL-SHIFT-Q
-//    so that it would not collide with the ColorTable's accelerator. 
-// 
-//    Kathleen Bonnell, Wed Aug 18 09:44:09 PDT 2004 
+//    so that it would not collide with the ColorTable's accelerator.
+//
+//    Kathleen Bonnell, Wed Aug 18 09:44:09 PDT 2004
 //    Added Interactors window.
 //
 //    Jeremy Meredith, Wed Aug 25 09:52:06 PDT 2004
@@ -454,12 +453,12 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
     selFileAct = NULL;
     if (advancedMenuShowing)
     {
-        selFileAct = filePopup->addAction(*openIcon, tr("Select &file . . ."), 
-                         this, SIGNAL(activateFileWindow()), 
+        selFileAct = filePopup->addAction(*openIcon, tr("Select &file . . ."),
+                         this, SIGNAL(activateFileWindow()),
                          QKeySequence(Qt::CTRL + Qt::Key_F));
     }
     // keep this action so we can add reopen after it in certian cases
-    openFileAct = filePopup->addAction(*openIcon, tr("Open file . . ."), 
+    openFileAct = filePopup->addAction(*openIcon, tr("Open file . . ."),
                                        this, SIGNAL(activateFileOpenWindow()),
                                        QKeySequence(Qt::CTRL + Qt::Key_O));
 
@@ -481,18 +480,18 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
         closePopupAct = filePopup->addMenu(closePopup);
     closePopupAct->setEnabled(false);
 
-    // ReOpen pull-right menu.    
-    reopenPopup = new QMenu(tr("ReOpen file"), 
+    // ReOpen pull-right menu.
+    reopenPopup = new QMenu(tr("ReOpen file"),
                          advancedMenuShowing ? fileAdvancedPopup : filePopup);
     connect(reopenPopup, SIGNAL(triggered(QAction*)),
             this, SLOT(reopenFile(QAction*)));
     reopenPopupAct = filePopup->addMenu(reopenPopup);
     reopenPopupAct->setEnabled(false);
 
-    refreshFileListAct = filePopup->addAction(tr("Refresh file list"), 
-                          this, SIGNAL(refreshFileList()), 
+    refreshFileListAct = filePopup->addAction(tr("Refresh file list"),
+                          this, SIGNAL(refreshFileList()),
                           QKeySequence(Qt::CTRL + Qt::Key_R));
-    filePopup->addAction(tr("File &information . . ."), 
+    filePopup->addAction(tr("File &information . . ."),
                          this, SIGNAL(activateFileInformationWindow()),
                          QKeySequence(Qt::CTRL + Qt::Key_I));
     filePopup->addAction(tr("SeedMe . . ."),
@@ -528,7 +527,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
                          this, SIGNAL(saveWindow()),
                          QKeySequence(Qt::CTRL + Qt::Key_S));
     filePopup->addAction(tr("Set save &options . . ."),
-                         this, SIGNAL(activateSaveWindow()), 
+                         this, SIGNAL(activateSaveWindow()),
                          QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_O));
     filePopup->addAction(saveMovieIcon, tr("Save movie . . ."),
                          this, SIGNAL(saveMovie()));
@@ -545,7 +544,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
 
     filePopup->addSeparator();
 
-    filePopup->addAction(tr("Compute &engines . . ."), 
+    filePopup->addAction(tr("Compute &engines . . ."),
                          this, SIGNAL(activateEngineWindow()),
                          QKeySequence(Qt::CTRL + Qt::Key_E));
 
@@ -568,7 +567,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
                      this, SIGNAL(activateAnimationWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_A));
     ctrls->addAction(annotIcon, tr("A&nnotation . . ."),
-                     this, SIGNAL(activateAnnotationWindow()), 
+                     this, SIGNAL(activateAnnotationWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_N));
     ctrls->addAction(rainbowIcon, tr("Color &table . . ."),
                      this, SIGNAL(activateColorTableWindow()),
@@ -577,27 +576,27 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
                      this, SIGNAL(activateCLI()),
                      QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_C));
     ctrls->addAction(commandIcon, tr("Command . . ."),
-                     this, SIGNAL(activateCommandWindow()), 
+                     this, SIGNAL(activateCommandWindow()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C));
     ctrls->addAction(tr("&Data level comparisons . . ."),
-                     this, SIGNAL(setupCMFE()), 
+                     this, SIGNAL(setupCMFE()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_D));
     ctrls->addAction(correlationIcon, tr("&Database correlations . . ."),
-                      this, SIGNAL(activateCorrelationListWindow()), 
+                      this, SIGNAL(activateCorrelationListWindow()),
                       QKeySequence(Qt::CTRL + Qt::Key_D));
     ctrls->addAction(exprIcon, tr("&Expressions . . ."),
                      this, SIGNAL(activateExpressionsWindow()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_E));
     ctrls->addAction(keyframeIcon, tr("&Keyframing . . ."),
-                     this, SIGNAL(activateKeyframeWindow()), 
+                     this, SIGNAL(activateKeyframeWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_K));
-    ctrls->addAction(lightIcon, tr("&Lighting . . ."), 
+    ctrls->addAction(lightIcon, tr("&Lighting . . ."),
                      this, SIGNAL(activateLightingWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_L));
     ctrls->addAction(globalLineoutIcon, tr("&Lineout . . ."),
                      this, SIGNAL(activateGlobalLineoutWindow()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_L));
-    ctrls->addAction(tr("Macros . . ."), 
+    ctrls->addAction(tr("Macros . . ."),
                      this, SIGNAL(activateMacroWindow()));
     ctrls->addAction(materialIcon, tr("&Material options . . ."),
                      this, SIGNAL(activateMaterialWindow()),
@@ -610,40 +609,40 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_P));
 
 #if defined(Q_OS_MAC)
-    ctrls->addAction(tr("Quer&y . . ."), 
+    ctrls->addAction(tr("Quer&y . . ."),
                      this, SIGNAL(activateQueryWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_Y));
     ctrls->addAction(tr("Quer&y over time options . . ."),
-                     this, SIGNAL(activateQueryOverTimeWindow()), 
+                     this, SIGNAL(activateQueryOverTimeWindow()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Y));
 #else
     ctrls->addAction(tr("&Query over time options . . ."),
-                     this, SIGNAL(activateQueryOverTimeWindow()), 
+                     this, SIGNAL(activateQueryOverTimeWindow()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Q));
     ctrls->addAction(tr("&Query . . ."),
-                     this, SIGNAL(activateQueryWindow()), 
+                     this, SIGNAL(activateQueryWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_Q));
 #endif
     ctrls->addAction(selectionIcon, tr("Selections . . ."),
                      this, SIGNAL(activateSelectionsWindow()),
                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S));
     ctrls->addAction(subsetIcon, tr("S&ubset . . ."),
-                     this, SIGNAL(activateSubsetWindow()), 
+                     this, SIGNAL(activateSubsetWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_U));
     ctrls->addAction(viewIcon, tr("&View . . ."),
-                     this, SIGNAL(activateViewWindow()), 
+                     this, SIGNAL(activateViewWindow()),
                      QKeySequence(Qt::CTRL + Qt::Key_V));
 
     //
     // Add the Prefs menu.
     //
     QMenu *pref = menuBar()->addMenu(tr("&Options"));
-    pref->addAction(tr("&Appearance . . ."), 
-                    this, SIGNAL(activateAppearanceWindow()), 
+    pref->addAction(tr("&Appearance . . ."),
+                    this, SIGNAL(activateAppearanceWindow()),
                     QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_A));
     pref->addSeparator();
     pref->addAction(computerIcon, tr("&Host profiles . . ."),
-                    this, SIGNAL(activateHostWindow()), 
+                    this, SIGNAL(activateHostWindow()),
                     QKeySequence(Qt::CTRL + Qt::Key_H));
     pref->addAction(tr("Host profiles and configuration setup . . ."),
                     this, SIGNAL(activateSetupHostProfilesAndConfig()));
@@ -679,7 +678,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
     winPopup->addAction(copyIcon, tr("Clone"),this, SLOT(windowClone()));
 
     winPopup->addAction(QPixmap(deletewindow_xpm), tr("Delete"),
-                         this, SLOT(windowDelete()), 
+                         this, SLOT(windowDelete()),
                          QKeySequence(Qt::CTRL + Qt::Key_Delete));
 
     winPopup->addAction(tr("Clear all"), this, SLOT(windowClearAll()));
@@ -750,7 +749,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
 
 
     topCopyPopupAct = winPopup->addMenu(topCopyPopup);
-    topCopyPopupAct->setEnabled(false);    
+    topCopyPopupAct->setEnabled(false);
 
     // Clear sub menu
     clearPopup = new QMenu(tr("Clear"));
@@ -826,7 +825,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
 
     // Create the output button and put it in the status bar as a
     // permanent widget.
-    // need to add a label to the status bar so the output button 
+    // need to add a label to the status bar so the output button
     // ends up on the right side
     statusBar()->addWidget(new QLabel("",this),10);
     outputButton = new QPushButton(statusBar());
@@ -859,7 +858,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
 // ****************************************************************************
 // Method: QvisMainWindow::~QvisMainWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisMainWindow class.
 //
 // Programmer: Brad Whitlock
@@ -921,21 +920,21 @@ QvisMainWindow::~QvisMainWindow()
 // ****************************************************************************
 // Method: QvisMainWindow::SetDefaultSplitterSizes
 //
-// Purpose: 
+// Purpose:
 //   Set the default splitter sizes for the window configuration.
 //
 // Arguments:
 //   h : The window height that we're splitting up.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri May  7 15:30:15 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -985,7 +984,7 @@ QvisMainWindow::SetDefaultSplitterSizes(int h)
 // ****************************************************************************
 // Method: QvisMainWindow::AddHelpMenu
 //
-// Purpose: 
+// Purpose:
 //   Creates the Help menu on the menubar.
 //
 // Programmer: Sean Ahern
@@ -1045,6 +1044,9 @@ QvisMainWindow::AddHelpMenu(void)
 //   Brad Whitlock, Fri Jul 23 15:40:19 PDT 2010
 //   I added code to connect the selection list.
 //
+//   Kathleen Biagas, Mon Sep 30 09:37:00 PDT 2019
+//   Connect plotList to time slider control.
+//
 // ****************************************************************************
 
 void
@@ -1071,6 +1073,7 @@ QvisMainWindow::CreateMainContents(QSplitter *parent)
     tsControl = new QvisTimeSliderControlWidget(mainControls);
     tsControl->ConnectFileServer(fileServer);
     tsControl->ConnectWindowInformation(GetViewerState()->GetWindowInformation());
+    tsControl->ConnectPlotList(GetViewerState()->GetPlotList());
     connect(tsControl, SIGNAL(reopenOnNextFrame()),
             this, SIGNAL(reopenOnNextFrame()));
     layout->addWidget(tsControl, 0);
@@ -1121,7 +1124,7 @@ QvisMainWindow::CreateMainContents(QvisPostableMainWindow *win)
 // ****************************************************************************
 // Method: QvisMainWindow::CreateGlobalArea
 //
-// Purpose: 
+// Purpose:
 //   This method creates the "global area" which is a bunch of widgets
 //   that show stuff like autoupdate and the active window list.
 //
@@ -1141,7 +1144,7 @@ QvisMainWindow::CreateMainContents(QvisPostableMainWindow *win)
 //   Brad Whitlock, Tue Sep 17 15:43:22 PST 2002
 //   I removed maintain view/data.
 //
-//   Eric Brugger, Fri Apr 18 09:10:03 PDT 2003 
+//   Eric Brugger, Fri Apr 18 09:10:03 PDT 2003
 //   I added maintain view limits.
 //
 //   Eric Brugger, Mon Mar 29 13:07:58 PST 2004
@@ -1201,7 +1204,7 @@ QvisMainWindow::CreateGlobalArea(QWidget *par)
 // ****************************************************************************
 // Method: QvisMainWindow::Update
 //
-// Purpose: 
+// Purpose:
 //   Updates the window when one of the subjects that it observes
 //   is changed.
 //
@@ -1257,7 +1260,7 @@ QvisMainWindow::CreateGlobalArea(QWidget *par)
 //   Added code to handle the crash recovery timer.
 //
 //   Brad Whitlock, Tue Apr 29 10:23:52 PDT 2008
-//   Access the message text via MessageAttributes_GetText to try and 
+//   Access the message text via MessageAttributes_GetText to try and
 //   preserve unicode from the viewer, if possible.
 //
 //   Cyrus Harrison, Mon Jun 30 14:14:59 PDT 2008
@@ -1382,11 +1385,11 @@ QvisMainWindow::Update(Subject *TheChangedSubject)
 // ****************************************************************************
 // Method: QvisMainWindow::UpdateGlobalArea
 //
-// Purpose: 
+// Purpose:
 //   This method updates the parts of the main window that depend on
 //   the GlobalAttributes state object.
 //
-// Note:       
+// Note:
 //   Note that the main window does not care about all of the attributes
 //   in the GlobalAttributes state object.
 //
@@ -1415,8 +1418,8 @@ QvisMainWindow::Update(Subject *TheChangedSubject)
 //   Brad Whitlock, Thu Mar 20 11:05:52 PDT 2003
 //   I updated the numbering in the switch statement because I removed
 //   some fields from the middle of GlobalAttributes.
-//   
-//   Eric Brugger, Fri Apr 18 09:10:03 PDT 2003 
+//
+//   Eric Brugger, Fri Apr 18 09:10:03 PDT 2003
 //   I added maintain view limits.
 //
 //   Brad Whitlock, Fri Jan 23 17:32:11 PST 2004
@@ -1496,7 +1499,7 @@ QvisMainWindow::UpdateGlobalArea(bool doAll)
             break;
         case GlobalAttributes::ID_windowLayout:
         { // new scope
-            
+
             layoutActions[0]->setChecked(globalAtts->GetWindowLayout() == 1);
             layoutActions[1]->setChecked(globalAtts->GetWindowLayout() == 2);
             layoutActions[2]->setChecked(globalAtts->GetWindowLayout() == 4);
@@ -1522,7 +1525,7 @@ QvisMainWindow::UpdateGlobalArea(bool doAll)
 // ****************************************************************************
 // Method: QvisMainWindow::UpdateFileMenuPopup
 //
-// Purpose: 
+// Purpose:
 //   Updates the contents of the specified file menu.
 //
 // Arguments:
@@ -1559,7 +1562,7 @@ QvisMainWindow::UpdateFileMenuPopup(QMenu *m, QAction *action)
 
     // Clear out the old list and add the new list.
     m->clear();
-    
+
     for(size_t i = 0; i < simpleNames.size(); ++i)
         m->addAction(simpleNames[i].c_str());
 
@@ -1573,7 +1576,7 @@ QvisMainWindow::UpdateFileMenuPopup(QMenu *m, QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::UpdateWindowList
 //
-// Purpose: 
+// Purpose:
 //   Updates the active window list.
 //
 // Arguments:
@@ -1586,7 +1589,7 @@ QvisMainWindow::UpdateFileMenuPopup(QMenu *m, QAction *action)
 // Modifications:
 //   Eric Brugger, Fri Sep 22 10:05:24 PDT 2000
 //   I modified the setting of the active window to work properly.
-//   
+//
 //   Brad Whitlock, Fri Sep 13 15:48:27 PST 2002
 //   I changed it so it also updates the new Active window menu.
 //
@@ -1653,7 +1656,7 @@ QvisMainWindow::UpdateWindowList(bool doList)
 // ****************************************************************************
 // Method: QvisMainWindow::UpdateWindowMenu
 //
-// Purpose: 
+// Purpose:
 //   Updates the items in the window's sub-menus.
 //
 // Arguments:
@@ -1722,14 +1725,14 @@ QvisMainWindow::UpdateWindowMenu(bool updateNumbers)
     // Set the enabled state of the copy and clear menus.
     bool enoughPlots = (plotList->GetNumPlots() > 0);
     bool enoughWindows = (indices.size() > 1);
-    
+
     topCopyPopupAct->setEnabled(enoughWindows);
     copyPopupAct[0]->setEnabled(enoughPlots && enoughWindows);
     copyPopupAct[1]->setEnabled(enoughWindows);
     copyPopupAct[2]->setEnabled(enoughWindows);
     copyPopupAct[3]->setEnabled(enoughWindows);
     copyPopupAct[4]->setEnabled(enoughWindows);
-    
+
     copyPopupAct[0]->setEnabled(enoughPlots && enoughWindows);
     copyPopupAct[1]->setEnabled(enoughWindows);
     copyPopupAct[2]->setEnabled(enoughWindows);
@@ -1741,10 +1744,10 @@ QvisMainWindow::UpdateWindowMenu(bool updateNumbers)
     lockTimeAct->setChecked(windowInfo->GetLockTime());
     lockToolsAct->setChecked(windowInfo->GetLockTools());
     lockViewAct->setChecked(windowInfo->GetLockView());
-    
+
     fullFrameModeAct->setEnabled(enoughPlots);
     fullFrameModeAct->setChecked(windowInfo->GetFullFrame());
-    
+
     spinModeAct->setEnabled(enoughPlots);
     spinModeAct->setChecked(windowInfo->GetSpin());
 
@@ -1757,7 +1760,7 @@ QvisMainWindow::UpdateWindowMenu(bool updateNumbers)
 // ****************************************************************************
 // Method: QvisMainWindow::ConnectGlobalAttributes
 //
-// Purpose: 
+// Purpose:
 //   Registers the main window as an observer of the viewer proxy's
 //   GlobalAttributes object.
 //
@@ -1769,7 +1772,7 @@ QvisMainWindow::UpdateWindowMenu(bool updateNumbers)
 // Creation:   Sat Sep 16 13:23:20 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1785,7 +1788,7 @@ QvisMainWindow::ConnectGlobalAttributes(GlobalAttributes *globalAtts_)
 // ****************************************************************************
 // Method: QvisMainWindow::ConnectViewerStatusAttributes
 //
-// Purpose: 
+// Purpose:
 //   Connects the viewer's status attributes so the main window observes them.
 //
 // Arguments:
@@ -1795,7 +1798,7 @@ QvisMainWindow::ConnectGlobalAttributes(GlobalAttributes *globalAtts_)
 // Creation:   Wed May 2 15:24:36 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1808,14 +1811,14 @@ QvisMainWindow::ConnectViewerStatusAttributes(StatusAttributes *s)
 // ****************************************************************************
 // Method: QvisMainWindow::ConnectGUIMessageAttributes
 //
-// Purpose: 
+// Purpose:
 //   Makes the window observe GUIBase's message attributes.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Oct 25 18:30:44 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1827,7 +1830,7 @@ QvisMainWindow::ConnectGUIMessageAttributes()
 // ****************************************************************************
 // Method: QvisMainWindow::ConnectPlotList
 //
-// Purpose: 
+// Purpose:
 //   Makes the window observe the viewer's plot list.
 //
 // Arguments:
@@ -1837,7 +1840,7 @@ QvisMainWindow::ConnectGUIMessageAttributes()
 // Creation:   Thu Sep 12 18:04:23 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1850,7 +1853,7 @@ QvisMainWindow::ConnectPlotList(PlotList *pl)
 // ****************************************************************************
 // Method: QvisMainWindow::ConnectWindowInformation
 //
-// Purpose: 
+// Purpose:
 //   Makes the window observe the viewer's window information.
 //
 // Arguments:
@@ -1860,7 +1863,7 @@ QvisMainWindow::ConnectPlotList(PlotList *pl)
 // Creation:   Mon Sep 16 15:55:45 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1873,7 +1876,7 @@ QvisMainWindow::ConnectWindowInformation(WindowInformation *w)
 // ****************************************************************************
 // Method: QvisMainWindow::SubjectRemoved
 //
-// Purpose: 
+// Purpose:
 //   Unregisters the main window as an observer of TheRemovedSubject.
 //
 // Arguments:
@@ -1919,7 +1922,7 @@ QvisMainWindow::SubjectRemoved(Subject *TheRemovedSubject)
 // ****************************************************************************
 // Method: QvisMainWindow::GetNotepad
 //
-// Purpose: 
+// Purpose:
 //   Returns a pointer to the notepad area so postable windows can
 //   know the widget that they post to.
 //
@@ -1927,7 +1930,7 @@ QvisMainWindow::SubjectRemoved(Subject *TheRemovedSubject)
 // Creation:   Wed Jul 26 09:44:24 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisNotepadArea *
@@ -1939,14 +1942,14 @@ QvisMainWindow::GetNotepad()
 // ****************************************************************************
 // Method: QvisMainWindow::GetPlotManager
 //
-// Purpose: 
+// Purpose:
 //   Returns a pointer to the main window's plot manager widget.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Sep 7 12:48:07 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisPlotManagerWidget *
@@ -1958,7 +1961,7 @@ QvisMainWindow::GetPlotManager()
 // ****************************************************************************
 // Method: QvisMainWindow::SetOrientation
 //
-// Purpose: 
+// Purpose:
 //   Set the orientation to vertical or horizontal.
 //
 // Arguments:
@@ -1981,7 +1984,7 @@ QvisMainWindow::SetOrientation(int orientation)
 {
     if(splitter != 0)
     {
-        splitter->setOrientation((orientation < 2) ? 
+        splitter->setOrientation((orientation < 2) ?
                                   Qt::Vertical : Qt::Horizontal);
     }
 }
@@ -1989,7 +1992,7 @@ QvisMainWindow::SetOrientation(int orientation)
 // ****************************************************************************
 // Method: QvisMainWindow::CreateNode
 //
-// Purpose: 
+// Purpose:
 //   Saves the main window's attributes to the config file.
 //
 // Arguments:
@@ -2033,7 +2036,7 @@ QvisMainWindow::CreateNode(DataNode *parentNode)
         QList<int> splitterSizes(splitter->sizes());
         floatVector ss;
         for(int i = 0; i < splitterSizes.size(); ++i)
-            ss.push_back(float(splitterSizes[i]) / 
+            ss.push_back(float(splitterSizes[i]) /
                          float(splitter->height()));
         if(ss.size() >= 2)
             node->AddNode(new DataNode("SPLITTER_VALUES_V2", ss));
@@ -2043,7 +2046,7 @@ QvisMainWindow::CreateNode(DataNode *parentNode)
 // ****************************************************************************
 // Method: QvisMainWindow::SetFromNode
 //
-// Purpose: 
+// Purpose:
 //   Sets the size, position, and splitter values for the main window.
 //
 // Arguments:
@@ -2056,7 +2059,7 @@ QvisMainWindow::CreateNode(DataNode *parentNode)
 //             flag is passed in then it means that the geometry was already
 //             passed on the command line or was already read from the
 //             config file.
-// 
+//
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 25 10:13:38 PDT 2006
 //
@@ -2119,7 +2122,7 @@ QvisMainWindow::SetFromNode(DataNode *parentNode, bool overrideGeometry,
         if((node = winNode->GetNode("SPLITTER_VALUES_V2")) != 0)
         {
             const floatVector &ss = node->AsFloatVector();
-    
+
             if(ss.size() >= 2)
             {
                 float sum = 0.;
@@ -2151,7 +2154,7 @@ QvisMainWindow::SetFromNode(DataNode *parentNode, bool overrideGeometry,
         }
         else
         {
-            debug1 << mName << "Could not locate key SPLITTER_VALUES"  
+            debug1 << mName << "Could not locate key SPLITTER_VALUES"
                    " so the default splitter values will be used."
                    << endl;
         }
@@ -2177,7 +2180,7 @@ QvisMainWindow::SetFromNode(DataNode *parentNode, bool overrideGeometry,
 // ****************************************************************************
 // Method: QvisMainWindow::closeEvent
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the application that it
 //   is okay to quit when a close event is received.
 //
@@ -2206,7 +2209,7 @@ QvisMainWindow::closeEvent( QCloseEvent* ce )
 // ****************************************************************************
 // Method: QvisMainWindow::hideEvent
 //
-// Purpose: 
+// Purpose:
 //   This is an event handler that emits an iconifyWindows signal if the
 //   hide event was initiated by the window manager.
 //
@@ -2217,7 +2220,7 @@ QvisMainWindow::closeEvent( QCloseEvent* ce )
 // Creation:   Thu Apr 19 10:40:34 PDT 2001
 //
 // Modifications:
-//   
+//
 //   Hank Childs, Thu Jan 13 13:19:31 PST 2005
 //   Add argument to iconify windows that indicates if the request is
 //   spontaneous.
@@ -2240,7 +2243,7 @@ QvisMainWindow::hideEvent(QHideEvent *e)
 // ****************************************************************************
 // Method: QvisMainWindow::showEvent
 //
-// Purpose: 
+// Purpose:
 //   This is an event handler that emits a deIconifyWindows signal if the
 //   show event was initiated by the window manager.
 //
@@ -2251,7 +2254,7 @@ QvisMainWindow::hideEvent(QHideEvent *e)
 // Creation:   Thu Apr 19 10:40:34 PDT 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2272,7 +2275,7 @@ QvisMainWindow::showEvent(QShowEvent *e)
 // ****************************************************************************
 // Method: QvisMainWindow::show
 //
-// Purpose: 
+// Purpose:
 //   Shows the window and raises it.
 //
 // Note:       We override this method from QvisWindowBase because we don't
@@ -2282,7 +2285,7 @@ QvisMainWindow::showEvent(QShowEvent *e)
 // Creation:   Wed Nov 22 10:54:52 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2298,7 +2301,7 @@ QvisMainWindow::show()
 // ****************************************************************************
 // Method: QvisMainWindow::reopenFile
 //
-// Purpose: 
+// Purpose:
 //   Tells the viewer to reopen the specified file. This makes the reopened
 //   file be the new active source.
 //
@@ -2342,7 +2345,7 @@ QvisMainWindow::reopenFile(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::closeFile
 //
-// Purpose: 
+// Purpose:
 //   Tells the viewer to close the specified file.
 //
 // Arguments:
@@ -2417,7 +2420,7 @@ void
 QvisMainWindow::windowClearAll()
 {
     // Tell the viewer to clear all windows.
-    GetViewerMethods()->ClearAllWindows();    
+    GetViewerMethods()->ClearAllWindows();
 }
 
 void
@@ -2465,7 +2468,7 @@ QvisMainWindow::windowLayout3x3()
 // ****************************************************************************
 // Method: QvisMainWindow::emitActivateOutputWindow
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the window's
 //   output button is clicked. It sets the outputButton's pixmap to
 //   the blue icon and emits a signal to activate the output window.
@@ -2496,7 +2499,7 @@ QvisMainWindow::emitActivateOutputWindow()
 // ****************************************************************************
 // Method: QvisMainWindow::IndicateUnreadOutput
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the main window to set the output
 //   button's icon.
 //
@@ -2523,7 +2526,7 @@ QvisMainWindow::unreadOutput(bool val)
 // ****************************************************************************
 // Method: QvisMainWindow::SetTimeStateFormat
 //
-// Purpose: 
+// Purpose:
 //   This a Qt slot function that sets the file panel's timestate format.
 //
 // Arguments:
@@ -2548,7 +2551,7 @@ QvisMainWindow::SetTimeStateFormat(const TimeFormat &fmt)
 // ****************************************************************************
 // Method: QvisMainWindow::GetTimeStateFormat
 //
-// Purpose: 
+// Purpose:
 //   Returns the file panel's timestate format
 //
 // Returns:    The file panel's timestate format.
@@ -2571,7 +2574,7 @@ QvisMainWindow::GetTimeStateFormat() const
 // ****************************************************************************
 // Method: QvisMainWindow::SetShowSelectedFiles
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets whether or not the selected files
 //   should be showing.
 //
@@ -2627,7 +2630,7 @@ QvisMainWindow::SetShowSelectedFiles(bool val)
         if(!advancedMenuShowing)
         {
             selFileAct = filePopup->addAction(*openIcon, tr("Select &file . . ."),
-                         this, SIGNAL(activateFileWindow()), 
+                         this, SIGNAL(activateFileWindow()),
                          QKeySequence(Qt::CTRL + Qt::Key_F));
             filePopup->insertAction(openFileAct, selFileAct);
 
@@ -2735,7 +2738,7 @@ QvisMainWindow::SetShowSelectedFiles(bool val)
 // ****************************************************************************
 // Method: QvisMainWindow::GetShowSelectedFiles
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the selected files should be showing.
 //
 // Programmer: Brad Whitlock
@@ -2756,7 +2759,7 @@ QvisMainWindow::GetShowSelectedFiles() const
 // ****************************************************************************
 // Method: QvisMainWindow::GetAllowFileSelectionChange
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the selected files' selection should be changed when
 //   the source changes.
 //
@@ -2764,7 +2767,7 @@ QvisMainWindow::GetShowSelectedFiles() const
 // Creation:   Fri Apr 9 14:37:38 PST 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -2776,7 +2779,7 @@ QvisMainWindow::GetAllowFileSelectionChange() const
 // ****************************************************************************
 // Method: QvisMainWindow::SetAllowFileSelectionChange
 //
-// Purpose: 
+// Purpose:
 //   Sets whether the file panel is allowed to change the file selection.
 //
 // Arguments:
@@ -2787,7 +2790,7 @@ QvisMainWindow::GetAllowFileSelectionChange() const
 // Creation:   Tue Apr 6 14:36:53 PST 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2799,14 +2802,14 @@ QvisMainWindow::SetAllowFileSelectionChange(bool val)
 // ****************************************************************************
 // Method: QvisMainWindow::OkayToSaveRecoveryFile
 //
-// Purpose: 
+// Purpose:
 //   Sets whether VisIt is launched enough to consider saving the recovery file.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jan 31 10:48:01 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2819,20 +2822,20 @@ QvisMainWindow::OkayToSaveRecoveryFile()
 // ****************************************************************************
 // Method: QvisMainWindow::UpdateCrashRecoveryTimer
 //
-// Purpose: 
+// Purpose:
 //   Updates the crash recovery timer based on the preference in globalAtts.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jan 31 12:28:33 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2857,7 +2860,7 @@ QvisMainWindow::UpdateCrashRecoveryTimer()
 // ****************************************************************************
 // Method: QvisMainWindow::autoUpdateToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the auto update check box
 //   is toggled.
 //
@@ -2868,7 +2871,7 @@ QvisMainWindow::UpdateCrashRecoveryTimer()
 // Creation:   Mon Mar 4 11:45:12 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2913,7 +2916,7 @@ QvisMainWindow::winset(int index)
 // ****************************************************************************
 // Method: QvisMainWindow::winset2
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when an item in the Window
 //   menu's "Active window" menu is clicked.
 //
@@ -2941,7 +2944,7 @@ QvisMainWindow::winset2(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::copyView
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the view from another window to
 //   be copied to the active window.
 //
@@ -2970,7 +2973,7 @@ QvisMainWindow::copyView(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::copyLighting
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the lighting from another window
 //   to be copied to the active window.
 //
@@ -2999,7 +3002,7 @@ QvisMainWindow::copyLighting(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::copyAnnotations
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the annotations from another
 //   window to be copied to the active window.
 //
@@ -3028,7 +3031,7 @@ QvisMainWindow::copyAnnotations(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::copyAnnotations
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the plots from another
 //   window to be copied to the active window.
 //
@@ -3057,7 +3060,7 @@ QvisMainWindow::copyPlots(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::copyAll
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the view, annotations, lighting
 //   from another window to be copied to the active window.
 //
@@ -3094,14 +3097,14 @@ QvisMainWindow::copyAll(QAction *action)
 // ****************************************************************************
 // Method: QvisMainWindow::clearPlots
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that clears the plots from the active window.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 16 17:25:51 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3113,14 +3116,14 @@ QvisMainWindow::clearPlots()
 // ****************************************************************************
 // Method: QvisMainWindow::clearReferenceLines
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that clears the reflines from the active window.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 16 17:25:51 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3132,14 +3135,14 @@ QvisMainWindow::clearReferenceLines()
 // ****************************************************************************
 // Method: QvisMainWindow::clearPickPoints
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that clears the picks from the active window.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 16 17:25:51 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3151,7 +3154,7 @@ QvisMainWindow::clearPickPoints()
 // ****************************************************************************
 // Method: QvisMainWindow::toggleSpinMode
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the active window to toggle its
 //   spin mode.
 //
@@ -3159,7 +3162,7 @@ QvisMainWindow::clearPickPoints()
 // Creation:   Mon Sep 16 17:25:51 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 
@@ -3172,7 +3175,7 @@ QvisMainWindow::toggleSpinMode()
 // ****************************************************************************
 // Method: QvisMainWindow::toggleFullFrameMode
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the active window to toggle its
 //   fullframe mode.
 //
@@ -3180,7 +3183,7 @@ QvisMainWindow::toggleSpinMode()
 // Creation:   Wed May 21 07:44:49 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3192,7 +3195,7 @@ QvisMainWindow::toggleFullFrameMode()
 // ****************************************************************************
 // Method: QvisMainWindow::lockTime
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the active window to toggle its
 //   lockTime mode.
 //
@@ -3200,7 +3203,7 @@ QvisMainWindow::toggleFullFrameMode()
 // Creation:   Mon Nov 11 13:02:58 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3212,7 +3215,7 @@ QvisMainWindow::lockTime()
 // ****************************************************************************
 // Method: QvisMainWindow::lockTools
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the active window to toggle its
 //   lockTools mode.
 //
@@ -3220,7 +3223,7 @@ QvisMainWindow::lockTime()
 // Creation:   Mon Nov 11 13:02:58 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3232,7 +3235,7 @@ QvisMainWindow::lockTools()
 // ****************************************************************************
 // Method: QvisMainWindow::lockView
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that causes the active window to toggle its
 //   lockView mode.
 //
@@ -3240,7 +3243,7 @@ QvisMainWindow::lockTools()
 // Creation:   Mon Nov 11 13:02:58 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3252,14 +3255,14 @@ QvisMainWindow::lockView()
 // ****************************************************************************
 // Method: QvisMainWindow::unlockEverything
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that turns off all of the locks.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jan 23 10:48:12 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisTimeSliderControlWidget.C
+++ b/src/gui/QvisTimeSliderControlWidget.C
@@ -44,7 +44,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QTreeWidget>
-#include <QTreeWidgetItem> 
+#include <QTreeWidgetItem>
 #include <QLayout>
 #include <QPushButton>
 #include <QLineEdit>
@@ -72,7 +72,7 @@
 // ****************************************************************************
 // Method: QvisTimeSliderControl::QvisTimeSliderControl
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisTimeSliderControl class.
 //
 // Arguments:
@@ -85,6 +85,8 @@
 // Creation:   Thu Aug 31 10:35:07 PDT 2000
 //
 // Modifications:
+//  Kathleen Biagas, Mon Sep 30 09:25:45 PDT 2019
+//  Set inital state of VCR play buttons to disabled. Add plotList.
 //
 // ****************************************************************************
 
@@ -136,6 +138,7 @@ QvisTimeSliderControlWidget::QvisTimeSliderControlWidget(QWidget *parent) :
     // Create the VCR controls.
     vcrControls = new QvisVCRControl(this);
     vcrControls->setEnabled(false);
+    vcrControls->SetPlayEnabledState(false);
     connect(vcrControls, SIGNAL(prevFrame()), this, SLOT(backwardStep()));
     connect(vcrControls, SIGNAL(reversePlay()), this, SLOT(reversePlay()));
     connect(vcrControls, SIGNAL(stop()), this, SLOT(stop()));
@@ -145,19 +148,22 @@ QvisTimeSliderControlWidget::QvisTimeSliderControlWidget(QWidget *parent) :
 
     // Initialize the attached subjects
     windowInfo = NULL;
+    plotList = NULL;
 
 }
 
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::~QvisTimeSliderControlWidget
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisTimeSliderControl class.
 //
 // Programmer: Cyrus Harrison
 // Creation:   Fri Mar 12 10:59:55 PST 2010
 //
 // Modifications:
+//  Kathleen Biagas, Mon Sep 30 09:29:12 PDT 2019
+//  Added plotList.
 //
 // ****************************************************************************
 
@@ -169,16 +175,19 @@ QvisTimeSliderControlWidget::~QvisTimeSliderControlWidget()
     if(windowInfo)
         windowInfo->Detach(this);
 
+    if(plotList)
+        plotList->Detach(this);
+
 }
 
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::SetTimeStateFormat
 //
-// Purpose: 
+// Purpose:
 //   Sets the display mode for the file panel. We can make it display files
 //   using cycle information or we can make it use time information.
 //
-// Arguments: 
+// Arguments:
 //   m : The new timestate display mode.
 //
 // Notes:      This method resets the text on the expanded databases, which
@@ -207,7 +216,7 @@ QvisTimeSliderControlWidget::~QvisTimeSliderControlWidget()
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -230,7 +239,7 @@ QvisTimeSliderControlWidget::SetTimeStateFormat(const TimeFormat &m)
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::GetTimeStateFormat
 //
-// Purpose: 
+// Purpose:
 //   Returns the time state format.
 //
 // Returns:    The time state format.
@@ -253,7 +262,7 @@ QvisTimeSliderControlWidget::GetTimeStateFormat() const
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::Update
 //
-// Purpose: 
+// Purpose:
 //   This method tells the widget to update itself when the subject
 //   changes.
 //
@@ -266,22 +275,38 @@ QvisTimeSliderControlWidget::GetTimeStateFormat() const
 //   Brad Whitlock, Sun Jan 25 01:28:23 PDT 2004
 //   I made it use windowInfo instead of globalAtts.
 //
+//   Kathleen Biagas, Mon Sep 30 09:29:50 PDT 2019
+//   Added plotList. Set 'shouldEnablePlay; based on active, completed
+//   time-varying plot that follows time.
+//
 // ****************************************************************************
 
 void
 QvisTimeSliderControlWidget::Update(Subject *TheChangedSubject)
 {
-    if(fileServer == 0 || windowInfo == 0)
+    if(fileServer == 0 || windowInfo == 0 || plotList == 0)
         return;
     else if(TheChangedSubject == windowInfo)
         UpdateAnimationControls(false);
+    else if(TheChangedSubject == plotList)
+    {
+        bool shouldEnablePlay = false;
+        for (int i = 0; i < plotList->GetNumPlots() && !shouldEnablePlay; ++i)
+        {
+            const Plot &current = plotList->operator[](i);
+            shouldEnablePlay = (current.GetActiveFlag() &&
+                                current.GetFollowsTime() &&
+                                current.GetStateType() == Plot::Completed);
+        }
+        vcrControls->SetPlayEnabledState(shouldEnablePlay);
+    }
 }
 
 
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::UpdateAnimationControls
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the GlobalAttributes subject that this
 //   widget watches is updated.
 //
@@ -387,7 +412,7 @@ QvisTimeSliderControlWidget::UpdateAnimationControls(bool doAll)
             {
                 int index = -1;
                 for(size_t j = 0; j < sources.size(); ++j)
-                { 
+                {
                     if(sources[j] == tsNames[i])
                     {
                         index = j;
@@ -531,7 +556,7 @@ QvisTimeSliderControlWidget::UpdateAnimationControlsEnabledState()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::UpdateTimeFieldText
 //
-// Purpose: 
+// Purpose:
 //   Updates the text in the time/cycle text field.
 //
 // Arguments:
@@ -666,9 +691,9 @@ QvisTimeSliderControlWidget::UpdateTimeFieldText(int timeState)
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::SetTimeFieldText
 //
-// Purpose: 
-//   Sets the text in the time/cycle text field, makes sure the text is 
-//   visible to the user. 
+// Purpose:
+//   Sets the text in the time/cycle text field, makes sure the text is
+//   visible to the user.
 //
 // Arguments:
 //   text: Text value to set.
@@ -685,7 +710,7 @@ QvisTimeSliderControlWidget::UpdateTimeFieldText(int timeState)
 void
 QvisTimeSliderControlWidget::SetTimeFieldText(const QString &text)
 {
-    int w  = timeField->width(); 
+    int w  = timeField->width();
     int nw = timeField->fontMetrics().width("  " + text);
     if(w < nw)
         timeField->setMinimumWidth(nw);
@@ -696,7 +721,7 @@ QvisTimeSliderControlWidget::SetTimeFieldText(const QString &text)
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::FormattedCycleString
 //
-// Purpose: 
+// Purpose:
 //   Returns a formatted cycle string.
 //
 // Arguments:
@@ -724,7 +749,7 @@ QvisTimeSliderControlWidget::FormattedCycleString(const int cycle) const
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::FormattedTimeString
 //
-// Purpose: 
+// Purpose:
 //   Returns a formatted time string.
 //
 // Arguments:
@@ -738,7 +763,7 @@ QvisTimeSliderControlWidget::FormattedCycleString(const int cycle) const
 // Creation:   Mon Oct 13 16:03:37 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QString
@@ -811,12 +836,28 @@ QvisTimeSliderControlWidget::ConnectWindowInformation(WindowInformation *wi)
     UpdateAnimationControls(true);
 }
 
+void
+QvisTimeSliderControlWidget::ConnectPlotList(PlotList *pl)
+{
+    plotList = pl;
+    plotList->Attach(this);
+
+    bool shouldEnablePlay = false;
+    for (int i = 0; i < plotList->GetNumPlots() && !shouldEnablePlay; ++i)
+    {
+        const Plot &current = plotList->operator[](i);
+        shouldEnablePlay = (current.GetActiveFlag() &&
+                            current.GetFollowsTime() &&
+                            current.GetStateType() == Plot::Completed);
+    }
+    vcrControls->SetPlayEnabledState(shouldEnablePlay);
+}
 
 
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::SetTimeSliderState
 //
-// Purpose: 
+// Purpose:
 //   Sets the animation frame.
 //
 // Arguments:
@@ -853,7 +894,7 @@ QvisTimeSliderControlWidget::SetTimeSliderState(int state)
              GetViewerMethods()->SetTimeSliderState(state);
          }
          else
-         {  
+         {
              QString msg;
              msg.sprintf(" %d.", state);
              Message(tr("The active time slider is already at state") + msg);
@@ -870,7 +911,7 @@ QvisTimeSliderControlWidget::SetTimeSliderState(int state)
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::backwardStep
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the viewer to switch to
 //   the previous time state for the active time slider.
 //
@@ -897,7 +938,7 @@ QvisTimeSliderControlWidget::backwardStep()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::reversePlay
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the viewer to play the
 //   current animation in reverse.
 //
@@ -921,7 +962,7 @@ QvisTimeSliderControlWidget::reversePlay()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::stop
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the viewer to stop playing
 //   the current animation.
 //
@@ -946,7 +987,7 @@ QvisTimeSliderControlWidget::stop()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::play
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the viewer to play the
 //   current animation.
 //
@@ -970,7 +1011,7 @@ QvisTimeSliderControlWidget::play()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::forwardStep
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the viewer to switch to
 //   the next frame in an animation.
 //
@@ -1020,7 +1061,7 @@ QvisTimeSliderControlWidget::forwardStep()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::sliderStart
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the animation
 //   slider is pressed.
 //
@@ -1049,14 +1090,14 @@ QvisTimeSliderControlWidget::sliderStart()
     int activeTS = windowInfo->GetActiveTimeSlider();
     if(activeTS >= 0)
         sliderVal = windowInfo->GetTimeSliderCurrentStates()[activeTS];
-    else 
+    else
         sliderVal = 0;
 }
 
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::sliderMove
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the animation
 //   slider is moved.
 //
@@ -1087,7 +1128,7 @@ QvisTimeSliderControlWidget::sliderMove(int val)
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::sliderEnd
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the slider is
 //   released. It will change the current frame of the animation to
 //   the last slider value.
@@ -1164,9 +1205,9 @@ QvisTimeSliderControlWidget::sliderChange(int val)
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::processTimeText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that processes the text entered by
-//   the user and looks for the closest cycle number and sets the 
+//   the user and looks for the closest cycle number and sets the
 //   animation to that cycle number.
 //
 // Programmer: Brad Whitlock
@@ -1226,7 +1267,7 @@ QvisTimeSliderControlWidget::processTimeText()
         {
             SetTimeFieldText("");
             return;
-        } 
+        }
 
         // Loop through the times for the current file while the
         // time that was entered is greater than or equal to the
@@ -1249,7 +1290,7 @@ QvisTimeSliderControlWidget::processTimeText()
         {
             SetTimeFieldText("");
             return;
-        } 
+        }
 
         // Loop through the cycles for the current file while the
         // cycle that was entered is greater than or equal to the
@@ -1275,7 +1316,7 @@ QvisTimeSliderControlWidget::processTimeText()
 // ****************************************************************************
 // Method: QvisTimeSliderControlWidget::changeActiveTimeSlider
 //
-// Purpose: 
+// Purpose:
 //   Tell the viewer to switch to the new active time slider.
 //
 // Arguments:

--- a/src/gui/QvisTimeSliderControlWidget.h
+++ b/src/gui/QvisTimeSliderControlWidget.h
@@ -63,6 +63,7 @@ class QvisVCRControl;
 
 class avtDatabaseMetaData;
 class FileServerList;
+class PlotList;
 class WindowInformation;
 class ViewerProxy;
 
@@ -81,6 +82,9 @@ class ViewerProxy;
 //
 //
 // Modifications:
+//  Kathleen Biagas, Mon Sep 30 09:25:45 PDT 2019
+//  Observe PlotList so VCR controls play and reverse play buttons enabled
+//  state can be dependent upon the active plots being drawn.
 //
 // ****************************************************************************
 
@@ -97,6 +101,7 @@ public:
 
     void ConnectFileServer(FileServerList *);
     void ConnectWindowInformation(WindowInformation *);
+    void ConnectPlotList(PlotList *);
 
     void SetTimeStateFormat(const TimeFormat &fmt);
     const TimeFormat &GetTimeStateFormat() const;
@@ -135,6 +140,7 @@ private:
     WindowInformation        *windowInfo;
     int                       sliderVal;
     TimeFormat                timeStateFormat;
+    PlotList                 *plotList;
 };
 
 #endif

--- a/src/gui/QvisVCRControl.C
+++ b/src/gui/QvisVCRControl.C
@@ -317,7 +317,7 @@ char QvisVCRControl::augmentedForeground[15];
 // Purpose: This is the constructor for the QvisVCRControl class. It
 //          creates some QPushButtons and adds them to the button
 //          group.
-//   
+//
 //
 // Notes:      The QvisVCRControl class is a widget that contains 5 buttons
 //             that correspond to reverse, rewind, stop, play, advance.
@@ -343,10 +343,15 @@ char QvisVCRControl::augmentedForeground[15];
 //   Set the icon size to something reasonable.  (It's way too small in
 //   virtually every Qt style.)
 //
+//   Kathleen Biagas, Mon Sep 30 09:19:57 PDT 2019
+//   Add playShouldBeEnabled. Change initial enabled state of play and reverse
+//   play to false.
+//
 // ****************************************************************************
 
 QvisVCRControl::QvisVCRControl(QWidget *parent) : QWidget(parent)
 {
+    playShouldBeEnabled = false;
     // Make the stop button active.
     activeButton = 2;
 
@@ -383,6 +388,7 @@ QvisVCRControl::QvisVCRControl(QWidget *parent) : QWidget(parent)
     buttons[1]->setCheckable(true);
     buttons[1]->setDown(false);
     buttons[1]->setIconSize(iconsize);
+    buttons[1]->setEnabled(false);
 
     buttons[2] = new QPushButton(this);
     buttons[2]->setIcon(QIcon(p3));
@@ -395,6 +401,7 @@ QvisVCRControl::QvisVCRControl(QWidget *parent) : QWidget(parent)
     buttons[3]->setCheckable(true);
     buttons[3]->setDown(false);
     buttons[3]->setIconSize(iconsize);
+    buttons[3]->setEnabled(false);
 
     buttons[4] = new QPushButton(this);
     buttons[4]->setIcon(QIcon(p5));
@@ -417,15 +424,15 @@ QvisVCRControl::QvisVCRControl(QWidget *parent) : QWidget(parent)
 // Method: QvisVCRControl
 //
 // Purpose: This is the destructor for the QvisVCRControl class.
-//   
 //
-// Notes:      
+//
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jul 12 11:28:07 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisVCRControl::~QvisVCRControl()
@@ -434,15 +441,42 @@ QvisVCRControl::~QvisVCRControl()
 }
 
 // ****************************************************************************
+// Method: QvisVCRControl::SetPlayEnabledState
+//
+// Purpose:
+//   Sets the enabled state for the forward and reverse play buttons.
+//
+// Arguments:
+//   shouldEnabledPlay : The new enabled state
+//
+// Programmer: Kathleen Biagas
+// Creation:   September 30, 2019
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+QvisVCRControl::SetPlayEnabledState(bool shouldEnablePlay)
+{
+    blockSignals(true);
+    playShouldBeEnabled = shouldEnablePlay;
+    buttons[1]->setEnabled(shouldEnablePlay);
+    buttons[3]->setEnabled(shouldEnablePlay);
+    blockSignals(false);
+}
+
+
+// ****************************************************************************
 // Method: QvisVCRControl::SetActiveButton
 //
-// Purpose: 
+// Purpose:
 //   This method sets the active button.
 //
 // Arguments:
 //   btn : The index of the button to make active.
 //
-// Note:       
+// Note:
 //   This method will emit signals due to the calls of the b#_clicked
 //   slot functions.
 //
@@ -450,7 +484,7 @@ QvisVCRControl::~QvisVCRControl()
 // Creation:   Tue Sep 26 15:55:06 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -472,13 +506,13 @@ QvisVCRControl::SetActiveButton(int btn)
         break;
     case 4:
         b4_clicked();
-    }    
+    }
 }
 
 // ****************************************************************************
 // Method: QvisVCRControl::AugmentPixmap
 //
-// Purpose: 
+// Purpose:
 //   This method augments pixmap data so that the application's foreground
 //   color is used instead of the default of black.
 //
@@ -503,7 +537,7 @@ QvisVCRControl::AugmentPixmap(const char *xpm[])
     QColor foreground(palette().color(QPalette::Text));
 
     // Turn the third element into the foreground color.
-    sprintf(augmentedForeground, "X c #%02x%02x%02x", 
+    sprintf(augmentedForeground, "X c #%02x%02x%02x",
             foreground.red(), foreground.green(),
             foreground.blue());
     augmentedData[2] = augmentedForeground;
@@ -513,8 +547,8 @@ QvisVCRControl::AugmentPixmap(const char *xpm[])
 // Method: QvisVCRControl::b0_clicked()
 //
 // Purpose: slot function that emits the prevFrame signal.
-//   
-// Notes:      
+//
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jul 12 13:33:47 PST 2000
@@ -564,7 +598,7 @@ QvisVCRControl::b0_clicked()
 //
 // Purpose: slot function that emits the reversePlay signal.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jul 12 13:33:47 PST 2000
@@ -572,7 +606,7 @@ QvisVCRControl::b0_clicked()
 // Modifications:
 //   Brad Whitlock, Tue Jun  3 14:02:23 PDT 2008
 //   Qt 4.
-//   
+//
 // ****************************************************************************
 
 void
@@ -605,7 +639,7 @@ QvisVCRControl::b1_clicked()
 //
 // Purpose: slot function that emits the stop signal.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jul 12 13:33:47 PST 2000
@@ -652,7 +686,7 @@ QvisVCRControl::b2_clicked()
 //
 // Purpose: slot function that emits the play signal.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jul 12 13:33:47 PST 2000
@@ -696,7 +730,7 @@ QvisVCRControl::b3_clicked()
 //
 // Purpose: slot function that emits the nextFrame signal.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jul 12 13:33:47 PST 2000
@@ -752,6 +786,9 @@ QvisVCRControl::b4_clicked()
 // Creation:   Sun Dec 18, 2011
 //
 // Modifications:
+//  Kathleen Biagas, Mon Sep 30 09:22:55 PDT 2019
+//  Make enabled state of forward (3) and reverse (1) play buttons be dependent
+//  on the playShouldBeEnabled flag.
 //
 // ****************************************************************************
 
@@ -761,8 +798,8 @@ QvisVCRControl::SetDDTSimEnabled(bool enabled)
     // This is a DDT-sourced simulation.
     // Enable the stop, play, and step operations.
     buttons[0]->setEnabled(!enabled);
-    buttons[1]->setEnabled(!enabled);
+    buttons[1]->setEnabled(!enabled && playShouldBeEnabled);
     buttons[2]->setEnabled(true);
-    buttons[3]->setEnabled(true);
+    buttons[3]->setEnabled(playShouldBeEnabled);
     buttons[4]->setEnabled(true);
 }

--- a/src/gui/QvisVCRControl.h
+++ b/src/gui/QvisVCRControl.h
@@ -50,7 +50,7 @@ class QPushButton;
 //   This is a widget that encapsulates the individual VCR buttons
 //   into a new VCR controls widget.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Jul 24 13:41:24 PST 2000
@@ -71,6 +71,11 @@ class QPushButton;
 //   Add a method to enable animation controls suitable for controlling
 //   a ddtsim-based simulation
 //
+//   Kathleen Biagas, Mon Sep 30 09:19:57 PDT 2019
+//   Add SetPlayEnabledState to control the enabled state of forward
+//   and reverse play buttons. Allows play to be disabled if the
+//   plots aren't yet drawn.
+//
 // *******************************************************************
 
 class GUI_API QvisVCRControl : public QWidget
@@ -80,7 +85,8 @@ public:
     QvisVCRControl(QWidget * parent=0);
     ~QvisVCRControl();
     void SetActiveButton(int btn);
-    void SetDDTSimEnabled(bool enabled);
+    void SetDDTSimEnabled(bool);
+    void SetPlayEnabledState(bool);
 signals:
     void prevFrame();
     void reversePlay();
@@ -101,6 +107,7 @@ private:
 
     static char *augmentedData[];
     static char  augmentedForeground[];
+    bool playShouldBeEnabled;
 };
 
 #endif

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.0.3</font></b></p>
 <ul>
   <li>Fixed bug with VTK reader parsing .vtm files when 'DataSet' tag doesn't have a 'file' attribute.</li>
+  <li>Disable VCR play/reverse play buttons when there is not active drawn plot.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #3864

I made the Time Slider control widget observe the plot list, so it could change the enabled state
of VCR play/reverse play depending upon active plot being completed and time varying.

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I opened a time-varying dataset and verified the VCR play/reverse play buttons did not become active until the plot was drawn.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
