### PR TITLE
Feature/rusu1/visit 3831 min max multi args

### DIFF
--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
@@ -221,7 +221,7 @@ avtMultipleInputMathExpression::CreateOutputVariable(int arraysToConsider)
     for (int i = 0; i < arraysToConsider; ++i)
     {
         int nCompsi = dataArrays[i]->GetNumberOfComponents();
-        if (nCompsi != nComps)
+        if (nCompsi != 1 && nCompsi != nComps)
         {
             // We can support one-multi components, but we can only support
             // multi-multi if they are the same values.
@@ -238,7 +238,7 @@ avtMultipleInputMathExpression::CreateOutputVariable(int arraysToConsider)
         }
 
         int nValsi = dataArrays[i]->GetNumberOfTuples();
-        if (nValsi != nVals)
+        if (nValsi != 1 && nValsi != nVals)
         {
             // We can support singleton values but we cannot support mismatched
             // number of tuples
@@ -248,7 +248,7 @@ avtMultipleInputMathExpression::CreateOutputVariable(int arraysToConsider)
             }
             else
             {
-                EXCEPTION2(ExpressionException, outputVariableName, "Cannot"
+                EXCEPTION2(ExpressionException, outputVariableName, "Cannot "
                         "process variables with different number of "
                         "elements.");
             }

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
@@ -182,6 +182,27 @@ avtMultipleInputMathExpression::ExractCenteredData(avtCentering *centering_out,
     }
 }
 
+
+// ****************************************************************************
+//  Method: avtMultipleInputMathExpression::CreateOutputVariable
+//
+//  Purpose:
+//      Generate the output variable with the correct number of components
+//      and tuples.
+//
+//  Arguments:
+//      arraysToConsider    Indicates how many arrays (in order of input) to
+//                          consider in determining the component and tuple
+//                          count. Default behavior is to use all of the
+//                          processed arrays.
+//
+//  Returns:    Data array of appropriate size.
+//
+//  Programmer: Eddie Rusu
+//  Creation:   Mon Sep 30 14:49:38 PDT 2019
+//
+// ****************************************************************************
+
 vtkDataArray*
 avtMultipleInputMathExpression::CreateOutputVariable()
 {
@@ -191,6 +212,8 @@ avtMultipleInputMathExpression::CreateOutputVariable()
 vtkDataArray*
 avtMultipleInputMathExpression::CreateOutputVariable(int arraysToConsider)
 {
+    debug5 << "Entering avtMultipleInputMathExpression::"
+              "CreateOutputVariable(int)" << std::endl;
     // Loop over all inputs and determine the number of components and
     // tuples
     int nComps = 1;
@@ -236,7 +259,11 @@ avtMultipleInputMathExpression::CreateOutputVariable(int arraysToConsider)
     vtkDataArray* output = vtkDoubleArray::New();
     output->SetNumberOfComponents(nComps);
     output->SetNumberOfTuples(nVals);
+    debug5 << "Number of tuples: " << nVals << std::endl;
+    debug5 << "Number of components: " << nComps << std::endl;
 
+    debug5 << "Exiting  avtMultipleInputMathExpression::"
+              "CreateOutputVariable(int)" << std::endl;
     return output;
 }
 

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
@@ -179,3 +179,52 @@ avtMultipleInputMathExpression::ExractCenteredData(avtCentering *centering_out,
         return out;
     }
 }
+
+
+// ****************************************************************************
+//  Method: avtMultipleInputMathExpression::RecenterData
+//
+//  Purpose:
+//      Determines the centering of the input variables. If there is mixed
+//      centering, default to zone-centered.
+//
+//  Arguments:
+//      in_ds   The vtkDataSet that holds all the arrays. Arrays and
+//              centerings are already stored in dataArrays and centerings,
+//              which are class vectors, so in_ds is only needed because
+//              the call to avtExpressionFilter::Recenter requires it.
+//
+//  Programmer: Eddie Rusu
+//  Creation:   Mon Sep 30 10:38:44 PDT 2019
+//
+// ****************************************************************************
+
+void
+avtMultipleInputMathExpression::RecenterData(vtkDataSet* in_ds)
+{
+    debug5 << "Entering avtMultipleInputMathExpression::RecenterData(vtkDataSet*)"
+            << std::endl;
+
+    // Determine the centering
+    centering = centerings[0];
+    for (int i = 1; i < nProcessedArgs; ++i)
+    {
+        if (centerings[i] != centering)
+        {
+            centering = AVT_ZONECENT;
+            break;
+        }
+    }
+
+    // Recenter variables as needed
+    for (int i = 0; i < nProcessedArgs; ++i)
+    {
+        if (centerings[i] != centering)
+        {
+            dataArrays[i] = Recenter(in_ds, dataArrays[0], centerings[0],
+                outputVariableName);
+        }
+    }
+    debug5 << "Exiting  avtMultipleInputMathExpression::RecenterData(vtkDataSet*)"
+            << std::endl;
+}

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
@@ -308,7 +308,7 @@ avtMultipleInputMathExpression::RecenterData(vtkDataSet* in_ds)
     {
         if (centerings[i] != centering)
         {
-            dataArrays[i] = Recenter(in_ds, dataArrays[0], centerings[0],
+            dataArrays[i] = Recenter(in_ds, dataArrays[i], centerings[i],
                 outputVariableName);
         }
     }

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
@@ -47,8 +47,6 @@
 
 #include <vtkDataArray.h>
 
-class vtkDataArray;
-
 // ****************************************************************************
 //  Class: avtMultipleInputMathExpression
 //

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
@@ -58,6 +58,11 @@ class vtkDataArray;
 //  Programmer: Eddie Rusu
 //  Creation:   Tue Sep 24 09:07:44 PDT 2019
 //
+//  Modifications:
+//
+//      Eddie Rusu, Mon Sep 30 15:00:24 PDT 2019
+//      Added CreateOutputVariable and modified RecenterData.
+//
 // ****************************************************************************
 
 class EXPRESSION_API avtMultipleInputMathExpression

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
@@ -45,6 +45,8 @@
 
 #include <avtMultipleInputExpressionFilter.h>
 
+#include <vtkDataArray.h>
+
 class vtkDataArray;
 
 // ****************************************************************************
@@ -65,13 +67,18 @@ class EXPRESSION_API avtMultipleInputMathExpression
                  avtMultipleInputMathExpression();
         virtual ~avtMultipleInputMathExpression();
 
-        virtual const char *GetType() {return "avtMultipleInputMathExpression";};
+        virtual const char *GetType() {
+                return "avtMultipleInputMathExpression";
+            };
         virtual const char *GetDescription() = 0;
         virtual int         NumVariableArguments() {return nProcessedArgs;};
 
     protected:
         virtual vtkDataArray *DeriveVariable(vtkDataSet*, int);
-        virtual vtkDataArray *ExractCenteredData(avtCentering*, vtkDataSet*, const char*);
+        virtual vtkDataArray *ExractCenteredData(avtCentering*, vtkDataSet*,
+                                                 const char*);
+        virtual vtkDataArray *CreateOutputVariable();
+        virtual vtkDataArray *CreateOutputVariable(int);
         virtual vtkDataArray *DoOperation() = 0;
         virtual void          RecenterData(vtkDataSet*);
 

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
@@ -73,7 +73,7 @@ class EXPRESSION_API avtMultipleInputMathExpression
         virtual vtkDataArray *DeriveVariable(vtkDataSet*, int);
         virtual vtkDataArray *ExractCenteredData(avtCentering*, vtkDataSet*, const char*);
         virtual vtkDataArray *DoOperation() = 0;
-        virtual void          RecenterData(vtkDataSet*) = 0;
+        virtual void          RecenterData(vtkDataSet*);
 
         avtCentering centering;
         std::vector<vtkDataArray*> dataArrays;

--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -105,50 +105,7 @@ avtMinMaxExpression::~avtMinMaxExpression()
 vtkDataArray*
 avtMinMaxExpression::DoOperation()
 {
-    // Loop over all inputs and determine the number of components and
-    // tuples
-    int nComps = 1;
-    int nVals = 1;
-    for (int i = 0; i < nProcessedArgs; ++i)
-    {
-        int nCompsi = dataArrays[i]->GetNumberOfComponents();
-        if (nCompsi != nComps)
-        {
-            // We can support one-multi components, but we can only support
-            // multi-multi if they are the same values.
-            if (nComps == 1)
-            {
-                nComps = nCompsi;
-            }
-            else
-            {
-                EXCEPTION2(ExpressionException, outputVariableName, 
-                        "Don't know how to take minimums or maximums with data "
-                        "of differing dimensions.");
-            }
-        }
-
-        int nValsi = dataArrays[i]->GetNumberOfTuples();
-        if (nValsi != nVals)
-        {
-            // We can support singleton values but we cannot support mismatched
-            // number of tuples
-            if (nVals == 1)
-            {
-                nVals = nValsi;
-            }
-            else
-            {
-                EXCEPTION2(ExpressionException, outputVariableName, 
-                        "Mismatched data sizes in the input variables.");
-            }
-        }
-    }
-    
-    // Setup the output variable
-    vtkDataArray* output = vtkDoubleArray::New();
-    output->SetNumberOfComponents(nComps);
-    output->SetNumberOfTuples(nVals);
+    vtkDataArray* output = CreateOutputVariable();
 
     // Loop over all inputs and determine the min/max
     DoOperationHelper(output, dataArrays[0], dataArrays[1]);

--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -59,6 +59,11 @@
 //  Programmer: Hank Childs
 //  Creation:   March 13, 2006
 //
+//  Modifications:
+//
+//      Eddie Rusu, Mon Sep 30 14:49:38 PDT 2019
+//      Added alternate constructor that takes doMin as input.
+//
 // ****************************************************************************
 
 avtMinMaxExpression::avtMinMaxExpression()

--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -43,8 +43,10 @@
 #include <avtMinMaxExpression.h>
 
 #include <vtkDataArray.h>
+#include <vtkDoubleArray.h>
 
 #include <ExpressionException.h>
+#include <DebugStream.h>
 
 
 // ****************************************************************************
@@ -62,6 +64,11 @@
 avtMinMaxExpression::avtMinMaxExpression()
 {
     doMin = false;
+}
+
+avtMinMaxExpression::avtMinMaxExpression(bool _doMin)
+{
+    doMin = _doMin;
 }
 
 
@@ -83,19 +90,58 @@ avtMinMaxExpression::~avtMinMaxExpression()
 }
 
 
+vtkDataArray*
+avtMinMaxExpression::DoOperation()
+{
+    // Setup the output variable
+    // Loop over all inputs and determine the number of components
+    int nComps = 1;
+    for (int i = 0; i < nProcessedArgs; ++i)
+    {
+        int nCompsi = dataArrays[i]->GetNumberOfComponents();
+        if (nCompsi != nComps)
+        {
+            // We can support one-multi components, but we can only support
+            // multi-multi if they are the same values.
+            if (nComps == 1)
+            {
+                nComps = nCompsi;
+            }
+            else
+            {
+                EXCEPTION2(ExpressionException, outputVariableName, 
+                        "Don't know how to take minimums or maximums with data "
+                        "of differing dimensions.");
+            }
+        }
+    }
+    
+    int nVals = dataArrays[0]->GetNumberOfTuples();
+    vtkDataArray* output = vtkDoubleArray::New();
+    output->SetNumberOfComponents(nComps);
+    output->SetNumberOfTuples(nVals);
+
+    // Loop over all inputs and determine the min/max
+    DoOperationHelper(output, dataArrays[0], dataArrays[1]);
+    for (int i = 2; i < nProcessedArgs; ++i)
+    {
+        DoOperationHelper(output, output, dataArrays[i]);
+    }
+
+    return output;
+}
+
 // ****************************************************************************
 //  Method: avtMinMaxExpression::DoOperation
 //
 //  Purpose:
-//      Finds the minimum or maximum value.
+//      Finds the minimum or maximum value between two arrays
 //
 //  Arguments:
-//      in1           The first input data array.
-//      in2           The second input data array.
+//      out     The output variable.
+//      in1     The first input data array.
+//      in2     The second input data array.
 //      out           The output data array.
-//      ncomponents   The number of components ('1' for scalar, '2' or '3' for
-//                    vectors, etc.)
-//      ntuples       The number of tuples (ie 'npoints' or 'ncells')
 //
 //  Programmer: Hank Childs
 //  Creation:   March 13, 2006
@@ -108,15 +154,20 @@ avtMinMaxExpression::~avtMinMaxExpression()
 //    Kathleen Biagas, Wed Apr 4 12:13:10 PDT 2012
 //    Change float to double.
 //
+//    Eddie Rusu, Mon Sep 30 11:13:18 PDT 2019
+//    Modified inputs for use with new multi-variable architecture.
+//
 // ****************************************************************************
 
 void
-avtMinMaxExpression::DoOperation(vtkDataArray *in1, vtkDataArray *in2,
-                                vtkDataArray *out, int ncomponents,int ntuples)
+avtMinMaxExpression::DoOperationHelper(vtkDataArray *out, vtkDataArray *in1,
+        vtkDataArray *in2)
 {
+    debug4 << "Entering avtMinMaxExpression::DoOperationHelper()" << std::endl;
     bool var1IsSingleton = (in1->GetNumberOfTuples() == 1);
     bool var2IsSingleton = (in2->GetNumberOfTuples() == 1);
 
+    int ntuples = out->GetNumberOfTuples();
     int in1ncomps = in1->GetNumberOfComponents();
     int in2ncomps = in2->GetNumberOfComponents();
     if (in1ncomps == in2ncomps)
@@ -188,7 +239,8 @@ avtMinMaxExpression::DoOperation(vtkDataArray *in1, vtkDataArray *in2,
     else
     {
         EXCEPTION2(ExpressionException, outputVariableName, 
-                         "Don't know how to take minimums or "
-                         "maximums with data of differing dimensions.");
+                "Don't know how to take minimums or maximums with data of "
+                "differing dimensions.");
     }
+    debug4 << "Exiting  avtMinMaxExpression::DoOperationHelper()" << std::endl;
 }

--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -110,6 +110,7 @@ avtMinMaxExpression::~avtMinMaxExpression()
 vtkDataArray*
 avtMinMaxExpression::DoOperation()
 {
+    debug4 << "Entering avtMinMaxExpression::DoOperation()" << std::endl;
     vtkDataArray* output = CreateOutputVariable();
 
     // Loop over all inputs and determine the min/max
@@ -119,6 +120,7 @@ avtMinMaxExpression::DoOperation()
         DoOperationHelper(output, output, dataArrays[i]);
     }
 
+    debug4 << "Exiting  avtMinMaxExpression::DoOperation()" << std::endl;
     return output;
 }
 

--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -90,12 +90,25 @@ avtMinMaxExpression::~avtMinMaxExpression()
 }
 
 
+// ****************************************************************************
+//  Method: avtMinMaxExpression::DoOperation
+//
+//  Purpose:
+//      Finds the max or min among all the input variables stored in
+//      dataArrays.
+//
+//  Programmer: Eddie Rusu
+//  Creation:   Mon Sep 30 14:09:49 PDT 2019
+//
+// ****************************************************************************
+
 vtkDataArray*
 avtMinMaxExpression::DoOperation()
 {
-    // Setup the output variable
-    // Loop over all inputs and determine the number of components
+    // Loop over all inputs and determine the number of components and
+    // tuples
     int nComps = 1;
+    int nVals = 1;
     for (int i = 0; i < nProcessedArgs; ++i)
     {
         int nCompsi = dataArrays[i]->GetNumberOfComponents();
@@ -114,9 +127,25 @@ avtMinMaxExpression::DoOperation()
                         "of differing dimensions.");
             }
         }
+
+        int nValsi = dataArrays[i]->GetNumberOfTuples();
+        if (nValsi != nVals)
+        {
+            // We can support singleton values but we cannot support mismatched
+            // number of tuples
+            if (nVals == 1)
+            {
+                nVals = nValsi;
+            }
+            else
+            {
+                EXCEPTION2(ExpressionException, outputVariableName, 
+                        "Mismatched data sizes in the input variables.");
+            }
+        }
     }
     
-    int nVals = dataArrays[0]->GetNumberOfTuples();
+    // Setup the output variable
     vtkDataArray* output = vtkDoubleArray::New();
     output->SetNumberOfComponents(nComps);
     output->SetNumberOfTuples(nVals);
@@ -132,7 +161,7 @@ avtMinMaxExpression::DoOperation()
 }
 
 // ****************************************************************************
-//  Method: avtMinMaxExpression::DoOperation
+//  Method: avtMinMaxExpression::DoOperationHelper
 //
 //  Purpose:
 //      Finds the minimum or maximum value between two arrays
@@ -141,7 +170,6 @@ avtMinMaxExpression::DoOperation()
 //      out     The output variable.
 //      in1     The first input data array.
 //      in2     The second input data array.
-//      out           The output data array.
 //
 //  Programmer: Hank Childs
 //  Creation:   March 13, 2006
@@ -155,7 +183,8 @@ avtMinMaxExpression::DoOperation()
 //    Change float to double.
 //
 //    Eddie Rusu, Mon Sep 30 11:13:18 PDT 2019
-//    Modified inputs for use with new multi-variable architecture.
+//    Modified inputs for use with new multi-variable architecture. Changed
+//    name from DoOperation to DoOperationHelper.
 //
 // ****************************************************************************
 
@@ -163,13 +192,14 @@ void
 avtMinMaxExpression::DoOperationHelper(vtkDataArray *out, vtkDataArray *in1,
         vtkDataArray *in2)
 {
-    debug4 << "Entering avtMinMaxExpression::DoOperationHelper()" << std::endl;
+    debug5 << "Entering avtMinMaxExpression::DoOperationHelper()" << std::endl;
     bool var1IsSingleton = (in1->GetNumberOfTuples() == 1);
     bool var2IsSingleton = (in2->GetNumberOfTuples() == 1);
 
     int ntuples = out->GetNumberOfTuples();
     int in1ncomps = in1->GetNumberOfComponents();
     int in2ncomps = in2->GetNumberOfComponents();
+
     if (in1ncomps == in2ncomps)
     {
         for (int i = 0 ; i < ntuples ; i++)
@@ -242,5 +272,5 @@ avtMinMaxExpression::DoOperationHelper(vtkDataArray *out, vtkDataArray *in1,
                 "Don't know how to take minimums or maximums with data of "
                 "differing dimensions.");
     }
-    debug4 << "Exiting  avtMinMaxExpression::DoOperationHelper()" << std::endl;
+    debug5 << "Exiting  avtMinMaxExpression::DoOperationHelper()" << std::endl;
 }

--- a/src/avt/Expressions/General/avtMinMaxExpression.h
+++ b/src/avt/Expressions/General/avtMinMaxExpression.h
@@ -43,7 +43,7 @@
 #ifndef AVT_MINMAX_EXPRESSION_H
 #define AVT_MINMAX_EXPRESSION_H
 
-#include <avtBinaryMathExpression.h>
+#include <avtMultipleInputMathExpression.h>
 
 class     vtkDataArray;
 
@@ -68,24 +68,29 @@ class     vtkDataArray;
 //
 // ****************************************************************************
 
-class EXPRESSION_API avtMinMaxExpression : public avtBinaryMathExpression
+class EXPRESSION_API avtMinMaxExpression
+    : public avtMultipleInputMathExpression
 {
   public:
-                              avtMinMaxExpression();
-    virtual                  ~avtMinMaxExpression();
+             avtMinMaxExpression();
+             avtMinMaxExpression(bool);
+    virtual ~avtMinMaxExpression();
 
-    virtual const char       *GetType(void) 
-                                 { return "avtMinMaxExpression"; };
-    virtual const char       *GetDescription(void)
-                                 { return "Calculating min or max"; };
-    bool                      SetDoMinimum(bool b) { doMin = b; return true; };
+    virtual const char *GetType(void) { return "avtMinMaxExpression"; };
+    virtual const char *GetDescription(void)
+                          { return "Calculating min or max"; };
+
+    bool SetDoMinimum(bool b) { doMin = b; return true; };
+    // TODO: remove this
 
   protected:
-    bool             doMin;
+    virtual vtkDataArray *DoOperation();
+    virtual bool          CanHandleSingletonConstants(void) {return true;};
 
-    virtual void     DoOperation(vtkDataArray *in1, vtkDataArray *in2,
-                                 vtkDataArray *out, int ncomps, int ntuples);
-    virtual bool     CanHandleSingletonConstants(void) {return true;};
+    bool doMin;
+  
+  private:
+    void DoOperationHelper(vtkDataArray*, vtkDataArray*, vtkDataArray*);
 };
 
 

--- a/src/avt/Expressions/General/avtMinMaxExpression.h
+++ b/src/avt/Expressions/General/avtMinMaxExpression.h
@@ -80,9 +80,6 @@ class EXPRESSION_API avtMinMaxExpression
     virtual const char *GetDescription(void)
                           { return "Calculating min or max"; };
 
-    bool SetDoMinimum(bool b) { doMin = b; return true; };
-    // TODO: remove this
-
   protected:
     virtual vtkDataArray *DoOperation();
     virtual bool          CanHandleSingletonConstants(void) {return true;};

--- a/src/avt/Expressions/General/avtMinMaxExpression.h
+++ b/src/avt/Expressions/General/avtMinMaxExpression.h
@@ -66,6 +66,10 @@ class     vtkDataArray;
 //    Hank Childs, Mon Jan 14 17:58:58 PST 2008
 //    Allow constants to be created as singletons.
 //
+//    Eddie Rusu, Mon Sep 30 15:00:24 PDT 2019
+//    Inherit from avtMultiInputMathExpressions to allow taking the min/max
+//    over more than 2 variables.
+//
 // ****************************************************************************
 
 class EXPRESSION_API avtMinMaxExpression

--- a/src/avt/Expressions/Management/avtExprNode.C
+++ b/src/avt/Expressions/Management/avtExprNode.C
@@ -631,17 +631,9 @@ avtFunctionExpr::CreateFilters(string functionName)
     if (functionName == "distance_to_best_fit_line2")
         return new avtDistanceToBestFitLineExpression(false);
     if (functionName == "min" || functionName == "minimum")
-    {
-        avtMinMaxExpression *mm = new avtMinMaxExpression;
-        mm->SetDoMinimum(true);
-        return mm;
-    }
+        return new avtMinMaxExpression(true);
     if (functionName == "max" || functionName == "maximum")
-    {
-        avtMinMaxExpression *mm = new avtMinMaxExpression;
-        mm->SetDoMinimum(false);
-        return mm;
-    }
+        return new avtMinMaxExpression(false);
     if (functionName == "geodesic_vector_quantize")
         return new avtGeodesicVectorQuantizeExpression();
     if (functionName == "color")

--- a/src/avt/Expressions/Management/avtExprNode.C
+++ b/src/avt/Expressions/Management/avtExprNode.C
@@ -511,6 +511,10 @@ avtVectorExpr::CreateFilters(ExprPipelineState *state)
 //    Timo Bremer, Fri Oct 28 09:09:27 PDT 2016
 //    Added merge_tree, split_tree and local_threshold.
 //
+//    Eddie Rusu, Mon Sep 30 14:49:38 PDT 2019
+//    Changed MinMax expression creation so that they construct with doMin
+//    as a construction parameter.
+//
 // ****************************************************************************
 
 avtExpressionFilter *

--- a/src/avt/Expressions/Math/avtSmartDivideExpression.C
+++ b/src/avt/Expressions/Math/avtSmartDivideExpression.C
@@ -146,6 +146,12 @@ avtSmartDivideExpression::RecenterData(vtkDataSet* in_ds)
 //  Programmer: Eddie Rusu
 //  Creation:   Tue Sep 24 09:07:44 PDT 2019.
 //
+//  Modifications:
+//
+//      Eddie Rusu, Mon Sep 30 14:49:38 PDT 2019
+//      Replaced output variable setup with
+//      avtMultiInputMathExpression::CreateOutputVariable.
+//
 // ****************************************************************************
 
 vtkDataArray*

--- a/src/avt/Expressions/Math/avtSmartDivideExpression.C
+++ b/src/avt/Expressions/Math/avtSmartDivideExpression.C
@@ -100,7 +100,7 @@ avtSmartDivideExpression::~avtSmartDivideExpression()
 //      in_ds   The vtkDataSet that holds all the arrays. Arrays and
 //              centerings are already stored in dataArrays and centerings,
 //              which are class vectors, so in_ds is only needed because
-//              the call to Recenter requires it.
+//              the call to avtExpressionFilter::Recenter requires it.
 //
 //  Programmer: Eddie Rusu
 //  Creation:   Tue Sep 24 09:07:44 PDT 2019

--- a/src/avt/Expressions/Math/avtSmartDivideExpression.C
+++ b/src/avt/Expressions/Math/avtSmartDivideExpression.C
@@ -182,15 +182,8 @@ avtSmartDivideExpression::DoOperation()
     }
 
     // Setup the output variable
-    int nComps =
-        data1->GetNumberOfComponents() >= data2->GetNumberOfComponents() ?
-        data1->GetNumberOfComponents() :
-        data2->GetNumberOfComponents();
-    int nVals = data1->GetNumberOfTuples();
-
-    vtkDataArray* output = vtkDoubleArray::New();
-    output->SetNumberOfComponents(nComps);
-    output->SetNumberOfTuples(nVals);
+    vtkDataArray *output = CreateOutputVariable(2);
+    int nVals = output->GetNumberOfTuples();
 
     // Perform the division
     bool var1IsSingleton = (data1->GetNumberOfTuples() == 1);

--- a/src/doc/gui_manual/Quantitative/Expressions.rst
+++ b/src/doc/gui_manual/Quantitative/Expressions.rst
@@ -371,17 +371,17 @@ Base 10 Logarithm Function (``log10()``) : ``log10(expr0)``
     Creates a new expression which is everywhere the base 10 logarithm of its
     argument.
 
-.. _Pairwise_Max_Expression_Function:
+.. _Max_Expression_Function:
 
-Pairwise Max Function (``max()``) : ``max(expr0,exrp1)``
-    Creates a new expression which is everywhere the pairwise maximum of its
-    two arguments.
+Max Function (``max()``) : ``max(expr0, exrp1 [, ...])``
+    Creates a new expression which is everywhere the maximum among all input
+    variables.
 
-.. _Pairwise_Min_Expression_Function:
+.. _Min_Expression_Function:
 
-Pairwise Min Function (``min()``) : ``min(expr0,exrp1)``
-    Creates a new expression which is everywhere the pairwise minimum of its
-    two arguments.
+Min Function (``min()``) : ``min(expr0, exrp1 [, ...])``
+    Creates a new expression which is everywhere the minimum among all input
+    variables.
 
 .. _Modulo_Expression_Function:
 

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.0.3</font></b></p>
 <ul>
   <li>Added "divide" built-in expression for enhanced divison to allow users to specify divide by zero value and tolerance for zero.</li>
+  <li>Enhanced min/max expressssion to support more than 2 input variables.</li>
   <li></li>
 </ul>
 

--- a/src/test/tests/hybrid/expressions.py
+++ b/src/test/tests/hybrid/expressions.py
@@ -380,32 +380,34 @@ DefineScalarExpression('divide3', 'divide(d,p,1.0,2.0)')
 AddPlot('Pseudocolor','divide3')
 DrawPlots()
 Test('divide3')
+DeleteAllPlots()
 
 # Test min/max expression
-DefineScalarExpressions('min1', 'min(10.0, 5.0, d+p)')
+DefineScalarExpression('min1', 'min(10.0, 5.0, d+p)')
 AddPlot('Pseudocolor', 'min1')
 DrawPlots()
 Test('min1')
 DeleteAllPlots()
 
-DefineScalarExpressions('min2', 'min(d+p, 5.0, 10.0)')
+DefineScalarExpression('min2', 'min(d+p, 5.0, 10.0)')
 AddPlot('Pseudocolor', 'min2')
 DrawPlots()
 Test('min2')
 DeleteAllPlots()
 
-DefineScalarExpressions('max1', 'max(10.0, 5.0, d+p)')
+DefineScalarExpression('max1', 'max(10.0, 5.0, d+p)')
 AddPlot('Pseudocolor', 'max1')
 DrawPlots()
 Test('max1')
 DeleteAllPlots()
 
-DefineScalarExpressions('min3', 'min(2.0, d+p, d*p+2*d)')
+DefineScalarExpression('min3', 'min(2.0, d+p, d*p+2*d)')
 AddPlot('Pseudocolor', 'min3')
 DrawPlots()
 Test('min3')
 DeleteAllPlots()
 
+# Test resrad
 DefineScalarExpression("resrad", "resrad(recenter(u), 0.1)")
 AddPlot("Pseudocolor", "resrad")
 DrawPlots()

--- a/src/test/tests/hybrid/expressions.py
+++ b/src/test/tests/hybrid/expressions.py
@@ -381,6 +381,31 @@ AddPlot('Pseudocolor','divide3')
 DrawPlots()
 Test('divide3')
 
+# Test min/max expression
+DefineScalarExpressions('min1', 'min(10.0, 5.0, d+p)')
+AddPlot('Pseudocolor', 'min1')
+DrawPlots()
+Test('min1')
+DeleteAllPlots()
+
+DefineScalarExpressions('min2', 'min(d+p, 5.0, 10.0)')
+AddPlot('Pseudocolor', 'min2')
+DrawPlots()
+Test('min2')
+DeleteAllPlots()
+
+DefineScalarExpressions('max1', 'max(10.0, 5.0, d+p)')
+AddPlot('Pseudocolor', 'max1')
+DrawPlots()
+Test('max1')
+DeleteAllPlots()
+
+DefineScalarExpressions('min3', 'min(2.0, d+p, d*p+2*d)')
+AddPlot('Pseudocolor', 'min3')
+DrawPlots()
+Test('min3')
+DeleteAllPlots()
+
 DefineScalarExpression("resrad", "resrad(recenter(u), 0.1)")
 AddPlot("Pseudocolor", "resrad")
 DrawPlots()

--- a/test/baseline/hybrid/expressions/max1.png
+++ b/test/baseline/hybrid/expressions/max1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6920d916cdf5a8d88a660fc6f4f111bbf5c0c9eb753776ebf094f232936c8fb8
+size 1066

--- a/test/baseline/hybrid/expressions/min1.png
+++ b/test/baseline/hybrid/expressions/min1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d23317d83cd7b7d39fdea114c6826e131c5230850afd8a1c1a066302619ae7a2
+size 3162

--- a/test/baseline/hybrid/expressions/min2.png
+++ b/test/baseline/hybrid/expressions/min2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d23317d83cd7b7d39fdea114c6826e131c5230850afd8a1c1a066302619ae7a2
+size 3162

--- a/test/baseline/hybrid/expressions/min3.png
+++ b/test/baseline/hybrid/expressions/min3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:414bef10b2ebb123ef06e614deb45a7a79315c829979c10cfd46af5494803e2c
+size 2590


### PR DESCRIPTION
### Description

Resolves #3831 

min and max expressions now support multiple number of arguments.


### Type of change

- [X] New feature

### How Has This Been Tested?

Added four tests to the test suite that test the mulit-argument and ordering of the arguments for min and max.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have made corresponding changes to the documentation
- [X] I have added debugging support to my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added any new baselines to the repo
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
