### PR TITLE
Add missing checksums to build_visit.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -67,7 +67,7 @@ function bv_adios2_info
     export ADIOS2_URL=${ADIOS2_URL:-"https://github.com/ornladios/ADIOS2/releases/download/v2.4.0-rc"}
     export ADIOS2_BUILD_DIR=${ADIOS2_BUILD_DIR:-"ADIOS2-"${ADIOS2_VERSION}}
     export ADIOS2_MD5_CHECKSUM="be3f5c7d7ab4f7df65599bebc91e0ce4"
-    export ADIOS2_SHA256_CHECKSUM=""
+    export ADIOS2_SHA256_CHECKSUM="a1b2487cbf6d4d0fb63eb2efc28ce7bcc4992e28d99b6b621694c318cd9c7b50"
 }
 
 function bv_adios2_print

--- a/src/tools/dev/scripts/bv_support/bv_tcmalloc.sh
+++ b/src/tools/dev/scripts/bv_support/bv_tcmalloc.sh
@@ -25,7 +25,7 @@ function bv_tcmalloc_info
     export TCMALLOC_COMPATIBILITY_VERSION=${TCMALLOC_COMPATIBILITY_VERSION:-"0.97"}
     export TCMALLOC_BUILD_DIR=${TCMALLOC_BUILD_DIR:-"google-perftools-0.97"}
     export TCMALLOC_MD5_CHECKSUM="5168bdca5557bc5630a866f132f8f7c1"
-    export TCMALLOC_SHA256_CHECKSUM=""
+    export TCMALLOC_SHA256_CHECKSUM="c879267296d91ccadf3aacb9340ca5801b41fbd37aad097b2b6081bf27bb505c"
 }
 
 function bv_tcmalloc_print

--- a/src/tools/dev/scripts/bv_support/bv_xercesc.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xercesc.sh
@@ -26,6 +26,7 @@ function bv_xercesc_info
     export XERCESC_BUILD_DIR=${XERCESC_BUILD_DIR:-"xerces-c-${XERCESC_VERSION}"}
     export XERCESC_URL=${XERCESC_URL:-"http://archive.apache.org/dist/xerces/c/3/sources"}
     export XERCESC_MD5_CHECKSUM="9eb1048939e88d6a7232c67569b23985"
+    export XERCESC_SHA256_CHECKSUM="743bd0a029bf8de56a587c270d97031e0099fe2b7142cef03e0da16e282655a0"
 }
 
 function bv_xercesc_print
@@ -34,8 +35,6 @@ function bv_xercesc_print
     printf "%s%s\n" "XERCESC_VERSION=" "${XERCESC_VERSION}"
     printf "%s%s\n" "XERCESC_COMPATIBILITY_VERSION=" "${XERCESC_COMPATIBILITY_VERSION}"
     printf "%s%s\n" "XERCESC_BUILD_DIR=" "${XERCESC_BUILD_DIR}"
-    printf "%s%s\n" "XERCESC_URL=" "${XERCESC_URL}"
-    printf "%s%s\n" "XERCESC_MD5_CHECKSUM=" "${XERCESC_MD5_CHECKSUM}"
 }
 
 function bv_xercesc_print_usage

--- a/src/tools/dev/scripts/bv_support/bv_xsd.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xsd.sh
@@ -25,7 +25,8 @@ function bv_xsd_info
     export XSD_COMPATIBILITY_VERSION=${XSD_COMPATIBILITY_VERSION:-"4.0"}
     export XSD_BUILD_DIR=${XSD_BUILD_DIR:-"xsd-${XSD_VERSION}+dep"}
     export XSD_URL=${XSD_URL:-"http://www.codesynthesis.com/download/xsd/4.0"}
-    export XSD_SHA1_CHECKSUM="ad3de699eb140e747a0a214462d95fc81a21b494"
+    export XSD_MD5_CHECKSUM="ae64d7fcd258addc9b045fe3f96208bb"
+    export XSD_SHA256_CHECKSUM="eca52a9c8f52cdbe2ae4e364e4a909503493a0d51ea388fc6c9734565a859817"
 }
 
 function bv_xsd_print

--- a/src/tools/dev/scripts/bv_support/bv_zlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_zlib.sh
@@ -27,6 +27,7 @@ function bv_zlib_info
     export ZLIB_COMPATIBILITY_VERSION=${ZLIB_COMPATIBILITY_VERSION:-"1.2"}
     export ZLIB_URL=${ZLIB_URL:-https://www.zlib.net}
     export ZLIB_BUILD_DIR=${ZLIB_BUILD_DIR:-"zlib-${ZLIB_VERSION}"}
+    export ZLIB_MD5_CHECKSUM="85adef240c5f370b308da8c938951a68"
     export ZLIB_SHA256_CHECKSUM="4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066"
 }
 


### PR DESCRIPTION
### Description

Resolves #3416 

I added any missing checksums to build_visit. I standardized on md5 and sha256 for all the modules. I didn't do 2 because they appeared non-functional (bv_pyqt.sh and bv_mdsplus.sh). I submitted a ticket about them. For any files that weren't already at NERSC, I added them and made sure the permissions for them were correct.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I didn't test the changes. They are pretty trivial.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code