### PR TITLE
Corrected several issues with build_visit3_0_2.

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -60,18 +60,24 @@ export VISIT_VERSION=${VISIT_VERSION:-"3.0.2"}
 ####
 # Trunk:
 ####
-export TRUNK_BUILD="yes"
+#export TRUNK_BUILD="yes"
+#export RC_BUILD="no"
+#export TAGGED_BUILD="no"
 
 ###
 # RC Branch:
 ###
-#export TRUNK_BUILD="no"
+export TRUNK_BUILD="no"
+export RC_BUILD="yes"
+export TAGGED_BUILD="no"
 
 
 ###
 # Tagged Release:
 ###
 #export TRUNK_BUILD="no"
+#export RC_BUILD="no"
+#export TAGGED_BUILD="yes"
 
 export INITIAL_PWD=$PWD
 
@@ -408,6 +414,8 @@ function bv_write_unified_file
     echo "export VISIT_VERSION=\${VISIT_VERSION:-\"$VISIT_VERSION\"}" >> $OUTPUT_bv_FILE
 
     echo "export TRUNK_BUILD=\"$TRUNK_BUILD\"" >> $OUTPUT_bv_FILE
+    echo "export RC_BUILD=\"$RC_BUILD\"" >> $OUTPUT_bv_FILE
+    echo "export TAGGED_BUILD=\"$TAGGED_BUILD\"" >> $OUTPUT_bv_FILE
 
     echo "export INITIAL_PWD=\$PWD" >> $OUTPUT_bv_FILE
 

--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -55,7 +55,7 @@
 #5  bv_<module>_depends_on [not implemented yet], also may be removed in favor of xml structure
 #6. bv_<module>_build builds the module
 
-export VISIT_VERSION=${VISIT_VERSION:-"3.0.1"}
+export VISIT_VERSION=${VISIT_VERSION:-"3.0.2"}
 
 ####
 # Trunk:

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -1268,9 +1268,9 @@ function run_build_visit()
     fi
 
     #
-    # If we doing a trunk build then make sure we are using GIT
+    # If we doing a trunk or RC build then make sure we are using GIT
     #
-    if [[ "$TRUNK_BUILD" == "yes" ]]; then
+    if [[ "$TRUNK_BUILD" == "yes" || "$RC_BUILD" == "yes" ]]; then
         if [[ "$DO_GIT" == "no" ]]; then
             DO_GIT="yes"
             DO_GIT_ANON="yes"


### PR DESCRIPTION
### Description

Resolves #3950

I fixed several issues with build_visit3_0_2. The first was that the version still had 3.0.1. The rest had to do with always using a git clone of develop for the visit sources. It should do a git clone of the RC if on the RC and when it's released it should use either a git clone of the tagged version or the release tar file. I also implemented a git clone with a specific revision. I also cleaned up some code and removed some dead code.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran build_visit in the following scenarios on quartz. I only tested the download, since building wasn't a problem.

Trunk version
./build_visit3_0_2 --skip-opengl-context-check --required --download-only

RC version
./build_visit3_0_2 --skip-opengl-context-check --required --download-only

Tagged version
./build_visit3_0_2 --skip-opengl-context-check --required --download-only

Tagged version with git
./build_visit3_0_2 --skip-opengl-context-check --required --download-only --git

Revision specified with gi
./build_visit3_0_2 --skip-opengl-context-check --required --download-only --git --git-revision 98a8907

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code