### PR TITLE
Corrected several issues with build_visit3_0_2. (#3952)

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -55,23 +55,29 @@
 #5  bv_<module>_depends_on [not implemented yet], also may be removed in favor of xml structure
 #6. bv_<module>_build builds the module
 
-export VISIT_VERSION=${VISIT_VERSION:-"3.0.0"}
+export VISIT_VERSION=${VISIT_VERSION:-"3.1.0"}
 
 ####
 # Trunk:
 ####
 export TRUNK_BUILD="yes"
+export RC_BUILD="no"
+export TAGGED_BUILD="no"
 
 ###
 # RC Branch:
 ###
 #export TRUNK_BUILD="no"
+#export RC_BUILD="yes"
+#export TAGGED_BUILD="no"
 
 
 ###
 # Tagged Release:
 ###
 #export TRUNK_BUILD="no"
+#export RC_BUILD="no"
+#export TAGGED_BUILD="yes"
 
 export INITIAL_PWD=$PWD
 
@@ -408,6 +414,8 @@ function bv_write_unified_file
     echo "export VISIT_VERSION=\${VISIT_VERSION:-\"$VISIT_VERSION\"}" >> $OUTPUT_bv_FILE
 
     echo "export TRUNK_BUILD=\"$TRUNK_BUILD\"" >> $OUTPUT_bv_FILE
+    echo "export RC_BUILD=\"$RC_BUILD\"" >> $OUTPUT_bv_FILE
+    echo "export TAGGED_BUILD=\"$TAGGED_BUILD\"" >> $OUTPUT_bv_FILE
 
     echo "export INITIAL_PWD=\$PWD" >> $OUTPUT_bv_FILE
 

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -1268,9 +1268,9 @@ function run_build_visit()
     fi
 
     #
-    # If we doing a trunk build then make sure we are using GIT
+    # If we doing a trunk or RC build then make sure we are using GIT
     #
-    if [[ "$TRUNK_BUILD" == "yes" ]]; then
+    if [[ "$TRUNK_BUILD" == "yes" || "$RC_BUILD" == "yes" ]]; then
         if [[ "$DO_GIT" == "no" ]]; then
             DO_GIT="yes"
             DO_GIT_ANON="yes"


### PR DESCRIPTION
Resolves #3950 
Merge from the 3.0RC to develop.

There are a couple of minor differences in build_visit between the RC and develop. The version number (3.1.0 vs 3.0.2 in this case) and that build_visit on the trunk is set up to do a git clone of develop while build_visit on the RC is set up to do a git clone of the RC.