### PR TITLE
Task/brugger1/2019 10 11 build visit fix

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -39,7 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.0.3</font></b></p>
 <ul>
-  <li></li>
+  <li>Corrected a bug in build_visit that prevented MesaGL from building from within a Git checkout.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -39,7 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.0.3</font></b></p>
 <ul>
-  <li>Corrected a bug in build_visit that prevented MesaGL from building from within a Git checkout.</li>
+  <li>Corrected a bug in build_visit that prevented OSMesa and MesaGL from building from within a Git checkout.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -106,6 +106,38 @@ function bv_mesagl_dry_run
     fi
 }
 
+function apply_mesagl_patch
+{
+    patch -p0 << \EOF
+diff -c configure.ac.orig configure.ac
+*** configure.ac.orig	Thu Oct 10 15:44:18 2019
+--- configure.ac	Thu Oct 10 15:44:26 2019
+***************
+*** 2690,2696 ****
+      dnl (See https://llvm.org/bugs/show_bug.cgi?id=6823)
+      if test "x$enable_llvm_shared_libs" = xyes; then
+          dnl We can't use $LLVM_VERSION because it has 'svn' stripped out,
+!         LLVM_SO_NAME=LLVM-`$LLVM_CONFIG --version`
+          AS_IF([test -f "$LLVM_LIBDIR/lib$LLVM_SO_NAME.$IMP_LIB_EXT"], [llvm_have_one_so=yes])
+  
+          if test "x$llvm_have_one_so" = xyes; then
+--- 2690,2696 ----
+      dnl (See https://llvm.org/bugs/show_bug.cgi?id=6823)
+      if test "x$enable_llvm_shared_libs" = xyes; then
+          dnl We can't use $LLVM_VERSION because it has 'svn' stripped out,
+!         LLVM_SO_NAME=LLVM-$LLVM_VERSION
+          AS_IF([test -f "$LLVM_LIBDIR/lib$LLVM_SO_NAME.$IMP_LIB_EXT"], [llvm_have_one_so=yes])
+  
+          if test "x$llvm_have_one_so" = xyes; then
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "MesaGL patch failed."
+        return 1
+    fi
+
+    return 0;
+}
+
 function build_mesagl
 {
     #
@@ -119,10 +151,27 @@ function build_mesagl
     fi
 
     #
-    # Build MESAGL.
+    # Apply patches
     #
     cd $MESAGL_BUILD_DIR || error "Couldn't cd to mesagl build dir."
 
+    info "Patching MesaGL"
+    apply_mesagl_patch
+    if [[ $? != 0 ]] ; then
+        if [[ $untarred_mesagl == 1 ]] ; then
+            warn "Giving up on MesaGL build because the patch failed."
+            return 1
+        else
+            warn "Patch failed, but continuing.  I believe that this script\n" \
+                 "tried to apply a patch to an existing directory that had\n" \
+                 "already been patched ... that is, the patch is\n" \
+                 "failing harmlessly on a second application."
+        fi
+    fi
+
+    #
+    # Build MESAGL.
+    #
     if [[ "$DO_STATIC_BUILD" == "yes" ]]; then
         MESAGL_STATIC_DYNAMIC="--disable-shared --disable-shared-glapi --enable-static --enable-static-glapi"
     fi

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -108,6 +108,38 @@ function bv_osmesa_dry_run
     fi
 }
 
+function apply_osmesa_patch
+{
+    patch -p0 << \EOF
+diff -c configure.ac.orig configure.ac
+*** configure.ac.orig	Thu Oct 10 15:44:18 2019
+--- configure.ac	Thu Oct 10 15:44:26 2019
+***************
+*** 2690,2696 ****
+      dnl (See https://llvm.org/bugs/show_bug.cgi?id=6823)
+      if test "x$enable_llvm_shared_libs" = xyes; then
+          dnl We can't use $LLVM_VERSION because it has 'svn' stripped out,
+!         LLVM_SO_NAME=LLVM-`$LLVM_CONFIG --version`
+          AS_IF([test -f "$LLVM_LIBDIR/lib$LLVM_SO_NAME.$IMP_LIB_EXT"], [llvm_have_one_so=yes])
+  
+          if test "x$llvm_have_one_so" = xyes; then
+--- 2690,2696 ----
+      dnl (See https://llvm.org/bugs/show_bug.cgi?id=6823)
+      if test "x$enable_llvm_shared_libs" = xyes; then
+          dnl We can't use $LLVM_VERSION because it has 'svn' stripped out,
+!         LLVM_SO_NAME=LLVM-$LLVM_VERSION
+          AS_IF([test -f "$LLVM_LIBDIR/lib$LLVM_SO_NAME.$IMP_LIB_EXT"], [llvm_have_one_so=yes])
+  
+          if test "x$llvm_have_one_so" = xyes; then
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "OSMesa patch failed."
+        return 1
+    fi
+
+    return 0;
+}
+
 function build_osmesa
 {
     #
@@ -121,10 +153,27 @@ function build_osmesa
     fi
 
     #
-    # Build OSMESA.
+    # Apply patches
     #
     cd $OSMESA_BUILD_DIR || error "Couldn't cd to osmesa build dir."
 
+    info "Patching MesaGL"
+    apply_mesagl_patch
+    if [[ $? != 0 ]] ; then
+        if [[ $untarred_mesagl == 1 ]] ; then
+            warn "Giving up on MesaGL build because the patch failed."
+            return 1
+        else
+            warn "Patch failed, but continuing.  I believe that this script\n" \
+                 "tried to apply a patch to an existing directory that had\n" \
+                 "already been patched ... that is, the patch is\n" \
+                 "failing harmlessly on a second application."
+        fi
+    fi
+
+    #
+    # Build OSMESA.
+    #
     if [[ "$DO_STATIC_BUILD" == "yes" ]]; then
         OSMESA_STATIC_DYNAMIC="--disable-shared --disable-shared-glapi --enable-static --enable-static-glapi"
     fi

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -157,11 +157,11 @@ function build_osmesa
     #
     cd $OSMESA_BUILD_DIR || error "Couldn't cd to osmesa build dir."
 
-    info "Patching MesaGL"
-    apply_mesagl_patch
+    info "Patching OSMesa"
+    apply_osmesa_patch
     if [[ $? != 0 ]] ; then
-        if [[ $untarred_mesagl == 1 ]] ; then
-            warn "Giving up on MesaGL build because the patch failed."
+        if [[ $untarred_osmesa == 1 ]] ; then
+            warn "Giving up on OSMesa build because the patch failed."
             return 1
         else
             warn "Patch failed, but continuing.  I believe that this script\n" \


### PR DESCRIPTION
### Description

Resolves #3962 

I corrected a bug in build_visit when building mesagl from within a git checkout. The mesagl configure script gets the name of the llvm library wrong in this case. I added a patch to bv_mesagl.sh that corrects this behavior.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I did the following on quartz and it succeeded.
git clone ...
git checkout 3.0RC
cd visit
mkdir third_party
cd third_party

../src/tools/dev/scripts/build_visit --parallel --llvm --all-io --boost --zlib --no-visit --makeflags -j12 --no-fastbit --no-fastquery --no-gdal --no-adios --no-adios2 --no-uintah --openssl --embree --ospray --tbb --ispc --mesagl

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have updated the release notes