### PR TITLE
Fix indentation for build_visit help text.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_embree.sh
+++ b/src/tools/dev/scripts/bv_support/bv_embree.sh
@@ -87,7 +87,7 @@ function bv_embree_host_profile
 function bv_embree_print_usage
 {
     #embree does not have an option, it is only dependent on embree.
-    printf "%-15s %s [%s]\n" "--embree" "Build embree" "$DO_EMBREE"
+    printf "%-20s %s [%s]\n" "--embree" "Build embree" "$DO_EMBREE"
 }
 
 function bv_embree_ensure

--- a/src/tools/dev/scripts/bv_support/bv_ispc.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ispc.sh
@@ -88,7 +88,7 @@ function bv_ispc_host_profile
 function bv_ispc_print_usage
 {
     #ispc does not have an option, it is only dependent on ispc.
-    printf "%-15s %s [%s]\n" "--ispc" "Build ISPC" "$DO_ISPC"
+    printf "%-20s %s [%s]\n" "--ispc" "Build ISPC" "$DO_ISPC"
 }
 
 function bv_ispc_ensure

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -39,7 +39,7 @@ function bv_mesagl_print
 
 function bv_mesagl_print_usage
 {
-    printf "%-15s %s [%s]\n" "--mesagl" "Build MesaGL" "$DO_MESAGL"
+    printf "%-20s %s [%s]\n" "--mesagl" "Build MesaGL" "$DO_MESAGL"
 }
 
 function bv_mesagl_host_profile

--- a/src/tools/dev/scripts/bv_support/bv_openexr.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openexr.sh
@@ -64,7 +64,7 @@ function bv_openexr_host_profile
 function bv_openexr_print_usage
 {
     #openexr does not have an option, it is only dependent on openexr.
-    printf "%-15s %s [%s]\n" "--openexr" "Build OpenEXR" "$DO_OPENEXR"
+    printf "%-20s %s [%s]\n" "--openexr" "Build OpenEXR" "$DO_OPENEXR"
 }
 
 function bv_openexr_ensure

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -40,7 +40,7 @@ function bv_osmesa_print
 
 function bv_osmesa_print_usage
 {
-    printf "%-15s %s [%s]\n" "--osmesa" "Build OSMesa" "$DO_OSMESA"
+    printf "%-20s %s [%s]\n" "--osmesa" "Build OSMesa" "$DO_OSMESA"
 }
 
 function bv_osmesa_host_profile

--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -81,7 +81,7 @@ function bv_ospray_print
 
 function bv_ospray_print_usage
 {
-    printf "%-15s %s [%s]\n" "--ospray" "Build OSPRay rendering support" "$DO_OSPRAY"
+    printf "%-20s %s [%s]\n" "--ospray" "Build OSPRay rendering support" "$DO_OSPRAY"
 }
 
 function bv_ospray_host_profile

--- a/src/tools/dev/scripts/bv_support/bv_tbb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_tbb.sh
@@ -91,7 +91,7 @@ function bv_tbb_host_profile
 function bv_tbb_print_usage
 {
     #tbb does not have an option, it is only dependent on tbb.
-    printf "%-15s %s [%s]\n" "--tbb" "Build TBB" "$DO_TBB"
+    printf "%-20s %s [%s]\n" "--tbb" "Build TBB" "$DO_TBB"
 }
 
 function bv_tbb_ensure

--- a/src/tools/dev/scripts/bv_support/construct_build_visit_module.sh
+++ b/src/tools/dev/scripts/bv_support/construct_build_visit_module.sh
@@ -71,8 +71,8 @@ function bv_${output}_print
 #print how to install and uninstall module..
 function bv_${output}_print_usage
 {
-    printf \"%-15s %s [%s]\n\" \"--${output}\"   \"Build ${uppercase_out}\" \"\$DO_${uppercase_out}\"
-    printf \"%-15s %s [%s]\n\" \"--no-${output}\"   \"Do not Build ${uppercase_out}\" \"\$DO_${uppercase_out}\"
+    printf \"%-20s %s [%s]\n\" \"--${output}\"   \"Build ${uppercase_out}\" \"\$DO_${uppercase_out}\"
+    printf \"%-20s %s [%s]\n\" \"--no-${output}\"   \"Do not Build ${uppercase_out}\" \"\$DO_${uppercase_out}\"
 }
 
 #values to add to host profile, write to \$HOSTCONF


### PR DESCRIPTION
Update the module construction to use the correct indentation for usage text.
Fixed a couple of models that use the old indentation.
