### PR TITLE
Resolves #3745. Added lambda2 and q-crit documentation to the GUI

### DIFF
--- a/src/doc/gui_manual/Quantitative/Expressions.rst
+++ b/src/doc/gui_manual/Quantitative/Expressions.rst
@@ -1784,13 +1784,21 @@ isnan Function: ``isnan()`` : ``isnan(expr0)``
 
 .. _Q_Criterion_Expression_Function:
 
-q criterion Function: ``q_criterion()`` : ``q_criterion(expr0)``
-    No description available.
+q criterion Function: ``q_criterion()`` : ``q_criterion(<gradient(velocity[0])>, <gradient(velocity[1])>, <gradient(velocity[2])>)``
+    Generates the Q-criterion value developed by Hunt et. al.. It is based on the 
+    observation that, in regions where the Q-criterion is greater than zero, rotation 
+    exceeds strain and, in conjunction with a pressure min, indicates the presence of 
+    a vortex. The three arguments to the function are gradient vectors of the x-, y-, 
+    and z-velocity. The gradient function (see :ref:`gradient() <Gradient_Expression_Function>`) can be used to create the gradient vectors. 
 
 .. _Lambda2_Expression_Function:
 
-lambda2 Function: ``lambda2()`` : ``lambda2(expr0)``
-    No description available.
+lambda2 Function: ``lambda2()`` : ``lambda2(<gradient(velocity[0])>, <gradient(velocity[1])>, <gradient(velocity[2])>)``
+    Generates the Lambda-2 criterion. It is based on the observation that, in 
+    regions where Lambda-2 is less than zero, rotation exceeds strain and, in 
+    conjunction with a pressure min, indicates the presence of a vortex. The three
+    arguments to the function are gradient vectors of the x-, y-, and z-velocity.
+    The gradient function (see :ref:`gradient() <Gradient_Expression_Function>`) can be used to create the gradient vectors. 
 
 .. _Mean_Curvature_Expression_Function:
 


### PR DESCRIPTION
### Description

Added lambda2 and q-crit documentation to the GUI manual.
Resolves #3745 

Please include a summary of the change

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [ ] New feature
- [x] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Rebuilt the sphinx documentation and verified that the GUI manual was updated.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
