### PR TITLE
Re-enable Remote Host profile import on Windows.

### DIFF
--- a/src/gui/QvisHostProfileWindow.C
+++ b/src/gui/QvisHostProfileWindow.C
@@ -427,10 +427,9 @@ QvisHostProfileWindow::CreateWindowContents()
 
     launchProfilesGroup = CreateLaunchProfilesGroup();
     machineTabs->addTab(launchProfilesGroup, tr("Launch Profiles"));
-#ifndef WIN32
+
     remoteProfilesGroup = CreateRemoteProfilesGroup();
     masterWidget->addTab(remoteProfilesGroup, tr("Remote Profiles"));
-#endif
 
     ((DropListWidget*)hostList)->window = this;
 }


### PR DESCRIPTION
In conjunction with https://github.com/visit-dav/visit-deps/commit/d43838b00f9916b6cb195bb84ee192f90ee80641

Resolves #3918

The visit-dav commit added qt with openssl support to the windows build precompiled binaries.
This commit re-enables the remote profile import functionality on Windows.
