### PR TITLE
Re-enable remote host profile import on Windows.

### DIFF
--- a/src/gui/QvisHostProfileWindow.C
+++ b/src/gui/QvisHostProfileWindow.C
@@ -391,10 +391,9 @@ QvisHostProfileWindow::CreateWindowContents()
 
     launchProfilesGroup = CreateLaunchProfilesGroup();
     machineTabs->addTab(launchProfilesGroup, tr("Launch Profiles"));
-#ifndef WIN32
+
     remoteProfilesGroup = CreateRemoteProfilesGroup();
     masterWidget->addTab(remoteProfilesGroup, tr("Remote Profiles"));
-#endif
 
     ((DropListWidget*)hostList)->window = this;
 }


### PR DESCRIPTION
This is a merge from 3.0RC.

In conjunction with visit-dav/visit-deps@d43838b

Resolves #3918

The visit-dav commit added qt with openssl support to the windows build precompiled binaries.
This commit re-enables the remote profile import functionality on Windows.
