### PR TITLE
Added a patch to build_visit so that Qt builds on CentOS 8.

### DIFF
--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -40,6 +40,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.0.3</font></b></p>
 <ul>
   <li>Corrected a bug in build_visit that prevented OSMesa and MesaGL from building from within a Git checkout.</li>
+  <li>Added a patch to build_visit so that Qt builds on CentOS 8.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Resolves #3980 

I added a patch to build_visit so that Qt builds on CentOS 8. The patch is only applied in the case of CentOS 8.0.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I created a new build_visit and ran it on a Docker image running CentOS 8.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have updated the release notes