### PR TITLE
OpenPMD plugin introduced compilation bugs

### DIFF
--- a/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
@@ -370,6 +370,8 @@ PMDField::SetGridGlobalOffset(char * name,
             this->gridGlobalOffset[1] = tmpArray[1];
             this->gridGlobalOffset[2] = 0;
         }
+
+		delete tmpArray;
     }
 }
 

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
@@ -318,7 +318,8 @@ PMDField::SetGridSpacing(char * name,
             this->gridSpacing[1] = tmpArray[1];
             this->gridSpacing[2] = 0;
         }
-		delete tmpArray;
+        
+        delete tmpArray;
     }
 }
 
@@ -371,7 +372,7 @@ PMDField::SetGridGlobalOffset(char * name,
             this->gridGlobalOffset[2] = 0;
         }
 
-		delete tmpArray;
+        delete tmpArray;
     }
 }
 
@@ -422,7 +423,7 @@ PMDField::SetGridPosition(char * name,
             gridPosition[2] = 0;
         }
 
-		delete tmpArray;
+        delete tmpArray;
     }
 }
 
@@ -543,7 +544,7 @@ PMDField::SetGeometry(char * name,
             cerr << " tmpchar is not a valid geometry" << endl;
         }
 
-		delete buffer;
+        delete buffer;
     }
 }
 
@@ -607,7 +608,7 @@ PMDField::SetAxisLabels(char * name,
             }
         }
 
-		delete buffer;
+        delete buffer;
     }
 }
 
@@ -717,7 +718,7 @@ void PMDField::SetUnitDimension(char * name,
         }
         //cerr << this->unitsLabel << endl;
 
-		delete powers;
+        delete powers;
     }
 }
 
@@ -779,7 +780,8 @@ PMDField::SetFieldBoundary(char * name,
             }
             //cerr << this->fieldBoundary[iLabel] << endl;
         }
-		delete buffer;
+
+        delete buffer;
     }
 }
 
@@ -840,7 +842,7 @@ PMDField::SetFieldBoundaryParameters(char * name,
             }
         }
 
-		delete buffer;
+        delete buffer;
     }
 }
 
@@ -883,7 +885,8 @@ PMDField::SetDataOrder(char * name,
         buffer[size] = '\0';
 
         this->dataOrder = buffer;
-		delete buffer;
+
+        delete buffer;
     }
 }
 
@@ -942,8 +945,7 @@ PMDField::SetGeometryParameters(char * name,
         return -1;
       }
 
-	  delete buffer;
-
+      delete buffer;
   }
   else
   {

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
@@ -302,7 +302,7 @@ PMDField::SetGridSpacing(char * name,
 
         int npoints = H5Sget_simple_extent_npoints(attrSpace);
 
-        double tmpArray[npoints];
+        double *tmpArray = new double[npoints];
 
         err = H5Aread(attrId, attrType, tmpArray);
 
@@ -318,6 +318,7 @@ PMDField::SetGridSpacing(char * name,
             this->gridSpacing[1] = tmpArray[1];
             this->gridSpacing[2] = 0;
         }
+		delete tmpArray;
     }
 }
 
@@ -353,7 +354,7 @@ PMDField::SetGridGlobalOffset(char * name,
 
         int npoints = H5Sget_simple_extent_npoints(attrSpace);
 
-        double tmpArray[npoints];
+        double *tmpArray = new double[npoints];
 
         err = H5Aread(attrId, attrType, tmpArray);
 
@@ -402,7 +403,7 @@ PMDField::SetGridPosition(char * name,
 
         int npoints = H5Sget_simple_extent_npoints(attrSpace);
 
-        double tmpArray[npoints];
+        double *tmpArray = new double[npoints];
 
         err = H5Aread(attrId, attrType, tmpArray);
 
@@ -418,6 +419,8 @@ PMDField::SetGridPosition(char * name,
             gridPosition[1] = tmpArray[1];
             gridPosition[2] = 0;
         }
+
+		delete tmpArray;
     }
 }
 
@@ -519,7 +522,7 @@ PMDField::SetGeometry(char * name,
         size_t size = H5Tget_size (attrType);
 
         // buffer
-        char buffer[size+1];
+        char *buffer = new char[size+1];
 
         err = H5Aread(attrId, attrType, buffer);
         buffer[size] = '\0';
@@ -537,6 +540,8 @@ PMDField::SetGeometry(char * name,
             cerr << " Error in PMDField::SetGeometry:" << endl;
             cerr << " tmpchar is not a valid geometry" << endl;
         }
+
+		delete buffer;
     }
 }
 
@@ -586,7 +591,7 @@ PMDField::SetAxisLabels(char * name,
              << " size: " << size
              << endl;*/
 
-        char buffer[size*npoints];
+        char *buffer = new char[size*npoints];
 
         // We put all the labels in buffer
         err = H5Aread(attrId, attrType, buffer);
@@ -599,6 +604,8 @@ PMDField::SetAxisLabels(char * name,
                 this->axisLabels[iLabel] += buffer[i + iLabel*size];
             }
         }
+
+		delete buffer;
     }
 }
 
@@ -637,7 +644,7 @@ void PMDField::SetUnitDimension(char * name,
         int npoints = H5Sget_simple_extent_npoints(attrSpace);
 
         // Unit powers
-        double powers[npoints];
+        double *powers = new double[npoints];
 
         err = H5Aread(attrId, attrType, powers);
 
@@ -707,6 +714,8 @@ void PMDField::SetUnitDimension(char * name,
             }
         }
         //cerr << this->unitsLabel << endl;
+
+		delete powers;
     }
 }
 
@@ -755,7 +764,7 @@ PMDField::SetFieldBoundary(char * name,
              << endl;*/
 
         // Creation of the buffer
-        char buffer[size*npoints];
+        char *buffer = new char[size*npoints];
 
         err = H5Aread(attrId, attrType, buffer);
 
@@ -768,6 +777,7 @@ PMDField::SetFieldBoundary(char * name,
             }
             //cerr << this->fieldBoundary[iLabel] << endl;
         }
+		delete buffer;
     }
 }
 
@@ -815,7 +825,7 @@ PMDField::SetFieldBoundaryParameters(char * name,
              << " size: " << size
              << endl;*/
 
-        char buffer[size*npoints];
+        char *buffer = new char[size*npoints];
 
         err = H5Aread(attrId, attrType, buffer);
 
@@ -827,6 +837,8 @@ PMDField::SetFieldBoundaryParameters(char * name,
                 this->fieldBoundaryParameters[iLabel] += buffer[i + iLabel*size];
             }
         }
+
+		delete buffer;
     }
 }
 
@@ -863,13 +875,13 @@ PMDField::SetDataOrder(char * name,
         // Size of an elements
         size_t size = H5Tget_size (attrType);
 
-        char buffer[size+1];
+        char *buffer = new char[size+1];
 
         err = H5Aread(attrId, attrType, buffer);
         buffer[size] = '\0';
 
         this->dataOrder = buffer;
-
+		delete buffer;
     }
 }
 
@@ -906,7 +918,7 @@ PMDField::SetGeometryParameters(char * name,
       size_t size = H5Tget_size (attrType);
 
       // Buffer to get the attribute
-      char buffer[size+1];
+      char *buffer = new char[size+1];
 
       // Reading of the attribute
       err = H5Aread(attrId, attrType, buffer);
@@ -927,6 +939,8 @@ PMDField::SetGeometryParameters(char * name,
         cerr << " Sign of imag is not recongnized" << endl;
         return -1;
       }
+
+	  delete buffer;
 
   }
   else

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -186,37 +186,38 @@ void PMDFile::ScanFileAttributes()
 		if (strcmp(attrName,"openPMD")==0)
 		{
 			char *buffer = new char[size + 1];
+
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
 
 			this->version = buffer;
 
-			delete buffer;
+            delete buffer;
 		}
 		else if (strcmp(attrName,"meshesPath")==0)
 		{
-
 			char *buffer = new char[size + 1];
+
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
 
 			strncpy(this->meshesPath,buffer,sizeof(buffer));
-			
 			delete buffer;
 
 		}
 		else if (strcmp(attrName,"particlesPath")==0)
 		{
-			char *buffer = new char[size + 1];
+            char *buffer = new char[size + 1];
+
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
 
 			strncpy(this->particlesPath,buffer,sizeof(buffer));
 
-			delete buffer;
+            delete buffer;
 		}
     }
 
@@ -730,8 +731,8 @@ PMDFile::ReadFieldScalarBlock(void * array,
                 // Dimension sizes of the dataset in memory when we read
                 // selection from the dataset on the disk
                 hsize_t mdim[] = {static_cast<hsize_t>(fieldBlock->nbNodes[0]),
-								  static_cast<hsize_t>(fieldBlock->nbNodes[1]),
-								  static_cast<hsize_t>(fieldBlock->nbNodes[2])};
+                                  static_cast<hsize_t>(fieldBlock->nbNodes[1]),
+                                  static_cast<hsize_t>(fieldBlock->nbNodes[2])};
 
                 // Define the memory dataspace.
                 memspace = H5Screate_simple (fieldBlock->ndims, mdim, NULL);
@@ -794,7 +795,7 @@ PMDFile::ReadFieldScalarBlock(void * array,
                 // Dimension sizes of the dataset in memory when
                 // we read selection from the dataset on the disk
                 hsize_t mdim[] = { static_cast<hsize_t>(fieldBlock->nbNodes[0]),
-								   static_cast<hsize_t>(fieldBlock->nbNodes[1])};
+                                   static_cast<hsize_t>(fieldBlock->nbNodes[1])};
 
                 // Define the memory dataspace.
                 memspace = H5Screate_simple(fieldBlock->ndims, mdim, NULL);

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -159,8 +159,6 @@ void PMDFile::ScanFileAttributes()
 	hid_t 			aspace;
 	size_t 			size;
 	int				nPoints;
-	const size_t buffSize = 1024;
-	char buffer[buffSize];
 
 	// OpenPMD files always contain a data group at the root
 	groupId = H5Gopen(fileId, "/",H5P_DEFAULT);
@@ -187,32 +185,38 @@ void PMDFile::ScanFileAttributes()
 
 		if (strcmp(attrName,"openPMD")==0)
 		{
-
+			char *buffer = new char[size + 1];
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
 
 			this->version = buffer;
 
+			delete buffer;
 		}
 		else if (strcmp(attrName,"meshesPath")==0)
 		{
 
+			char *buffer = new char[size + 1];
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
 
 			strncpy(this->meshesPath,buffer,sizeof(buffer));
+			
+			delete buffer;
 
 		}
 		else if (strcmp(attrName,"particlesPath")==0)
 		{
+			char *buffer = new char[size + 1];
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
 
 			strncpy(this->particlesPath,buffer,sizeof(buffer));
 
+			delete buffer;
 		}
     }
 

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -725,9 +725,9 @@ PMDFile::ReadFieldScalarBlock(void * array,
                 // Create memory dataspace.
                 // Dimension sizes of the dataset in memory when we read
                 // selection from the dataset on the disk
-                hsize_t mdim[] = {fieldBlock->nbNodes[0],
-                                  fieldBlock->nbNodes[1],
-                                  fieldBlock->nbNodes[2]};
+                hsize_t mdim[] = {static_cast<hsize_t>(fieldBlock->nbNodes[0]),
+								  static_cast<hsize_t>(fieldBlock->nbNodes[1]),
+								  static_cast<hsize_t>(fieldBlock->nbNodes[2])};
 
                 // Define the memory dataspace.
                 memspace = H5Screate_simple (fieldBlock->ndims, mdim, NULL);
@@ -789,8 +789,8 @@ PMDFile::ReadFieldScalarBlock(void * array,
                 // Create memory dataspace.
                 // Dimension sizes of the dataset in memory when
                 // we read selection from the dataset on the disk
-                hsize_t mdim[] = {fieldBlock->nbNodes[0],
-                                  fieldBlock->nbNodes[1]};
+                hsize_t mdim[] = { static_cast<hsize_t>(fieldBlock->nbNodes[0]),
+								   static_cast<hsize_t>(fieldBlock->nbNodes[1])};
 
                 // Define the memory dataspace.
                 memspace = H5Screate_simple(fieldBlock->ndims, mdim, NULL);
@@ -967,7 +967,7 @@ int PMDFile::ReadParticleScalarBlock(void * array,
             // Create memory dataspace.
             // Dimension sizes of the dataset in memory when we read
             // selection from the dataset on the disk
-            hsize_t mdim[] = {particleBlock->numParticles};
+            hsize_t mdim[] = { static_cast<hsize_t>(particleBlock->numParticles)};
 
             // Define the memory dataspace.
             memspace = H5Screate_simple (1, mdim, NULL);

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -159,6 +159,8 @@ void PMDFile::ScanFileAttributes()
 	hid_t 			aspace;
 	size_t 			size;
 	int				nPoints;
+	const size_t buffSize = 1024;
+	char buffer[buffSize];
 
 	// OpenPMD files always contain a data group at the root
 	groupId = H5Gopen(fileId, "/",H5P_DEFAULT);
@@ -186,8 +188,6 @@ void PMDFile::ScanFileAttributes()
 		if (strcmp(attrName,"openPMD")==0)
 		{
 
-			char buffer[size+1];
-
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
@@ -198,9 +198,6 @@ void PMDFile::ScanFileAttributes()
 		else if (strcmp(attrName,"meshesPath")==0)
 		{
 
-			// Buffer of char
-			char buffer[size+1];
-
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';
@@ -210,10 +207,6 @@ void PMDFile::ScanFileAttributes()
 		}
 		else if (strcmp(attrName,"particlesPath")==0)
 		{
-
-			// Buffer of char
-			char buffer[size+1];
-
 			// Read attribute
 			H5Aread (attrId, atype, buffer);
 			buffer[size] = '\0';

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDIteration.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDIteration.C
@@ -509,12 +509,12 @@ void PMDIteration::PrintInfo()
 			   << " zshift: " << field->gridPosition[2] << endl;
 		  cout << " - Unit SI: " << field->unitSI<< endl;
 		  cout << " - Grid Unit SI: " << field->gridUnitSI<< endl;
-		  cout << " - Geometry: " << field->geometry << endl;
-		  cout << " - xlabel: " << field->axisLabels[0]
-			   << " ylabel: " << field->axisLabels[1]
-			   << " zlabel: " << field->axisLabels[2] << endl;
-		  cout << " - Units: " << field->unitsLabel << endl;
-		  cout << " - Data order: " << field->dataOrder << endl;
+		  cout << " - Geometry: " << field->geometry.c_str() << endl;
+		  cout << " - xlabel: " << field->axisLabels[0].c_str()
+			   << " ylabel: " << field->axisLabels[1].c_str()
+			   << " zlabel: " << field->axisLabels[2].c_str() << endl;
+		  cout << " - Units: " << field->unitsLabel.c_str() << endl;
+		  cout << " - Data order: " << field->dataOrder.c_str() << endl;
 		  cout << endl;
 	}
 	cout << endl;
@@ -536,7 +536,7 @@ void PMDIteration::PrintInfo()
 			for (i=0;i<particle->GetNumScalarDatasets();i++)
 		  {
 				cout << " - Name: " << particle->scalarDataSets[i].name
-					<< ", Unit Label: " << particle->scalarDataSets[i].unitLabel
+					<< ", Unit Label: " << particle->scalarDataSets[i].unitLabel.c_str()
 					<< ", path: " << particle->scalarDataSets[i].path
 					<< ", unitSI: " << particle->scalarDataSets[i].unitSI
 					<< endl;
@@ -546,7 +546,7 @@ void PMDIteration::PrintInfo()
 			for (i=0;i<particle->GetNumVectorDatasets();i++)
 		  {
 				cout << " - Name: " << particle->vectorDataSets[i].name
-					 << ", Unit Label: " << particle->vectorDataSets[i].unitLabel
+					 << ", Unit Label: " << particle->vectorDataSets[i].unitLabel.c_str()
 					 << ", path: " << particle->vectorDataSets[i].path
 					 << ", scalar datasets: "
 					 << particle->vectorDataSets[i].dataSetId[0]

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDIteration.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDIteration.C
@@ -536,7 +536,7 @@ void PMDIteration::PrintInfo()
 			for (i=0;i<particle->GetNumScalarDatasets();i++)
 		  {
 				cout << " - Name: " << particle->scalarDataSets[i].name
-					<< ", Unit Label: " << particle->scalarDataSets[i].unitLabel.c_str()
+                    << ", Unit Label: " << particle->scalarDataSets[i].unitLabel.c_str()
 					<< ", path: " << particle->scalarDataSets[i].path
 					<< ", unitSI: " << particle->scalarDataSets[i].unitSI
 					<< endl;
@@ -546,7 +546,7 @@ void PMDIteration::PrintInfo()
 			for (i=0;i<particle->GetNumVectorDatasets();i++)
 		  {
 				cout << " - Name: " << particle->vectorDataSets[i].name
-					 << ", Unit Label: " << particle->vectorDataSets[i].unitLabel.c_str()
+                     << ", Unit Label: " << particle->vectorDataSets[i].unitLabel.c_str()
 					 << ", path: " << particle->vectorDataSets[i].path
 					 << ", scalar datasets: "
 					 << particle->vectorDataSets[i].dataSetId[0]

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
@@ -1205,4 +1205,7 @@ PMDParticle::GetBlockProperties(int scalarDataSetId,
     particleBlock->maxParticle = particleBlock->minParticle
                                 + particleBlock->numParticles -1;
 
+
+	return 0;
+
 }

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
@@ -1028,7 +1028,7 @@ PMDParticle::SetUnitDimension(char * name,
 
         int npoints = H5Sget_simple_extent_npoints(attrSpace);
 
-        double powers[npoints];
+        double *powers = new double[npoints];
 
         err = H5Aread(attrId, attrType, powers);
 
@@ -1093,6 +1093,8 @@ PMDParticle::SetUnitDimension(char * name,
                 unitLabel += units;
             }
         }
+		
+		delete powers;
     }
     //cerr << unitLabel << endl;
     return unitLabel;

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
@@ -1093,8 +1093,8 @@ PMDParticle::SetUnitDimension(char * name,
                 unitLabel += units;
             }
         }
-		
-		delete powers;
+
+        delete powers;
     }
     //cerr << unitLabel << endl;
     return unitLabel;
@@ -1206,6 +1206,6 @@ PMDParticle::GetBlockProperties(int scalarDataSetId,
                                 + particleBlock->numParticles -1;
 
 
-	return 0;
+    return 0;
 
 }

--- a/src/databases/OpenPMD/avtOpenPMDFileFormat.C
+++ b/src/databases/OpenPMD/avtOpenPMDFileFormat.C
@@ -39,8 +39,11 @@
 // ***************************************************************************
 //                            avtOpenPMDFileFormat.C
 // ***************************************************************************
-
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <avtOpenPMDFileFormat.h>
 


### PR DESCRIPTION
### Description
OpenPMD plugin introduced some bugs for Visual Studio and Power64.

Windows: vc++ does not support variable length arrays.
Windows: operator<< is in <string> not <string.h>
Windows: unistd.h -> io.h
Power64: Narrowing of type on list initialization is an error for power64 clang.
### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Win10 Enterprise, Visual Studio 2017 (15.0 26228.98)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
