### PR TITLE
Updated call to QApplication since the GUIenabled flag is no longer available in QT5 

### DIFF
--- a/src/include/ViewerInfo.plist.in
+++ b/src/include/ViewerInfo.plist.in
@@ -33,7 +33,7 @@
     <key>LSRequiresCarbon</key>
     <true/>
     <key>LSUIElement</key>
-    <string>1</string>
+    <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright (c) 2000 - 2019, Lawrence Livermore National Security, LLC</string>
     <key>NSHighResolutionCapable</key>

--- a/src/viewer/main/viewer.C
+++ b/src/viewer/main/viewer.C
@@ -152,6 +152,12 @@ Viewer_LogQtMessages(QtMsgType type, const QMessageLogContext &context, const QS
 //    files. The GUI has the sole responsiblity for removing the crash
 //    session files on exit.
 //
+//    Kevin Griffin, Wed Oct 23 14:28:32 PDT 2019
+//    The GUIenabled flag was removed from the QApplication constructor which
+//    was used to trigger 'nowin' mode that allowed the VisIt CLI to run
+//    without a window system. To get the same effect, instantiating a plain
+//    QCoreApplication is done when nowin mode is set.
+//
 // ****************************************************************************
 
 int
@@ -193,12 +199,10 @@ ViewerMain(int argc, char *argv[])
         // Create the QApplication. This sets the qApp pointer.
         //
         bool add_platform_arg = false;
-
         int nExtraArgs = 5;
-// Instead of being exclusionary, should the check insted be
-// #if defined(Q_OS_LINUX) ??
+        
 #if !defined(_WIN32) && !defined(Q_OS_MAC)
-        if (viewer.GetNowinMode())
+        if(viewer.GetNowinMode())
         {
             // really only need this if X11 not running, but how to test?
             add_platform_arg = true;
@@ -220,7 +224,7 @@ ViewerMain(int argc, char *argv[])
         argv2[real_argc+1] = (char*)viewer.State()->GetAppearanceAttributes()->GetFontName().c_str();
         argv2[real_argc+2] = (char*)"-name";
         argv2[real_argc+3] = (char*)"visit-viewer";
-        if (add_platform_arg)
+        if(add_platform_arg)
         {
             argv2[real_argc+4] = (char*)"-platform";
             argv2[real_argc+5] = (char*)"minimal";
@@ -237,7 +241,15 @@ ViewerMain(int argc, char *argv[])
         surfaceFormat.setAlphaBufferSize(0);
         QSurfaceFormat::setDefaultFormat(surfaceFormat);
 
-        QApplication *mainApp = new QApplication(argc2, argv2, !viewer.GetNowinMode());
+        QCoreApplication *mainApp = NULL;
+        if(viewer.GetNowinMode())
+        {
+            mainApp = new QCoreApplication(argc2, argv2);
+        }
+        else
+        {
+            mainApp = new QApplication(argc2, argv2);
+        }
 
         //
         // Now that we've created the QApplication, let's call the viewer's


### PR DESCRIPTION
# Description

The GUIenabled flag was removed from the QApplication constructor which was used to trigger 'nowin' mode that allowed the VisIt CLI to run without a window system. To get the same effect, instantiating a plain QCoreApplication is done when nowin mode is set.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [ ] New feature
- [ ] New Documentation
- [x] Other (please describe below)

### How Has This Been Tested?

Built VisIt and ran in nowin mode and regular mode.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
