### PR TITLE
QOT cleanup

### DIFF
--- a/src/engine/main/Executors.h
+++ b/src/engine/main/Executors.h
@@ -1593,6 +1593,10 @@ EngineRPCExecutor<RenderRPC>::Execute(RenderRPC *rpc)
 //    Moved the actual cloning procedure to AddQueryOverTimeFilter so
 //    that the correct type of clone can be chosen.
 //
+//    Alister Maguire, Mon Nov  4 09:30:28 MST 2019
+//    If we're not performing a QOT, let's still allow a clone to take
+//    place (in case this has a future use case).
+//
 // ****************************************************************************
 template<>
 void
@@ -1603,9 +1607,20 @@ EngineRPCExecutor<CloneNetworkRPC>::Execute(CloneNetworkRPC *rpc)
     debug2 << "Executing CloneNetworkRPC: " << rpc->GetID() << endl;
     TRY
     {
+        //
+        // If we're performing a QOT, the clone will be taken care
+        // after the QOT has been set-up in the network manager.
+        //
         if (rpc->GetQueryOverTimeAtts() != NULL)
+        {
             netmgr->AddQueryOverTimeFilter(rpc->GetQueryOverTimeAtts(),
                                            rpc->GetID());
+        }
+        else
+        {
+            netmgr->CloneNetwork(rpc->GetID());
+        }
+
         rpc->SendReply();
     }
     CATCH2(VisItException, e)


### PR DESCRIPTION
### Description
Minor cleanup of the QOT cloning process. I added in some logic to allow the CloneRPC to be used for cases other than QOT. It's currently only used for QOT, but it's possible that it could have another use case in the future. 


### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New Documentation
- [x] Other (please describe below)

### How Has This Been Tested?
I re-ran the relevant tests.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
