### PR TITLE
Modify build_visit to build openssl by default.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.0.html
+++ b/src/resources/help/en_US/relnotes3.1.0.html
@@ -33,7 +33,6 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">General features added in version 3.1</font></b></p>
 <ul>
   <li>A Binary distribution has been added for CentOS 8.</li>
-
   <li></li>
 </ul>
 
@@ -96,7 +95,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Build_features"></a>
 <p><b><font size="4">Build features added in version 3.1</font></b></p>
 <ul>
-  <li></li>
+  <li>Build_visit has been enhanced to enable OpenSSL by default since Python depends on OpenSSL and Python is enabled by default.</li>
 </ul>
 </ul>
 

--- a/src/tools/dev/scripts/bv_support/bv_openssl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openssl.sh
@@ -1,6 +1,6 @@
 function bv_openssl_initialize
 {
-    export DO_OPENSSL="no"
+    export DO_OPENSSL="yes"
 }
 
 function bv_openssl_enable


### PR DESCRIPTION
### Description

Resolves #3967
I modified build_visit to enable OpenSSL by default since Python depends on OpenSSL and Python is enabled by default.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran the following command on quartz and it completed successfully.

./build_visit3_1_0 --mesagl --llvm --makeflags -j20

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have updated the release notes