### PR TITLE
Suppressed the Qt Warning for passing empty filename.

### DIFF
--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -385,7 +385,7 @@ LongFileName(const std::string &shortName)
 // ****************************************************************************
 // Method: GUI_LogQtMessages
 //
-// Purpose: 
+// Purpose:
 //   Message handler that routes Qt messages to the debug logs.
 //
 // Arguments:
@@ -396,19 +396,24 @@ LongFileName(const std::string &shortName)
 // Creation:   Thu Mar 15 18:17:47 PST 2007
 //
 // Modifications:
-//   
+//
 //   Hank Childs, Fri Dec 14 11:09:45 PST 2007
-//   Issue an error message to the console if we cannot connect to the 
+//   Issue an error message to the console if we cannot connect to the
 //   X server.
+//
+//   Kevin Griffin, Wed Nov  6 13:43:17 PST 2019
+//   Added the "Empty filename passed to function" warning to the suppress list.
+//   Added the additional context information if available. By default, the
+//   context information is only recorded in debug builds.
 //
 // ****************************************************************************
 
 static void
 GUI_LogQtMessages(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    const int n_strs_to_suppress = 1;
+    const int n_strs_to_suppress = 2;
     const char *strs_to_suppress[] =
-       { "Invalid XLFD" };
+    { "Invalid XLFD", "Empty filename passed to function" };
     bool shouldPrint = true;
     for (int i = 0 ; i < n_strs_to_suppress ; i++)
     {
@@ -418,31 +423,52 @@ GUI_LogQtMessages(QtMsgType type, const QMessageLogContext &context, const QStri
             break;
         }
     }
-
-    if (shouldPrint)
-        cerr << msg.toStdString() << endl;
-
+    
+    std::string qtMsgStr;
+    bool isFatal = false;
     switch(type)
     {
-    case QtInfoMsg:
-        debug1 << "Qt: Info: " << msg.toStdString() << endl;
-        break;
-    case QtDebugMsg:
-        debug1 << "Qt: Debug: " << msg.toStdString() << endl;
-        break;
-    case QtWarningMsg:
-        debug1 << "Qt: Warning: " << msg.toStdString() << endl;
-        break;
-    case QtCriticalMsg:
-        debug1 << "Qt: Critical: " << msg.toStdString() << endl;
-        break;
-    case QtFatalMsg:
-        debug1 << "Qt: Fatal: " << msg.toStdString() << endl;
-        abort(); // HOOKS_IGNORE
-        break;
+        case QtInfoMsg:
+            qtMsgStr.append("Qt: Info: ");
+            break;
+        case QtDebugMsg:
+            qtMsgStr.append("Qt: Debug: ");
+            break;
+        case QtWarningMsg:
+            qtMsgStr.append("Qt: Warning: ");
+            break;
+        case QtCriticalMsg:
+            qtMsgStr.append("Qt: Critical: ");
+            break;
+        case QtFatalMsg:
+            qtMsgStr.append("Qt: Fatal: ");
+            isFatal = true;
+            break;
     }
+    
+    // Build QT message
+    qtMsgStr.append(msg.toStdString());
+    
+    // Print additional information if provided
+    if(context.file != NULL)
+    {
+        qtMsgStr.append(" [");
+        qtMsgStr.append(context.file);
+        qtMsgStr.append(":");
+        qtMsgStr.append(std::to_string(context.line));
+        qtMsgStr.append(":");
+        qtMsgStr.append(context.function);
+        qtMsgStr.append("]");
+    }
+    
+    if(shouldPrint)
+        cerr << qtMsgStr << endl;
+    
+    debug1 << qtMsgStr << endl;
+    
+    if(isFatal)
+        abort(); // HOOKS_IGNORE
 }
-
 
 // ****************************************************************************
 // Method: QvisGUIApplication::QvisGUIApplication

--- a/src/resources/help/en_US/relnotes3.0.3.html
+++ b/src/resources/help/en_US/relnotes3.0.3.html
@@ -44,6 +44,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug in build_visit that prevented OSMesa and MesaGL from building from within a Git checkout.</li>
   <li>Added a patch to build_visit so that Qt builds on CentOS 8.</li>
   <li>Added OSX-specific update to the sed command in bv_adios2.sh to fix the adios2 configuration error.</li>
+  <li>Suppressed the Qt warning 'Empty filename passed to function'. Also added additional context information to the Qt log message if available.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Resolves #3858. 
Suppressed the Qt Warning for passing empty filename. Added additional context info to the Qt log message if available.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [ ] New feature
- [ ] New Documentation
- [x] Other (please describe below)

### How Has This Been Tested?

Built and installed visit and ran with the -noconfig switch. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
