### PR TITLE
Correct an OpenPMD bug and updated some test suite baselines.

### DIFF
--- a/src/databases/OpenPMD/OpenPMD.xml
+++ b/src/databases/OpenPMD/OpenPMD.xml
@@ -12,7 +12,6 @@
     <FilePatterns>
       *.pmd
       *.opmd
-      *.h5
     </FilePatterns>
     <Files components="M">
       OpenPMDClasses/PMDParticle.C

--- a/src/databases/OpenPMD/OpenPMDPluginInfo.C
+++ b/src/databases/OpenPMD/OpenPMDPluginInfo.C
@@ -168,7 +168,6 @@ OpenPMDGeneralPluginInfo::GetDefaultFilePatterns() const
     std::vector<std::string> defaultPatterns;
     defaultPatterns.push_back("*.pmd");
     defaultPatterns.push_back("*.opmd");
-    defaultPatterns.push_back("*.h5");
 
     return defaultPatterns;
 }

--- a/test/baseline/databases/OpenPMD/openPMD_3D_Fieldsrho.png
+++ b/test/baseline/databases/OpenPMD/openPMD_3D_Fieldsrho.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5adc2565eb3416e9dc223cf1f36e1bade176204b9725b80a345bdbded1f3beaf
-size 23257
+oid sha256:d9e4b95402c2801d6e5400f32698dcf68a4a578bf29c8fd3b82c1fb732935c0f
+size 23292

--- a/test/baseline/plugins/databasesVsInstall/databasesVsInstall.txt
+++ b/test/baseline/plugins/databasesVsInstall/databasesVsInstall.txt
@@ -74,6 +74,7 @@
     'OVERFLOW': 'success',
     'OpenEXR': 'success',
     'OpenFOAM': 'success',
+    'OpenPMD': 'success',
     'PATRAN': 'success',
     'PDB': 'success',
     'PFLOTRAN': 'success',


### PR DESCRIPTION
### Description

I removed "*.h5" as a file match for the OpenPMD reader, since this is a common file pattern and there is no logic in the reader to check if this is actually a valid OpenPMD file. I also updated a couple of baseline results in the test suite related to the addition of this reader.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

These are trivial changes so I didn't do any testing. The test suite passing tonight will be a sufficient test of the changes.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code