### PR TITLE
Add a scalable,parallel,icet mode specific baseline for OpenPMD tests.

### DIFF
--- a/test/baseline/databases/OpenPMD/mode_specific.json
+++ b/test/baseline/databases/OpenPMD/mode_specific.json
@@ -1,0 +1,5 @@
+{"modes":
+    {"scalable,parallel,icet":
+        {"openPMD_3D_Fieldsrho.png" : "scalable_parallel"}
+    }
+}

--- a/test/baseline/databases/OpenPMD/scalable_parallel/openPMD_3D_Fieldsrho.png
+++ b/test/baseline/databases/OpenPMD/scalable_parallel/openPMD_3D_Fieldsrho.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:402b2c56197a86bb6d39ea3b885c9b7401ce2c8f313146ea296daa604c608082
+size 23285


### PR DESCRIPTION
### Description

Added a scalable,parallel,icet mode specific baseline for one of the databases/OpenPMD.py tests.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran the OpenPMD.py test on pascal in scalable,parallel,icet mode and it passed.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code