### PR TITLE
Add a mode specific baseline for parallel OpenPMD database test.

### DIFF
--- a/test/baseline/databases/OpenPMD/mode_specific.json
+++ b/test/baseline/databases/OpenPMD/mode_specific.json
@@ -1,5 +1,9 @@
-{"modes":
+{"modes": [
+    {"parallel":
+        {"openPMD_3D_Fieldsrho.png" : "parallel"}
+    },
     {"scalable,parallel,icet":
         {"openPMD_3D_Fieldsrho.png" : "scalable_parallel"}
     }
+    ]
 }

--- a/test/baseline/databases/OpenPMD/parallel/openPMD_3D_Fieldsrho.png
+++ b/test/baseline/databases/OpenPMD/parallel/openPMD_3D_Fieldsrho.png
@@ -1,0 +1,1 @@
+../scalable_parallel/openPMD_3D_Fieldsrho.png


### PR DESCRIPTION
### Description

I added a mode specific baseline for the parallel OpenPMD database test.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran the OpenPMD test in both the parallel and scalable,parallel,icet modes on pascal and it passed both of them.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code