### PR TITLE
Removed OpenPMD scalable parallel baseline.

### DIFF
--- a/test/baseline/databases/OpenPMD/mode_specific.json
+++ b/test/baseline/databases/OpenPMD/mode_specific.json
@@ -1,9 +1,5 @@
-{"modes": [
+{"modes":
     {"parallel":
         {"openPMD_3D_Fieldsrho.png" : "parallel"}
-    },
-    {"scalable,parallel,icet":
-        {"openPMD_3D_Fieldsrho.png" : "scalable_parallel"}
     }
-    ]
 }

--- a/test/baseline/databases/OpenPMD/parallel/openPMD_3D_Fieldsrho.png
+++ b/test/baseline/databases/OpenPMD/parallel/openPMD_3D_Fieldsrho.png
@@ -1,1 +1,3 @@
-../scalable_parallel/openPMD_3D_Fieldsrho.png
+version https://git-lfs.github.com/spec/v1
+oid sha256:402b2c56197a86bb6d39ea3b885c9b7401ce2c8f313146ea296daa604c608082
+size 23285

--- a/test/baseline/databases/OpenPMD/scalable_parallel/openPMD_3D_Fieldsrho.png
+++ b/test/baseline/databases/OpenPMD/scalable_parallel/openPMD_3D_Fieldsrho.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:402b2c56197a86bb6d39ea3b885c9b7401ce2c8f313146ea296daa604c608082
-size 23285


### PR DESCRIPTION
### Description

I removed the OpenPMD scalable parallel mode specific baseline since the difference was within the scalable parallel tolerance. I also changed the parallel mode specific baseline from a link to an image, since the link became broken.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran the OpenPMD test in both parallel and scalable parallel modes and both passed.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code