### PR TITLE
Removed the visual artifacts of the Expressions window

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -925,6 +925,10 @@ QvisExpressionsWindow::UpdateWindowSingleItem()
 //    Cyrus Harrison, Wed Jun 11 13:49:19 PDT 2008
 //    Initial Qt4 Port.
 //
+//    Kevin Griffin, Tue Nov 12 14:30:34 PST 2019
+//    Added a call to update() to remove the visual artificats present during
+//    the first draw of the expressions window.
+//
 // ****************************************************************************
 
 void
@@ -950,6 +954,8 @@ QvisExpressionsWindow::UpdateWindowSensitivity()
 
     stdEditorWidget->setEnabled(enable && stdExprActive);
     pyEditorWidget->setEnabled(enable && pyExprActive);
+    
+    this->update();
 }
 
 // ****************************************************************************

--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -952,8 +952,9 @@ QvisExpressionsWindow::UpdateWindowSensitivity()
     typeList->setEnabled(enable);
     notHidden->setEnabled(enable);
 
-    stdEditorWidget->setEnabled(enable && stdExprActive);
-    pyEditorWidget->setEnabled(enable && pyExprActive);
+    editorTabs->setTabEnabled(0, enable && stdExprActive);
+    editorTabs->setTabEnabled(1, enable && pyExprActive);
+    editorTabs->update();
     
     this->update();
 }

--- a/src/resources/help/en_US/relnotes3.1.0.html
+++ b/src/resources/help/en_US/relnotes3.1.0.html
@@ -73,6 +73,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Changing the opacity for a Pseudocolor plot no longer affects the glyph type of glyphed points.</li>
   <li>Corrected an issue with installing host profiles after deleting or moving the .visit folder while VisIt is running.</li>
+  <li>Removed the visual artifacts of the Expressions window that were present on first draw.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
### Description

Removed the visual artifacts of the Expressions window that were present on first draw.

Resolves #3910. 

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Built and ran VisIt and verified that the visual artifacts were gone.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
