### PR TITLE
Add no-openssl when --no-thirdparty flag is used.

### DIFF
--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -104,6 +104,7 @@
 
         <group name="no-thirdparty" comment="Do not build required 3rd party libraries" enabled="no">
             <lib name="no-cmake"/>
+            <lib name="no-openssl"/>
             <lib name="no-python"/>
             <lib name="no-qt" />
             <lib name="no-qwt" />


### PR DESCRIPTION
I ran build_visit --no-thirdparty and it complained that I hadn't specified openssl.
This adds 'no-openssl' when 'no-thirdparty' is specified.
