### PR TITLE
Correct some compile errors when using Open MPI 1.6.5.

### DIFF
--- a/src/avt/Filters/avtXRayFilter.C
+++ b/src/avt/Filters/avtXRayFilter.C
@@ -141,16 +141,16 @@ inline void Cross(double result[3], const double v1[3], const double v2[3])
 //-----------------------------
 // method def
 template <typename T>
-int VisIt_XRay_MPI_Alltoallv(T *sendbuf, const int *sendcounts,
-                             const int *sdispls, T *recvbuf,
-                             const int *recvcounts, const int *rdispls,
+int VisIt_XRay_MPI_Alltoallv(T *sendbuf, int *sendcounts,
+                             int *sdispls, T *recvbuf,
+                             int *recvcounts, int *rdispls,
                              MPI_Comm comm);
 
 // case specifically for floats
 template<>
-int VisIt_XRay_MPI_Alltoallv<float>(float *sendbuf, const int *sendcounts,
-                                    const int *sdispls, float *recvbuf,
-                                    const int *recvcounts, const int *rdispls,
+int VisIt_XRay_MPI_Alltoallv<float>(float *sendbuf, int *sendcounts,
+                                    int *sdispls, float *recvbuf,
+                                    int *recvcounts, int *rdispls,
                                     MPI_Comm comm)
 {
     return MPI_Alltoallv(sendbuf, sendcounts, sdispls, MPI_FLOAT,
@@ -160,9 +160,9 @@ int VisIt_XRay_MPI_Alltoallv<float>(float *sendbuf, const int *sendcounts,
 
 // case specifically for double
 template<>
-int VisIt_XRay_MPI_Alltoallv<double>(double *sendbuf, const int *sendcounts,
-                                     const int *sdispls, double *recvbuf,
-                                     const int *recvcounts, const int *rdispls,
+int VisIt_XRay_MPI_Alltoallv<double>(double *sendbuf, int *sendcounts,
+                                     int *sdispls, double *recvbuf,
+                                     int *recvcounts, int *rdispls,
                                      MPI_Comm comm)
 {
     return MPI_Alltoallv(sendbuf, sendcounts, sdispls, MPI_DOUBLE,

--- a/src/resources/help/en_US/relnotes3.1.0.html
+++ b/src/resources/help/en_US/relnotes3.1.0.html
@@ -89,6 +89,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.1</font></b></p>
 <ul>
   <li>Suppressed the Qt warning 'Empty filename passed to function'. Also added additional context information to the Qt log message if available.</li>
+  <li>Corrected compile errors when using Open MPI 1.6.5.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Resolves #4085 
Correct some compile errors when using Open MPI 1.6.5. There was a templated interface class to an MPI_Alltoallv that had the appropriate arguments const qualified. Unfortunately, the version of MPI being used was back from 2013 and their version of MPI_Alltoallv didn't have const qualified arguments. I removed the const qualification from all the arguments in the templated interface class.

### Type of change

- [X] Bug fix

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code