### PR TITLE
Enhance build_visit to compile llvm with icc 19.0.4.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.0.html
+++ b/src/resources/help/en_US/relnotes3.1.0.html
@@ -83,6 +83,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug in build_visit that prevented OSMesa and MesaGL from building from within a Git checkout.</li>
   <li>Added a patch to build_visit so that Qt builds on CentOS 8 and Ubuntu 19.</li>
   <li>Modified build_visit so that it would build Adios2 on Mac OS X.</li>
+  <li>Modified build_visit to correct a compile error with LLVM compiling with icc 19.0.4.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_llvm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_llvm.sh
@@ -158,6 +158,31 @@ EOF
         warn "llvm patch for include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h failed"
         return 1
     fi
+
+    # fixes a bug in LLVM 5.0.0
+    # where a static_assert fails with icc 19.0.4.227. This patch removes
+    # the static_assert since it isn't critical for it to run.
+
+    patch -p0 << \EOF
+diff -c lib/IR/Attributes.cpp.orig lib/IR/Attributes.cpp
+*** lib/IR/Attributes.cpp.orig	Fri Nov 22 12:13:23 2019
+--- lib/IR/Attributes.cpp	Fri Nov 22 12:13:45 2019
+***************
+*** 810,817 ****
+    static_assert(Attribute::EndAttrKinds <=
+                      sizeof(AvailableFunctionAttrs) * CHAR_BIT,
+                  "Too many attributes");
+-   static_assert(attrIdxToArrayIdx(AttributeList::FunctionIndex) == 0U,
+-                 "function should be stored in slot 0");
+    for (Attribute I : Sets[0]) {
+      if (!I.isStringAttribute())
+        AvailableFunctionAttrs |= 1ULL << I.getKindAsEnum();
+--- 810,815 ----
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "llvm patch for lib/IR/Attributes.cpp failed"
+        return 1
+    fi
 }
 
 function build_llvm


### PR DESCRIPTION
### Description

Resolves #4062 
I added a patch to remove a static_assert from llvm so that it would compile with icc 19.0.4.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I ran build_visit on quartz with the fix and it successfully built llvm with icc 19.0.4.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes