### PR TITLE
Fix failing expression test

### DIFF
--- a/src/test/tests/expressions/tensor_expr.py
+++ b/src/test/tests/expressions/tensor_expr.py
@@ -190,7 +190,7 @@ DeleteAllPlots()
 
 # Confirm principal_tensor function gives same result as above
 TestSection("Cross Principal Stresses and Eigenvalues")
-DefineVectorExpression("pcomps_complex/result", "principal_tensor(<eigvals_symm/tensor>)")
+DefineVectorExpression("pcomps_symm/result", "principal_tensor(<eigvals_symm/tensor>)")
 AddPlot("Vector", "pcomps_symm/result")
 DrawPlots()
 p = PickByNode(0)


### PR DESCRIPTION
There was a typo in the python code.

It is fixed now.

the other tests involve "chars" failure are indeed re-baselines.