### PR TITLE
python 2 to 3 update for cli doc strings

### DIFF
--- a/src/doc/cli_manual/contributing.rst
+++ b/src/doc/cli_manual/contributing.rst
@@ -1,37 +1,35 @@
 Contributing To VisIt CLI Documentation
 =======================================
 
-**Note: This procedure is planned for change in the future.**
+.. note::
+   We are still refining this procedure!
 
-At present, all VisIt Python CLI documentation is actually composed directly
-as Python strings in the source C++ file in ``../../visitpy/common/MethodDoc.C``.
+The Python doc strings for most functions in VisIt's cli are generated
+from the examples embedded in the ``cli_manual/functions.rst`` file.
+This allows us to have a single source for both our CLI sphinx docs 
+and the doc strings embedded in VisIt's compiled Python module. 
+The ``functions_to_method_doc.py``
 
-We recognize this isn't the most convenient way to write documentation and are
-planning on changing it in the future. However, it does permit us to have a 
-single source file for documentation which is then used to provide ``help(func)``
-at the Python prompt as well as generate the restructured text used here.
-
-In the future, we will swap this arrangement and write documentation in 
-restructured text and then generate the contents of ``../../visitpy/common/MethodDoc.C``
-from the restructured text.
-
-The documentation here is then generated from the ``MethodDoc.C`` file using the script
-``../sphinx_cli_extractor.py``. That script produces ``attributes.rst``, ``events.rst``
-and ``functions.rst`` files. The other ``.rst`` files here are manually managed and can
-be modified normally as needed.
+The Python doc strings for Attribute objects and Events are extracted from the CLI 
+for use in the CLI sphinx docs.  The ``sphinx_cli_extractor.py`` runs VisIt to 
+generate ``cli_manual/attributes.rst``  and ``cli_manual/events.rst``
 
 Steps to update the CLI Manual
 ------------------------------
 
-#. Modify ``../../visitpy/common/MethodDoc.C`` as needed
+#. Modify ``cli_manual/functions.rst``
+#. Run ``functions_to_plain_py.py`` to generate ``PY_RST_FUNCTIONS_TO_PYTHON.py``
+#. Run ``2to3 -p PY_RST_FUNCTIONS_TO_PYTHON.py`` to check for Python syntax errors and Python 3 compatibly 
+#. Run ``functions_to_method_doc.py`` to regenerate ``MethodDoc.C``
 #. Build and run the VisIt_ cli and assure yourself ``help(<your-new-func-doc>)``
-   produces the desired output 
-#. Run the ``sphinx_cli_extractor.py`` tool producing new ``attributes.rst``,
-   ``events.rst`` and ``functions.rst`` files. To do so, you may need to use
+   produces the desired output
+
+#. Run the ``sphinx_cli_extractor.py`` tool producing new ``attributes.rst``
+   and ``events.rst`` files. To do so, you may need to use
    a combination of the ``PATH`` and ``PYTHONPATH`` environment variables to tell the
    ``sphinx_cli_extractor.py`` script where to find the VisIt_ module, ``visit`` in
    VisIt_'s ``site-packages`` and where to find the Python installation that that
-   module is expecting to run with. In addition, you may need to use the ``PTHONHOME``
+   module is expecting to run with. In addition, you may need to use the ``PYTHONHOME``
    environment variable to tell VisIt_'s ``visit`` module where to find standard Python
    libraries. For example, to use an installed version of VisIt_ on my OSX machine,
    the command would look like...
@@ -55,8 +53,8 @@ Steps to update the CLI Manual
 
    The whole process only takes a few seconds.
 
-#. Assuming you succesfully run the above command, producing new ``attributes.rts``,
-   ``events.rst`` and ``functions.rst`` files, then do a local build of the
+#. Assuming you successfully run the above command, producing new ``attributes.rts``
+   and ``events.rst`` files, then do a local build of the
    documentation here and confirm there are no errors in the build
 
    .. code-block:: shell

--- a/src/doc/cli_manual/contributing.rst
+++ b/src/doc/cli_manual/contributing.rst
@@ -8,7 +8,9 @@ The Python doc strings for most functions in VisIt's cli are generated
 from the examples embedded in the ``cli_manual/functions.rst`` file.
 This allows us to have a single source for both our CLI sphinx docs 
 and the doc strings embedded in VisIt's compiled Python module. 
-The ``functions_to_method_doc.py``
+The ``functions_to_method_doc.py`` helper script generates ``MethodDoc.C``
+from the examples embedded in the rst source.
+
 
 The Python doc strings for Attribute objects and Events are extracted from the CLI 
 for use in the CLI sphinx docs.  The ``sphinx_cli_extractor.py`` runs VisIt to 
@@ -53,7 +55,7 @@ Steps to update the CLI Manual
 
    The whole process only takes a few seconds.
 
-#. Assuming you successfully run the above command, producing new ``attributes.rts``
+#. Assuming you successfully ran the above command, producing new ``attributes.rst``
    and ``events.rst`` files, then do a local build of the
    documentation here and confirm there are no errors in the build
 

--- a/src/doc/cli_manual/functions.rst
+++ b/src/doc/cli_manual/functions.rst
@@ -574,7 +574,7 @@ return type : CLI_return_t
   OpenDatabase("localhost:very_large_database")
   # Do a lot of work
   ClearCache("localhost")
-  OpenDatabase(localhost:another_large_database")
+  OpenDatabase("localhost:another_large_database")
   # Do more work
   OpenDatabase("remotehost:yet_another_database")
   # Do more work
@@ -620,7 +620,7 @@ return type : CLI_return_t
   OpenDatabase("localhost:very_large_database")
   # Do a lot of work
   ClearCache("localhost")
-  OpenDatabase(localhost:another_large_database")
+  OpenDatabase("localhost:another_large_database")
   # Do more work
   OpenDatabase("remotehost:yet_another_database")
   # Do more work
@@ -748,7 +748,7 @@ return type : CLI_return_t
   SetViewKeyframe()
   ToggleCameraViewMode()
   for i in range(10):
-  SetTimeSliderState(i)
+      SetTimeSliderState(i)
   ClearViewKeyframes()
 
 
@@ -989,9 +989,9 @@ return type : tuple
   AddPlot("Pseudocolor", "u")
   DrawPlots()
   for ct in ColorTableNames():
-  p = PseudocolorAttributes()
-  p.colorTableName = ct
-  SetPlotOptions(p)
+      p = PseudocolorAttributes()
+      p.colorTableName = ct
+      SetPlotOptions(p)
 
 
 ConstructDataBinning
@@ -1374,7 +1374,7 @@ return type : CLI_return_t
   # Animate through time using the "common" database correlation's
   # time slider.
   for i in range(TimeSliderGetNStates()):
-  SetTimeSliderState(i)
+      SetTimeSliderState(i)
 
 
 CreateNamedSelection
@@ -2183,7 +2183,7 @@ frame : integer
   AddPlot("Pseudocolor", "pressure")
   SetPlotDatabaseState(0, 0, 60)
   # Repeat time state 60 for the first few animation frames by adding a
-  keyframe at frame 3.
+  # keyframe at frame 3.
   SetPlotDatabaseState(0, 3, 60)
   SetPlotDatabaseState(0, 19, 0)
   DrawPlots()
@@ -2247,7 +2247,7 @@ frame : integer
   ListPlots()
   # Iterate over all animation frames and wrap around to the first one.
   for i in list(range(TimeSliderGetNStates())) + [0]:
-  SetTimeSliderState(i)
+      SetTimeSliderState(i)
   # Delete the plot keyframe at frame 19 so the min won't
   # change anymore.
   DeletePlotKeyframe(19)
@@ -2301,13 +2301,13 @@ frame : integer
   ToggleCameraViewMode()
   # Iterate over the animation frames to watch the view change.
   for i in list(range(10)) + [0]:
-  SetTimeSliderState(i)
+      SetTimeSliderState(i)
   # Delete the last view keyframe, which is on frame 9.
   DeleteViewKeyframe(9)
   # Iterate over the animation frames again. The view should stay
   # the same.
   for i in range(10):
-  SetTimeSliderState(i)
+      SetTimeSliderState(i)
 
 
 DeleteWindow
@@ -2571,9 +2571,9 @@ return : double
   # Fly around the plots using the views that have been specified.
   nSteps = 100
   for i in range(nSteps):
-  t = float(i) / float(nSteps - 1)
-  newView = EvalCubic(t, v0, v1, v2, v3)
-  SetView3D(newView)
+      t = float(i) / float(nSteps - 1)
+      newView = EvalCubic(t, v0, v1, v2, v3)
+      SetView3D(newView)
 
 
 EvalCubicSpline
@@ -2642,19 +2642,19 @@ return : double
 
 ::
 
-    #% visit -cli
-    OpenDatabase("/usr/gapps/visit/data/globe.silo")
-    AddPlot("Pseudocolor", "u")
-    DrawPlots()
-    c0 = GetView3D()
-    c1 = GetView3D()
-    c1.viewNormal = (-0.499159, 0.475135, 0.724629)
-    c1.viewUp = (0.196284, 0.876524, -0.439521)
-    nSteps = 100
-    for i in range(nSteps):
-    t = float(i) / float(nSteps - 1)
-    v = EvalLinear(t, c0, c1)
-    SetView3D(v)
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
+  AddPlot("Pseudocolor", "u")
+  DrawPlots()
+  c0 = GetView3D()
+  c1 = GetView3D()
+  c1.viewNormal = (-0.499159, 0.475135, 0.724629)
+  c1.viewUp = (0.196284, 0.876524, -0.439521)
+  nSteps = 100
+  for i in range(nSteps):
+      t = float(i) / float(nSteps - 1)
+      v = EvalLinear(t, c0, c1)
+      SetView3D(v)
 
 
 EvalQuadratic
@@ -2697,21 +2697,21 @@ return : double
 
 ::
 
-    % visit -cli
-    OpenDatabase("/usr/gapps/visit/data/globe.silo")
-    AddPlot("Pseudocolor", "u")
-    DrawPlots()
-    v0 = GetView3D()
-    # rotate the plots 
-    v1 = GetView3D()
-    # rotate the plots one last time.
-    v2 = GetView3D()
-    # Fly around the plots using the views that have been specified.
-    nSteps = 100
-    for i in range(nSteps):
-    t = float(i) / float(nSteps - 1)
-    newView = EvalQuadratic(t, v0, v1, v2)
-    SetView3D(newView)
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
+  AddPlot("Pseudocolor", "u")
+  DrawPlots()
+  v0 = GetView3D()
+  # rotate the plots 
+  v1 = GetView3D()
+  # rotate the plots one last time.
+  v2 = GetView3D()
+  # Fly around the plots using the views that have been specified.
+  nSteps = 100
+  for i in range(nSteps):
+      t = float(i) / float(nSteps - 1)
+      newView = EvalQuadratic(t, v0, v1, v2)
+      SetView3D(newView)
 
 
 ExecuteMacro
@@ -2746,9 +2746,10 @@ return type : value
 ::
 
   def SetupMyPlots():
-  OpenDatabase('noise.silo')
-  AddPlot('Pseudocolor', 'hardyglobal')
-  DrawPlots()
+      OpenDatabase('noise.silo')
+      AddPlot('Pseudocolor', 'hardyglobal')
+      DrawPlots()
+      
   RegisterMacro('Setup My Plots', SetupMyPlots)
   ExecuteMacro('Setup My Plots')
 
@@ -2838,11 +2839,11 @@ return type : tuple of expression tuples
   DefineScalarExpression("neg_u", "-u")
   DefineScalarExpression("bob", "sin_u + cos_u")
   for i in range(1,5):
-  SetActiveWindow(i)
-  OpenDatabase("/usr/gapps/visit/data/globe.silo")
-  exprName = Expressions()[i-1][0]
-  AddPlot("Pseudocolor", exprName)
-  DrawPlots()
+      SetActiveWindow(i)
+      OpenDatabase("/usr/gapps/visit/data/globe.silo")
+      exprName = Expressions()[i-1][0]
+      AddPlot("Pseudocolor", exprName)
+      DrawPlots()
 
 
 GetActiveContinuousColorTable
@@ -3322,7 +3323,7 @@ return type : tuple of strings
   print doms
   # Turn off all but the last domain, one after the other.
   for d in doms[:-1]:
-  TurnDomainsOff(d)
+      TurnDomainsOff(d)
 
 
 GetEngineList
@@ -3370,8 +3371,8 @@ return type : tuple of strings
   AddPlot("Mesh", "mesh1")
   DrawPlots()
   for name in GetEngineList():
-  print "VisIt has a compute engine running on %s" % name
-  CloseComputeEngine(GetEngineList()[1])
+      print "VisIt has a compute engine running on %s" % name
+      CloseComputeEngine(GetEngineList()[1])
 
 
 GetEngineProperties
@@ -3816,7 +3817,7 @@ return type : tuple of strings
   DrawPlots()
   mats = GetMaterials()
   for m in mats[:-1]:
-  TurnMaterialOff(m)
+      TurnMaterialOff(m)
 
 
 GetMeshManagementAttributes
@@ -3892,7 +3893,7 @@ return type : avtDatabaseMetaData object
 
   md = GetMetaData('noise.silo')
   for i in xrange(md.GetNumScalars()):
-  AddPlot('Pseudocolor', md.GetScalars(i).name)
+      AddPlot('Pseudocolor', md.GetScalars(i).name)
   DrawPlots()
 
 
@@ -4169,7 +4170,7 @@ return type : PlotList object
   pL = GetPlotList()
   AddWindow()
   for i in xrange(pL.GetNumPlots()):
-  AddPlot(PlotPlugins()[pL.GetPlots(i).plotType], pL.GetPlots(i).plotVar)
+      AddPlot(PlotPlugins()[pL.GetPlots(i).plotType], pL.GetPlots(i).plotVar)
   DrawPlots()
 
 
@@ -4665,9 +4666,9 @@ return type : tuple of strings
   path = "/usr/gapps/visit/data/"
   dbs = (path + "/dbA00.pdb", path + "dbB00.pdb", path + "dbC00.pdb")
   for db in dbs:
-  OpenDatabase(db)
-  AddPlot("FilledBoundary", "material(mesh)")
-  DrawPlots()
+      OpenDatabase(db)
+      AddPlot("FilledBoundary", "material(mesh)")
+      DrawPlots()
   CreateDatabaseCorrelation("common", dbs, 1)
   print "The list of time sliders is: ", GetTimeSliders()
 
@@ -4726,9 +4727,9 @@ return type : View2DAttributes object
   v1 = GetView3D()
   print v0
   for i in range(0,20):
-  t = float(i) / 19.
-  v2 = (1. - t) * v1 + t * v0
-  SetView3D(v2) # Animate the view back to the first view.
+      t = float(i) / 19.
+      v2 = (1. - t) * v1 + t * v0
+      SetView3D(v2) # Animate the view back to the first view.
 
 
 GetView3D
@@ -4765,9 +4766,9 @@ return type : View3DAttributes object
   v1 = GetView3D()
   print v0
   for i in range(0,20):
-  t = float(i) / 19.
-  v2 = (1. - t) * v1 + t * v0
-  SetView3D(v2) # Animate the view back to the first view.
+      t = float(i) / 19.
+      v2 = (1. - t) * v1 + t * v0
+      SetView3D(v2) # Animate the view back to the first view.
 
 
 GetViewAxisArray
@@ -4804,9 +4805,9 @@ return type : ViewAxisArrayAttributes object
   v1 = GetView3D()
   print v0
   for i in range(0,20):
-  t = float(i) / 19.
-  v2 = (1. - t) * v1 + t * v0
-  SetView3D(v2) # Animate the view back to the first view.
+      t = float(i) / 19.
+      v2 = (1. - t) * v1 + t * v0
+      SetView3D(v2) # Animate the view back to the first view.
 
 
 GetViewCurve
@@ -4843,9 +4844,9 @@ return type : ViewCurveAttributes object
   v1 = GetView3D()
   print v0
   for i in range(0,20):
-  t = float(i) / 19.
-  v2 = (1. - t) * v1 + t * v0
-  SetView3D(v2) # Animate the view back to the first view.
+      t = float(i) / 19.
+      v2 = (1. - t) * v1 + t * v0
+      SetView3D(v2) # Animate the view back to the first view.
 
 
 GetWindowInformation
@@ -4880,17 +4881,17 @@ return type : WindowInformation object
   path = "/usr/gapps/visit/data/"
   dbs = (path + "dbA00.pdb", path + "dbB00.pdb", path + "dbC00.pdb")
   for db in dbs:
-  OpenDatabase(db)
-  AddPlot("FilledBoundary", "material(mesh)")
-  DrawPlots()
+      OpenDatabase(db)
+      AddPlot("FilledBoundary", "material(mesh)")
+      DrawPlots()
   CreateDatabaseCorrelation("common", dbs, 1)
   # Get the list of available time sliders.
   tsList = GetWindowInformation().timeSliders
   # Iterate through "time" on each time slider.
   for ts in tsList:
-  SetActiveTimeSlider(ts)
+      SetActiveTimeSlider(ts)
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
   # Print the window information to examine the other attributes
   # that are available.
   GetWindowInformation()
@@ -5094,10 +5095,10 @@ return type : CLI_return_t
 
 ::
 
-    import visit
-    import visit
-    visit.AddArgument("-nowin")
-    visit.Launch()
+  import visit
+  import visit
+  visit.AddArgument("-nowin")
+  visit.Launch()
 
 
 LaunchNowin
@@ -5133,10 +5134,10 @@ return type : CLI_return_t
 
 ::
 
-    import visit
-    visit.AddArgument("-geometry")
-    visit.AddArgument("1024x1024")
-    visit.LaunchNowin()
+  import visit
+  visit.AddArgument("-geometry")
+  visit.AddArgument("1024x1024")
+  visit.LaunchNowin()
 
 
 Lineout
@@ -5408,11 +5409,11 @@ LoadUltra
 ::
 
   #% visit -cli
-  >>> LoadUltra()
-  U-> rd "../../data/distribution.ultra"
-  U-> select 1
-  U-> end
-  >>>
+  #>>> LoadUltra()
+  #U-> rd "../../data/distribution.ultra"
+  #U-> select 1
+  #U-> end
+  #>>>
 
 
 LocalNameSpace
@@ -5558,10 +5559,10 @@ newFrame : integer
   SetPlotDatabaseKeyframe(0, nFrames-1, 0)
   DrawPlots()
   for state in list(range(TimeSliderGetNStates())) + [0]:
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
   MovePlotDatabaseKeyframe(0, nFrames/2, nFrames/4)
   for state in list(range(TimeSliderGetNStates())) + [0]:
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
 
 
 MovePlotKeyframe
@@ -5614,15 +5615,15 @@ newFrame : integer
   SetTimeSliderState(nFrames-1)
   SetPlotOptions(c)
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
   temp = nFrames-2
   MovePlotKeyframe(0, nFrames/2, temp)
   MovePlotKeyframe(0, nFrames-1, nFrames/2)
   MovePlotKeyframe(0, temp, nFrames-1)
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 MovePlotOrderTowardFirst
@@ -5879,8 +5880,8 @@ return type : CLI_return_t
   DrawPlots()
   print "There are %d color tables." % NumColorTableNames()
   for ct in ColorTableNames():
-  SetActiveContinuousColorTable(ct)
-  SaveWindow()
+      SetActiveContinuousColorTable(ct)
+      SaveWindow()
 
 
 NumOperatorPlugins
@@ -6107,9 +6108,9 @@ return type : CLI_return_t
 
 ::
 
-  -assume_format PDB
-  % visit -cli
-  args = ("-dir", "/my/private/visit/version/", "-assume_format", "PDB", "-debug", "4")
+  
+  #% visit -cli -assume_format PDB
+  #args = ("-dir", "/my/private/visit/version/", "-assume_format", "PDB", "-debug", "4")
   # Open a metadata server before the call to OpenDatabase so we
   # can launch it how we want.
   OpenMDServer("thunder", args)
@@ -6145,7 +6146,7 @@ return type : tuple of strings
 
   #% visit -cli
   for plugin in OperatorPlugins():
-  print "The %s operator plugin is loaded." % plugin
+      print "The %s operator plugin is loaded." % plugin
 
 
 OverlayDatabase
@@ -6409,7 +6410,7 @@ return type : dictionary
   # examine output
   print 'value of u at node 200: %g' % pick_out['u']
   # Pick on node 100 in domain 5 and return information for two additional
-  variables.
+  # variables.
   pick_out = PickByNode(domain=5, element=100, vars=("u", "v", "d"))
   # examine output
   print 'incident zones for node 100: ', pick_out['incident_zones']
@@ -6491,7 +6492,7 @@ return type : dictionary
   # examine output
   print 'value of d at "node 4": %g' % pick_out['d']
   # Pick on node labeled "node 12" return information for two additional
-  variables.
+  # variables.
   pick_out = PickByNodeLabel(element_label="node 12", vars=("d", "u", "v"))
   # examine output
   print 'incident nodes for "node 12": ', pick_out['incident_nodes']
@@ -6573,7 +6574,7 @@ return type : dictionary
   # examine output
   print 'value of d at zone 200: %g' % pick_out['d']
   # Pick on cell 100 in domain 5 and return information for two additional
-  variables.
+  # variables.
   pick_out = PickByZone(element=100, domain=5, vars=("d", "u", "v"))
   # examine output
   print 'incident nodes for zone 100: ', pick_out['incident_nodes']
@@ -6655,7 +6656,7 @@ return type : dictionary
   # examine output
   print 'value of d at "brick 4": %g' % pick_out['d']
   # Pick on cell labeled "shell 12" return information for two additional
-  variables.
+  # variables.
   pick_out = PickByZoneLabel(element_label="shell 12", vars=("d", "u", "v"))
   # examine output
   print 'incident nodes for "shell 12": ', pick_out['incident_nodes']
@@ -6690,7 +6691,7 @@ return type : tuple of strings
 
   #% visit -cli
   for plugin in PluginPlugins():
-  print "The %s plot plugin is loaded." % plugin
+      print "The %s plot plugin is loaded." % plugin
 
 
 PointPick
@@ -6941,11 +6942,11 @@ return type : tuple of strings
   DrawPlots()
   # Execute each of the queries over time on the plots.
   for q in QueriesOverTime():
-  QueryOverTime(q)
-  You can control timestates used in the query via start_time,
-  end_time, and stride as follows:
+      QueryOverTime(q)
+  # You can control timestates used in the query via start_time,
+  # end_time, and stride as follows:
   QueryOverTime("Volume", start_time=5, end_time=250, stride=5)
-  (Defaults used if not specified are 0, nStates, 1)
+  # (Defaults used if not specified are 0, nStates, 1)
 
 
 Query
@@ -7046,7 +7047,7 @@ return type : CLI_return_t
     Quantitative Analysis chapter. You can get also get a list of queries that
     can be executed over time using 'QueriesOverTime' function.
     Since queries can take a wide array of arguments, the Query function takes
-    either a python dictorary or a list of named arguments specific to the
+    either a python dictionary or a list of named arguments specific to the
     given query.  To obtain the possible options for a given query, use the
     GetQueryParameters(name) function.  If the query accepts additional
     arguments beyond its name, this function will return a python dictionary
@@ -7064,8 +7065,8 @@ return type : CLI_return_t
   AddPlot("Pseudocolor", "pressure")
   DrawPlots()
   for q in QueriesOverTime():
-  QueryOverTime(q)
-  ResetView()
+      QueryOverTime(q)
+
 
 
 ReOpenDatabase
@@ -7114,12 +7115,12 @@ return type : CLI_return_t
   DrawPlots()
   last = TimeSliderGetNStates()
   for state in range(last):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
   ReOpenDatabase("edge:/usr/gapps/visit/data/wave*.silo database")
   for state in range(last, TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 ReadHostProfilesFromDirectory
@@ -7300,7 +7301,8 @@ return type : CLI_return_t
 
   import visit
   def print_sliceatts(atts):
-  print "SLICEATTS=", atts
+      print "SLICEATTS=", atts
+      
   visit.RegisterCallback("SliceAttributes", print_sliceatts)
 
 
@@ -7337,9 +7339,10 @@ callable : python function
 ::
 
   def SetupMyPlots():
-  OpenDatabase('noise.silo')
-  AddPlot('Pseudocolor', 'hardyglobal')
-  DrawPlots()
+      OpenDatabase('noise.silo')
+      AddPlot('Pseudocolor', 'hardyglobal')
+      DrawPlots()
+      
   RegisterMacro('Setup My Plots', SetupMyPlots)
 
 
@@ -7601,7 +7604,7 @@ return type : CLI_return_t
 ::
 
   #% visit -cli
-  OpenDatabase("/usr/gapps/visit/data/globe.silo)
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
   AddPlot("Pseudocolor", "u")
   DrawPlots()
   ReplaceDatabase("/usr/gapps/visit/data/curv3d.silo")
@@ -7868,8 +7871,8 @@ return type : CLI_return_t
   # my .visit directory.
   RestoreSessionFile("visit.session", 1)
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 RestoreSessionWithDifferentSources
@@ -7923,8 +7926,8 @@ return type : CLI_return_t
   # my .visit directory.
   RestoreSessionFile("visit.session", 1)
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 SaveAttribute
@@ -8303,15 +8306,15 @@ return type : CLI_return_t
   path = "/usr/gapps/visit/data/"
   dbs = (path + "dbA00.pdb", path + "dbB00.pdb", path + "dbC00.pdb")
   for db in dbs:
-  OpenDatabase(db)
-  AddPlot("FilledBoundary", "material(mesh)")
-  DrawPlots()
+      OpenDatabase(db)
+      AddPlot("FilledBoundary", "material(mesh)")
+      DrawPlots()
   CreateDatabaseCorrelation("common", dbs, 1)
   tsNames = GetWindowInformation().timeSliders
   for ts in tsNames:
-  SetActiveTimeSlider(ts)
+      SetActiveTimeSlider(ts)
   for state in list(range(TimeSliderGetNStates())) + [0]:
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
 
 
 SetActiveWindow
@@ -8748,7 +8751,7 @@ return type : CLI_return_t
   wi = GetWindowInformation()
   print "Active time slider: " % wi.timeSliders[wi.activeTimeSlider]
   # This will set time for both databases since the database correlation is
-  the active time slider.
+  # the active time slider.
   SetTimeSliderState(5)
 
 
@@ -9613,7 +9616,7 @@ return type : CLI_return_t
   AddPlot("Mesh", "quadmesh")
   DrawPlots()
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
 
 
 SetPlotDatabaseState
@@ -9665,9 +9668,9 @@ state : integer
   SetPlotDatabaseState(0, 0, 70)
   SetPlotDatabaseState(0, nFrames-1, 0)
   # Animate through the animation frames since the "Keyframe animation"
-  time slider is active.
+  # time slider is active.
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
 
 
 SetPlotDescription
@@ -9781,13 +9784,13 @@ end : integer
   AddPlot("Mesh", "quadmesh")
   DrawPlots()
   # Make the Pseudocolor plot take up the first half of the animation frames
-  before it disappears.
+  # before it disappears.
   SetPlotFrameRange(0, 0, nFrames/2-1)
   # Make the Mesh plot take up the second half of the animation frames.
   SetPlotFrameRange(1, nFrames/2, nFrames-1)
-  for state in range(TimeSliderGetNStates())
-  SetTimeSliderState(state)
-  SaveWindow()
+  for state in range(TimeSliderGetNStates()):
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 SetPlotOptions
@@ -9985,8 +9988,8 @@ typeAsString : string
 
 ::
 
-    SetPrecisionType("double")
-    SetPrecisionType(2)
+  SetPrecisionType("double")
+  SetPrecisionType(2)
 
 
 SetPreferredFileFormats
@@ -10161,10 +10164,10 @@ SetQueryOutputToString
   SetQueryOutputToString()
   query_output = Query("MinMax")
   print query_output
-  '
+  '''
   d -- Min = 0.0235702 (zone 434 at coord <0.483333, 0.483333>)
   d -- Max = 0.948976 (zone 1170 at coord <0.0166667, 1.31667>)
-  '
+  '''
 
 
 SetQueryOutputToValue
@@ -10415,15 +10418,15 @@ return type : CLI_return_t
   path = "/usr/gapps/visit/data/"
   dbs = (path + "dbA00.pdb", path + "dbB00.pdb", path + "dbC00.pdb")
   for db in dbs:
-  OpenDatabase(db)
-  AddPlot("FilledBoundary", "material(mesh)")
-  DrawPlots()
+      OpenDatabase(db)
+      AddPlot("FilledBoundary", "material(mesh)")
+      DrawPlots()
   CreateDatabaseCorrelation("common", dbs, 1)
   tsNames = GetWindowInformation().timeSliders
   for ts in tsNames:
-  SetActiveTimeSlider(ts)
+      SetActiveTimeSlider(ts)
   for state in list(range(TimeSliderGetNStates())) + [0]:
-  SetTimeSliderState(state)
+      SetTimeSliderState(state)
 
 
 SetTreatAllDBsAsTimeVarying
@@ -10565,21 +10568,21 @@ return type : CLI_return_t
 
 ::
 
-    % visit -cli
-    OpenDatabase("/usr/gapps/visit/data/globe.silo")
-    AddPlot("Pseudocolor", "v")
-    DrawPlots()
-    va = GetView3D()
-    va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
-    SetView3D(va)
-    v0 = GetView3D()
-    v1 = GetView3D()
-    v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
-    v1.parallelScale = 10.
-    for i in range(0,20):
-    t = float(i) / 19.
-    v2 = (1. - t) * v0 + t * v1
-    SetView3D(v2) # Animate the view.
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
+  AddPlot("Pseudocolor", "v")
+  DrawPlots()
+  va = GetView3D()
+  va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
+  SetView3D(va)
+  v0 = GetView3D()
+  v1 = GetView3D()
+  v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
+  v1.parallelScale = 10.
+  for i in range(0,20):
+      t = float(i) / 19.
+      v2 = (1. - t) * v0 + t * v1
+      SetView3D(v2) # Animate the view.
 
 
 SetView3D
@@ -10620,21 +10623,21 @@ return type : CLI_return_t
 
 ::
 
-    % visit -cli
-    OpenDatabase("/usr/gapps/visit/data/globe.silo")
-    AddPlot("Pseudocolor", "v")
-    DrawPlots()
-    va = GetView3D()
-    va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
-    SetView3D(va)
-    v0 = GetView3D()
-    v1 = GetView3D()
-    v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
-    v1.parallelScale = 10.
-    for i in range(0,20):
-    t = float(i) / 19.
-    v2 = (1. - t) * v0 + t * v1
-    SetView3D(v2) # Animate the view.
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
+  AddPlot("Pseudocolor", "v")
+  DrawPlots()
+  va = GetView3D()
+  va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
+  SetView3D(va)
+  v0 = GetView3D()
+  v1 = GetView3D()
+  v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
+  v1.parallelScale = 10.
+  for i in range(0,20):
+      t = float(i) / 19.
+      v2 = (1. - t) * v0 + t * v1
+      SetView3D(v2) # Animate the view.
 
 
 SetViewAxisArray
@@ -10671,21 +10674,21 @@ return type : CLI_return_t
 
 ::
 
-    % visit -cli
-    OpenDatabase("/usr/gapps/visit/data/globe.silo")
-    AddPlot("Pseudocolor", "v")
-    DrawPlots()
-    va = GetView3D()
-    va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
-    SetView3D(va)
-    v0 = GetView3D()
-    v1 = GetView3D()
-    v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
-    v1.parallelScale = 10.
-    for i in range(0,20):
-    t = float(i) / 19.
-    v2 = (1. - t) * v0 + t * v1
-    SetView3D(v2) # Animate the view.
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
+  AddPlot("Pseudocolor", "v")
+  DrawPlots()
+  va = GetView3D()
+  va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
+  SetView3D(va)
+  v0 = GetView3D()
+  v1 = GetView3D()
+  v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
+  v1.parallelScale = 10.
+  for i in range(0,20):
+      t = float(i) / 19.
+      v2 = (1. - t) * v0 + t * v1
+      SetView3D(v2) # Animate the view.
 
 
 SetViewCurve
@@ -10722,21 +10725,21 @@ return type : CLI_return_t
 
 ::
 
-    % visit -cli
-    OpenDatabase("/usr/gapps/visit/data/globe.silo")
-    AddPlot("Pseudocolor", "v")
-    DrawPlots()
-    va = GetView3D()
-    va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
-    SetView3D(va)
-    v0 = GetView3D()
-    v1 = GetView3D()
-    v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
-    v1.parallelScale = 10.
-    for i in range(0,20):
-    t = float(i) / 19.
-    v2 = (1. - t) * v0 + t * v1
-    SetView3D(v2) # Animate the view.
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/globe.silo")
+  AddPlot("Pseudocolor", "v")
+  DrawPlots()
+  va = GetView3D()
+  va.RotateAxis(1,30.0) # rotate around the y axis 30 degrees.
+  SetView3D(va)
+  v0 = GetView3D()
+  v1 = GetView3D()
+  v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)
+  v1.parallelScale = 10.
+  for i in range(0,20):
+      t = float(i) / 19.
+      v2 = (1. - t) * v0 + t * v1
+      SetView3D(v2) # Animate the view.
 
 
 SetViewExtentsType
@@ -10781,14 +10784,14 @@ return type : CLI_return_t
   v.viewUp = (0.276106, 0.891586, -0.358943)
   SetView3D(v)
   mats = GetMaterials()
-  nmats = len(mats):
+  nmats = len(mats)
   # Turn off all but the last material in sequence and watch
   # the view update each time.
   for i in range(nmats-1):
-  index = nmats-1-i
-  TurnMaterialsOff(mats[index])
-  SaveWindow()
-  SetViewExtentsType("original")
+      index = nmats-1-i
+      TurnMaterialsOff(mats[index])
+      SaveWindow()
+      SetViewExtentsType("original")
 
 
 SetViewKeyframe
@@ -10841,8 +10844,8 @@ return type : CLI_return_t
   SetViewKeyframe()
   ToggleCameraViewMode()
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 SetWindowArea
@@ -10993,7 +10996,7 @@ return type : CLI_return_t
 
 ::
 
-  % python
+  #% python
   import visit
   visit.Launch()
   visit.ShowAllWindows()
@@ -11213,8 +11216,8 @@ return type : CLI_return_t
   AddPlot("Pseudocolor", "pressure")
   DrawPlots()
   for state in range(TimeSliderGetNStates()):
-  SetTimeSliderState(state)
-  SaveWindow()
+      SetTimeSliderState(state)
+      SaveWindow()
 
 
 TimeSliderNextState
@@ -11241,15 +11244,15 @@ return type : CLI_return_t
 ::
 
   # Assume that files are being written to the disk.
-  % visit -cli
+  #% visit -cli
   OpenDatabase("dynamic*.silo database")
   AddPlot("Pseudocolor", "var")
   AddPlot("Mesh", "mesh")
   DrawPlots()
   SetTimeSliderState(TimeSliderGetNStates() - 1)
   while 1:
-  SaveWindow()
-  TimeSliderPreviousState()
+      SaveWindow()
+      TimeSliderPreviousState()
 
 
 TimeSliderPreviousState
@@ -11276,14 +11279,14 @@ return type : CLI_return_t
 ::
 
   # Assume that files are being written to the disk.
-  % visit -cli
+  #% visit -cli
   OpenDatabase("dynamic*.silo database")
   AddPlot("Pseudocolor", "var")
   AddPlot("Mesh", "mesh")
   DrawPlots()
   while 1:
-  TimeSliderNextState()
-  SaveWindow()
+      TimeSliderNextState()
+      SaveWindow()
 
 
 TimeSliderSetState
@@ -11318,15 +11321,15 @@ return type : CLI_return_t
   path = "/usr/gapps/visit/data/"
   dbs = (path + "dbA00.pdb", path + "dbB00.pdb", path + "dbC00.pdb")
   for db in dbs:
-  OpenDatabase(db)
-  AddPlot("FilledBoundary", "material(mesh)")
-  DrawPlots()
+      OpenDatabase(db)
+      AddPlot("FilledBoundary", "material(mesh)")
+      DrawPlots()
   CreateDatabaseCorrelation("common", dbs, 1)
   tsNames = GetWindowInformation().timeSliders
   for ts in tsNames:
-  SetActiveTimeSlider(ts)
+      SetActiveTimeSlider(ts)
   for state in list(range(TimeSliderGetNStates())) + [0]:
-  TimeSliderSetState(state)
+      TimeSliderSetState(state)
 
 
 ToggleBoundingBoxMode
@@ -11364,7 +11367,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11404,7 +11407,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11445,7 +11448,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11487,7 +11490,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11557,7 +11560,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11597,7 +11600,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11635,7 +11638,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 
@@ -11674,7 +11677,7 @@ return type : CLI_return_t
   # Turn on spin mode.
   ToggleSpinMode()
   # Rotate the plot interactively using the mouse and watch it keep spinning
-  after the mouse release.
+  # after the mouse release.
   # Turn off spin mode.
   ToggleSpinMode()
 

--- a/src/doc/cli_manual/functions.rst
+++ b/src/doc/cli_manual/functions.rst
@@ -12047,7 +12047,7 @@ WriteScript
   f = open('script.py', 'wt')
   WriteScript(f)
   f.close()
-  
+
 
 
 ZonePick

--- a/src/doc/cli_manual/functions.rst
+++ b/src/doc/cli_manual/functions.rst
@@ -484,7 +484,7 @@ return type : CLI_return_t
   # coordinates and print the value.
   ResetView()
   ChooseCenterOfRotation(0.5, 0.3)
-  print "The new center of rotation is:", GetView3D().centerOfRotation
+  print("The new center of rotation is:{}".format(GetView3D().centerOfRotation))
 
 
 ClearAllWindows
@@ -954,9 +954,9 @@ return type : CLI_return_t
   OpenDatabase(db)
   AddPlot("Pseudocolor", "u")
   DrawPlots()
-  print "This won't work: retval = %d" % CloseDatabase(db)
+  print("This won't work: retval = %d" % CloseDatabase(db))
   DeleteAllPlots()
-  print "Now it works: retval = %d" % CloseDatabase(db)
+  print("Now it works: retval = %d" % CloseDatabase(db))
 
 
 ColorTableNames
@@ -1292,7 +1292,7 @@ return type : annotation object
   AddPlot("Pseudocolor", "pressure")
   DrawPlots()
   slider = CreateAnnotationObject("TimeSlider")
-  print slider
+  print(slider)
   slider.startColor = (255,0,0,255)
   slider.endColor = (255,255,0,255)
 
@@ -1370,7 +1370,7 @@ return type : CLI_return_t
   # Creating a new database correlation also creates a new time
   # slider and makes it be active.
   w = GetWindowInformation()
-  print "Active time slider: %s" % w.timeSliders[w.activeTimeSlider]
+  print("Active time slider: %s" % w.timeSliders[w.activeTimeSlider])
   # Animate through time using the "common" database correlation's
   # time slider.
   for i in range(TimeSliderGetNStates()):
@@ -1462,8 +1462,8 @@ return type : dictionary
 
   #% visit -cli
   dbp = DatabasePlugins("localhost")
-  print dbp["host"]
-  print dbp["plugins"]
+  print(dbp["host"])
+  print(dbp["plugins"])
 
 
 DeIconifyAllWindows
@@ -2883,8 +2883,8 @@ return type : string
 ::
 
   #% visit -cli
-  print "Default continuous color table: %s" % GetActiveContinuousColorTable()
-  print "Default discrete color table: %s" % GetActiveDiscreteColorTable()
+  print("Default continuous color table: %s" % GetActiveContinuousColorTable())
+  print("Default discrete color table: %s" % GetActiveDiscreteColorTable())
 
 
 GetActiveDiscreteColorTable
@@ -2924,10 +2924,8 @@ return type : string
 ::
 
   #% visit -cli
-  print "Default continuous color table: %s" % \
-  GetActiveContinuousColorTable()
-  print "Default discrete color table: %s" % \
-  GetActiveDiscreteColorTable()
+  print("Default continuous color table: %s" % GetActiveContinuousColorTable())
+  print("Default discrete color table: %s" % GetActiveDiscreteColorTable())
 
 
 GetActiveTimeSlider
@@ -2965,9 +2963,9 @@ return type : string
   AddPlot("FilledBoundary", "material(mesh)")
   OpenDatabase("dbB00.pdb")
   AddPlot("FilledBoundary", "materials(mesh)")
-  print "Active time slider: %s" % GetActiveTimeSlider()
+  print("Active time slider: %s" % GetActiveTimeSlider())
   CreateDatabaseCorrelation("common", ("dbA00.pdb", "dbB00.pdb"), 2)
-  print "Active time slider: %s" % GetActiveTimeSlider()
+  print("Active time slider: %s" % GetActiveTimeSlider())
 
 
 GetAnimationAttributes
@@ -2995,7 +2993,7 @@ return type : AnimationAttributes object
 ::
 
   a = GetAnimationAttributes()
-  print a
+  print(a)
 
 
 GetAnimationTimeout
@@ -3025,7 +3023,7 @@ return type : CLI_return_t
 ::
 
   #% visit -cli
-  print "Animation timeout = %d" % GetAnimationTimeout()
+  print("Animation timeout = %d" % GetAnimationTimeout())
 
 
 GetAnnotationAttributes
@@ -3060,7 +3058,7 @@ return type : AnnotationAttributes object
   AddPlot("Pseudocolor", "u")
   DrawPlots()
   a = GetAnnotationAttributes()
-  print a
+  print(a)
   a.backgroundMode = a.BACKGROUNDMODE_GRADIENT
   a.gradientColor1 = (0, 0, 255)
   SetAnnotationAttributes(a)
@@ -3109,7 +3107,7 @@ return type : Annotation object
   GetAnnotationObjectNames()
   ["plot0000", "TimeSlider1"]
   ref = GetAnnotationObject("TimeSlider1")
-  print ref
+  print(ref)
 
 
 GetAnnotationObjectNames
@@ -3162,7 +3160,7 @@ return type : CLI_return_t
 
   cbName = 'OpenDatabaseRPC'
   count = GetCallbackArgumentCount(cbName)
-  print 'The number of arguments for %s is: %d' % (cbName, count)
+  print('The number of arguments for %s is: %d' % (cbName, count))
 
 
 GetCallbackNames
@@ -3190,7 +3188,7 @@ return type : tuple of string objects
 ::
 
   import visit
-  print visit.GetCallbackNames()
+  print(visit.GetCallbackNames())
 
 
 GetDatabaseNStates
@@ -3222,7 +3220,7 @@ return type : CLI_return_t
 
   #% visit -cli
   OpenDatabase("/usr/gapps/visit/data/wave*.silo database")
-  print "Number of time states: %d" % GetDatabaseNStates()
+  print("Number of time states: %d" % GetDatabaseNStates())
 
 
 GetDebugLevel
@@ -3251,7 +3249,7 @@ return type : CLI_return_t
 ::
 
   #% visit -cli -debug 2
-  print "VisIt's debug level is: %d" % GetDebugLevel()
+  print("VisIt's debug level is: %d" % GetDebugLevel())
 
 
 GetDefaultFileOpenOptions
@@ -3320,7 +3318,7 @@ return type : tuple of strings
   AddPlot("Pseudocolor", "u")
   DrawPlots()
   doms = GetDomains()
-  print doms
+  print(doms)
   # Turn off all but the last domain, one after the other.
   for d in doms[:-1]:
       TurnDomainsOff(d)
@@ -3371,7 +3369,7 @@ return type : tuple of strings
   AddPlot("Mesh", "mesh1")
   DrawPlots()
   for name in GetEngineList():
-      print "VisIt has a compute engine running on %s" % name
+      print("VisIt has a compute engine running on %s" % name)
       CloseComputeEngine(GetEngineList()[1])
 
 
@@ -3448,7 +3446,7 @@ return type : GlobalAttributes object
   AddPlot("Pseudocolor", "u")
   DrawPlots()
   g = GetGlobalAttributes()
-  print g
+  print(g)
 
 
 GetGlobalLineoutAttributes
@@ -3486,7 +3484,7 @@ return type : GlobalLineoutAttributes object
   AddPlot("Pseudocolor", "d")
   DrawPlots()
   g = GetGlobalLineoutAttributes()
-  print g
+  print(g)
   g.samplingOn = 1
   g.windowId = 4
   g.createWindow = 0
@@ -3526,7 +3524,7 @@ return type : InteractorAttributes object
 
   #% visit -cli
   ia = GetInteractorAttributes()
-  print ia
+  print(ia)
   ia.showGuidelines = 0
   SetInteractorAttributes(ia)
 
@@ -3559,7 +3557,7 @@ return type : KeyframeAttributes object
 
   #% visit -cli
   k = GetKeyframeAttributes()
-  print k
+  print(k)
   k.enabled,k.nFrames,k.nFramesWasUserSet = 1, 100, 1
   SetKeyframeAttributes(k)
 
@@ -3590,7 +3588,7 @@ return type : string
 
   #% visit -cli
   OpenDatabase("/this/database/does/not/exist")
-  print "VisIt Error: %s" % GetLastError()
+  print("VisIt Error: %s" % GetLastError())
 
 
 GetLight
@@ -3632,7 +3630,7 @@ return type : LightAttributes object
   DrawPlots()
   InvertBackgroundColor()
   light = GetLight(0)
-  print light
+  print(light)
   light.enabledFlag = 1
   light.direction = (0,-1,0)
   light.color = (255,0,0,255)
@@ -3666,8 +3664,8 @@ return type : string
 ::
 
   #% visit -cli
-  print "Local machine name is: %s" % GetLocalHostName()
-  print "My username: %s" % GetLocalUserName()
+  print("Local machine name is: %s" % GetLocalHostName())
+  print("My username: %s" % GetLocalUserName())
 
 
 GetLocalUserName
@@ -3695,8 +3693,8 @@ return type : string
 ::
 
   #% visit -cli
-  print "Local machine name is: %s" % GetLocalHostName()
-  print "My username: %s" % GetLocalUserName()
+  print("Local machine name is: %s" % GetLocalHostName())
+  print("My username: %s" % GetLocalUserName())
 
 
 GetMachineProfile
@@ -3892,7 +3890,7 @@ return type : avtDatabaseMetaData object
 ::
 
   md = GetMetaData('noise.silo')
-  for i in xrange(md.GetNumScalars()):
+  for i in range(md.GetNumScalars()):
       AddPlot('Pseudocolor', md.GetScalars(i).name)
   DrawPlots()
 
@@ -3920,13 +3918,13 @@ return type : CLI_return_t
 ::
 
   #% visit -cli
-  print "Number of plots", GetNumPlots()
+  print("Number of plots", GetNumPlots())
   OpenDatabase("/usr/gapps/visit/data/curv2d.silo")
   AddPlot("Pseudocolor", "d")
-  print "Number of plots", GetNumPlots()
+  print("Number of plots", GetNumPlots())
   AddPlot("Mesh", "curvmesh2d")
   DrawPlots()
-  print "Number of plots", GetNumPlots()
+  print("Number of plots", GetNumPlots())
 
 
 GetOperatorOptions
@@ -3960,7 +3958,7 @@ return type : operator attributes object
   AddOperator('Transform')
   AddOperator('Transform')
   t = GetOperatorOptions(1)
-  print 'Attributes for the 2nd Transform operator:', t
+  print('Attributes for the 2nd Transform operator:', t)
 
 
 GetPickAttributes
@@ -3997,7 +3995,7 @@ return type : PickAttributes object
   AddPlot("Pseudocolor", "mesh/ireg")
   DrawPlots()
   p = GetPickAttributes()
-  print p
+  print(p)
   p.variables = ("default", "mesh/a", "mesh/mixvar")
   SetPickAttributes(p)
   # Now do some interactive picks and you'll see pick information
@@ -4037,7 +4035,7 @@ return type : string
   DrawPlots()
   ZonePick(coord=(0.4, 0.6, 0), vars=("default", "u", "v"))
   s = GetPickOutput()
-  print s
+  print(s)
 
 
 GetPickOutputObject
@@ -4069,7 +4067,7 @@ return type : dictionary
   DrawPlots()
   ZonePick(coord=(0.4, 0.6, 0), vars=("default", "u", "v"))
   o = GetPickOutputObject()
-  print o
+  print(o)
 
 
 GetPipelineCachingMode
@@ -4100,7 +4098,7 @@ return type : CLI_return_t
 
   #%visit -cli
   offon = ("off", "on")
-  print "Pipeline caching is %s" % offon[GetPipelineCachingMode()]
+  print("Pipeline caching is %s" % offon[GetPipelineCachingMode()])
 
 
 GetPlotInformation
@@ -4135,7 +4133,7 @@ return type : dictionary
   SetActiveWindow(2)
   info = GetPlotInformation()
   lineout = info["Curve"]
-  print "The first lineout point is: [%g, %g] " % lineout[0], lineout[1]
+  print("The first lineout point is: [%g, %g] " % lineout[0], lineout[1])
 
 
 GetPlotList
@@ -4169,7 +4167,7 @@ return type : PlotList object
   # Copy plots (without operators to window 2)
   pL = GetPlotList()
   AddWindow()
-  for i in xrange(pL.GetNumPlots()):
+  for i in range(pL.GetNumPlots()):
       AddPlot(PlotPlugins()[pL.GetPlots(i).plotType], pL.GetPlots(i).plotVar)
   DrawPlots()
 
@@ -4264,8 +4262,8 @@ return type : dictionary or value
   AddPlot("Pseudocolor", "d")
   DrawPlots()
   Query("MinMax")
-  print GetQueryOutputString()
-  print "The min is: %g and the max is: %g" % GetQueryOutputValue()
+  print(GetQueryOutputString())
+  print("The min is: %g and the max is: %g" % GetQueryOutputValue())
 
 
 GetQueryOutputString
@@ -4300,8 +4298,8 @@ return type : string
   AddPlot("Pseudocolor", "d")
   DrawPlots()
   Query("MinMax")
-  print GetQueryOutputString()
-  print "The min is: %g and the max is: %g" % GetQueryOutputValue()
+  print(GetQueryOutputString())
+  print("The min is: %g and the max is: %g" % GetQueryOutputValue())
 
 
 GetQueryOutputValue
@@ -4337,8 +4335,8 @@ return type : double, tuple of doubles
   AddPlot("Pseudocolor", "d")
   DrawPlots()
   Query("MinMax")
-  print GetQueryOutputString()
-  print "The min is: %g and the max is: %g" % GetQueryOutputValue()
+  print(GetQueryOutputString())
+  print("The min is: %g and the max is: %g" % GetQueryOutputValue())
 
 
 GetQueryOutputXML
@@ -4373,8 +4371,8 @@ return type : string
   AddPlot("Pseudocolor", "d")
   DrawPlots()
   Query("MinMax")
-  print GetQueryOutputString()
-  print "The min is: %g and the max is: %g" % GetQueryOutputValue()
+  print(GetQueryOutputString())
+  print("The min is: %g and the max is: %g" % GetQueryOutputValue())
 
 
 GetQueryOverTimeAttributes
@@ -4409,7 +4407,7 @@ return type : QueryOverTimeAttributes object
   AddPlot("Pseudocolor", "mesh/mixvar")
   DrawPlots()
   qot = GetQueryOverTimeAttributes()
-  print qot
+  print(qot)
   # Make queries over time go to window 4.
   qot.createWindow,q.windowId = 0, 4
   SetQueryOverTimeAttributes(qot)
@@ -4531,11 +4529,11 @@ return type : SaveWindowAttributes object
 
   #% visit -cli
   s = GetSaveWindowAttributes()
-  print s
+  print(s)
   s.width = 600
   s.height = 600
   s.format = s.RGB
-  print s
+  print(s)
 
 
 GetSelection
@@ -4634,7 +4632,7 @@ return type : SelectionSummary object
 
 ::
 
-  print GetSelectionSummary('selection1')
+  print(GetSelectionSummary('selection1'))
 
 
 GetTimeSliders
@@ -4670,7 +4668,7 @@ return type : tuple of strings
       AddPlot("FilledBoundary", "material(mesh)")
       DrawPlots()
   CreateDatabaseCorrelation("common", dbs, 1)
-  print "The list of time sliders is: ", GetTimeSliders()
+  print("The list of time sliders is: ", GetTimeSliders())
 
 
 GetUltraScript
@@ -4725,7 +4723,7 @@ return type : View2DAttributes object
   v0 = GetView3D()
   # Change the view again using the mouse
   v1 = GetView3D()
-  print v0
+  print(v0)
   for i in range(0,20):
       t = float(i) / 19.
       v2 = (1. - t) * v1 + t * v0
@@ -4764,7 +4762,7 @@ return type : View3DAttributes object
   v0 = GetView3D()
   # Change the view again using the mouse
   v1 = GetView3D()
-  print v0
+  print(v0)
   for i in range(0,20):
       t = float(i) / 19.
       v2 = (1. - t) * v1 + t * v0
@@ -4803,7 +4801,7 @@ return type : ViewAxisArrayAttributes object
   v0 = GetView3D()
   # Change the view again using the mouse
   v1 = GetView3D()
-  print v0
+  print(v0)
   for i in range(0,20):
       t = float(i) / 19.
       v2 = (1. - t) * v1 + t * v0
@@ -4842,7 +4840,7 @@ return type : ViewCurveAttributes object
   v0 = GetView3D()
   # Change the view again using the mouse
   v1 = GetView3D()
-  print v0
+  print(v0)
   for i in range(0,20):
       t = float(i) / 19.
       v2 = (1. - t) * v1 + t * v0
@@ -5878,7 +5876,7 @@ return type : CLI_return_t
   p.colorTableName = "default"
   SetPlotOptions(p)
   DrawPlots()
-  print "There are %d color tables." % NumColorTableNames()
+  print("There are %d color tables." % NumColorTableNames())
   for ct in ColorTableNames():
       SetActiveContinuousColorTable(ct)
       SaveWindow()
@@ -5908,8 +5906,8 @@ return type : CLI_return_t
 ::
 
   #% visit -cli
-  print "The number of operator plugins is: ", NumOperatorPlugins()
-  print "The names of the plugins are: ", OperatorPlugins()
+  print("The number of operator plugins is: ", NumOperatorPlugins())
+  print("The names of the plugins are: ", OperatorPlugins())
 
 
 NumPlotPlugins
@@ -5935,8 +5933,8 @@ return type : CLI_return_t
 ::
 
   #% visit -cli
-  print "The number of plot plugins is: ", NumPlotPlugins()
-  print "The names of the plugins are: ", PlotPlugins()
+  print("The number of plot plugins is: ", NumPlotPlugins())
+  print("The names of the plugins are: ", PlotPlugins())
 
 
 OpenComputeEngine
@@ -6146,7 +6144,7 @@ return type : tuple of strings
 
   #% visit -cli
   for plugin in OperatorPlugins():
-      print "The %s operator plugin is loaded." % plugin
+      print("The %s operator plugin is loaded." % plugin)
 
 
 OverlayDatabase
@@ -6260,10 +6258,10 @@ return type : dictionary
   # Pick on global node 236827
   pick_out = PickByGlobalNode(element=246827)
   # examine output
-  print 'value of dist at global node 246827: %g' % pick_out['dist']
-  print 'local domain/node: %d/%d' % (pick_out['domain_id'], pick_out['node_id'])
+  print('value of dist at global node 246827: %g' % pick_out['dist'])
+  print('local domain/node: %d/%d' % (pick_out['domain_id'], pick_out['node_id']))
   # get last pick output as string
-  print 'Last pick = ', GetPickOutput()
+  print('Last pick = ', GetPickOutput())
 
 
 PickByGlobalZone
@@ -6331,10 +6329,10 @@ return type : dictionary
   # Pick on global zone 237394
   pick_out = PickByGlobalZone(element=237394)
   # examine output
-  print 'value of p at global zone 237394: %g' % pick_out['p']
-  print 'local domain/zone: %d/%d' % (pick_out['domain_id'], pick_out['zone_id'])
+  print('value of p at global zone 237394: %g' % pick_out['p'])
+  print('local domain/zone: %d/%d' % (pick_out['domain_id'], pick_out['zone_id']))
   # get last pick output as string
-  print 'Last pick = ', GetPickOutput()
+  print('Last pick = ', GetPickOutput())
 
 
 PickByNode
@@ -6408,15 +6406,15 @@ return type : dictionary
   # Pick on node 200 in the first domain.
   pick_out = PickByNode(element=200, domain=1)
   # examine output
-  print 'value of u at node 200: %g' % pick_out['u']
+  print('value of u at node 200: %g' % pick_out['u'])
   # Pick on node 100 in domain 5 and return information for two additional
   # variables.
   pick_out = PickByNode(domain=5, element=100, vars=("u", "v", "d"))
   # examine output
-  print 'incident zones for node 100: ', pick_out['incident_zones']
-  print 'value of d at incident zone %d: %g' % (pick_out['incident_zones'][0], pick_out['d'][str(pick_out['incident_zones'][0])])
+  print('incident zones for node 100: ', pick_out['incident_zones'])
+  print('value of d at incident zone %d: %g' % (pick_out['incident_zones'][0], pick_out['d'][str(pick_out['incident_zones'][0])]))
   # print results formatted as string
-  print "Last pick = ", GetPickOutput()
+  print("Last pick = ", GetPickOutput())
 
 
 PickByNodeLabel
@@ -6490,15 +6488,15 @@ return type : dictionary
   opts["element_label"] ="node 4"
   pick_out = PickByNodeLabel(opts)
   # examine output
-  print 'value of d at "node 4": %g' % pick_out['d']
+  print('value of d at "node 4": %g' % pick_out['d'])
   # Pick on node labeled "node 12" return information for two additional
   # variables.
   pick_out = PickByNodeLabel(element_label="node 12", vars=("d", "u", "v"))
   # examine output
-  print 'incident nodes for "node 12": ', pick_out['incident_nodes']
-  print 'values of u at incident node %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])])
+  print('incident nodes for "node 12": ', pick_out['incident_nodes'])
+  print('values of u at incident node %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])]))
   # print results formatted as string
-  print "Last pick = ", GetPickOutput()
+  print("Last pick = ", GetPickOutput())
 
 
 PickByZone
@@ -6572,15 +6570,15 @@ return type : dictionary
   # Pick on cell 200 in the second domain.
   pick_out = PickByZone(element=200, domain=2)
   # examine output
-  print 'value of d at zone 200: %g' % pick_out['d']
+  print('value of d at zone 200: %g' % pick_out['d'])
   # Pick on cell 100 in domain 5 and return information for two additional
   # variables.
   pick_out = PickByZone(element=100, domain=5, vars=("d", "u", "v"))
   # examine output
-  print 'incident nodes for zone 100: ', pick_out['incident_nodes']
-  print 'values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])])
+  print('incident nodes for zone 100: ', pick_out['incident_nodes'])
+  print('values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])]))
   # print results formatted as string
-  print "Last pick = ", GetPickOutput()
+  print("Last pick = ", GetPickOutput())
 
 
 PickByZoneLabel
@@ -6654,15 +6652,15 @@ return type : dictionary
   opts["element_label"] ="brick 4"
   pick_out = PickByZoneLabel(opts)
   # examine output
-  print 'value of d at "brick 4": %g' % pick_out['d']
+  print('value of d at "brick 4": %g' % pick_out['d'])
   # Pick on cell labeled "shell 12" return information for two additional
   # variables.
   pick_out = PickByZoneLabel(element_label="shell 12", vars=("d", "u", "v"))
   # examine output
-  print 'incident nodes for "shell 12": ', pick_out['incident_nodes']
-  print 'values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])])
+  print('incident nodes for "shell 12": ', pick_out['incident_nodes'])
+  print('values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])]))
   # print results formatted as string
-  print "Last pick = ", GetPickOutput()
+  print("Last pick = ", GetPickOutput())
 
 
 PlotPlugins
@@ -6691,7 +6689,7 @@ return type : tuple of strings
 
   #% visit -cli
   for plugin in PluginPlugins():
-      print "The %s plot plugin is loaded." % plugin
+      print("The %s plot plugin is loaded." % plugin)
 
 
 PointPick
@@ -6910,7 +6908,7 @@ return type : tuple of strings
 ::
 
   #% visit -cli
-  print "supported queries: ", Queries()
+  print("supported queries: ", Queries())
 
 
 QueriesOverTime
@@ -7301,7 +7299,7 @@ return type : CLI_return_t
 
   import visit
   def print_sliceatts(atts):
-      print "SLICEATTS=", atts
+      print("SLICEATTS=", atts)
       
   visit.RegisterCallback("SliceAttributes", print_sliceatts)
 
@@ -8105,7 +8103,7 @@ return type : string
   s.fileName = "test"
   SetSaveWindowAttributes(s)
   name = SaveWindow()
-  print "name = %s" % name
+  print("name = %s" % name)
 
 
 SendSimulationCommand
@@ -8749,7 +8747,7 @@ return type : CLI_return_t
   # The AddPlot caused a database correlation to be created.
   DrawPlots()
   wi = GetWindowInformation()
-  print "Active time slider: " % wi.timeSliders[wi.activeTimeSlider]
+  print("Active time slider: " % wi.timeSliders[wi.activeTimeSlider])
   # This will set time for both databases since the database correlation is
   # the active time slider.
   SetTimeSliderState(5)
@@ -8786,7 +8784,7 @@ level : string
 ::
 
   #% visit -cli -debug 2
-  print "VisIt's debug level is: %d" % GetDebugLevel()
+  print("VisIt's debug level is: %d" % GetDebugLevel())
 
 
 SetDefaultAnnotationAttributes
@@ -8915,7 +8913,7 @@ return type : CLI_return_t
 
   #% visit -cli
   ia = GetInteractorAttributes()
-  print ia
+  print(ia)
   ia.showGuidelines = 0
   SetInteractorAttributes(ia)
 
@@ -9236,7 +9234,7 @@ return type : CLI_return_t
 
   #% visit -cli
   ia = GetInteractorAttributes()
-  print ia
+  print(ia)
   ia.showGuidelines = 0
   SetInteractorAttributes(ia)
 
@@ -9276,7 +9274,7 @@ return type : CLI_return_t
 
   #% visit -cli
   k = GetKeyframeAttributes()
-  print k
+  print(k)
   k.enabled,k.nFrames,k.nFramesWasUserSet = 1, 100, 1
   SetKeyframeAttributes(k)
 
@@ -9319,7 +9317,7 @@ return type : CLI_return_t
   DrawPlots()
   InvertBackgroundColor()
   light = GetLight(0)
-  print light
+  print(light)
   light.enabledFlag = 1
   light.direction = (0,-1,0)
   light.color = (255,0,0,255)
@@ -10130,7 +10128,7 @@ SetQueryOutputToObject
   # Set query output type.
   SetQueryOutputToObject()
   query_output = Query("MinMax")
-  print query_output
+  print(query_output)
 
 
 SetQueryOutputToString
@@ -10163,7 +10161,7 @@ SetQueryOutputToString
   # Set query output type.
   SetQueryOutputToString()
   query_output = Query("MinMax")
-  print query_output
+  print(query_output)
   '''
   d -- Min = 0.0235702 (zone 434 at coord <0.483333, 0.483333>)
   d -- Max = 0.948976 (zone 1170 at coord <0.0166667, 1.31667>)
@@ -10200,7 +10198,7 @@ SetQueryOutputToValue
   # Set query output type.
   SetQueryOutputToValue()
   query_output = Query("MinMax")
-  print query_output
+  print(query_output)
   (0.02357020415365696, 0.9489759802818298)
 
 
@@ -10335,7 +10333,7 @@ return type : CLI_return_t
   light.direction = (0,1,-1)
   SetLight(0, light)
   r = GetRenderingAttributes()
-  print r
+  print(r)
   r.scalableActivationMode = r.Always
   r.doShadowing = 1
   SetRenderingAttributes(r)
@@ -11141,7 +11139,7 @@ return type : CLI_return_t
   # Turn off automatic printing of Query output.
   SuppressQueryOutputOn()
   Query("MinMax")
-  print "The min is: %g and the max is: %g" % GetQueryOutputValue()
+  print("The min is: %g and the max is: %g" % GetQueryOutputValue())
   # Turn on automatic printing of Query output.
   SuppressQueryOutputOff()
   Query("MinMax")
@@ -11178,7 +11176,7 @@ return type : CLI_return_t
   # Turn off automatic printing of Query output.
   SuppressQueryOutputOn()
   Query("MinMax")
-  print "The min is: %g and the max is: %g" % GetQueryOutputValue()
+  print("The min is: %g and the max is: %g" % GetQueryOutputValue())
   # Turn on automatic printing of Query output.
   SuppressQueryOutputOff()
   Query("MinMax")
@@ -12003,7 +12001,7 @@ return type : string
 ::
 
   #% visit -cli
-  print "We are running VisIt version %s" % Version()
+  print("We are running VisIt version %s" % Version())
 
 
 WriteConfigFile

--- a/src/doc/functions_to_method_doc.py
+++ b/src/doc/functions_to_method_doc.py
@@ -250,7 +250,20 @@ if __name__ == '__main__':
             block_dict['example'] = ExampleContainer()
             
         elif cur_block is not None:
-            block_dict[cur_block].extend(line.strip())
+            # for examples sources, we need to preserve spaces in 
+            # the example script to keep python code valid
+            if cur_block == 'example' and line.strip() != "":
+                # find the leading number of spaces using lstrip
+                padding = len(line) - len(line.lstrip())
+                # assume padding of 2 spaces in rst
+                padding = padding - 2
+                next_text = ""
+                for i in range(padding):
+                    next_text += " "
+                next_text += line.strip()
+            else:
+                next_text = line.strip()
+            block_dict[cur_block].extend(next_text)
     
     # Write the last function
     block_dict[cur_block].set_last(True)

--- a/src/doc/functions_to_plain_py.py
+++ b/src/doc/functions_to_plain_py.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+#
+# file: functions_to_plain_py.py
+# author: cyrush (but most code taken from functions_to_method_doc.py)
+#
+
+import sys
+
+##############################################################################
+# This is a hacked up version of functions_to_method_doc.py
+# it creates a single output file:
+#   FUNCTIONS_FLAT_PYTHON.py 
+# with all of the python examples from functions.rst
+#
+# Why is it useful? You can use this to check python syntax 
+# for all of our examples, and to check python 3 compat with 2to3.
+##############################################################################
+
+
+# --------------- #
+# --- Classes --- #
+# --------------- #
+
+class PyFunction(object):
+    def __init__(self, _name):
+        if _name[-1] == '\n':
+            self.name = _name[0:-1]
+        else:
+            self.name = _name
+        self.pre_text = ''
+        self.post_text = ''
+    
+    def __str__(self):
+        output = "# " + self.name  + " (EXAMPLE)\n"
+        output += "\n"
+        output += "\n"
+        return output
+
+
+class Container(object):
+    """
+        A container to hold and format documentation.
+    """
+    def __init__(self):
+        self.text = []
+        self.last = False
+    
+    def extend(self, extension):
+        self.text.append(extension)
+    
+    def set_last(self, is_last):
+        self.last = is_last
+    
+    def __str__(self):
+        """
+            Overridden str method. When str() is called on
+            the Container, it will be converted to a string
+            formatted for MethodDoc.C
+
+            returns:
+                A formatted string. 
+        """
+        if self.last:
+            self.text = self.text[0:-1]
+        output = ""
+        output += "\n"
+        for line in self.text:
+            output +=  line  + "\n"
+        if self.last:
+            output += "\n"
+        else:
+            output += "\n\n"
+        return output
+
+
+class SynopsisContainer(Container):
+    def __init__(self):
+        self.title = 'Synopsis:'
+        Container.__init__(self)
+
+
+class ArgumentsContainer(Container):
+    """
+        A container to hold and format a function synopsis. 
+    """ 
+    def __init__(self, arg_name):
+        self.title = 'Arguments:'
+        Container.__init__(self)
+        self.text.append(split_colon_add_spaces(arg_name))
+
+    def extend(self, extension):
+        self.text.append(split_colon_add_spaces(extension))
+
+
+class ReturnsContainer(Container):
+    def __init__(self):
+        self.title = 'Returns:'
+        Container.__init__(self)
+    
+    def extend(self, extension):
+        self.text.append(split_colon_add_spaces(extension))
+
+
+class DescriptionContainer(Container):
+    def __init__(self):
+        self.title = 'Description:'
+        Container.__init__(self)
+
+
+class ExampleContainer(Container): 
+    def __init__(self):
+        self.title = 'Example:'
+        Container.__init__(self)
+
+
+
+# ----------------- #
+# --- Functions --- #
+# ----------------- #
+
+def split_colon_add_spaces(line):
+    colon_index = line.find(':')
+    if colon_index > -1:
+        output = line[:colon_index-1]
+    else:
+        output = '    ' + line
+    return output
+
+
+def write_state(writer, state_dict):
+    # 
+    if state_dict['example']:
+        writer.write(str(state_dict['example']))
+
+# ------------ #
+# --- Main --- #
+# ------------ #
+
+if __name__ == '__main__':
+
+    func_file_name = 'cli_manual/functions.rst'
+    py_output_name = 'FUNCTIONS_FLAT_PYTHON.py'
+
+    func_file   = open(func_file_name, 'r')
+    py_output    = open(py_output_name,'w')
+        
+    block_dict = {'synopsis': None, 'arguments': None, 'returns': None, 'description': None, 'example': None}
+    cur_block = None
+    first_func = True
+    
+    func_file_lines = func_file.readlines()
+    for i in range(0, len(func_file_lines)):
+        line = func_file_lines[i]
+        # print line[0:-1]
+        
+        if line[0] in ['\n', '|', ':', '='] or line == 'Functions\n':
+            continue
+            
+        if line[0] == '-': # The previous line was a function name
+            # Output the last state of the block_dict
+            if not first_func:
+                block_dict[cur_block].set_last(True)
+                write_state(py_output, block_dict)
+        
+            first_func = False
+            # Setup the next function
+            cur_block = 'Function:'
+            block_dict = {'synopsis': None, 'arguments': None, 'returns': None, 'description': None, 'example': None}
+            py_output.write(str(PyFunction(func_file_lines[i-1])))
+        
+        elif line == '.. end of the file':
+            break;
+            
+        elif line[0:13] == '**Synopsis:**':
+            cur_block = 'synopsis'
+            block_dict['synopsis'] = SynopsisContainer()
+            
+        elif cur_block != 'arguments' and line[0:6] != 'return' and line.find(' : ') > -1:
+            cur_block = 'arguments'
+            block_dict['arguments'] = ArgumentsContainer(line.strip())
+            
+        elif line[0:6] == 'return':
+            cur_block = 'returns'
+            block_dict['returns'] = ReturnsContainer()
+            
+        elif line[0:16] == '**Description:**':
+            cur_block = 'description'
+            block_dict['description'] = DescriptionContainer()
+            
+        elif line[0:12] == '**Example:**':
+            cur_block = 'example'
+            block_dict['example'] = ExampleContainer()
+            
+        elif cur_block is not None:
+            if line.startswith("  "):
+                spaces = len(line) - len(line.lstrip())
+                spaces = spaces - 2
+                # custom strip, we don't want to loose indent!
+                # add back in spaces after "  "
+                r = ""
+                for i in range(spaces):
+                    r += " "
+                line = r + line.strip()
+            block_dict[cur_block].extend(line)
+    
+    # Write the last function
+    block_dict[cur_block].set_last(True)
+    write_state(py_output, block_dict)
+   
+    func_file.close()
+    py_output.close()
+

--- a/src/doc/functions_to_plain_py.py
+++ b/src/doc/functions_to_plain_py.py
@@ -9,7 +9,7 @@ import sys
 ##############################################################################
 # This is a hacked up version of functions_to_method_doc.py
 # it creates a single output file:
-#   FUNCTIONS_FLAT_PYTHON.py 
+#   PY_RST_FUNCTIONS_TO_PYTHON.py 
 # with all of the python examples from functions.rst
 #
 # Why is it useful? You can use this to check python syntax 
@@ -139,7 +139,7 @@ def write_state(writer, state_dict):
 if __name__ == '__main__':
 
     func_file_name = 'cli_manual/functions.rst'
-    py_output_name = 'FUNCTIONS_FLAT_PYTHON.py'
+    py_output_name = 'PY_RST_FUNCTIONS_TO_PYTHON.py'
 
     func_file   = open(func_file_name, 'r')
     py_output    = open(py_output_name,'w')
@@ -190,19 +190,22 @@ if __name__ == '__main__':
         elif line[0:12] == '**Example:**':
             cur_block = 'example'
             block_dict['example'] = ExampleContainer()
-            
+
         elif cur_block is not None:
-            if line.startswith("  "):
-                spaces = len(line) - len(line.lstrip())
-                spaces = spaces - 2
-                # custom strip, we don't want to loose indent!
-                # add back in spaces after "  "
-                r = ""
-                for i in range(spaces):
-                    r += " "
-                line = r + line.strip()
-            block_dict[cur_block].extend(line)
-    
+            # for examples sources, we need to preserve spaces in 
+            # the example script to keep python code valid
+            if cur_block == 'example' and line.strip() != "":
+                # find the leading number of spaces using lstrip
+                padding = len(line) - len(line.lstrip())
+                # assume padding of 2 spaces in rst
+                padding = padding - 2
+                next_text = ""
+                for i in range(padding):
+                    next_text += " "
+                next_text += line.strip()
+            else:
+                next_text = line.strip()
+            block_dict[cur_block].extend(next_text)    
     # Write the last function
     block_dict[cur_block].set_last(True)
     write_state(py_output, block_dict)

--- a/src/visitpy/common/MethodDoc.C
+++ b/src/visitpy/common/MethodDoc.C
@@ -475,7 +475,7 @@ const char *visit_ChooseCenterOfRotation_doc =
 "# coordinates and print the value.\n"
 "ResetView()\n"
 "ChooseCenterOfRotation(0.5, 0.3)\n"
-"print \"The new center of rotation is:\", GetView3D().centerOfRotation\n"
+"print(\"The new center of rotation is:{}\".format(GetView3D().centerOfRotation))\n"
 ;
 const char *visit_ClearAllWindows_doc = 
 "ClearAllWindows\n"
@@ -562,7 +562,7 @@ const char *visit_ClearCache_doc =
 "OpenDatabase(\"localhost:very_large_database\")\n"
 "# Do a lot of work\n"
 "ClearCache(\"localhost\")\n"
-"OpenDatabase(localhost:another_large_database\")\n"
+"OpenDatabase(\"localhost:another_large_database\")\n"
 "# Do more work\n"
 "OpenDatabase(\"remotehost:yet_another_database\")\n"
 "# Do more work\n"
@@ -605,7 +605,7 @@ const char *visit_ClearCacheForAllEngines_doc =
 "OpenDatabase(\"localhost:very_large_database\")\n"
 "# Do a lot of work\n"
 "ClearCache(\"localhost\")\n"
-"OpenDatabase(localhost:another_large_database\")\n"
+"OpenDatabase(\"localhost:another_large_database\")\n"
 "# Do more work\n"
 "OpenDatabase(\"remotehost:yet_another_database\")\n"
 "# Do more work\n"
@@ -718,7 +718,7 @@ const char *visit_ClearViewKeyframes_doc =
 "SetViewKeyframe()\n"
 "ToggleCameraViewMode()\n"
 "for i in range(10):\n"
-"SetTimeSliderState(i)\n"
+"    SetTimeSliderState(i)\n"
 "ClearViewKeyframes()\n"
 ;
 const char *visit_ClearWindow_doc = 
@@ -914,9 +914,9 @@ const char *visit_CloseDatabase_doc =
 "OpenDatabase(db)\n"
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
-"print \"This won't work: retval = %d\" % CloseDatabase(db)\n"
+"print(\"This won't work: retval = %d\" % CloseDatabase(db))\n"
 "DeleteAllPlots()\n"
-"print \"Now it works: retval = %d\" % CloseDatabase(db)\n"
+"print(\"Now it works: retval = %d\" % CloseDatabase(db))\n"
 ;
 const char *visit_ColorTableNames_doc = 
 "ColorTableNames\n"
@@ -947,9 +947,9 @@ const char *visit_ColorTableNames_doc =
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
 "for ct in ColorTableNames():\n"
-"p = PseudocolorAttributes()\n"
-"p.colorTableName = ct\n"
-"SetPlotOptions(p)\n"
+"    p = PseudocolorAttributes()\n"
+"    p.colorTableName = ct\n"
+"    SetPlotOptions(p)\n"
 ;
 const char *visit_ConstructDataBinning_doc = 
 "ConstructDataBinning\n"
@@ -1244,7 +1244,7 @@ const char *visit_CreateAnnotationObject_doc =
 "AddPlot(\"Pseudocolor\", \"pressure\")\n"
 "DrawPlots()\n"
 "slider = CreateAnnotationObject(\"TimeSlider\")\n"
-"print slider\n"
+"print(slider)\n"
 "slider.startColor = (255,0,0,255)\n"
 "slider.endColor = (255,255,0,255)\n"
 ;
@@ -1320,11 +1320,11 @@ const char *visit_CreateDatabaseCorrelation_doc =
 "# Creating a new database correlation also creates a new time\n"
 "# slider and makes it be active.\n"
 "w = GetWindowInformation()\n"
-"print \"Active time slider: %s\" % w.timeSliders[w.activeTimeSlider]\n"
+"print(\"Active time slider: %s\" % w.timeSliders[w.activeTimeSlider])\n"
 "# Animate through time using the \"common\" database correlation's\n"
 "# time slider.\n"
 "for i in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(i)\n"
+"    SetTimeSliderState(i)\n"
 ;
 const char *visit_CreateNamedSelection_doc = 
 "CreateNamedSelection\n"
@@ -1411,8 +1411,8 @@ const char *visit_DatabasePlugins_doc =
 "\n"
 "#% visit -cli\n"
 "dbp = DatabasePlugins(\"localhost\")\n"
-"print dbp[\"host\"]\n"
-"print dbp[\"plugins\"]\n"
+"print(dbp[\"host\"])\n"
+"print(dbp[\"plugins\"])\n"
 ;
 const char *visit_DeIconifyAllWindows_doc = 
 "DeIconifyAllWindows\n"
@@ -2109,7 +2109,7 @@ const char *visit_DeletePlotDatabaseKeyframe_doc =
 "AddPlot(\"Pseudocolor\", \"pressure\")\n"
 "SetPlotDatabaseState(0, 0, 60)\n"
 "# Repeat time state 60 for the first few animation frames by adding a\n"
-"keyframe at frame 3.\n"
+"# keyframe at frame 3.\n"
 "SetPlotDatabaseState(0, 3, 60)\n"
 "SetPlotDatabaseState(0, 19, 0)\n"
 "DrawPlots()\n"
@@ -2170,7 +2170,7 @@ const char *visit_DeletePlotKeyframe_doc =
 "ListPlots()\n"
 "# Iterate over all animation frames and wrap around to the first one.\n"
 "for i in list(range(TimeSliderGetNStates())) + [0]:\n"
-"SetTimeSliderState(i)\n"
+"    SetTimeSliderState(i)\n"
 "# Delete the plot keyframe at frame 19 so the min won't\n"
 "# change anymore.\n"
 "DeletePlotKeyframe(19)\n"
@@ -2222,13 +2222,13 @@ const char *visit_DeleteViewKeyframe_doc =
 "ToggleCameraViewMode()\n"
 "# Iterate over the animation frames to watch the view change.\n"
 "for i in list(range(10)) + [0]:\n"
-"SetTimeSliderState(i)\n"
+"    SetTimeSliderState(i)\n"
 "# Delete the last view keyframe, which is on frame 9.\n"
 "DeleteViewKeyframe(9)\n"
 "# Iterate over the animation frames again. The view should stay\n"
 "# the same.\n"
 "for i in range(10):\n"
-"SetTimeSliderState(i)\n"
+"    SetTimeSliderState(i)\n"
 ;
 const char *visit_DeleteWindow_doc = 
 "DeleteWindow\n"
@@ -2478,9 +2478,9 @@ const char *visit_EvalCubic_doc =
 "# Fly around the plots using the views that have been specified.\n"
 "nSteps = 100\n"
 "for i in range(nSteps):\n"
-"t = float(i) / float(nSteps - 1)\n"
-"newView = EvalCubic(t, v0, v1, v2, v3)\n"
-"SetView3D(newView)\n"
+"    t = float(i) / float(nSteps - 1)\n"
+"    newView = EvalCubic(t, v0, v1, v2, v3)\n"
+"    SetView3D(newView)\n"
 ;
 const char *visit_EvalCubicSpline_doc = 
 "EvalCubicSpline\n"
@@ -2559,9 +2559,9 @@ const char *visit_EvalLinear_doc =
 "c1.viewUp = (0.196284, 0.876524, -0.439521)\n"
 "nSteps = 100\n"
 "for i in range(nSteps):\n"
-"t = float(i) / float(nSteps - 1)\n"
-"v = EvalLinear(t, c0, c1)\n"
-"SetView3D(v)\n"
+"    t = float(i) / float(nSteps - 1)\n"
+"    v = EvalLinear(t, c0, c1)\n"
+"    SetView3D(v)\n"
 ;
 const char *visit_EvalQuadratic_doc = 
 "EvalQuadratic\n"
@@ -2602,7 +2602,7 @@ const char *visit_EvalQuadratic_doc =
 "\n"
 "Example:\n"
 "\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
@@ -2614,9 +2614,9 @@ const char *visit_EvalQuadratic_doc =
 "# Fly around the plots using the views that have been specified.\n"
 "nSteps = 100\n"
 "for i in range(nSteps):\n"
-"t = float(i) / float(nSteps - 1)\n"
-"newView = EvalQuadratic(t, v0, v1, v2)\n"
-"SetView3D(newView)\n"
+"    t = float(i) / float(nSteps - 1)\n"
+"    newView = EvalQuadratic(t, v0, v1, v2)\n"
+"    SetView3D(newView)\n"
 ;
 const char *visit_ExecuteMacro_doc = 
 "ExecuteMacro\n"
@@ -2651,9 +2651,10 @@ const char *visit_ExecuteMacro_doc =
 "Example:\n"
 "\n"
 "def SetupMyPlots():\n"
-"OpenDatabase('noise.silo')\n"
-"AddPlot('Pseudocolor', 'hardyglobal')\n"
-"DrawPlots()\n"
+"    OpenDatabase('noise.silo')\n"
+"    AddPlot('Pseudocolor', 'hardyglobal')\n"
+"    DrawPlots()\n"
+"\n"
 "RegisterMacro('Setup My Plots', SetupMyPlots)\n"
 "ExecuteMacro('Setup My Plots')\n"
 ;
@@ -2739,11 +2740,11 @@ const char *visit_Expressions_doc =
 "DefineScalarExpression(\"neg_u\", \"-u\")\n"
 "DefineScalarExpression(\"bob\", \"sin_u + cos_u\")\n"
 "for i in range(1,5):\n"
-"SetActiveWindow(i)\n"
-"OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
-"exprName = Expressions()[i-1][0]\n"
-"AddPlot(\"Pseudocolor\", exprName)\n"
-"DrawPlots()\n"
+"    SetActiveWindow(i)\n"
+"    OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
+"    exprName = Expressions()[i-1][0]\n"
+"    AddPlot(\"Pseudocolor\", exprName)\n"
+"    DrawPlots()\n"
 ;
 const char *visit_GetActiveContinuousColorTable_doc = 
 "GetActiveContinuousColorTable\n"
@@ -2780,8 +2781,8 @@ const char *visit_GetActiveContinuousColorTable_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"Default continuous color table: %s\" % GetActiveContinuousColorTable()\n"
-"print \"Default discrete color table: %s\" % GetActiveDiscreteColorTable()\n"
+"print(\"Default continuous color table: %s\" % GetActiveContinuousColorTable())\n"
+"print(\"Default discrete color table: %s\" % GetActiveDiscreteColorTable())\n"
 ;
 const char *visit_GetActiveDiscreteColorTable_doc = 
 "GetActiveDiscreteColorTable\n"
@@ -2818,10 +2819,8 @@ const char *visit_GetActiveDiscreteColorTable_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"Default continuous color table: %s\" % \\n"
-"GetActiveContinuousColorTable()\n"
-"print \"Default discrete color table: %s\" % \\n"
-"GetActiveDiscreteColorTable()\n"
+"print(\"Default continuous color table: %s\" % GetActiveContinuousColorTable())\n"
+"print(\"Default discrete color table: %s\" % GetActiveDiscreteColorTable())\n"
 ;
 const char *visit_GetActiveTimeSlider_doc = 
 "GetActiveTimeSlider\n"
@@ -2857,9 +2856,9 @@ const char *visit_GetActiveTimeSlider_doc =
 "AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
 "OpenDatabase(\"dbB00.pdb\")\n"
 "AddPlot(\"FilledBoundary\", \"materials(mesh)\")\n"
-"print \"Active time slider: %s\" % GetActiveTimeSlider()\n"
+"print(\"Active time slider: %s\" % GetActiveTimeSlider())\n"
 "CreateDatabaseCorrelation(\"common\", (\"dbA00.pdb\", \"dbB00.pdb\"), 2)\n"
-"print \"Active time slider: %s\" % GetActiveTimeSlider()\n"
+"print(\"Active time slider: %s\" % GetActiveTimeSlider())\n"
 ;
 const char *visit_GetAnimationAttributes_doc = 
 "GetAnimationAttributes\n"
@@ -2884,7 +2883,7 @@ const char *visit_GetAnimationAttributes_doc =
 "Example:\n"
 "\n"
 "a = GetAnimationAttributes()\n"
-"print a\n"
+"print(a)\n"
 ;
 const char *visit_GetAnimationTimeout_doc = 
 "GetAnimationTimeout\n"
@@ -2912,7 +2911,7 @@ const char *visit_GetAnimationTimeout_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"Animation timeout = %d\" % GetAnimationTimeout()\n"
+"print(\"Animation timeout = %d\" % GetAnimationTimeout())\n"
 ;
 const char *visit_GetAnnotationAttributes_doc = 
 "GetAnnotationAttributes\n"
@@ -2945,7 +2944,7 @@ const char *visit_GetAnnotationAttributes_doc =
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
 "a = GetAnnotationAttributes()\n"
-"print a\n"
+"print(a)\n"
 "a.backgroundMode = a.BACKGROUNDMODE_GRADIENT\n"
 "a.gradientColor1 = (0, 0, 255)\n"
 "SetAnnotationAttributes(a)\n"
@@ -2994,7 +2993,7 @@ const char *visit_GetAnnotationObject_doc =
 "GetAnnotationObjectNames()\n"
 "[\"plot0000\", \"TimeSlider1\"]\n"
 "ref = GetAnnotationObject(\"TimeSlider1\")\n"
-"print ref\n"
+"print(ref)\n"
 ;
 const char *visit_GetAnnotationObjectNames_doc = 
 "GetAnnotationObjectNames\n"
@@ -3043,7 +3042,7 @@ const char *visit_GetCallbackArgumentCount_doc =
 "\n"
 "cbName = 'OpenDatabaseRPC'\n"
 "count = GetCallbackArgumentCount(cbName)\n"
-"print 'The number of arguments for %s is: %d' % (cbName, count)\n"
+"print('The number of arguments for %s is: %d' % (cbName, count))\n"
 ;
 const char *visit_GetCallbackNames_doc = 
 "GetCallbackNames\n"
@@ -3069,7 +3068,7 @@ const char *visit_GetCallbackNames_doc =
 "Example:\n"
 "\n"
 "import visit\n"
-"print visit.GetCallbackNames()\n"
+"print(visit.GetCallbackNames())\n"
 ;
 const char *visit_GetDatabaseNStates_doc = 
 "GetDatabaseNStates\n"
@@ -3099,7 +3098,7 @@ const char *visit_GetDatabaseNStates_doc =
 "\n"
 "#% visit -cli\n"
 "OpenDatabase(\"/usr/gapps/visit/data/wave*.silo database\")\n"
-"print \"Number of time states: %d\" % GetDatabaseNStates()\n"
+"print(\"Number of time states: %d\" % GetDatabaseNStates())\n"
 ;
 const char *visit_GetDebugLevel_doc = 
 "GetDebugLevel\n"
@@ -3126,7 +3125,7 @@ const char *visit_GetDebugLevel_doc =
 "Example:\n"
 "\n"
 "#% visit -cli -debug 2\n"
-"print \"VisIt's debug level is: %d\" % GetDebugLevel()\n"
+"print(\"VisIt's debug level is: %d\" % GetDebugLevel())\n"
 ;
 const char *visit_GetDefaultFileOpenOptions_doc = 
 "GetDefaultFileOpenOptions\n"
@@ -3192,10 +3191,10 @@ const char *visit_GetDomains_doc =
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
 "doms = GetDomains()\n"
-"print doms\n"
+"print(doms)\n"
 "# Turn off all but the last domain, one after the other.\n"
 "for d in doms[:-1]:\n"
-"TurnDomainsOff(d)\n"
+"    TurnDomainsOff(d)\n"
 ;
 const char *visit_GetEngineList_doc = 
 "GetEngineList\n"
@@ -3243,8 +3242,8 @@ const char *visit_GetEngineList_doc =
 "AddPlot(\"Mesh\", \"mesh1\")\n"
 "DrawPlots()\n"
 "for name in GetEngineList():\n"
-"print \"VisIt has a compute engine running on %s\" % name\n"
-"CloseComputeEngine(GetEngineList()[1])\n"
+"    print(\"VisIt has a compute engine running on %s\" % name)\n"
+"    CloseComputeEngine(GetEngineList()[1])\n"
 ;
 const char *visit_GetEngineProperties_doc = 
 "GetEngineProperties\n"
@@ -3313,7 +3312,7 @@ const char *visit_GetGlobalAttributes_doc =
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
 "g = GetGlobalAttributes()\n"
-"print g\n"
+"print(g)\n"
 ;
 const char *visit_GetGlobalLineoutAttributes_doc = 
 "GetGlobalLineoutAttributes\n"
@@ -3349,7 +3348,7 @@ const char *visit_GetGlobalLineoutAttributes_doc =
 "AddPlot(\"Pseudocolor\", \"d\")\n"
 "DrawPlots()\n"
 "g = GetGlobalLineoutAttributes()\n"
-"print g\n"
+"print(g)\n"
 "g.samplingOn = 1\n"
 "g.windowId = 4\n"
 "g.createWindow = 0\n"
@@ -3387,7 +3386,7 @@ const char *visit_GetInteractorAttributes_doc =
 "\n"
 "#% visit -cli\n"
 "ia = GetInteractorAttributes()\n"
-"print ia\n"
+"print(ia)\n"
 "ia.showGuidelines = 0\n"
 "SetInteractorAttributes(ia)\n"
 ;
@@ -3418,7 +3417,7 @@ const char *visit_GetKeyframeAttributes_doc =
 "\n"
 "#% visit -cli\n"
 "k = GetKeyframeAttributes()\n"
-"print k\n"
+"print(k)\n"
 "k.enabled,k.nFrames,k.nFramesWasUserSet = 1, 100, 1\n"
 "SetKeyframeAttributes(k)\n"
 ;
@@ -3447,7 +3446,7 @@ const char *visit_GetLastError_doc =
 "\n"
 "#% visit -cli\n"
 "OpenDatabase(\"/this/database/does/not/exist\")\n"
-"print \"VisIt Error: %s\" % GetLastError()\n"
+"print(\"VisIt Error: %s\" % GetLastError())\n"
 ;
 const char *visit_GetLight_doc = 
 "GetLight\n"
@@ -3489,7 +3488,7 @@ const char *visit_GetLight_doc =
 "DrawPlots()\n"
 "InvertBackgroundColor()\n"
 "light = GetLight(0)\n"
-"print light\n"
+"print(light)\n"
 "light.enabledFlag = 1\n"
 "light.direction = (0,-1,0)\n"
 "light.color = (255,0,0,255)\n"
@@ -3520,8 +3519,8 @@ const char *visit_GetLocalHostName_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"Local machine name is: %s\" % GetLocalHostName()\n"
-"print \"My username: %s\" % GetLocalUserName()\n"
+"print(\"Local machine name is: %s\" % GetLocalHostName())\n"
+"print(\"My username: %s\" % GetLocalUserName())\n"
 ;
 const char *visit_GetLocalUserName_doc = 
 "GetLocalUserName\n"
@@ -3546,8 +3545,8 @@ const char *visit_GetLocalUserName_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"Local machine name is: %s\" % GetLocalHostName()\n"
-"print \"My username: %s\" % GetLocalUserName()\n"
+"print(\"Local machine name is: %s\" % GetLocalHostName())\n"
+"print(\"My username: %s\" % GetLocalUserName())\n"
 ;
 const char *visit_GetMachineProfile_doc = 
 "GetMachineProfile\n"
@@ -3663,7 +3662,7 @@ const char *visit_GetMaterials_doc =
 "DrawPlots()\n"
 "mats = GetMaterials()\n"
 "for m in mats[:-1]:\n"
-"TurnMaterialOff(m)\n"
+"    TurnMaterialOff(m)\n"
 ;
 const char *visit_GetMeshManagementAttributes_doc = 
 "GetMeshManagementAttributes\n"
@@ -3735,8 +3734,8 @@ const char *visit_GetMetaData_doc =
 "Example:\n"
 "\n"
 "md = GetMetaData('noise.silo')\n"
-"for i in xrange(md.GetNumScalars()):\n"
-"AddPlot('Pseudocolor', md.GetScalars(i).name)\n"
+"for i in range(md.GetNumScalars()):\n"
+"    AddPlot('Pseudocolor', md.GetScalars(i).name)\n"
 "DrawPlots()\n"
 ;
 const char *visit_GetNumPlots_doc = 
@@ -3761,13 +3760,13 @@ const char *visit_GetNumPlots_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"Number of plots\", GetNumPlots()\n"
+"print(\"Number of plots\", GetNumPlots())\n"
 "OpenDatabase(\"/usr/gapps/visit/data/curv2d.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"d\")\n"
-"print \"Number of plots\", GetNumPlots()\n"
+"print(\"Number of plots\", GetNumPlots())\n"
 "AddPlot(\"Mesh\", \"curvmesh2d\")\n"
 "DrawPlots()\n"
-"print \"Number of plots\", GetNumPlots()\n"
+"print(\"Number of plots\", GetNumPlots())\n"
 ;
 const char *visit_GetOperatorOptions_doc = 
 "GetOperatorOptions\n"
@@ -3801,7 +3800,7 @@ const char *visit_GetOperatorOptions_doc =
 "AddOperator('Transform')\n"
 "AddOperator('Transform')\n"
 "t = GetOperatorOptions(1)\n"
-"print 'Attributes for the 2nd Transform operator:', t\n"
+"print('Attributes for the 2nd Transform operator:', t)\n"
 ;
 const char *visit_GetPickAttributes_doc = 
 "GetPickAttributes\n"
@@ -3836,7 +3835,7 @@ const char *visit_GetPickAttributes_doc =
 "AddPlot(\"Pseudocolor\", \"mesh/ireg\")\n"
 "DrawPlots()\n"
 "p = GetPickAttributes()\n"
-"print p\n"
+"print(p)\n"
 "p.variables = (\"default\", \"mesh/a\", \"mesh/mixvar\")\n"
 "SetPickAttributes(p)\n"
 "# Now do some interactive picks and you'll see pick information\n"
@@ -3874,7 +3873,7 @@ const char *visit_GetPickOutput_doc =
 "DrawPlots()\n"
 "ZonePick(coord=(0.4, 0.6, 0), vars=(\"default\", \"u\", \"v\"))\n"
 "s = GetPickOutput()\n"
-"print s\n"
+"print(s)\n"
 ;
 const char *visit_GetPickOutputObject_doc = 
 "GetPickOutputObject\n"
@@ -3904,7 +3903,7 @@ const char *visit_GetPickOutputObject_doc =
 "DrawPlots()\n"
 "ZonePick(coord=(0.4, 0.6, 0), vars=(\"default\", \"u\", \"v\"))\n"
 "o = GetPickOutputObject()\n"
-"print o\n"
+"print(o)\n"
 ;
 const char *visit_GetPipelineCachingMode_doc = 
 "GetPipelineCachingMode\n"
@@ -3933,7 +3932,7 @@ const char *visit_GetPipelineCachingMode_doc =
 "\n"
 "#%visit -cli\n"
 "offon = (\"off\", \"on\")\n"
-"print \"Pipeline caching is %s\" % offon[GetPipelineCachingMode()]\n"
+"print(\"Pipeline caching is %s\" % offon[GetPipelineCachingMode()])\n"
 ;
 const char *visit_GetPlotInformation_doc = 
 "GetPlotInformation\n"
@@ -3966,7 +3965,7 @@ const char *visit_GetPlotInformation_doc =
 "SetActiveWindow(2)\n"
 "info = GetPlotInformation()\n"
 "lineout = info[\"Curve\"]\n"
-"print \"The first lineout point is: [%g, %g] \" % lineout[0], lineout[1]\n"
+"print(\"The first lineout point is: [%g, %g] \" % lineout[0], lineout[1])\n"
 ;
 const char *visit_GetPlotList_doc = 
 "GetPlotList\n"
@@ -3997,8 +3996,8 @@ const char *visit_GetPlotList_doc =
 "# Copy plots (without operators to window 2)\n"
 "pL = GetPlotList()\n"
 "AddWindow()\n"
-"for i in xrange(pL.GetNumPlots()):\n"
-"AddPlot(PlotPlugins()[pL.GetPlots(i).plotType], pL.GetPlots(i).plotVar)\n"
+"for i in range(pL.GetNumPlots()):\n"
+"    AddPlot(PlotPlugins()[pL.GetPlots(i).plotType], pL.GetPlots(i).plotVar)\n"
 "DrawPlots()\n"
 ;
 const char *visit_GetPlotOptions_doc = 
@@ -4085,8 +4084,8 @@ const char *visit_GetQueryOutputObject_doc =
 "AddPlot(\"Pseudocolor\", \"d\")\n"
 "DrawPlots()\n"
 "Query(\"MinMax\")\n"
-"print GetQueryOutputString()\n"
-"print \"The min is: %g and the max is: %g\" % GetQueryOutputValue()\n"
+"print(GetQueryOutputString())\n"
+"print(\"The min is: %g and the max is: %g\" % GetQueryOutputValue())\n"
 ;
 const char *visit_GetQueryOutputString_doc = 
 "GetQueryOutputString\n"
@@ -4119,8 +4118,8 @@ const char *visit_GetQueryOutputString_doc =
 "AddPlot(\"Pseudocolor\", \"d\")\n"
 "DrawPlots()\n"
 "Query(\"MinMax\")\n"
-"print GetQueryOutputString()\n"
-"print \"The min is: %g and the max is: %g\" % GetQueryOutputValue()\n"
+"print(GetQueryOutputString())\n"
+"print(\"The min is: %g and the max is: %g\" % GetQueryOutputValue())\n"
 ;
 const char *visit_GetQueryOutputValue_doc = 
 "GetQueryOutputValue\n"
@@ -4154,8 +4153,8 @@ const char *visit_GetQueryOutputValue_doc =
 "AddPlot(\"Pseudocolor\", \"d\")\n"
 "DrawPlots()\n"
 "Query(\"MinMax\")\n"
-"print GetQueryOutputString()\n"
-"print \"The min is: %g and the max is: %g\" % GetQueryOutputValue()\n"
+"print(GetQueryOutputString())\n"
+"print(\"The min is: %g and the max is: %g\" % GetQueryOutputValue())\n"
 ;
 const char *visit_GetQueryOutputXML_doc = 
 "GetQueryOutputXML\n"
@@ -4188,8 +4187,8 @@ const char *visit_GetQueryOutputXML_doc =
 "AddPlot(\"Pseudocolor\", \"d\")\n"
 "DrawPlots()\n"
 "Query(\"MinMax\")\n"
-"print GetQueryOutputString()\n"
-"print \"The min is: %g and the max is: %g\" % GetQueryOutputValue()\n"
+"print(GetQueryOutputString())\n"
+"print(\"The min is: %g and the max is: %g\" % GetQueryOutputValue())\n"
 ;
 const char *visit_GetQueryOverTimeAttributes_doc = 
 "GetQueryOverTimeAttributes\n"
@@ -4222,7 +4221,7 @@ const char *visit_GetQueryOverTimeAttributes_doc =
 "AddPlot(\"Pseudocolor\", \"mesh/mixvar\")\n"
 "DrawPlots()\n"
 "qot = GetQueryOverTimeAttributes()\n"
-"print qot\n"
+"print(qot)\n"
 "# Make queries over time go to window 4.\n"
 "qot.createWindow,q.windowId = 0, 4\n"
 "SetQueryOverTimeAttributes(qot)\n"
@@ -4338,11 +4337,11 @@ const char *visit_GetSaveWindowAttributes_doc =
 "\n"
 "#% visit -cli\n"
 "s = GetSaveWindowAttributes()\n"
-"print s\n"
+"print(s)\n"
 "s.width = 600\n"
 "s.height = 600\n"
 "s.format = s.RGB\n"
-"print s\n"
+"print(s)\n"
 ;
 const char *visit_GetSelection_doc = 
 "GetSelection\n"
@@ -4438,7 +4437,7 @@ const char *visit_GetSelectionSummary_doc =
 "\n"
 "Example:\n"
 "\n"
-"print GetSelectionSummary('selection1')\n"
+"print(GetSelectionSummary('selection1'))\n"
 ;
 const char *visit_GetTimeSliders_doc = 
 "GetTimeSliders\n"
@@ -4468,11 +4467,11 @@ const char *visit_GetTimeSliders_doc =
 "path = \"/usr/gapps/visit/data/\"\n"
 "dbs = (path + \"/dbA00.pdb\", path + \"dbB00.pdb\", path + \"dbC00.pdb\")\n"
 "for db in dbs:\n"
-"OpenDatabase(db)\n"
-"AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
-"DrawPlots()\n"
+"    OpenDatabase(db)\n"
+"    AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
+"    DrawPlots()\n"
 "CreateDatabaseCorrelation(\"common\", dbs, 1)\n"
-"print \"The list of time sliders is: \", GetTimeSliders()\n"
+"print(\"The list of time sliders is: \", GetTimeSliders())\n"
 ;
 const char *visit_GetUltraScript_doc = 
 "GetUltraScript\n"
@@ -4524,11 +4523,11 @@ const char *visit_GetView2D_doc =
 "v0 = GetView3D()\n"
 "# Change the view again using the mouse\n"
 "v1 = GetView3D()\n"
-"print v0\n"
+"print(v0)\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v1 + t * v0\n"
-"SetView3D(v2) # Animate the view back to the first view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v1 + t * v0\n"
+"    SetView3D(v2) # Animate the view back to the first view.\n"
 ;
 const char *visit_GetView3D_doc = 
 "GetView3D\n"
@@ -4561,11 +4560,11 @@ const char *visit_GetView3D_doc =
 "v0 = GetView3D()\n"
 "# Change the view again using the mouse\n"
 "v1 = GetView3D()\n"
-"print v0\n"
+"print(v0)\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v1 + t * v0\n"
-"SetView3D(v2) # Animate the view back to the first view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v1 + t * v0\n"
+"    SetView3D(v2) # Animate the view back to the first view.\n"
 ;
 const char *visit_GetViewAxisArray_doc = 
 "GetViewAxisArray\n"
@@ -4598,11 +4597,11 @@ const char *visit_GetViewAxisArray_doc =
 "v0 = GetView3D()\n"
 "# Change the view again using the mouse\n"
 "v1 = GetView3D()\n"
-"print v0\n"
+"print(v0)\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v1 + t * v0\n"
-"SetView3D(v2) # Animate the view back to the first view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v1 + t * v0\n"
+"    SetView3D(v2) # Animate the view back to the first view.\n"
 ;
 const char *visit_GetViewCurve_doc = 
 "GetViewCurve\n"
@@ -4635,11 +4634,11 @@ const char *visit_GetViewCurve_doc =
 "v0 = GetView3D()\n"
 "# Change the view again using the mouse\n"
 "v1 = GetView3D()\n"
-"print v0\n"
+"print(v0)\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v1 + t * v0\n"
-"SetView3D(v2) # Animate the view back to the first view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v1 + t * v0\n"
+"    SetView3D(v2) # Animate the view back to the first view.\n"
 ;
 const char *visit_GetWindowInformation_doc = 
 "GetWindowInformation\n"
@@ -4672,17 +4671,17 @@ const char *visit_GetWindowInformation_doc =
 "path = \"/usr/gapps/visit/data/\"\n"
 "dbs = (path + \"dbA00.pdb\", path + \"dbB00.pdb\", path + \"dbC00.pdb\")\n"
 "for db in dbs:\n"
-"OpenDatabase(db)\n"
-"AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
-"DrawPlots()\n"
+"    OpenDatabase(db)\n"
+"    AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
+"    DrawPlots()\n"
 "CreateDatabaseCorrelation(\"common\", dbs, 1)\n"
 "# Get the list of available time sliders.\n"
 "tsList = GetWindowInformation().timeSliders\n"
 "# Iterate through \"time\" on each time slider.\n"
 "for ts in tsList:\n"
-"SetActiveTimeSlider(ts)\n"
+"    SetActiveTimeSlider(ts)\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 "# Print the window information to examine the other attributes\n"
 "# that are available.\n"
 "GetWindowInformation()\n"
@@ -5168,11 +5167,11 @@ const char *visit_LoadUltra_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-">>> LoadUltra()\n"
-"U-> rd \"../../data/distribution.ultra\"\n"
-"U-> select 1\n"
-"U-> end\n"
-">>>\n"
+"#>>> LoadUltra()\n"
+"#U-> rd \"../../data/distribution.ultra\"\n"
+"#U-> select 1\n"
+"#U-> end\n"
+"#>>>\n"
 ;
 const char *visit_LocalNameSpace_doc = 
 "LocalNameSpace\n"
@@ -5307,10 +5306,10 @@ const char *visit_MovePlotDatabaseKeyframe_doc =
 "SetPlotDatabaseKeyframe(0, nFrames-1, 0)\n"
 "DrawPlots()\n"
 "for state in list(range(TimeSliderGetNStates())) + [0]:\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 "MovePlotDatabaseKeyframe(0, nFrames/2, nFrames/4)\n"
 "for state in list(range(TimeSliderGetNStates())) + [0]:\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 ;
 const char *visit_MovePlotKeyframe_doc = 
 "MovePlotKeyframe\n"
@@ -5359,15 +5358,15 @@ const char *visit_MovePlotKeyframe_doc =
 "SetTimeSliderState(nFrames-1)\n"
 "SetPlotOptions(c)\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 "temp = nFrames-2\n"
 "MovePlotKeyframe(0, nFrames/2, temp)\n"
 "MovePlotKeyframe(0, nFrames-1, nFrames/2)\n"
 "MovePlotKeyframe(0, temp, nFrames-1)\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_MovePlotOrderTowardFirst_doc = 
 "MovePlotOrderTowardFirst\n"
@@ -5608,10 +5607,10 @@ const char *visit_NumColorTableNames_doc =
 "p.colorTableName = \"default\"\n"
 "SetPlotOptions(p)\n"
 "DrawPlots()\n"
-"print \"There are %d color tables.\" % NumColorTableNames()\n"
+"print(\"There are %d color tables.\" % NumColorTableNames())\n"
 "for ct in ColorTableNames():\n"
-"SetActiveContinuousColorTable(ct)\n"
-"SaveWindow()\n"
+"    SetActiveContinuousColorTable(ct)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_NumOperatorPlugins_doc = 
 "NumOperatorPlugins\n"
@@ -5636,8 +5635,8 @@ const char *visit_NumOperatorPlugins_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"The number of operator plugins is: \", NumOperatorPlugins()\n"
-"print \"The names of the plugins are: \", OperatorPlugins()\n"
+"print(\"The number of operator plugins is: \", NumOperatorPlugins())\n"
+"print(\"The names of the plugins are: \", OperatorPlugins())\n"
 ;
 const char *visit_NumPlotPlugins_doc = 
 "NumPlotPlugins\n"
@@ -5661,8 +5660,8 @@ const char *visit_NumPlotPlugins_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"The number of plot plugins is: \", NumPlotPlugins()\n"
-"print \"The names of the plugins are: \", PlotPlugins()\n"
+"print(\"The number of plot plugins is: \", NumPlotPlugins())\n"
+"print(\"The names of the plugins are: \", PlotPlugins())\n"
 ;
 const char *visit_OpenComputeEngine_doc = 
 "OpenComputeEngine\n"
@@ -5829,9 +5828,9 @@ const char *visit_OpenMDServer_doc =
 "\n"
 "Example:\n"
 "\n"
-"-assume_format PDB\n"
-"% visit -cli\n"
-"args = (\"-dir\", \"/my/private/visit/version/\", \"-assume_format\", \"PDB\", \"-debug\", \"4\")\n"
+"\n"
+"#% visit -cli -assume_format PDB\n"
+"#args = (\"-dir\", \"/my/private/visit/version/\", \"-assume_format\", \"PDB\", \"-debug\", \"4\")\n"
 "# Open a metadata server before the call to OpenDatabase so we\n"
 "# can launch it how we want.\n"
 "OpenMDServer(\"thunder\", args)\n"
@@ -5865,7 +5864,7 @@ const char *visit_OperatorPlugins_doc =
 "\n"
 "#% visit -cli\n"
 "for plugin in OperatorPlugins():\n"
-"print \"The %s operator plugin is loaded.\" % plugin\n"
+"    print(\"The %s operator plugin is loaded.\" % plugin)\n"
 ;
 const char *visit_OverlayDatabase_doc = 
 "OverlayDatabase\n"
@@ -5971,10 +5970,10 @@ const char *visit_PickByGlobalNode_doc =
 "# Pick on global node 236827\n"
 "pick_out = PickByGlobalNode(element=246827)\n"
 "# examine output\n"
-"print 'value of dist at global node 246827: %g' % pick_out['dist']\n"
-"print 'local domain/node: %d/%d' % (pick_out['domain_id'], pick_out['node_id'])\n"
+"print('value of dist at global node 246827: %g' % pick_out['dist'])\n"
+"print('local domain/node: %d/%d' % (pick_out['domain_id'], pick_out['node_id']))\n"
 "# get last pick output as string\n"
-"print 'Last pick = ', GetPickOutput()\n"
+"print('Last pick = ', GetPickOutput())\n"
 ;
 const char *visit_PickByGlobalZone_doc = 
 "PickByGlobalZone\n"
@@ -6035,10 +6034,10 @@ const char *visit_PickByGlobalZone_doc =
 "# Pick on global zone 237394\n"
 "pick_out = PickByGlobalZone(element=237394)\n"
 "# examine output\n"
-"print 'value of p at global zone 237394: %g' % pick_out['p']\n"
-"print 'local domain/zone: %d/%d' % (pick_out['domain_id'], pick_out['zone_id'])\n"
+"print('value of p at global zone 237394: %g' % pick_out['p'])\n"
+"print('local domain/zone: %d/%d' % (pick_out['domain_id'], pick_out['zone_id']))\n"
 "# get last pick output as string\n"
-"print 'Last pick = ', GetPickOutput()\n"
+"print('Last pick = ', GetPickOutput())\n"
 ;
 const char *visit_PickByNode_doc = 
 "PickByNode\n"
@@ -6104,15 +6103,15 @@ const char *visit_PickByNode_doc =
 "# Pick on node 200 in the first domain.\n"
 "pick_out = PickByNode(element=200, domain=1)\n"
 "# examine output\n"
-"print 'value of u at node 200: %g' % pick_out['u']\n"
+"print('value of u at node 200: %g' % pick_out['u'])\n"
 "# Pick on node 100 in domain 5 and return information for two additional\n"
-"variables.\n"
+"# variables.\n"
 "pick_out = PickByNode(domain=5, element=100, vars=(\"u\", \"v\", \"d\"))\n"
 "# examine output\n"
-"print 'incident zones for node 100: ', pick_out['incident_zones']\n"
-"print 'value of d at incident zone %d: %g' % (pick_out['incident_zones'][0], pick_out['d'][str(pick_out['incident_zones'][0])])\n"
+"print('incident zones for node 100: ', pick_out['incident_zones'])\n"
+"print('value of d at incident zone %d: %g' % (pick_out['incident_zones'][0], pick_out['d'][str(pick_out['incident_zones'][0])]))\n"
 "# print results formatted as string\n"
-"print \"Last pick = \", GetPickOutput()\n"
+"print(\"Last pick = \", GetPickOutput())\n"
 ;
 const char *visit_PickByNodeLabel_doc = 
 "PickByNodeLabel\n"
@@ -6179,15 +6178,15 @@ const char *visit_PickByNodeLabel_doc =
 "opts[\"element_label\"] =\"node 4\"\n"
 "pick_out = PickByNodeLabel(opts)\n"
 "# examine output\n"
-"print 'value of d at \"node 4\": %g' % pick_out['d']\n"
+"print('value of d at \"node 4\": %g' % pick_out['d'])\n"
 "# Pick on node labeled \"node 12\" return information for two additional\n"
-"variables.\n"
+"# variables.\n"
 "pick_out = PickByNodeLabel(element_label=\"node 12\", vars=(\"d\", \"u\", \"v\"))\n"
 "# examine output\n"
-"print 'incident nodes for \"node 12\": ', pick_out['incident_nodes']\n"
-"print 'values of u at incident node %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])])\n"
+"print('incident nodes for \"node 12\": ', pick_out['incident_nodes'])\n"
+"print('values of u at incident node %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])]))\n"
 "# print results formatted as string\n"
-"print \"Last pick = \", GetPickOutput()\n"
+"print(\"Last pick = \", GetPickOutput())\n"
 ;
 const char *visit_PickByZone_doc = 
 "PickByZone\n"
@@ -6253,15 +6252,15 @@ const char *visit_PickByZone_doc =
 "# Pick on cell 200 in the second domain.\n"
 "pick_out = PickByZone(element=200, domain=2)\n"
 "# examine output\n"
-"print 'value of d at zone 200: %g' % pick_out['d']\n"
+"print('value of d at zone 200: %g' % pick_out['d'])\n"
 "# Pick on cell 100 in domain 5 and return information for two additional\n"
-"variables.\n"
+"# variables.\n"
 "pick_out = PickByZone(element=100, domain=5, vars=(\"d\", \"u\", \"v\"))\n"
 "# examine output\n"
-"print 'incident nodes for zone 100: ', pick_out['incident_nodes']\n"
-"print 'values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])])\n"
+"print('incident nodes for zone 100: ', pick_out['incident_nodes'])\n"
+"print('values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])]))\n"
 "# print results formatted as string\n"
-"print \"Last pick = \", GetPickOutput()\n"
+"print(\"Last pick = \", GetPickOutput())\n"
 ;
 const char *visit_PickByZoneLabel_doc = 
 "PickByZoneLabel\n"
@@ -6328,15 +6327,15 @@ const char *visit_PickByZoneLabel_doc =
 "opts[\"element_label\"] =\"brick 4\"\n"
 "pick_out = PickByZoneLabel(opts)\n"
 "# examine output\n"
-"print 'value of d at \"brick 4\": %g' % pick_out['d']\n"
+"print('value of d at \"brick 4\": %g' % pick_out['d'])\n"
 "# Pick on cell labeled \"shell 12\" return information for two additional\n"
-"variables.\n"
+"# variables.\n"
 "pick_out = PickByZoneLabel(element_label=\"shell 12\", vars=(\"d\", \"u\", \"v\"))\n"
 "# examine output\n"
-"print 'incident nodes for \"shell 12\": ', pick_out['incident_nodes']\n"
-"print 'values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])])\n"
+"print('incident nodes for \"shell 12\": ', pick_out['incident_nodes'])\n"
+"print('values of u at incident zone %d: %g' % (pick_out['incident_nodes'][0], pick_out['u'][str(pick_out['incident_zones'][0])]))\n"
 "# print results formatted as string\n"
-"print \"Last pick = \", GetPickOutput()\n"
+"print(\"Last pick = \", GetPickOutput())\n"
 ;
 const char *visit_PlotPlugins_doc = 
 "PlotPlugins\n"
@@ -6363,7 +6362,7 @@ const char *visit_PlotPlugins_doc =
 "\n"
 "#% visit -cli\n"
 "for plugin in PluginPlugins():\n"
-"print \"The %s plot plugin is loaded.\" % plugin\n"
+"    print(\"The %s plot plugin is loaded.\" % plugin)\n"
 ;
 const char *visit_PointPick_doc = 
 "PointPick\n"
@@ -6569,7 +6568,7 @@ const char *visit_Queries_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"supported queries: \", Queries()\n"
+"print(\"supported queries: \", Queries())\n"
 ;
 const char *visit_QueriesOverTime_doc = 
 "QueriesOverTime\n"
@@ -6599,11 +6598,11 @@ const char *visit_QueriesOverTime_doc =
 "DrawPlots()\n"
 "# Execute each of the queries over time on the plots.\n"
 "for q in QueriesOverTime():\n"
-"QueryOverTime(q)\n"
-"You can control timestates used in the query via start_time,\n"
-"end_time, and stride as follows:\n"
+"    QueryOverTime(q)\n"
+"# You can control timestates used in the query via start_time,\n"
+"# end_time, and stride as follows:\n"
 "QueryOverTime(\"Volume\", start_time=5, end_time=250, stride=5)\n"
-"(Defaults used if not specified are 0, nStates, 1)\n"
+"# (Defaults used if not specified are 0, nStates, 1)\n"
 ;
 const char *visit_Query_doc = 
 "Query\n"
@@ -6704,7 +6703,7 @@ const char *visit_QueryOverTime_doc =
 "Quantitative Analysis chapter. You can get also get a list of queries that\n"
 "can be executed over time using 'QueriesOverTime' function.\n"
 "Since queries can take a wide array of arguments, the Query function takes\n"
-"either a python dictorary or a list of named arguments specific to the\n"
+"either a python dictionary or a list of named arguments specific to the\n"
 "given query.  To obtain the possible options for a given query, use the\n"
 "GetQueryParameters(name) function.  If the query accepts additional\n"
 "arguments beyond its name, this function will return a python dictionary\n"
@@ -6720,8 +6719,7 @@ const char *visit_QueryOverTime_doc =
 "AddPlot(\"Pseudocolor\", \"pressure\")\n"
 "DrawPlots()\n"
 "for q in QueriesOverTime():\n"
-"QueryOverTime(q)\n"
-"ResetView()\n"
+"    QueryOverTime(q)\n"
 ;
 const char *visit_ReOpenDatabase_doc = 
 "ReOpenDatabase\n"
@@ -6770,12 +6768,12 @@ const char *visit_ReOpenDatabase_doc =
 "DrawPlots()\n"
 "last = TimeSliderGetNStates()\n"
 "for state in range(last):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 "ReOpenDatabase(\"edge:/usr/gapps/visit/data/wave*.silo database\")\n"
 "for state in range(last, TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_ReadHostProfilesFromDirectory_doc = 
 "ReadHostProfilesFromDirectory\n"
@@ -6948,7 +6946,8 @@ const char *visit_RegisterCallback_doc =
 "\n"
 "import visit\n"
 "def print_sliceatts(atts):\n"
-"print \"SLICEATTS=\", atts\n"
+"    print(\"SLICEATTS=\", atts)\n"
+"\n"
 "visit.RegisterCallback(\"SliceAttributes\", print_sliceatts)\n"
 ;
 const char *visit_RegisterMacro_doc = 
@@ -6982,9 +6981,10 @@ const char *visit_RegisterMacro_doc =
 "Example:\n"
 "\n"
 "def SetupMyPlots():\n"
-"OpenDatabase('noise.silo')\n"
-"AddPlot('Pseudocolor', 'hardyglobal')\n"
-"DrawPlots()\n"
+"    OpenDatabase('noise.silo')\n"
+"    AddPlot('Pseudocolor', 'hardyglobal')\n"
+"    DrawPlots()\n"
+"\n"
 "RegisterMacro('Setup My Plots', SetupMyPlots)\n"
 ;
 const char *visit_RemoveAllOperators_doc = 
@@ -7240,7 +7240,7 @@ const char *visit_ReplaceDatabase_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"OpenDatabase(\"/usr/gapps/visit/data/globe.silo)\n"
+"OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"u\")\n"
 "DrawPlots()\n"
 "ReplaceDatabase(\"/usr/gapps/visit/data/curv3d.silo\")\n"
@@ -7501,8 +7501,8 @@ const char *visit_RestoreSession_doc =
 "# my .visit directory.\n"
 "RestoreSessionFile(\"visit.session\", 1)\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_RestoreSessionWithDifferentSources_doc = 
 "RestoreSessionWithDifferentSources\n"
@@ -7554,8 +7554,8 @@ const char *visit_RestoreSessionWithDifferentSources_doc =
 "# my .visit directory.\n"
 "RestoreSessionFile(\"visit.session\", 1)\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_SaveAttribute_doc = 
 "SaveAttribute\n"
@@ -7728,7 +7728,7 @@ const char *visit_SaveWindow_doc =
 "s.fileName = \"test\"\n"
 "SetSaveWindowAttributes(s)\n"
 "name = SaveWindow()\n"
-"print \"name = %s\" % name\n"
+"print(\"name = %s\" % name)\n"
 ;
 const char *visit_SendSimulationCommand_doc = 
 "SendSimulationCommand\n"
@@ -7926,15 +7926,15 @@ const char *visit_SetActiveTimeSlider_doc =
 "path = \"/usr/gapps/visit/data/\"\n"
 "dbs = (path + \"dbA00.pdb\", path + \"dbB00.pdb\", path + \"dbC00.pdb\")\n"
 "for db in dbs:\n"
-"OpenDatabase(db)\n"
-"AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
-"DrawPlots()\n"
+"    OpenDatabase(db)\n"
+"    AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
+"    DrawPlots()\n"
 "CreateDatabaseCorrelation(\"common\", dbs, 1)\n"
 "tsNames = GetWindowInformation().timeSliders\n"
 "for ts in tsNames:\n"
-"SetActiveTimeSlider(ts)\n"
+"    SetActiveTimeSlider(ts)\n"
 "for state in list(range(TimeSliderGetNStates())) + [0]:\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 ;
 const char *visit_SetActiveWindow_doc = 
 "SetActiveWindow\n"
@@ -8363,9 +8363,9 @@ const char *visit_SetDatabaseCorrelationOptions_doc =
 "# The AddPlot caused a database correlation to be created.\n"
 "DrawPlots()\n"
 "wi = GetWindowInformation()\n"
-"print \"Active time slider: \" % wi.timeSliders[wi.activeTimeSlider]\n"
+"print(\"Active time slider: \" % wi.timeSliders[wi.activeTimeSlider])\n"
 "# This will set time for both databases since the database correlation is\n"
-"the active time slider.\n"
+"# the active time slider.\n"
 "SetTimeSliderState(5)\n"
 ;
 const char *visit_SetDebugLevel_doc = 
@@ -8398,7 +8398,7 @@ const char *visit_SetDebugLevel_doc =
 "Example:\n"
 "\n"
 "#% visit -cli -debug 2\n"
-"print \"VisIt's debug level is: %d\" % GetDebugLevel()\n"
+"print(\"VisIt's debug level is: %d\" % GetDebugLevel())\n"
 ;
 const char *visit_SetDefaultAnnotationAttributes_doc = 
 "SetDefaultAnnotationAttributes\n"
@@ -8526,7 +8526,7 @@ const char *visit_SetDefaultInteractorAttributes_doc =
 "\n"
 "#% visit -cli\n"
 "ia = GetInteractorAttributes()\n"
-"print ia\n"
+"print(ia)\n"
 "ia.showGuidelines = 0\n"
 "SetInteractorAttributes(ia)\n"
 ;
@@ -8845,7 +8845,7 @@ const char *visit_SetInteractorAttributes_doc =
 "\n"
 "#% visit -cli\n"
 "ia = GetInteractorAttributes()\n"
-"print ia\n"
+"print(ia)\n"
 "ia.showGuidelines = 0\n"
 "SetInteractorAttributes(ia)\n"
 ;
@@ -8885,7 +8885,7 @@ const char *visit_SetKeyframeAttributes_doc =
 "\n"
 "#% visit -cli\n"
 "k = GetKeyframeAttributes()\n"
-"print k\n"
+"print(k)\n"
 "k.enabled,k.nFrames,k.nFramesWasUserSet = 1, 100, 1\n"
 "SetKeyframeAttributes(k)\n"
 ;
@@ -8927,7 +8927,7 @@ const char *visit_SetLight_doc =
 "DrawPlots()\n"
 "InvertBackgroundColor()\n"
 "light = GetLight(0)\n"
-"print light\n"
+"print(light)\n"
 "light.enabledFlag = 1\n"
 "light.direction = (0,-1,0)\n"
 "light.color = (255,0,0,255)\n"
@@ -9219,7 +9219,7 @@ const char *visit_SetPipelineCachingMode_doc =
 "AddPlot(\"Mesh\", \"quadmesh\")\n"
 "DrawPlots()\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 ;
 const char *visit_SetPlotDatabaseState_doc = 
 "SetPlotDatabaseState\n"
@@ -9267,9 +9267,9 @@ const char *visit_SetPlotDatabaseState_doc =
 "SetPlotDatabaseState(0, 0, 70)\n"
 "SetPlotDatabaseState(0, nFrames-1, 0)\n"
 "# Animate through the animation frames since the \"Keyframe animation\"\n"
-"time slider is active.\n"
+"# time slider is active.\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 ;
 const char *visit_SetPlotDescription_doc = 
 "SetPlotDescription\n"
@@ -9378,13 +9378,13 @@ const char *visit_SetPlotFrameRange_doc =
 "AddPlot(\"Mesh\", \"quadmesh\")\n"
 "DrawPlots()\n"
 "# Make the Pseudocolor plot take up the first half of the animation frames\n"
-"before it disappears.\n"
+"# before it disappears.\n"
 "SetPlotFrameRange(0, 0, nFrames/2-1)\n"
 "# Make the Mesh plot take up the second half of the animation frames.\n"
 "SetPlotFrameRange(1, nFrames/2, nFrames-1)\n"
-"for state in range(TimeSliderGetNStates())\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"for state in range(TimeSliderGetNStates()):\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_SetPlotOptions_doc = 
 "SetPlotOptions\n"
@@ -9712,7 +9712,7 @@ const char *visit_SetQueryOutputToObject_doc =
 "# Set query output type.\n"
 "SetQueryOutputToObject()\n"
 "query_output = Query(\"MinMax\")\n"
-"print query_output\n"
+"print(query_output)\n"
 ;
 const char *visit_SetQueryOutputToString_doc = 
 "SetQueryOutputToString\n"
@@ -9741,11 +9741,11 @@ const char *visit_SetQueryOutputToString_doc =
 "# Set query output type.\n"
 "SetQueryOutputToString()\n"
 "query_output = Query(\"MinMax\")\n"
-"print query_output\n"
-"'\n"
+"print(query_output)\n"
+"'''\n"
 "d -- Min = 0.0235702 (zone 434 at coord <0.483333, 0.483333>)\n"
 "d -- Max = 0.948976 (zone 1170 at coord <0.0166667, 1.31667>)\n"
-"'\n"
+"'''\n"
 ;
 const char *visit_SetQueryOutputToValue_doc = 
 "SetQueryOutputToValue\n"
@@ -9774,7 +9774,7 @@ const char *visit_SetQueryOutputToValue_doc =
 "# Set query output type.\n"
 "SetQueryOutputToValue()\n"
 "query_output = Query(\"MinMax\")\n"
-"print query_output\n"
+"print(query_output)\n"
 "(0.02357020415365696, 0.9489759802818298)\n"
 ;
 const char *visit_SetQueryOverTimeAttributes_doc = 
@@ -9909,7 +9909,7 @@ const char *visit_SetRenderingAttributes_doc =
 "light.direction = (0,1,-1)\n"
 "SetLight(0, light)\n"
 "r = GetRenderingAttributes()\n"
-"print r\n"
+"print(r)\n"
 "r.scalableActivationMode = r.Always\n"
 "r.doShadowing = 1\n"
 "SetRenderingAttributes(r)\n"
@@ -9990,15 +9990,15 @@ const char *visit_SetTimeSliderState_doc =
 "path = \"/usr/gapps/visit/data/\"\n"
 "dbs = (path + \"dbA00.pdb\", path + \"dbB00.pdb\", path + \"dbC00.pdb\")\n"
 "for db in dbs:\n"
-"OpenDatabase(db)\n"
-"AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
-"DrawPlots()\n"
+"    OpenDatabase(db)\n"
+"    AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
+"    DrawPlots()\n"
 "CreateDatabaseCorrelation(\"common\", dbs, 1)\n"
 "tsNames = GetWindowInformation().timeSliders\n"
 "for ts in tsNames:\n"
-"SetActiveTimeSlider(ts)\n"
+"    SetActiveTimeSlider(ts)\n"
 "for state in list(range(TimeSliderGetNStates())) + [0]:\n"
-"SetTimeSliderState(state)\n"
+"    SetTimeSliderState(state)\n"
 ;
 const char *visit_SetTreatAllDBsAsTimeVarying_doc = 
 "SetTreatAllDBsAsTimeVarying\n"
@@ -10142,7 +10142,7 @@ const char *visit_SetView2D_doc =
 "\n"
 "Example:\n"
 "\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"v\")\n"
 "DrawPlots()\n"
@@ -10154,9 +10154,9 @@ const char *visit_SetView2D_doc =
 "v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)\n"
 "v1.parallelScale = 10.\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v0 + t * v1\n"
-"SetView3D(v2) # Animate the view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v0 + t * v1\n"
+"    SetView3D(v2) # Animate the view.\n"
 ;
 const char *visit_SetView3D_doc = 
 "SetView3D\n"
@@ -10197,7 +10197,7 @@ const char *visit_SetView3D_doc =
 "\n"
 "Example:\n"
 "\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"v\")\n"
 "DrawPlots()\n"
@@ -10209,9 +10209,9 @@ const char *visit_SetView3D_doc =
 "v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)\n"
 "v1.parallelScale = 10.\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v0 + t * v1\n"
-"SetView3D(v2) # Animate the view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v0 + t * v1\n"
+"    SetView3D(v2) # Animate the view.\n"
 ;
 const char *visit_SetViewAxisArray_doc = 
 "SetViewAxisArray\n"
@@ -10248,7 +10248,7 @@ const char *visit_SetViewAxisArray_doc =
 "\n"
 "Example:\n"
 "\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"v\")\n"
 "DrawPlots()\n"
@@ -10260,9 +10260,9 @@ const char *visit_SetViewAxisArray_doc =
 "v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)\n"
 "v1.parallelScale = 10.\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v0 + t * v1\n"
-"SetView3D(v2) # Animate the view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v0 + t * v1\n"
+"    SetView3D(v2) # Animate the view.\n"
 ;
 const char *visit_SetViewCurve_doc = 
 "SetViewCurve\n"
@@ -10299,7 +10299,7 @@ const char *visit_SetViewCurve_doc =
 "\n"
 "Example:\n"
 "\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"/usr/gapps/visit/data/globe.silo\")\n"
 "AddPlot(\"Pseudocolor\", \"v\")\n"
 "DrawPlots()\n"
@@ -10311,9 +10311,9 @@ const char *visit_SetViewCurve_doc =
 "v1.camera,v1.viewUp = (1,1,1),(-1,1,-1)\n"
 "v1.parallelScale = 10.\n"
 "for i in range(0,20):\n"
-"t = float(i) / 19.\n"
-"v2 = (1. - t) * v0 + t * v1\n"
-"SetView3D(v2) # Animate the view.\n"
+"    t = float(i) / 19.\n"
+"    v2 = (1. - t) * v0 + t * v1\n"
+"    SetView3D(v2) # Animate the view.\n"
 ;
 const char *visit_SetViewExtentsType_doc = 
 "SetViewExtentsType\n"
@@ -10358,14 +10358,14 @@ const char *visit_SetViewExtentsType_doc =
 "v.viewUp = (0.276106, 0.891586, -0.358943)\n"
 "SetView3D(v)\n"
 "mats = GetMaterials()\n"
-"nmats = len(mats):\n"
+"nmats = len(mats)\n"
 "# Turn off all but the last material in sequence and watch\n"
 "# the view update each time.\n"
 "for i in range(nmats-1):\n"
-"index = nmats-1-i\n"
-"TurnMaterialsOff(mats[index])\n"
-"SaveWindow()\n"
-"SetViewExtentsType(\"original\")\n"
+"    index = nmats-1-i\n"
+"    TurnMaterialsOff(mats[index])\n"
+"    SaveWindow()\n"
+"    SetViewExtentsType(\"original\")\n"
 ;
 const char *visit_SetViewKeyframe_doc = 
 "SetViewKeyframe\n"
@@ -10416,8 +10416,8 @@ const char *visit_SetViewKeyframe_doc =
 "SetViewKeyframe()\n"
 "ToggleCameraViewMode()\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_SetWindowArea_doc = 
 "SetWindowArea\n"
@@ -10563,7 +10563,7 @@ const char *visit_ShowAllWindows_doc =
 "\n"
 "Example:\n"
 "\n"
-"% python\n"
+"#% python\n"
 "import visit\n"
 "visit.Launch()\n"
 "visit.ShowAllWindows()\n"
@@ -10702,7 +10702,7 @@ const char *visit_SuppressQueryOutputOff_doc =
 "# Turn off automatic printing of Query output.\n"
 "SuppressQueryOutputOn()\n"
 "Query(\"MinMax\")\n"
-"print \"The min is: %g and the max is: %g\" % GetQueryOutputValue()\n"
+"print(\"The min is: %g and the max is: %g\" % GetQueryOutputValue())\n"
 "# Turn on automatic printing of Query output.\n"
 "SuppressQueryOutputOff()\n"
 "Query(\"MinMax\")\n"
@@ -10737,7 +10737,7 @@ const char *visit_SuppressQueryOutputOn_doc =
 "# Turn off automatic printing of Query output.\n"
 "SuppressQueryOutputOn()\n"
 "Query(\"MinMax\")\n"
-"print \"The min is: %g and the max is: %g\" % GetQueryOutputValue()\n"
+"print(\"The min is: %g and the max is: %g\" % GetQueryOutputValue())\n"
 "# Turn on automatic printing of Query output.\n"
 "SuppressQueryOutputOff()\n"
 "Query(\"MinMax\")\n"
@@ -10773,8 +10773,8 @@ const char *visit_TimeSliderGetNStates_doc =
 "AddPlot(\"Pseudocolor\", \"pressure\")\n"
 "DrawPlots()\n"
 "for state in range(TimeSliderGetNStates()):\n"
-"SetTimeSliderState(state)\n"
-"SaveWindow()\n"
+"    SetTimeSliderState(state)\n"
+"    SaveWindow()\n"
 ;
 const char *visit_TimeSliderNextState_doc = 
 "TimeSliderNextState\n"
@@ -10799,15 +10799,15 @@ const char *visit_TimeSliderNextState_doc =
 "Example:\n"
 "\n"
 "# Assume that files are being written to the disk.\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"dynamic*.silo database\")\n"
 "AddPlot(\"Pseudocolor\", \"var\")\n"
 "AddPlot(\"Mesh\", \"mesh\")\n"
 "DrawPlots()\n"
 "SetTimeSliderState(TimeSliderGetNStates() - 1)\n"
 "while 1:\n"
-"SaveWindow()\n"
-"TimeSliderPreviousState()\n"
+"    SaveWindow()\n"
+"    TimeSliderPreviousState()\n"
 ;
 const char *visit_TimeSliderPreviousState_doc = 
 "TimeSliderPreviousState\n"
@@ -10832,14 +10832,14 @@ const char *visit_TimeSliderPreviousState_doc =
 "Example:\n"
 "\n"
 "# Assume that files are being written to the disk.\n"
-"% visit -cli\n"
+"#% visit -cli\n"
 "OpenDatabase(\"dynamic*.silo database\")\n"
 "AddPlot(\"Pseudocolor\", \"var\")\n"
 "AddPlot(\"Mesh\", \"mesh\")\n"
 "DrawPlots()\n"
 "while 1:\n"
-"TimeSliderNextState()\n"
-"SaveWindow()\n"
+"    TimeSliderNextState()\n"
+"    SaveWindow()\n"
 ;
 const char *visit_TimeSliderSetState_doc = 
 "TimeSliderSetState\n"
@@ -10874,15 +10874,15 @@ const char *visit_TimeSliderSetState_doc =
 "path = \"/usr/gapps/visit/data/\"\n"
 "dbs = (path + \"dbA00.pdb\", path + \"dbB00.pdb\", path + \"dbC00.pdb\")\n"
 "for db in dbs:\n"
-"OpenDatabase(db)\n"
-"AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
-"DrawPlots()\n"
+"    OpenDatabase(db)\n"
+"    AddPlot(\"FilledBoundary\", \"material(mesh)\")\n"
+"    DrawPlots()\n"
 "CreateDatabaseCorrelation(\"common\", dbs, 1)\n"
 "tsNames = GetWindowInformation().timeSliders\n"
 "for ts in tsNames:\n"
-"SetActiveTimeSlider(ts)\n"
+"    SetActiveTimeSlider(ts)\n"
 "for state in list(range(TimeSliderGetNStates())) + [0]:\n"
-"TimeSliderSetState(state)\n"
+"    TimeSliderSetState(state)\n"
 ;
 const char *visit_ToggleBoundingBoxMode_doc = 
 "ToggleBoundingBoxMode\n"
@@ -10918,7 +10918,7 @@ const char *visit_ToggleBoundingBoxMode_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -10956,7 +10956,7 @@ const char *visit_ToggleCameraViewMode_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -10995,7 +10995,7 @@ const char *visit_ToggleFullFrameMode_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -11035,7 +11035,7 @@ const char *visit_ToggleLockTime_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -11103,7 +11103,7 @@ const char *visit_ToggleLockTools_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -11141,7 +11141,7 @@ const char *visit_ToggleLockViewMode_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -11177,7 +11177,7 @@ const char *visit_ToggleMaintainViewMode_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -11214,7 +11214,7 @@ const char *visit_ToggleSpinMode_doc =
 "# Turn on spin mode.\n"
 "ToggleSpinMode()\n"
 "# Rotate the plot interactively using the mouse and watch it keep spinning\n"
-"after the mouse release.\n"
+"# after the mouse release.\n"
 "# Turn off spin mode.\n"
 "ToggleSpinMode()\n"
 ;
@@ -11529,7 +11529,7 @@ const char *visit_Version_doc =
 "Example:\n"
 "\n"
 "#% visit -cli\n"
-"print \"We are running VisIt version %s\" % Version()\n"
+"print(\"We are running VisIt version %s\" % Version())\n"
 ;
 const char *visit_WriteConfigFile_doc = 
 "WriteConfigFile\n"
@@ -11568,7 +11568,6 @@ const char *visit_WriteScript_doc =
 "f = open('script.py', 'wt')\n"
 "WriteScript(f)\n"
 "f.close()\n"
-"\n"
 ;
 const char *visit_ZonePick_doc = 
 "ZonePick\n"


### PR DESCRIPTION
Resolves #4127 and #4121 

* update our cli_manual/functions.rst examples to be both python 2 and 3 compatible 
* modifies functions_to_method_doc.py to preserve spaces in example scripts
* adds functions_to_plain_py.py helper that extracts all examples from functions.rst into a flat python file
* updates cli manual contributing docs

