### PR TITLE
Updated bv_adios2.sh with a minor fix in addition to Dave's fixes

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.0.html
+++ b/src/resources/help/en_US/relnotes3.1.0.html
@@ -106,6 +106,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Suppressed the Qt warning 'Empty filename passed to function'. Also added additional context information to the Qt log message if available.</li>
   <li>Corrected compile errors when using Open MPI 1.6.5.</li>
   <li>Silo plugin code sections for recognizing variable types in metadata was re-factored to a single function.</li>
+  <li>Fixed issues compiling adios2 on macOS 10.13.6</li>
 </ul>
 
 <a name="Doc_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -182,7 +182,7 @@ function build_adios2
             fi
 
             # Change all references from adios2 to adios2_mpi.
-            find . -name "CMakeLists.txt" -exec sed -i "s/adios2/adios2_mpi/g" {} \;
+            find . -name "CMakeLists.txt" -exec ${SED_CMD} "s/adios2/adios2_mpi/g" {} \;
             # This changes too many things, now we need to change specific things back.
 
             ${SED_CMD} "s/adios2_mpi/adios2/g" source/CMakeLists.txt


### PR DESCRIPTION
### Description
Updated bv_adios2.sh with a minor fix in addition to Dave's fixes.

Resolves #3982 

Please include a summary of the change
Updated the bv_adios2.sh file to use the correct sed command syntax for maxOS. Dave's updates caused an error with my initial fix.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Built the 3.1RC

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
