### PR TITLE
disable lighting options when appropriate

### DIFF
--- a/src/plots/Volume/QvisVolumePlotWindow.C
+++ b/src/plots/Volume/QvisVolumePlotWindow.C
@@ -1618,6 +1618,9 @@ QvisVolumePlotWindow::UpdateHistogram()
 //   Kathleen Biagas, Fri Mar  2 14:55:01 MST 2018
 //   Removed tuvok.
 //
+//   Alister Maguire, Tue Dec  3 15:27:41 MST 2019
+//   Enable/Disable materialProperties in relation to the lighting flag.
+//
 // ****************************************************************************
 
 void
@@ -1664,6 +1667,22 @@ QvisVolumePlotWindow::UpdateWindow(bool doAll)
             lightingToggle->blockSignals(true);
             lightingToggle->setChecked(volumeAtts->GetLightingFlag());
             lightingToggle->blockSignals(false);
+
+            //
+            // Only enable the lighting properites when lighting
+            // is being used.
+            //
+            if (lightingToggle->isChecked() &&
+                !materialProperties->isEnabled())
+            {
+                materialProperties->setEnabled(true);
+            }
+            else if (!lightingToggle->isChecked() &&
+                materialProperties->isEnabled())
+            {
+                materialProperties->setEnabled(false);
+            }
+
             break;
         case VolumeAttributes::ID_lowGradientLightingReduction:
             lowGradientLightingReductionCombo->blockSignals(true);


### PR DESCRIPTION
### Description
This change causes the lighting attributes (ambient, diffuse, etc.) within the volume attributes GUI to become disabled when the lighting option is un-checked. 

Resolves #4137


### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?
I've run VisIt's GUI and tested the changes. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
