### PR TITLE
Correct bug in build_visit with Conduit and Fortran.

### DIFF
--- a/src/config-site/kickit.llnl.gov.cmake
+++ b/src/config-site/kickit.llnl.gov.cmake
@@ -1,8 +1,8 @@
 #/usr/gapps/visit/thirdparty_shared/3.1.0/cmake/3.9.3/linux-x86_64_gcc-4.8/bin/cmake
 ##
 ## ./build_visit3_1_0 generated host.cmake
-## created: Wed Nov 13 17:02:59 PST 2019
-## system: Linux kickit 5.3.8-1.el7.elrepo.x86_64 #1 SMP Tue Oct 29 08:30:10 EDT 2019 x86_64 x86_64 x86_64 GNU/Linux
+## created: Fri Dec  6 14:15:17 PST 2019
+## system: Linux kickit 5.3.12-1.el7.elrepo.x86_64 #1 SMP Wed Nov 20 12:34:41 EST 2019 x86_64 x86_64 x86_64 GNU/Linux
 ## by: brugger1
 
 ##
@@ -60,6 +60,7 @@ VISIT_OPTION_DEFAULT(VISIT_OPENSSL_DIR ${VISITHOME}/openssl/1.0.2j/${VISITARCH})
 ## Python
 ##
 VISIT_OPTION_DEFAULT(VISIT_PYTHON_DIR ${VISITHOME}/python/2.7.14/${VISITARCH})
+VISIT_OPTION_DEFAULT(VISIT_PYTHON3_DIR ${VISITHOME}/python/3.7.5/${VISITARCH})
 
 ##
 ## Qt

--- a/src/tools/dev/scripts/bv_support/bv_conduit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_conduit.sh
@@ -179,7 +179,7 @@ function build_conduit
         cfg_opts="${cfg_opts} -DHDF5_DIR:STRING=$VISITDIR/hdf5/$HDF5_VERSION/$VISITARCH/"
     fi
 
-    if [[ -n "$FC_COMPILER" ]] ; then
+    if [[ "$FC_COMPILER" != "no" ]] ; then
         cfg_opts="${cfg_opts} -DENABLE_FORTRAN:BOOL=ON"
         cfg_opts="${cfg_opts} -DCMAKE_Fortran_COMPILER:STRING=${FC_COMPILER}"
     fi


### PR DESCRIPTION
### Description

I made a fix so that build_visit would correctly handle passing Fortran compiler information to Conduit. I also updated the kickit config site file for 3.1.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I will be testing it in a moment. If it doesn't work I'll be correcting it.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code