### PR TITLE
Add patch to build_visit for sphinx build.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -999,6 +999,16 @@ function build_sphinx
         fi
     fi
 
+    # patch
+    SED_CMD="sed -i "
+    if [[ "$OPSYS" == "Darwin" ]]; then
+                SED_CMD="sed -i \"\" "
+    fi
+    pushd $SPHINX_BUILD_DIR > /dev/null
+    ${SED_CMD} "s/docutils>=0.12/docutils<0.16,>=0.12/" ./Sphinx.egg-info/requires.txt
+    ${SED_CMD} "s/docutils>=0.12/docutils<0.16,>=0.12/" ./setup.py
+    popd > /dev/null
+
     PY3HOME="${VISITDIR}/python/${PYTHON3_VERSION}/${VISITARCH}"
     # install
     pushd $SPHINX_BUILD_DIR > /dev/null


### PR DESCRIPTION
### Description

Added a patch to build_visit for building sphinx to not use a version of docutils greater than version 0.15. Previously, it picked up the latest version, which was happened to be an alpha version that broke sphinx.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I tested this on kickit, quartz and lassen. In all cases it used version 0.15.2 of docutils.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code