### PR TITLE
Prevent windows-style line endings when run on Windows.

### DIFF
--- a/src/tools/dev/xml/main.C
+++ b/src/tools/dev/xml/main.C
@@ -127,6 +127,10 @@ public:
 //    Delete the QFile if we never call open on it; trying to use it anyway
 //    will cause a segfault.
 //
+//    Kathleen Biagas, Thu Dec 26 08:38:29 MST 2019
+//    Don't use QIODevice::Text on Windows, to prevent windows-style line
+//    endings, we want unix-style line endings.
+//
 // ****************************************************************************
 
 QFile *
@@ -141,12 +145,20 @@ Open(const QString &name_withoutpath)
     bool alreadyexists = false;
     QFile *file = new QFile(name);
     if (clobber)
+#ifdef WIN32
+        file->open(QIODevice::WriteOnly);
+#else
         file->open(QIODevice::WriteOnly | QIODevice::Text);
+#endif
     else
     {
         if (!file->exists())
         {
+#ifdef WIN32
+            file->open(QIODevice::WriteOnly);
+#else
             file->open(QIODevice::WriteOnly | QIODevice::Text);
+#endif
         }
         else
         {


### PR DESCRIPTION
Modified xml code-gen to output unix-style line endings even when run on Windows.
Resolves #4178.

- [X] Bug fix


 