### PR TITLE
Fixed the NetCDF build error on macOS 10.14

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_netcdf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_netcdf.sh
@@ -115,7 +115,7 @@ function bv_netcdf_dry_run
     fi
 }
 
-function apply_netcdf_411_OSX10_13_patch
+function apply_netcdf_411_macOS_patch
 {
     patch -p0 << \EOF
 diff -c netcdf-4.1.1/ncgen3/orig/genlib.h netcdf-4.1.1/ncgen3/genlib.h 
@@ -288,9 +288,10 @@ function apply_netcdf_patch
                 apply_netcdf_411_darwin_patch
             fi
             
-            if [[ `sw_vers -productVersion` == 10.13.[0-9]* ]] ; then
-                info "Applying OS X 10.13 patch . . ."
-                apply_netcdf_411_OSX10_13_patch
+            if [[ `sw_vers -productVersion` == 10.13.[0-9]* ||
+                  `sw_vers -productVersion` == 10.14.[0-9]* ]] ; then
+                info "Applying macOS patch . . ."
+                apply_netcdf_411_macOS_patch
             fi
         fi
     fi


### PR DESCRIPTION
### Description

Resolves #4273. Fixed the NetCDF build error on macOS 10.14.

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Ran build_visit
