### PR TITLE
Fix remote profile import on windows. Merge from 3.1RC

### DIFF
--- a/src/CMake/FindVisItQt.cmake
+++ b/src/CMake/FindVisItQt.cmake
@@ -33,6 +33,9 @@
 #   Installed the plugins/platforms and plugins/styles directories in the 
 #   xmledit.app and mcurvit.app directories.
 #
+#   Kathleen Biagas, Wed Jan 22 14:46:17 MST 2020
+#   Add ssl dlls to install for Windows.
+#
 #*****************************************************************************
 
 
@@ -269,5 +272,24 @@ if(NOT VISIT_QT_SKIP_INSTALL)
           # a way to find this via Qt's cmake mechanisms, hence this
           # hard-coded extra step
           THIRD_PARTY_INSTALL_LIBRARY(${VISIT_QT_DIR}/lib/libQt5XcbQpa.so)
+  endif()
+
+  if(WIN32)
+      # Need the ssl dll's too.
+      file(COPY ${VISIT_QT_DIR}/bin/libeay32.dll
+                ${VISIT_QT_DIR}/bin/ssleay32.dll
+           DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThirdParty
+           FILE_PERMISSIONS OWNER_READ OWNER_WRITE
+                            GROUP_READ GROUP_WRITE
+                            WORLD_READ
+      )
+      install(FILES ${VISIT_QT_DIR}/bin/libeay32.dll
+                    ${VISIT_QT_DIR}/bin/ssleay32.dll
+              DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
+              PERMISSIONS OWNER_READ OWNER_WRITE
+                          GROUP_READ GROUP_WRITE
+                          WORLD_READ
+              CONFIGURATIONS "" None Debug Release RelWithDebInfo MinSizeRel
+      )
   endif()
 endif()

--- a/src/resources/help/en_US/relnotes3.1.1.html
+++ b/src/resources/help/en_US/relnotes3.1.1.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Corrected a bug where the Data level comparison wizard would always enter zero for the simulation cycle.</li>
   <li>Corrected a bug where zone pick highlights were incorrect after transforms were applied.</li>
   <li>Corrected a bug where VisIt crashes on start-up on some Windows systems when the system OpenGL version is too old.  Added a test of the OpenGL version during install, and use Mesa3D as a drop-in replacement if needed, with a warning on the installer pages to notify user that graphics cards / drivers should be updated. </li>
+  <li>Importing remote profiles from a Windows system was fixed.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/hosts/README.txt
+++ b/src/resources/hosts/README.txt
@@ -1,0 +1,8 @@
+If you add/remove directories, please edit networks.dat accordingly.
+
+If you add/remove directories or files, please regenerate networks.json
+by running dump_dir_to_networks_jason.py.
+
+Note that if run on Windows, it will create dos-style line endings in
+networks.json.  Convert it to Unix style before committing.
+

--- a/src/resources/hosts/networks.json
+++ b/src/resources/hosts/networks.json
@@ -1,209 +1,429 @@
 {
-   "hosts": [
-       { "network": "anl",
-         "files" : [
-             {"name": "host_anl_cooley.xml"},
-             {"name": "host_anl_theta.xml"},
-             {"name": "host_anl_mcs_login.xml"},
-             {"name": "customlauncher"}
-         ]
-       },
-       { "network": "arl",
-         "files" : [
-             {"name": "customlauncher"}
-         ]
-       },
-       { "network": "asu",
-         "files" : [
-             {"name": "customlauncher"}
-         ]
-       },
-       { "network": "awe",
-         "files": [
-            {"name": "customlauncher"},
-            {"name": "host_awe_blackthorn.xml"},
-            {"name": "host_awe_pillowb.xml"},
-            {"name": "host_awe_sprig.xml"},
-            {"name": "host_awe_sprucea.xml"},
-            {"name": "host_awe_spruceb.xml"}
-         ]
-       },
-       { "network": "chombo",
-         "files": [
-            {"name": "config"},
-            {"name": "customlauncher"},
-            {"name": "guiconfig"},
-            {"name": "visitrc"}
-         ]
-       },
-       { "network": "clemson",
-         "files": [
-            {"name": "customlauncher"},
-            {"name": "host_clemson_insight.xml"}
-         ]
-       },
-       { "network": "cscs",
-         "files": [
-             {"name": "host_dora.xml"},
-             {"name": "host_daint.xml"}
-         ]
-       },
-       { "network": "eth_zuric",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_eth_zurich_euler.xml"}
-         ]
-       },
-       { "network": "lanl",
-         "files" : [
-             {"name": "host_lanl_lightshow.xml"}
-         ]
-       },
-       { "network": "llnl",
-         "files" : [
-             {"name": "config"},
-             {"name": "customlauncher"},
-             {"name": "host_llnl_ansel.xml"},
-             {"name": "host_llnl_borax.xml"},
-             {"name": "host_llnl_lassen.xml"},
-             {"name": "host_llnl_oslic.xml"},
-             {"name": "host_llnl_pascal.xml"},
-             {"name": "host_llnl_quartz.xml"},
-             {"name": "host_llnl_rzgw_rzalastor.xml"},
-             {"name": "host_llnl_rzgw_rzansel.xml"},
-             {"name": "host_llnl_rzgw_rzgenie.xml"},
-             {"name": "host_llnl_rzgw_rzhasgpu.xml"},
-             {"name": "host_llnl_rzgw_rztopaz.xml"},
-             {"name": "host_llnl_rzgw_rztrona.xml"},
-             {"name": "host_llnl_rzgw_rzuseq.xml"},
-             {"name": "host_llnl_surface.xml"},
-             {"name": "host_llnl_syrah.xml"},
-             {"name": "host_llnl_vulcan.xml"},
-             {"name": "host_slac_red.xml"}
-         ]
-       },
-       { "network": "llnl_closed",
-         "files" : [
-             {"name": "host_lanl_closed_trinity.xml"},
-             {"name": "host_llnl_closed_agate.xml"},
-             {"name": "host_llnl_closed_cmax.xml"},
-             {"name": "host_llnl_closed_jade.xml"},
-             {"name": "host_llnl_closed_jadeita.xml"},
-             {"name": "host_llnl_closed_max.xml"},
-             {"name": "host_llnl_closed_mica.xml"},
-             {"name": "host_llnl_closed_sequoia.xml"},
-             {"name": "host_llnl_closed_shark.xml"},
-             {"name": "host_llnl_closed_sierra.xml"},
-             {"name": "host_llnl_closed_zin.xml"},
-             {"name": "host_llnl_closed_zindev.xml"}
-         ]
-       },
-       { "network": "llnl_rz",
-         "files" : [
-             {"name": "host_llnl_rzgw_rzalastor.xml"},
-             {"name": "host_llnl_rzgw_rzansel.xml"},
-             {"name": "host_llnl_rzgw_rzgenie.xml"},
-             {"name": "host_llnl_rzgw_rzhasgpu.xml"},
-             {"name": "host_llnl_rzgw_rztopaz.xml"},
-             {"name": "host_llnl_rzgw_rztrona.xml"}
-         ]
-       },
-       { "network": "lrz",
-         "files" : [
-             {"name": "host_lrz_supermuc_ng.xml"},
-             {"name": "host_lrz_linux_cluster.xml"}
-         ]
-       },
-       { "network": "lsu",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_lsu_philip.xml"}
-         ]
-       },
-       { "network": "ncar",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_ncar_caldera.xml"},
-             {"name": "host_ncar_cheyenne.xml"},
-             {"name": "host_ncar_geyser.xml"}
-         ]
-       },
-       { "network": "ncsa",
-         "files" : [
-             {"name": "host_blue_waters.xml"}
-         ]
-       },
-       { "network": "nersc",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_nersc_cori.xml"}
-         ]
-       },
-       { "network": "nics",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_beacon004_mic0.xml"},
-             {"name": "host_nics_kraken.xml"},
-             {"name": "host_nics_nautilus.xml"}
-         ]
-       },
-       { "network": "ohio",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_owens_hpc_osc_edu.xml"}
-         ]
-       },
-       { "network": "ornl",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_ornl_jaguar.xml"},
-             {"name": "host_ornl_jaguarpf.xml"},
-             {"name": "host_ornl_photon.xml"},
-             {"name": "host_ornl_rhea.xml"},
-             {"name": "host_ornl_sith.xml"},
-             {"name": "host_ornl_summit.xml"},
-             {"name": "host_ornl_titan.xml"}
-         ]
-       },
-       { "network": "princeton",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_princeton_artemis.xml"},
-             {"name": "host_princeton_hecate.xml"},
-             {"name": "host_princeton_orbital.xml"},
-             {"name": "host_princeton_tiger.xml"},
-             {"name": "host_princeton_tigressdata.xml"}
-         ]
-       },
-       { "network": "sandia",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_sandia_glory.xml"},
-             {"name": "host_sandia_redsky.xml"}
-         ]
-       },
-       { "network": "sandia_closed",
-         "files" : [
-             {"name": "customlauncher"},
-             {"name": "host_lanl_closed_cielo.xml"},
-             {"name": "host_sandia_closed_redsky-s.xml"},
-             {"name": "host_sandia_closed_unity.xml"},
-             {"name": "host_sandia_closed_whitney.xml"}
-         ]
-       },
-       { "network": "umich",
-         "files" : [
-             {"name": "host_umich_flux.xml"}
-         ]
-       },
-       { "network": "utah",
-         "files" : [
-             {"name": "customlauncher.xml"},
-             {"name": "host_utah_chpc_ash.xml"},
-             {"name": "host_utah_chpc_ember.xml"},
-             {"name": "host_utah_chpc_prism.xml"}
-         ]
-       }
-   ]
+  "hosts": [
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_anl_cooley.xml"
+        }, 
+        {
+          "name": "host_anl_mcs_login.xml"
+        }, 
+        {
+          "name": "host_anl_theta.xml"
+        }
+      ], 
+      "network": "anl"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }
+      ], 
+      "network": "arl"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }
+      ], 
+      "network": "asu"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_awe_blackthorn.xml"
+        }, 
+        {
+          "name": "host_awe_pillowb.xml"
+        }, 
+        {
+          "name": "host_awe_sprig.xml"
+        }, 
+        {
+          "name": "host_awe_sprucea.xml"
+        }, 
+        {
+          "name": "host_awe_spruceb.xml"
+        }
+      ], 
+      "network": "awe"
+    }, 
+    {
+      "files": [
+        {
+          "name": "config"
+        }, 
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "guiconfig"
+        }, 
+        {
+          "name": "visitrc"
+        }
+      ], 
+      "network": "chombo"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_clemson_insight.xml"
+        }
+      ], 
+      "network": "clemson"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_daint.xml"
+        }, 
+        {
+          "name": "host_dora.xml"
+        }
+      ], 
+      "network": "cscs"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_eth_zurich_euler.xml"
+        }
+      ], 
+      "network": "eth_zurich"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_lanl_lightshow.xml"
+        }
+      ], 
+      "network": "lanl"
+    }, 
+    {
+      "files": [
+        {
+          "name": "config"
+        }, 
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_llnl_ansel.xml"
+        }, 
+        {
+          "name": "host_llnl_borax.xml"
+        }, 
+        {
+          "name": "host_llnl_lassen.xml"
+        }, 
+        {
+          "name": "host_llnl_oslic.xml"
+        }, 
+        {
+          "name": "host_llnl_pascal.xml"
+        }, 
+        {
+          "name": "host_llnl_quartz.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rzalastor.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rzansel.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rzgenie.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rzhasgpu.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rztopaz.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rztrona.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgw_rzuseq.xml"
+        }, 
+        {
+          "name": "host_llnl_surface.xml"
+        }, 
+        {
+          "name": "host_llnl_syrah.xml"
+        }, 
+        {
+          "name": "host_llnl_vulcan.xml"
+        }, 
+        {
+          "name": "host_slac_red.xml"
+        }
+      ], 
+      "network": "llnl"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_lanl_closed_trinity.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_agate.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_cmax.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_jade.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_jadeita.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_max.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_mica.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_sequoia.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_shark.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_sierra.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_zin.xml"
+        }, 
+        {
+          "name": "host_llnl_closed_zindev.xml"
+        }
+      ], 
+      "network": "llnl_closed"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_llnl_rzalastor.xml"
+        }, 
+        {
+          "name": "host_llnl_rzansel.xml"
+        }, 
+        {
+          "name": "host_llnl_rzgenie.xml"
+        }, 
+        {
+          "name": "host_llnl_rzhasgpu.xml"
+        }, 
+        {
+          "name": "host_llnl_rztopaz.xml"
+        }, 
+        {
+          "name": "host_llnl_rztrona.xml"
+        }
+      ], 
+      "network": "llnl_rz"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_lrz_linux_cluster.xml"
+        }, 
+        {
+          "name": "host_lrz_supermuc_ng.xml"
+        }
+      ], 
+      "network": "lrz"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_lsu_philip.xml"
+        }
+      ], 
+      "network": "lsu"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_ncar_caldera.xml"
+        }, 
+        {
+          "name": "host_ncar_cheyenne.xml"
+        }, 
+        {
+          "name": "host_ncar_geyser.xml"
+        }
+      ], 
+      "network": "ncar"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_blue_waters.xml"
+        }
+      ], 
+      "network": "ncsa"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_nersc_cori.xml"
+        }
+      ], 
+      "network": "nersc"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_beacon004_mic0.xml"
+        }, 
+        {
+          "name": "host_nics_kraken.xml"
+        }, 
+        {
+          "name": "host_nics_nautilus.xml"
+        }
+      ], 
+      "network": "nics"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_owens_hpc_osc_edu.xml"
+        }
+      ], 
+      "network": "ohio"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_ornl_photon.xml"
+        }, 
+        {
+          "name": "host_ornl_rhea.xml"
+        }, 
+        {
+          "name": "host_ornl_summit.xml"
+        }
+      ], 
+      "network": "ornl"
+    }, 
+    {
+      "files": [
+        {
+          "name": "config"
+        }, 
+        {
+          "name": "host_princeton_artemis.xml"
+        }, 
+        {
+          "name": "host_princeton_hecate.xml"
+        }, 
+        {
+          "name": "host_princeton_orbital.xml"
+        }, 
+        {
+          "name": "host_princeton_tiger.xml"
+        }, 
+        {
+          "name": "host_princeton_tigressdata.xml"
+        }
+      ], 
+      "network": "princeton"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_sandia_glory.xml"
+        }, 
+        {
+          "name": "host_sandia_redsky.xml"
+        }
+      ], 
+      "network": "sandia"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_lanl_closed_cielo.xml"
+        }, 
+        {
+          "name": "host_sandia_closed_redsky-s.xml"
+        }, 
+        {
+          "name": "host_sandia_closed_unity.xml"
+        }, 
+        {
+          "name": "host_sandia_closed_whitney.xml"
+        }
+      ], 
+      "network": "sandia_closed"
+    }, 
+    {
+      "files": [
+        {
+          "name": "host_umich_flux.xml"
+        }
+      ], 
+      "network": "umich"
+    }, 
+    {
+      "files": [
+        {
+          "name": "customlauncher"
+        }, 
+        {
+          "name": "host_utah_chpc_ash.xml"
+        }, 
+        {
+          "name": "host_utah_chpc_ember.xml"
+        }, 
+        {
+          "name": "host_utah_chpc_prism.xml"
+        }
+      ], 
+      "network": "utah"
+    }
+  ]
 }
-


### PR DESCRIPTION
Resolves #4277
The remote-profile download code uses QNetwork, which relies on ssl.
The ssl dlls weren't being installed, causing the QNetwork calls to fail.

Also, regenerate networks.json. (Diffs seem large due to hand modifications previously).
Added README for regenerating networks.json.

### Description

Resolves # (*If this PR is unrelated to a ticket, please erase this line*)

Please include a summary of the change


### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [ ] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
