### PR TITLE
Fix VTKm includes, to fix operatorsVsInstall regression.

### DIFF
--- a/src/CMake/FindVTKh.cmake
+++ b/src/CMake/FindVTKh.cmake
@@ -38,8 +38,8 @@ IF (DEFINED VISIT_VTKH_DIR)
    MESSAGE(STATUS "  VTKm_VERSION_FULL = ${VTKm_VERSION_FULL}")
    MESSAGE(STATUS "  VTKm_VERSION = ${VTKm_VERSION}")
 
-   set(VTKm_INCLUDE_DIRS "${VTKM_DIR}/include/${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR}"
-                         "${VTKM_DIR}/include/${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR}/vtkm/thirdparty/taotuple"
+   set(VTKm_INCLUDE_DIRS "${VTKM_DIR}/include/vtkm-${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR}"
+                         "${VTKM_DIR}/include/vtkm-${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR}/vtkm/thirdparty/taotuple"
        CACHE STRING "VTKm include directories")
 
    include(${VISIT_SOURCE_DIR}/CMake/ThirdPartyInstallLibrary.cmake)

--- a/src/CMake/PluginVsInstall.cmake.in
+++ b/src/CMake/PluginVsInstall.cmake.in
@@ -324,7 +324,8 @@ set(OPENEXR_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
 set(OPENEXR_LIB @OPENEXR_LIB@)
 
 set(VTKh_INCLUDE_DIRS  ${VISIT_INCLUDE_DIR}/vtkh/include)
-set(VTKM_DIR           ${VISIT_INCLUDE_DIR}/vtkm)
+set(VTKm_INCLUDE_DIRS  ${VISIT_INCLUDE_DIR}/vtkm/include/vtkm-@VTKm_VERSION_MAJOR@.@VTKm_VERSION_MINOR@
+                       ${VISIT_INCLUDE_DIR}/vtkm/include/vtkm-@VTKm_VERSION_MAJOR@.@VTKm_VERSION_MINOR@/vtkm/thirdparty/taotuple)
 
 include(${VISIT_INCLUDE_DIR}/VisItMacros.cmake)
 


### PR DESCRIPTION
Updated PluginVsInstall.cmake.in to set VTKm_INCLUDE_DIRS.

Discovered VTKm_INCLUDE_DIRS was set incorrectly in FindVTKh.cmake.
Even though the build didn't fail (due to the include being part of the INTERFACE for VTKh/VTKm),
I modified FindVTKh.cmake to use the correct include paths for VTKm.