### PR TITLE
Modified build_visit to download third party libraries from GitHub.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.1.html
+++ b/src/resources/help/en_US/relnotes3.1.1.html
@@ -42,8 +42,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.1</font></b></p>
 <ul>
-  <li>Updated build_visit script to work on macOS 10.14</li>
-  <li>Modified build_visit script to download the visit source code and third party libraries from GitHub instead of NERSC."</li>
+  <li>Updated build_visit to work on macOS 10.14</li>
+  <li>Modified build_visit to download the visit source code and third party libraries from GitHub instead of NERSC."</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.1.1.html
+++ b/src/resources/help/en_US/relnotes3.1.1.html
@@ -42,7 +42,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.1</font></b></p>
 <ul>
-  <li>Updated build_visit scripts to work on macOS 10.14</li>
+  <li>Updated build_visit script to work on macOS 10.14</li>
+  <li>Modified build_visit script to download the visit source code and third party libraries from GitHub instead of NERSC."</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -36,7 +36,6 @@
 #5  bv_<module>_depends_on [not implemented yet], also may be removed in favor of xml structure
 #6. bv_<module>_build builds the module
 
-export VISIT_MAJOR_VERSION=${VISIT_VERSION:-"3.1.0"}
 export VISIT_VERSION=${VISIT_VERSION:-"3.1.0"}
 
 ####
@@ -394,7 +393,6 @@ function bv_write_unified_file
     cd $INITIAL_PWD
 
     echo "#!/bin/bash" > $OUTPUT_bv_FILE
-    echo "export VISIT_MAJOR_VERSION=\${VISIT_MAJOR_VERSION:-\"$VISIT_MAJOR_VERSION\"}" >> $OUTPUT_bv_FILE
     echo "export VISIT_VERSION=\${VISIT_VERSION:-\"$VISIT_VERSION\"}" >> $OUTPUT_bv_FILE
 
     echo "export TRUNK_BUILD=\"$TRUNK_BUILD\"" >> $OUTPUT_bv_FILE

--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -36,6 +36,7 @@
 #5  bv_<module>_depends_on [not implemented yet], also may be removed in favor of xml structure
 #6. bv_<module>_build builds the module
 
+export VISIT_MAJOR_VERSION=${VISIT_VERSION:-"3.1.0"}
 export VISIT_VERSION=${VISIT_VERSION:-"3.1.0"}
 
 ####
@@ -71,7 +72,8 @@ export bv_PREFIX=$bv_PATH/bv_support/
 export build_version=""
 export webroot="http://visit.ilight.com/svn/visit/"
 export webaddr="${webroot}/trunk/src/tools/dev/scripts/bv_support/"
-export nerscroot="http://portal.nersc.gov/project/visit/releases"
+export visitroot="https://github.com/visit-dav/visit/releases/download/"
+export thirdpartyroot="https://github.com/visit-dav/third-party/releases/download/"
 
 #state = "disabled", "enabled", "installed"
 declare -a reqlibs
@@ -392,6 +394,7 @@ function bv_write_unified_file
     cd $INITIAL_PWD
 
     echo "#!/bin/bash" > $OUTPUT_bv_FILE
+    echo "export VISIT_MAJOR_VERSION=\${VISIT_MAJOR_VERSION:-\"$VISIT_MAJOR_VERSION\"}" >> $OUTPUT_bv_FILE
     echo "export VISIT_VERSION=\${VISIT_VERSION:-\"$VISIT_VERSION\"}" >> $OUTPUT_bv_FILE
 
     echo "export TRUNK_BUILD=\"$TRUNK_BUILD\"" >> $OUTPUT_bv_FILE
@@ -406,7 +409,8 @@ function bv_write_unified_file
     echo "export build_version=\"\"" >> $OUTPUT_bv_FILE
     echo "export webroot=\"http://visit.ilight.com/svn/visit/\"" >> $OUTPUT_bv_FILE
     echo "export webaddr=\"\${webroot}/trunk/src/tools/dev/scripts/bv_support/\"" >> $OUTPUT_bv_FILE
-    echo "export nerscroot=\"http://portal.nersc.gov/project/visit/releases\"" >> $OUTPUT_bv_FILE
+    echo "export visitroot=\"https://github.com/visit-dav/visit/releases/download/\"" >> $OUTPUT_bv_FILE
+    echo "export thirdpartyroot=\"https://github.com/visit-dav/third-party/releases/download/\"" >> $OUTPUT_bv_FILE
 
     echo "declare -a reqlibs" >> $OUTPUT_bv_FILE
     echo "declare -a optlibs" >> $OUTPUT_bv_FILE

--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -20,13 +20,8 @@ function bv_visit_depends_on
 
 function bv_visit_info
 {
-    if [[ "$USE_VISIT_FILE" == "yes" ]] ; then
-        export VISIT_MD5_CHECKSUM=""
-        export VISIT_SHA256_CHECKSUM=""
-    else
-        export VISIT_MD5_CHECKSUM="edccd6d6c289356ac1462b1606b10ef9"
-        export VISIT_SHA256_CHECKSUM="40c33f08de7a048fb436b8a72156b9e5303434e8e52d5d8590c7dc3ce8ac607d"
-    fi
+    export VISIT_MD5_CHECKSUM=""
+    export VISIT_SHA256_CHECKSUM=""
 }
 
 function bv_visit_print

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -486,8 +486,13 @@ function download_file
 
     # It must be a third party library, handle that now.
     #
-    # First try GitHub.
-    site="${thirdpartyroot}v${VISIT_MAJOR_VERSION}"
+    # First try GitHub. We only update the third party libraries on
+    # when doing a major release, so the patch is always 0. The fancy
+    # parsing below grabs the major and minor version numbers.
+    IFS="." read -r -a vers <<< "$VISIT_VERSION"
+    major=${vers[0]}
+    minor=${vers[1]}
+    site="${thirdpartyroot}v${major}.${minor}.0"
     try_download_file $site/$dfile $dfile
     if [[ $? == 0 ]] ; then
         return 0

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -486,8 +486,8 @@ function download_file
 
     # It must be a third party library, handle that now.
     #
-    # First try GitHub. We only update the third party libraries on
-    # when doing a major release, so the patch is always 0. The fancy
+    # First try GitHub. We only update the third party libraries when
+    # doing a major release, so the patch is always 0. The fancy
     # parsing below grabs the major and minor version numbers.
     IFS="." read -r -a vers <<< "$VISIT_VERSION"
     major=${vers[0]}

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -460,6 +460,10 @@ function verify_checksum_by_lookup
 #   Alister Maguire, Thu Jan  2 11:45:44 MST 2020                             #
 #   Added download attempt for links that exclude the file name.              #
 #                                                                             #
+#   Eric Brugger, Wed Jan 29 09:52:20 PST 2020                                #
+#   I modified the routine to download the visit tar file and third party     #
+#   libraries from github.                                                    #
+#                                                                             #
 # *************************************************************************** #
 
 function download_file
@@ -472,7 +476,7 @@ function download_file
     shift
 
     # If the visit source code is requested, handle that now.
-    site="${nerscroot}/${VISIT_VERSION}"
+    site="${visitroot}v${VISIT_VERSION}"
     if [[ "$dfile" == "$VISIT_FILE" ]] ; then
         try_download_file $site/$dfile $dfile
         if [[ $? == 0 ]] ; then
@@ -482,8 +486,8 @@ function download_file
 
     # It must be a third party library, handle that now.
     #
-    # First try NERSC.
-    site="${nerscroot}/${VISIT_VERSION}/third_party"
+    # First try GitHub.
+    site="${thirdpartyroot}v${VISIT_MAJOR_VERSION}"
     try_download_file $site/$dfile $dfile
     if [[ $? == 0 ]] ; then
         return 0


### PR DESCRIPTION
### Description

I modified build_visit to download the visit source tar file and third party library sources from GitHub instead of NERSC.

### Type of change

- [X] New feature

### How Has This Been Tested?

I ran build_visit on my local RHEL7 system and it successfully downloaded the files and visit source code tar file from GitHub and successfully built VisIt.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers