### PR TITLE
Bugfix/biagas/qot with operator created vars

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.1.html
+++ b/src/resources/help/en_US/relnotes3.1.1.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Summing mesh_quality/volume in a sub-material setting will now return the correct volume.</li>
   <li>Corrected a bug where VisIt crashes on start-up on some Windows systems when the system OpenGL version is too old.  Added a test of the OpenGL version during install, and use Mesa3D as a drop-in replacement if needed, with a warning on the installer pages to notify user that graphics cards / drivers should be updated. </li>
   <li>Importing remote profiles from a Windows system was fixed.</li>
+  <li>Corrected a bug performing QueryOverTime with plots involving operator-created expressions.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/viewer/core/ViewerPlot.C
+++ b/src/viewer/core/ViewerPlot.C
@@ -3692,6 +3692,10 @@ ViewerPlot::CreateActor(bool createNew,
 //    Added a check of the retval to make sure the pointer is not NULL.
 //    The engine could crash and the viewer received NULL.
 //
+//    Kathleen Biagas, Thu Jan 30 10:05:42 PST 2020
+//    Don't re-apply operators to a cloned network, they were applied during
+//    the cloning operation.
+//
 // ****************************************************************************
 
 avtDataObjectReader_p
@@ -3711,6 +3715,7 @@ ViewerPlot::GetDataObjectReader()
 
     TRY
     {
+        bool success = true;
         //
         // Only do this if plot isn't using a cloned network.
         //
@@ -3755,15 +3760,14 @@ ViewerPlot::GetDataObjectReader()
                                    ignoreExtents,
                                    this->GetNamedSelection(),
                                    this->GetWindowId());
-        }
 
-        //
-        // Apply any operators.
-        //
-        bool success = true;
-        for (int o=0; o < this->GetNOperators() && success; o++)
-        {
-            success &= this->GetOperator(o)->ExecuteEngineRPC();
+            //
+            // Apply any operators.
+            //
+            for (int o=0; o < this->GetNOperators() && success; o++)
+            {
+                success &= this->GetOperator(o)->ExecuteEngineRPC();
+            }
         }
 
         //

--- a/test/baseline/queries/queriesOverTime/OperatorCreatedVar_01.png
+++ b/test/baseline/queries/queriesOverTime/OperatorCreatedVar_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9499543073c9875952ce13f40ba4a5ecce0bfff09806e8943ffc23ce0debeae
+size 5058


### PR DESCRIPTION
### Description
Resolves #2842 and #3489

I made query-over-time work with operator-created-vars by preventing the viewer plot from re-applying operators to a cloned network.

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [X] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I tested the scenario's described in the bug tickets, and also created a test for the  test-suite.
I ran the test-suite and all tests passed.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added any new baselines to the repo
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
