### PR TITLE
Enhanced build_visit to build the VisIt manuals when building VisIt.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.1.html
+++ b/src/resources/help/en_US/relnotes3.1.1.html
@@ -52,6 +52,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Modified build_visit to download the visit source code and third party libraries from GitHub instead of NERSC."</li>
   <li>Updated build_visit to allow the user to disable the building of Sphinx. To disable building Sphinx specify "--no-sphinx".</li>
   <li>Enhanced build_visit to also package VisIt into a tar file after building it so that VisIt is ready to install.</li>
+  <li>Enhanced build_visit to also build the VisIt manuals when building VisIt.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -368,6 +368,12 @@ function build_visit
     # Build VisIt
     #
     info "Building VisIt . . . (~50 minutes)"
+    if [[ "${BUILD_SPHINX}" == "yes" ]] ; then
+        $MAKE $MAKE_OPT_FLAGS manuals
+        if [[ $? != 0 ]] ; then
+            warn "Building the VisIt manuals failed.  Continuing"
+        fi
+    fi
     $MAKE $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "VisIt build failed.  Giving up"


### PR DESCRIPTION
### Description

I enhanced build_visit to build the VisIt manuals when building VisIt. It only does this if sphinx has been built.

### Type of change

- [X] New feature

### How Has This Been Tested?

I ran build_visit with sphinx enabled and it built the manuals when building VisIt.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers