### PR TITLE
Enhanced build_visit to add checksums for VisIt when writing a unified file.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.1.html
+++ b/src/resources/help/en_US/relnotes3.1.1.html
@@ -53,6 +53,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated build_visit to allow the user to disable the building of Sphinx. To disable building Sphinx specify "--no-sphinx".</li>
   <li>Enhanced build_visit to also package VisIt into a tar file after building it so that VisIt is ready to install.</li>
   <li>Enhanced build_visit to also build the VisIt manuals when building VisIt.</li>
+  <li>Enhanced build_visit to add checksums for the VisIt source tar file when writing a unified file. It assumes that the tar file containing the VisIt source file is in the current directory. If any errors are encountered and it can't add the checksums a warning is printed.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -382,6 +382,29 @@ function bv_write_unified_file
 {
     OUTPUT_bv_FILE=$@
 
+    #
+    # Calculate the checksums for the visit tar file. They will be used
+    # in a sed command to add the checksums when bv_visit.sh is added to
+    # the output file.
+    #
+    tarfile="visit${VISIT_VERSION}.tar.gz"
+    md5sum=""
+    sha256sum=""
+    if [[ -f "$tarfile" ]]; then
+        if [[ $(type -P "md5sum") ]]; then
+            md5sum=`md5sum $tarfile | cut -d' ' -f 1`
+        else
+            echo "Warning md5sum is not in PATH, not adding md5sum for VisIt."
+        fi
+        if [[ $(type -P "sha256sum") ]]; then
+            sha256sum=`sha256sum $tarfile | cut -d' ' -f 1`
+        else
+            echo "Warning sha256sum is not in PATH, not adding sha256sum for VisIt."
+        fi
+    else
+        echo "Warning $tarfile doesn't exist, not adding checksums for VisIt."
+    fi
+
     echo "Writing to File: $OUTPUT_bv_FILE"
     #go up one directory so that if $bv_PREFIX was set to relative path it will work again..
     if [[ $OUTPUT_bv_FILE == "" ]]; then
@@ -426,7 +449,7 @@ function bv_write_unified_file
     cat $bv_PREFIX/bv_main.sh >> $OUTPUT_bv_FILE
     cat $bv_PREFIX/helper_funcs.sh >> $OUTPUT_bv_FILE
     cat ${bv_PREFIX}/bv_xml_parser.sh >> $OUTPUT_bv_FILE
-    cat ${bv_PREFIX}/bv_visit.sh >> $OUTPUT_bv_FILE
+    cat ${bv_PREFIX}/bv_visit.sh | sed "s/VISIT_MD5_CHECKSUM=\"\"/VISIT_MD5_CHECKSUM=\"$md5sum\"/" | sed "s/VISIT_SHA256_CHECKSUM=\"\"/VISIT_SHA256_CHECKSUM=\"$sha256sum\"/" >> $OUTPUT_bv_FILE
 
     for (( i = 0; i < ${#xmlp_alllibs[*]}; ++i ))
     do


### PR DESCRIPTION
### Description

Resolves #4330 

Enhanced build_visit to add checksums for the VisIt source tar file when writing a unified file. It assumes that the tar file containing the VisIt source file is in the current directory. If any errors are encountered and it can't add the checksums a warning is printed.

### Type of change

- [X] New feature

### How Has This Been Tested?

I first created a tar file of the current 3.1.1 source code. I then ran build_visit --write-unified-file build_visit3_1_1 and created the unified file. I checked the resulting build_visit3_1_1 file and the checksums were present. I then ran build_visit with the VisIt 3.1.1 source code tar file and VisIt successfully built.

I also tried the build_visit command without the source file present and it output a warning message.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers