### PR TITLE
Disable manuals target in absence of PYTHON3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2240,8 +2240,10 @@ ELSE (NOT WIN32)
     ENDIF(VISIT_MAKE_NSIS_INSTALLER)
 ENDIF (NOT WIN32)
 
+if(VISIT_PYTHON3_DIR)
 add_custom_target(manuals
                   COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build -b html ${VISIT_SOURCE_DIR}/doc ${VISIT_SOURCE_DIR}/resources/help/en_US/manual -a)
+endif()
 
 #CMake add subdirectory forces this action to go last
 #todo: find way for this function to execute as last


### PR DESCRIPTION
Fixes build failure on windows.