### PR TITLE
all of these plots were missing ProcessOldVersions in the xml and atts

### DIFF
--- a/src/plots/Contour/Contour.xml
+++ b/src/plots/Contour/Contour.xml
@@ -94,6 +94,8 @@
       </Function>
       <Function name="SetValue2" user="true" member="true">
       </Function>
+      <Function name="ProcessOldVersions" user="true" member="true">
+      </Function>
       <Function name="ContourViewerEnginePluginInfo::InitializeGlobalObjects" user="false" member="true">
       </Function>
       <Function name="ContourViewerEnginePluginInfo::InitializePlotAtts" user="false" member="true">

--- a/src/plots/Contour/ContourAttributes.C
+++ b/src/plots/Contour/ContourAttributes.C
@@ -1645,3 +1645,35 @@ ContourAttributes::SetValue(const std::string &name, const doubleVector &value)
     return retval;
 }
 
+// ****************************************************************************
+// Method: ContourAttributes::ProcessOldVersions
+//
+// Purpose:
+//   This method allows handling of older config/session files that may
+//   contain fields that are no longer present or have been modified/renamed.
+//
+// Programmer: Kathleen Biagas
+// Creation:   April 4, 2018
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+ContourAttributes::ProcessOldVersions(DataNode *parentNode,
+                                    const char *configVersion)
+{
+    if(parentNode == 0)
+        return;
+
+    DataNode *searchNode = parentNode->GetNode("ContourAttributes");
+    if(searchNode == 0)
+        return;
+
+    if (VersionLessThan(configVersion, "3.0.0"))
+    {
+        if (searchNode->GetNode("lineStyle") != 0)
+            searchNode->RemoveNode("lineStyle");
+    }
+}
+

--- a/src/plots/Contour/ContourAttributes.code
+++ b/src/plots/Contour/ContourAttributes.code
@@ -659,6 +659,7 @@ ContourViewerEnginePluginInfo::InitializeDefaultPalette(ContourAttributes *conto
     }
 }
 
+Target: xml2atts
 Function: ProcessOldVersions
 Declaration: virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
 Definition:

--- a/src/plots/Contour/ContourAttributes.h
+++ b/src/plots/Contour/ContourAttributes.h
@@ -166,6 +166,7 @@ public:
     void MarkColorAsChanged(int index);
     virtual bool SetValue(const std::string &name, const int &value);
     virtual bool SetValue(const std::string &name, const doubleVector &value);
+    virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
 
     // IDs that can be used to identify fields in case statements
     enum {

--- a/src/plots/Histogram/Histogram.xml
+++ b/src/plots/Histogram/Histogram.xml
@@ -107,6 +107,8 @@
       </Function>
       <Function name="CopyAttributes" user="false" member="true">
       </Function>
+      <Function name="ProcessOldVersions" user="true" member="true">
+      </Function>
       <Function name="HistogramViewerEnginePluginInfo::InitializePlotAtts" user="false" member="true">
       </Function>
       <Function name="HistogramViewerEnginePluginInfo::ReInitializePlotAtts" user="false" member="true">

--- a/src/plots/Histogram/HistogramAttributes.C
+++ b/src/plots/Histogram/HistogramAttributes.C
@@ -1488,3 +1488,35 @@ HistogramAttributes::VarChangeRequiresReset()
     return true;
 }
 
+// ****************************************************************************
+// Method: HistogramAttributes::ProcessOldVersions
+//
+// Purpose:
+//   This method allows handling of older config/session files that may
+//   contain fields that are no longer present or have been modified/renamed.
+//
+// Programmer: Kathleen Biagas
+// Creation:   April 4, 2018
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+HistogramAttributes::ProcessOldVersions(DataNode *parentNode,
+                                    const char *configVersion)
+{
+    if(parentNode == 0)
+        return;
+
+    DataNode *searchNode = parentNode->GetNode("HistogramAttributes");
+    if(searchNode == 0)
+        return;
+
+    if (VersionLessThan(configVersion, "3.0.0"))
+    {
+        if (searchNode->GetNode("lineStyle") != 0)
+            searchNode->RemoveNode("lineStyle");
+    }
+}
+

--- a/src/plots/Histogram/HistogramAttributes.h
+++ b/src/plots/Histogram/HistogramAttributes.h
@@ -168,6 +168,7 @@ public:
     // User-defined methods
     bool ChangesRequireRecalculation(const HistogramAttributes &) const;
     virtual bool VarChangeRequiresReset(void);
+    virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
 
     // IDs that can be used to identify fields in case statements
     enum {

--- a/src/plots/Molecule/Molecule.xml
+++ b/src/plots/Molecule/Molecule.xml
@@ -115,6 +115,8 @@
       <Field name="scalarMax" label="Maximum value" type="float" enabler="maxFlag:true">
         1.000000
       </Field>
+      <Function name="ProcessOldVersions" user="true" member="true">
+      </Function>
       <Function name="ChangesRequireRecalculation" user="true" member="true">
       </Function>
     </Attribute>

--- a/src/plots/Molecule/MoleculeAttributes.C
+++ b/src/plots/Molecule/MoleculeAttributes.C
@@ -1573,6 +1573,38 @@ MoleculeAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
 // User-defined methods.
 ///////////////////////////////////////////////////////////////////////////////
 
+// ****************************************************************************
+// Method: MoleculeAttributes::ProcessOldVersions
+//
+// Purpose:
+//   This method allows handling of older config/session files that may
+//   contain fields that are no longer present or have been modified/renamed.
+//
+// Programmer: Kathleen Biagas
+// Creation:   April 4, 2018
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+MoleculeAttributes::ProcessOldVersions(DataNode *parentNode,
+                                    const char *configVersion)
+{
+    if(parentNode == 0)
+        return;
+
+    DataNode *searchNode = parentNode->GetNode("MoleculeAttributes");
+    if(searchNode == 0)
+        return;
+
+    if (VersionLessThan(configVersion, "3.0.0"))
+    {
+        if (searchNode->GetNode("bondLineStyle") != 0)
+            searchNode->RemoveNode("bondLineStyle");
+    }
+}
+
 bool
 MoleculeAttributes::ChangesRequireRecalculation(const MoleculeAttributes &obj)
 {

--- a/src/plots/Molecule/MoleculeAttributes.h
+++ b/src/plots/Molecule/MoleculeAttributes.h
@@ -181,6 +181,7 @@ public:
     virtual bool                      FieldsEqual(int index, const AttributeGroup *rhs) const;
 
     // User-defined methods
+    virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
     bool ChangesRequireRecalculation(const MoleculeAttributes &);
 
     // IDs that can be used to identify fields in case statements

--- a/src/plots/WellBore/WellBore.xml
+++ b/src/plots/WellBore/WellBore.xml
@@ -92,6 +92,8 @@
       </Function>
       <Function name="MarkColorAsChanged" user="true" member="true">
       </Function>
+      <Function name="ProcessOldVersions" user="true" member="true">
+      </Function>
       <Function name="ChangesRequireRecalculation" user="true" member="true">
       </Function>
       <Function name="WellBoreViewerEnginePluginInfo::InitializeGlobalObjects" user="false" member="true">

--- a/src/plots/WellBore/WellBoreAttributes.C
+++ b/src/plots/WellBore/WellBoreAttributes.C
@@ -1559,6 +1559,38 @@ WellBoreAttributes::MarkColorAsChanged(int index)
     }
 }
 
+// ****************************************************************************
+// Method: WellBoreAttributes::ProcessOldVersions
+//
+// Purpose:
+//   This method allows handling of older config/session files that may
+//   contain fields that are no longer present or have been modified/renamed.
+//
+// Programmer: Kathleen Biagas
+// Creation:   April 4, 2018
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+WellBoreAttributes::ProcessOldVersions(DataNode *parentNode,
+                                    const char *configVersion)
+{
+    if(parentNode == 0)
+        return;
+
+    DataNode *searchNode = parentNode->GetNode("WellBoreAttributes");
+    if(searchNode == 0)
+        return;
+
+    if (VersionLessThan(configVersion, "3.0.0"))
+    {
+        if (searchNode->GetNode("wellLineStyle") != 0)
+            searchNode->RemoveNode("wellLineStyle");
+    }
+}
+
 bool
 WellBoreAttributes::ChangesRequireRecalculation(const WellBoreAttributes &obj)
 {

--- a/src/plots/WellBore/WellBoreAttributes.code
+++ b/src/plots/WellBore/WellBoreAttributes.code
@@ -262,6 +262,7 @@ WellBoreViewerEnginePluginInfo::InitializeDefaultPalette(
     }
 }
 
+Target: xml2atts
 Function: ProcessOldVersions
 Declaration: virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
 Definition:

--- a/src/plots/WellBore/WellBoreAttributes.h
+++ b/src/plots/WellBore/WellBoreAttributes.h
@@ -171,6 +171,7 @@ public:
     void EnlargeMultiColor(int newSize);
     bool ColorIsChanged(int index) const;
     void MarkColorAsChanged(int index);
+    virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
     bool ChangesRequireRecalculation(const WellBoreAttributes &);
 
     // IDs that can be used to identify fields in case statements


### PR DESCRIPTION
All of these plots had ProcessOldVersions in their respective .code files but not in their respective atts file because it was not called out in the xml file. 

I added <Function name="ProcessOldVersions" user="true" member="true"> </Function> to each xml file and rebuilt the atts.

I was not sure if this was on purpose or not but considering it was also missing from the vector plot (now fixed via 4347) I did the clean up.



