### PR TITLE
Fix uninitialized var to prevent segv in ffp plugin on windows.

### DIFF
--- a/src/databases/ffp/avtffpFileFormat.C
+++ b/src/databases/ffp/avtffpFileFormat.C
@@ -70,7 +70,7 @@ static int InitLibStripack()
 {
     static char const * const envar = "VISIT_FFP_STRIPACK_PATH";
 #ifdef WIN32
-    HINSTANCE libh;
+	HINSTANCE libh = NULL;
     if (Environment::exists(envar))
         libh = LoadLibrary(Environment::get(envar).c_str());
     if (!libh)


### PR DESCRIPTION
Fixes segv in ffp plugin.
