### PR TITLE
Expand centos versions that Qt centos patch is applied to in build_visit.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -217,7 +217,7 @@ function apply_qt_patch
     if [[ ${QT_VERSION} == 5.10.1 ]] ; then
         if [[ -f /etc/centos-release ]] ; then
             VER=`cat /etc/centos-release | cut -d' ' -f 4`
-            if [[ "${VER:0:3}" == "8.0" ]] ; then
+            if [[ "${VER:0:2}" == "8." ]] ; then
                 apply_qt_5101_centos8_patch
                 if [[ $? != 0 ]] ; then
                     return 1


### PR DESCRIPTION
### Description

Build_visit applied a patch for Qt to centos 8.0. The test was too specific and now that centos 8.1 is out, the patch doesn't get applied, but it needs to. I modified the test so that it applies to all versions of centos 8.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I used build_visit to build the third party libraries on a centos 8 system and it worked.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code