### PR TITLE
Enhance to automatically recognize multi-file multi-block CGNS files.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -33,7 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Removed the pbatch launch profile from the Lawrence Livermore National Laboratory's Max host profile.</li>
   <li>Enhanced the Pick Through Time to handle vectors, tensors, and arrays when picking original data. For vectors, the magnitude is used. For tensors and arrays, the major eigenvalue is used.</li>
-  <li>Enhanced the CGNS plugin to support a mesh decomposed across multiple CGNS files, one block per file as might be typical of file-per-processor parallel I/O. This requires that each file contain just a single CGNS mesh block. In addition, if all files do not also contain the same number of time steps, results will be indeterminate. Finally, the ensemble of CGNS files must be grouped together into a .visit file.</li>
+  <li>Enhanced the CGNS plugin to support a mesh decomposed across multiple CGNS files, one block per file as might be typical of file-per-processor parallel I/O. This requires that each file contain just a single CGNS mesh block. In addition, if all files do not also contain the same number of time steps, results will be indeterminate. The collection of CGNS files can be grouped together into a .visit file or follow the naming convention "basename.cgns.nblocks.iblock", where basename is any string, cgns is the string "cgns", nblocks is the number of blocks, and iblock is the block index.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

I enhanced VisIt to automatically recognize a collection of multi-file multi-block CGNS files when the filenames followed the convention "basename.cgns.nblocks.iblock", where basename is any series of characters, cgns is the string "cgns", nblocks is the number of blocks, and iblock is the block index.

### Type of change

- [X] New feature

### How Has This Been Tested?

I opened a collection of CGNS files that matched the naming collection and it recognized it. I opened a collection of VTK files that didn't match the naming collection and it handled that properly as well.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers