### PR TITLE
Add db expressions for VTK files

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -92,7 +92,7 @@ MESSAGE(STATUS "Configuring VisIt Binary Tarball Data Targets")
 # Set up archiver executable name (7z, 7za and p7zip are common ones)
 #-----------------------------------------------------------------------------
 IF(NOT VISIT_DATA_ARCHIVER_NAME)
-    list(APPEND VISIT_DATA_ARCHIVER_NAME "7z" "7za" "p7zip")
+    list(APPEND VISIT_DATA_ARCHIVER_NAME "7z" "7za" "7zr" "p7zip")
 ENDIF()
 
 #-----------------------------------------------------------------------------

--- a/data/vtk_test_data.7z
+++ b/data/vtk_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:746f5abc89bbf50217b7735e05d701407345a325a465767ede78141e3b59da32
-size 1039326
+oid sha256:e2111bf0cc3d983e8b79a8bb6ca60eeb2ae6297a27074d4a64e2c1de7365414d
+size 885892

--- a/src/databases/Shapefile/avtShapefileFileFormat.C
+++ b/src/databases/Shapefile/avtShapefileFileFormat.C
@@ -22,7 +22,6 @@
 #include <InvalidVariableException.h>
 #include <InvalidFilesException.h>
 #include <Expression.h>
-#include <ExpressionList.h>
 #include <DebugStream.h>
 #include <stdlib.h>
 

--- a/src/databases/VTK/avtVTKFileReader.C
+++ b/src/databases/VTK/avtVTKFileReader.C
@@ -665,6 +665,12 @@ avtVTKFileReader::ReadInDataset(int domain)
             std::vector<std::string> expr_substrs = StringHelpers::split(ve->GetValue(i),';');
             Expression::ExprType vtype = Expression::Unknown;
 
+            if (expr_substrs.size() != 3)
+            {
+                debug2 << "Ignoring invalid VisItExpression entry at index " << i << endl;
+                continue;
+            }
+
             if (!strcasecmp(expr_substrs[1].c_str(),"curve"))
                 vtype = Expression::CurveMeshVar;
             else if (!strcasecmp(expr_substrs[1].c_str(),"scalar"))

--- a/src/databases/VTK/avtVTKFileReader.h
+++ b/src/databases/VTK/avtVTKFileReader.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <void_ref_ptr.h>
 
+#include <ExpressionList.h>
+
 class vtkDataArray;
 class vtkDataSet;
 class vtkRectilinearGrid;
@@ -20,7 +22,6 @@ class vtkStructuredPoints;
 class vtkVisItXMLPDataReader;
 
 class DBOptionsAttributes;
-
 
 // ****************************************************************************
 //  Class: avtVTKFileReader
@@ -84,6 +85,8 @@ class DBOptionsAttributes;
 //    from the first non empty database for a collection of STSD databases
 //    that have been grouped into a multi data version using a visit file.
 //
+//    Mark C. Miller, Mon Mar  9 19:52:43 PDT 2020
+//    Add vtk_exprs to support expressions from VTK files.
 // ****************************************************************************
 
 class avtVTKFileReader
@@ -138,6 +141,7 @@ class avtVTKFileReader
     double                vtk_time;
     int                   vtk_cycle;
     std::string           vtk_meshname;
+    ExpressionList        vtk_exprs;
 
     std::string           fileExtension;
     std::string           pieceExtension;

--- a/src/databases/VTK/avtVTKWriter.C
+++ b/src/databases/VTK/avtVTKWriter.C
@@ -284,6 +284,7 @@ avtVTKWriter::WriteChunk(vtkDataSet *ds, int chunk)
         mn->SetNumberOfValues(used);
         mn->SetName("VisItExpressions");
         ds->GetFieldData()->AddArray(mn);
+        mn->Delete();
     }
 
     if (tetrahedralize)

--- a/src/databases/VTK/avtVTKWriter.h
+++ b/src/databases/VTK/avtVTKWriter.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include <ExpressionList.h>
+
 class DBOptionsAttributes;
 
 // ****************************************************************************
@@ -48,6 +50,9 @@ class DBOptionsAttributes;
 //
 //    Mark C. Miller, Tue Apr  9 18:44:50 PDT 2019
 //    Add tetrahedralize option.
+//
+//    Mark C. Miller, Mon Mar  9 19:51:15 PDT 2020
+//    Add exprList
 // ****************************************************************************
 
 class
@@ -66,6 +71,7 @@ avtVTKWriter : public virtual avtDatabaseWriter
     std::string    mbDirName;
     double         time;
     int            cycle;
+    ExpressionList exprList;
     bool           doBinary;
     bool           doXML;
     bool           tetrahedralize;

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Removed the pbatch launch profile from the Lawrence Livermore National Laboratory's Max host profile.</li>
   <li>Enhanced the Pick Through Time to handle vectors, tensors, and arrays when picking original data. For vectors, the magnitude is used. For tensors and arrays, the major eigenvalue is used.</li>
   <li>Enhanced the CGNS plugin to support a mesh decomposed across multiple CGNS files, one block per file as might be typical of file-per-processor parallel I/O. This requires that each file contain just a single CGNS mesh block. In addition, if all files do not also contain the same number of time steps, results will be indeterminate. Finally, the ensemble of CGNS files must be grouped together into a .visit file.</li>
+  <li>Enhanced VTK plugin to support reading and writing VisIt expressions as non-specific FIELD variable named "VisItExpressions" of type string. To see an example, look at the example file named <code>higher_order_triangles.vtk</code> in <a href="https://github.com/visit-dav/visit/blob/develop/data/vtk_test_data.7z?raw=true">vtk_test_data.7z</a></li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/databases/vtk.py
+++ b/src/test/tests/databases/vtk.py
@@ -80,6 +80,7 @@ def TestMaterials():
 
     TurnMaterialsOn()
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/globe_mats.vtk"))
 
 def TestXML():
     TestSection("VTK XML-style data files")
@@ -102,6 +103,7 @@ def TestXML():
     DrawPlots()
     Test("vtk_08")
     DeleteActivePlots()
+    CloseDatabase(data_path("vtk_xml_test_data/curv2d.vts"))
 
     OpenDatabase(data_path("vtk_xml_test_data/curv3d.vts"))
 
@@ -128,7 +130,7 @@ def TestXML():
     DrawPlots()
     Test("vtk_15")
     DeleteActivePlots()
-
+    CloseDatabase(data_path("vtk_xml_test_data/curv3d.vts"))
 
     OpenDatabase(data_path("vtk_xml_test_data/rect3d.vtr"))
 
@@ -155,6 +157,7 @@ def TestXML():
     DrawPlots()
     Test("vtk_22")
     DeleteActivePlots()
+    CloseDatabase(data_path("vtk_xml_test_data/rect3d.vtr"))
 
     OpenDatabase(data_path("vtk_xml_test_data/ucd2d.vtu"))
 
@@ -176,6 +179,7 @@ def TestXML():
     Test("vtk_27")
 
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_xml_test_data/ucd2d.vtu"))
 
 def TestHigherOrder():
     TestSection("Quadratic triangles in VTK")
@@ -211,6 +215,7 @@ def TestHigherOrder():
     DrawPlots()
     Test("vtk_29")
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/higher_order_triangles.vtk"))
 
 def TestNBLOCKS():
     TestSection("!NBLOCKS in a .visit file")
@@ -241,6 +246,7 @@ def TestNBLOCKS():
         txt = txt + "Cycle: %d, Time: %g\n" % (cycle, time)
     TestText("vtk_33", txt)
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/visitfile/dbA.visit"))
 
 def TestPVTU():
     TestSection("PVTU files")
@@ -254,6 +260,7 @@ def TestPVTU():
     DrawPlots()
     Test("vtk_34a")
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/blocks.pvtu"))
 
 def TestPVTI():
     TestSection("PVTI files")
@@ -263,6 +270,7 @@ def TestPVTI():
     ResetView()
     Test("vtk_35")
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_xml_test_data/earth.pvti"))
     
 def TestMixedTopology():
     TestSection("2D Unstructured grids with lines")
@@ -272,6 +280,7 @@ def TestMixedTopology():
     ResetView()
     Test("vtk_36")
     DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/test_bound.vtk"))
 
 def TestVTM():
     TestSection("VTM files")
@@ -355,6 +364,29 @@ def TestVTKGhostType():
     DeleteAllPlots()
     CloseDatabase(data_path("vtk_test_data/vtkGhostType.vtk"))
 
+def TestDBExpressions():
+    TestSection("Database Expressions in VTK")
+    OpenDatabase(data_path("vtk_test_data/higher_order_triangles.vtk"))
+
+    AddPlot("Mesh", "highorder_triangles");
+    AddPlot("Pseudocolor", "x")
+    AddPlot("Vector", "posvec")
+    DrawPlots()
+
+    v = View3DAttributes()
+    v.viewNormal = (-0.429056, 0.759111, 0.489553)
+    v.viewUp = (-0.901832, -0.39065, -0.184638)
+    v.parallelScale = 1.73205
+    v.nearPlane = -3.4641
+    v.farPlane = 3.4641
+    v.imageZoom = 1.45106
+    SetView3D(v)
+
+    Test("vtk_46")
+    DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/higher_order_triangles.vtk"))
+
+
 TestMaterials()
 TestXML()
 TestHigherOrder()
@@ -365,5 +397,6 @@ TestMixedTopology()
 TestVTM()
 TestPVTK()
 TestVTKGhostType()
+TestDBExpressions()
 
 Exit()

--- a/test/baseline/databases/vtk/vtk_46.png
+++ b/test/baseline/databases/vtk/vtk_46.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e314930fdb06b9752dfc916b2c8eda0cf219daad511e704ca7c04141fba58835
+size 48598


### PR DESCRIPTION
Resolves #4410 

This adds database expressions to VTK files (in both the reader and writer part of the VTK plugin) as non-specific (e.g. NOT cell or point data) string valued FIELD data.

I wanted to use a 3-component x N tuple where the 3 components would be the expression name, type and definition. However, VTK doesn't appear to support more than a single component of `vtkStringArrays` so I opted to use a semicolon separated string of the form `name;type;defn` where `type` substring is something like `scalar`, `vector`, etc.

This is what it looks like in a VTK ascii file

```
# vtk DataFile Version 3.0
a_FPI.060112.113129.glb
ASCII
DATASET UNSTRUCTURED_GRID
FIELD FieldData 2
MeshName 1 1 string
highorder_triangles

VisItExpressions 1 4 string
x;scalar;coord(<highorder_triangles>)[0]
y;scalar;coord(<highorder_triangles>)[1]
z;scalar;coord(<highorder_triangles>)[2]
posvec;vector;{x,y,z}
```

I added a test in one of the VTK test data files including adding a bunch of calls to `CloseDatabase()` to the .py file and updated the release notes (yay, I remembered)

### Ride-alongs

- Added `7zr` as one of the names of the 7z utility to `data/CMakeLists.txt`
- Removed unneeded `#include <ExpressionList.h>` in ShapeFile plugin