### PR TITLE
build_visit: use 3.1.0 as ver to allow proper fetch url

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -36,7 +36,7 @@
 #5  bv_<module>_depends_on [not implemented yet], also may be removed in favor of xml structure
 #6. bv_<module>_build builds the module
 
-export VISIT_VERSION=${VISIT_VERSION:-"3.2.0"}
+export VISIT_VERSION=${VISIT_VERSION:-"3.1.0"}
 
 ####
 # Trunk:


### PR DESCRIPTION
until 3.2.0 release exists

### Description

We still need to use 3.1.0 so build_visit can find the proper tarballs

### Type of change

Please select one below (*Please click check boxes AFTER submitting ticket*)

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I have a build_visit instance running now with these changes, that failed to fetch before them.

