### PR TITLE
Add a patch for building qt with gcc 9.2 to build_visit.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -40,7 +40,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.2</font></b></p>
 <ul>
-  <li></li>
+  <li>The build_visit script was enhanced to allow VisIt to build on Ubuntu 19.10 systems using gcc 9.2.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -249,9 +249,13 @@ function apply_qt_patch
             fi
         fi
 
-        apply_qt_5101_gcc_9_2_patch
-        if [[ $? != 0 ]] ; then
-            return 1
+        if [[ "$OPSYS" == "Linux" ]]; then
+            if [[ "$C_COMPILER" == "gcc" ]]; then
+                apply_qt_5101_gcc_9_2_patch
+                if [[ $? != 0 ]] ; then
+                    return 1
+                fi
+            fi
         fi
     fi
 

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -248,6 +248,11 @@ function apply_qt_patch
                 fi
             fi
         fi
+
+        apply_qt_5101_gcc_9_2_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
     fi
 
     return 0
@@ -388,6 +393,32 @@ diff -c qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm.ori
 EOF
     if [[ $? != 0 ]] ; then
         warn "qt 5.10.1 macOS 10.14 patch failed."
+        return 1
+    fi
+    
+    return 0;
+}
+
+function apply_qt_gcc_9_2_patch
+{
+    info "Patching qt 5.10.1 for gcc 9.2"
+    patch -p0 <<EOF
+diff -c qtbase/src/corelib/global/qrandom.cpp.orig qtbase/src/corelib/global/qrandom.cpp
+*** qtbase/src/corelib/global/qrandom.cpp.orig	Mon Mar  9 17:09:47 2020
+--- qtbase/src/corelib/global/qrandom.cpp	Mon Mar  9 17:10:42 2020
+***************
+*** 220,225 ****
+--- 220,226 ----
+  #endif // Q_OS_WINRT
+  
+      static SystemGenerator &self();
++     typedef quint32 result_type;
+      void generate(quint32 *begin, quint32 *end) Q_DECL_NOEXCEPT_EXPR(FillBufferNoexcept);
+  
+      // For std::mersenne_twister_engine implementations that use something
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.10.1 gcc 9.2 patch failed."
         return 1
     fi
     

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -399,7 +399,7 @@ EOF
     return 0;
 }
 
-function apply_qt_gcc_9_2_patch
+function apply_qt_5101_gcc_9_2_patch
 {
     info "Patching qt 5.10.1 for gcc 9.2"
     patch -p0 <<EOF

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -238,20 +238,18 @@ function apply_qt_patch
             if [[ $? != 0 ]] ; then
                 return 1
             fi
-        fi
 
-        if [[ "$OPSYS" == "Darwin" ]]; then
-            if [[ `sw_vers -productVersion` == 10.14.[0-9]* ]]; then
-                apply_qt_5101_macos_mojave_patch
+            if [[ "$C_COMPILER" == "gcc" ]]; then
+                apply_qt_5101_gcc_9_2_patch
                 if [[ $? != 0 ]] ; then
                     return 1
                 fi
             fi
         fi
 
-        if [[ "$OPSYS" == "Linux" ]]; then
-            if [[ "$C_COMPILER" == "gcc" ]]; then
-                apply_qt_5101_gcc_9_2_patch
+        if [[ "$OPSYS" == "Darwin" ]]; then
+            if [[ `sw_vers -productVersion` == 10.14.[0-9]* ]]; then
+                apply_qt_5101_macos_mojave_patch
                 if [[ $? != 0 ]] ; then
                     return 1
                 fi


### PR DESCRIPTION
### Description

I updated build_visit so that it compiles VisIt on ubuntu 19.10 systems. This involved adding a patch to Qt. The rest of the third party libraries and VisIt all built fine.

### Type of change

- [X] New feature

### How Has This Been Tested?

I used build_visit to build VisIt on an ubuntu 19.10 system as well as building Qt on a RHEL7 system. In both cases things built correctly.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers