### PR TITLE
Fix VTK test failures

### DIFF
--- a/data/vtk_test_data.7z
+++ b/data/vtk_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2111bf0cc3d983e8b79a8bb6ca60eeb2ae6297a27074d4a64e2c1de7365414d
-size 885892
+oid sha256:d0b5a3b55de64e7eeece81e538c0ba439608df8574080e2c1ac228101ac15dee
+size 886002

--- a/test/baseline/databases/vtk/vtk_46.png
+++ b/test/baseline/databases/vtk/vtk_46.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e314930fdb06b9752dfc916b2c8eda0cf219daad511e704ca7c04141fba58835
-size 48598
+oid sha256:277a5eac529f5c2013eccadf1c5523ac6c128b9b8387e04beb3b681261b70709
+size 47560


### PR DESCRIPTION
I introduced two problems to last night's tests...

- Generated image for test result`vtk_46.png` originally on OSX doesn't match pixel-for-pixel with test system.
- `vtk_test_data.7z` was missing some files! I don't know how I managed that.
   - I grabbed preceding version, unarchived it, merge the change I needed from yesterday's work on VTK plugin db expressions and re-archived it. 
   - The result was 20% smaller! I checked and confirmed all files matched previous except for my changes (see xxdiff screen capture below) but noticed the LZMA *Method* was different. So, maybe the 7z tool I am using now does a better job??
 
![Untitled](https://user-images.githubusercontent.com/5720676/76467026-ea4eae00-63a5-11ea-8e92-8c018733d3b4.png)
