### PR TITLE
Add a patch for building qt with gcc 9.2 to build_visit. (#4493)

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -44,7 +44,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.2</font></b></p>
 <ul>
-  <li></li>
+  <li>The build_visit script was enhanced to allow VisIt to build on Ubuntu 19.10 systems using gcc 9.2.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -239,6 +239,13 @@ function apply_qt_patch
             if [[ $? != 0 ]] ; then
                 return 1
             fi
+
+            if [[ "$C_COMPILER" == "gcc" ]]; then
+                apply_qt_5101_gcc_9_2_patch
+                if [[ $? != 0 ]] ; then
+                    return 1
+                fi
+            fi
         fi
 
         if [[ "$OPSYS" == "Darwin" ]]; then
@@ -389,6 +396,32 @@ diff -c qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm.ori
 EOF
     if [[ $? != 0 ]] ; then
         warn "qt 5.10.1 macOS 10.14 patch failed."
+        return 1
+    fi
+    
+    return 0;
+}
+
+function apply_qt_5101_gcc_9_2_patch
+{
+    info "Patching qt 5.10.1 for gcc 9.2"
+    patch -p0 <<EOF
+diff -c qtbase/src/corelib/global/qrandom.cpp.orig qtbase/src/corelib/global/qrandom.cpp
+*** qtbase/src/corelib/global/qrandom.cpp.orig	Mon Mar  9 17:09:47 2020
+--- qtbase/src/corelib/global/qrandom.cpp	Mon Mar  9 17:10:42 2020
+***************
+*** 220,225 ****
+--- 220,226 ----
+  #endif // Q_OS_WINRT
+  
+      static SystemGenerator &self();
++     typedef quint32 result_type;
+      void generate(quint32 *begin, quint32 *end) Q_DECL_NOEXCEPT_EXPR(FillBufferNoexcept);
+  
+      // For std::mersenne_twister_engine implementations that use something
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.10.1 gcc 9.2 patch failed."
         return 1
     fi
     


### PR DESCRIPTION
Merge from the 3.1RC to develop.