### PR TITLE
Bugfix/maguire7/lines reader rc

### DIFF
--- a/data/lines_test_data.7z
+++ b/data/lines_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5a9949e90e5e603bdaa1b16490fa3fe6b95f5997e8fa63652bd63133d958ae8
-size 3101
+oid sha256:4caa6b4e80a09a6f03af1d95d9ee66f6eb5f4718df8b429549fbd0c4441f854e
+size 3176

--- a/src/databases/Lines/avtLinesFileFormat.C
+++ b/src/databases/Lines/avtLinesFileFormat.C
@@ -22,8 +22,6 @@
 #include <StringHelpers.h>
 #include <InvalidFilesException.h>
 
-#include "visit_gzstream.h"
-
 
 using std::vector;
 using std::string;
@@ -175,6 +173,9 @@ avtLinesFileFormat::GetVar(int, const char *name)
 //    Jeremy Meredith, Fri Jan  8 16:40:54 EST 2010
 //    If we didn't get any data, it's not a Lines file so throw an exception.
 //
+//    Alister Maguire, Tue Mar 17 08:50:32 PDT 2020
+//    Get the dimensionality of the line mesh.
+//
 // ****************************************************************************
 
 void
@@ -188,12 +189,23 @@ avtLinesFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
                        "Parsed nothing useful from the file.");
     }
 
+    visit_ifstream ifile(filename.c_str());
+
+    if (ifile().fail())
+    {
+        debug1 << "Unable to open file " << filename.c_str() << endl;
+        return;
+    }
+
+    int meshDims = GetDimensionality(ifile);
+    ifile.close();
+
     avtMeshMetaData *mesh = new avtMeshMetaData;
     mesh->name = "Lines";
     mesh->meshType = AVT_UNSTRUCTURED_MESH;
     mesh->numBlocks = (int)lines.size();
     mesh->blockOrigin = 0;
-    mesh->spatialDimension = 3;
+    mesh->spatialDimension = meshDims;
     mesh->topologicalDimension = 1;
     mesh->blockNames = lineNames;
     mesh->blockTitle = "lines";
@@ -228,6 +240,10 @@ avtLinesFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
 //    Hank Childs, Tue Apr  8 09:10:58 PDT 2003
 //    Open the file here.
 //
+//    Alister Maguire, Tue Mar 17 08:50:32 PDT 2020
+//    Don't remove consecutive points if they are on different lines. Also,
+//    let's close the file when we're done with it.
+//
 // ****************************************************************************
 
 void
@@ -250,6 +266,8 @@ avtLinesFileFormat::ReadFile(void)
     vector<float> zl;
     vector<int>   cutoff;
     string  headerName = "";
+    bool newLine = true;
+
     while (!ifile().eof())
     {
         float   x, y, z;
@@ -260,10 +278,15 @@ avtLinesFileFormat::ReadFile(void)
             {
                 lineNames.push_back(headerName);
                 headerName = "";
+                newLine    = true;
             }
             size_t len = xl.size();
             bool shouldAddPoint = true;
-            if (len > 0)
+
+            //
+            // Remove consecutive, repeating points for each line.
+            //
+            if (len > 0 && !newLine)
             {
                 if (x == xl[len-1] && y == yl[len-1] && z == zl[len-1])
                 {
@@ -276,6 +299,8 @@ avtLinesFileFormat::ReadFile(void)
                 yl.push_back(y);
                 zl.push_back(z);
             }
+
+            newLine = false;
         }
         else
         {
@@ -285,7 +310,9 @@ avtLinesFileFormat::ReadFile(void)
             }
             cutoff.push_back((int)xl.size());
         }
-    }  
+    }
+
+    ifile.close();
 
     //
     // Now we can construct the lines as vtkPolyData.
@@ -415,3 +442,45 @@ avtLinesFileFormat::GetPoint(istream &ifile, float &x, float &y, float &z,
 }
 
 
+// ****************************************************************************
+//  Method: avtLinesFileFormat::GetDimensionality
+//
+//  Purpose:
+//    Make a pass through the file to determine dimensionality.
+//
+//  Arguments:
+//    ifile    The input file containing our lines.
+//
+//  Returns:
+//    The dimensions of the lines.
+//
+//  Programmer: Alister Maguire
+//  Creation:   March 16, 2020
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+int
+avtLinesFileFormat::GetDimensionality(visit_ifstream &ifile)
+{
+    //
+    // Assume we're in 2d until proven otherwise.
+    //
+    int dims = 2;
+    while (!ifile().eof())
+    {
+        float x, y, z;
+        string lineName;
+
+        if (GetPoint(ifile(), x, y, z, lineName))
+        {
+            if (z != 0.0)
+            {
+                dims = 3;
+            }
+        }
+    }
+
+    return dims;
+}

--- a/src/databases/Lines/avtLinesFileFormat.h
+++ b/src/databases/Lines/avtLinesFileFormat.h
@@ -15,6 +15,8 @@
 #include <string>
 #include <visitstream.h>
 
+#include "visit_gzstream.h"
+
 
 class     vtkPolyData;
 
@@ -31,6 +33,9 @@ class     vtkPolyData;
 //  Modifications:
 //    Kathleen Bonnell, Fri Feb  8 11:03:49 PST 2002
 //    vtkScalars has been deprecated in VTK 4.0, use vtkDataArray instead.
+//
+//    Alister Maguire, Tue Mar 17 08:50:32 PDT 2020
+//    Added GetDimensionality.
 //
 // ****************************************************************************
 
@@ -57,6 +62,7 @@ class avtLinesFileFormat : public avtSTMDFileFormat
     void                  ReadFile(void);
     bool                  GetPoint(istream &, float &, float &, float &,
                                    std::string &);
+    int                   GetDimensionality(visit_ifstream &);
 };
 
 

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -29,6 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed an issue where the pick operator would choose ghost zones while picking from mili datasets.</li>
   <li>Fixed bugs with the Blueprint plugin for cases where domain data also exists in the root file.</li>
   <li>Fixed ability to save a movie template via the Save Movie Wizard on Windows.</li>
+  <li>Fixed bugs with the avtLinesFileFormat reader. The reader can now distinguish 2D from 3D, and it will not remove identical consecutive points that exist on different lines.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/databases/lines.py
+++ b/src/test/tests/databases/lines.py
@@ -1,0 +1,76 @@
+# ----------------------------------------------------------------------------
+#  CLASSES: nightly
+#
+#  Test Case:  lines.py
+#
+#  Tests:      mesh      - 2D lines (unstructured), 3D lines (unstructured)
+#              plots     - mesh
+#
+#  Programmer: Alister Maguire
+#  Date:       Tue Mar 17 08:50:32 PDT 2020
+#
+#  Modifications:
+#
+# ----------------------------------------------------------------------------
+
+def TestMeshPlot():
+
+    #
+    # First, let's make sure that 3d lines are read appropriately.
+    #
+    v = GetView3D()
+    v.viewNormal = (0.9, 0.35, -0.88)
+    SetView3D(v)
+
+    OpenDatabase(data_path("lines_test_data/spring.lines"))
+    AddPlot("Mesh", "Lines", 1, 1)
+    DrawPlots()
+    Query("SpatialExtents")
+
+    # Check dimensionality.
+    ext_len = len(GetQueryOutputValue())
+    AssertEqual("Verifying 3D lines", ext_len, 6)
+
+    # Check the rendering.
+    Test("mesh_plot_00")
+    DeleteAllPlots()
+    CloseDatabase(data_path("lines_test_data/spring.lines"))
+
+    #
+    # Next, let's check 2d lines.
+    #
+    OpenDatabase(data_path("lines_test_data/2d.lines"))
+    AddPlot("Mesh", "Lines", 1, 1)
+    DrawPlots()
+    Query("SpatialExtents")
+
+    # Check dimensionality.
+    ext_len = len(GetQueryOutputValue())
+    AssertEqual("Verifying 2D lines", ext_len, 4)
+
+    # Check the rendering.
+    Test("mesh_plot_01")
+    DeleteAllPlots()
+
+    CloseDatabase(data_path("lines_test_data/2d.lines"))
+
+    #
+    # This test makes sure that consecutive points are only
+    # removed from one line at a time.
+    #
+    OpenDatabase(data_path("lines_test_data/consecutive.lines"))
+    AddPlot("Mesh", "Lines", 1, 1)
+    DrawPlots()
+
+    # Check the rendering.
+    Test("mesh_plot_02")
+    DeleteAllPlots()
+
+    CloseDatabase(data_path("lines_test_data/consecutive.lines"))
+
+
+def main():
+    TestMeshPlot()
+    Exit()
+
+main()

--- a/test/baseline/databases/lines/mesh_plot_00.png
+++ b/test/baseline/databases/lines/mesh_plot_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b50169482520068ab1bbf3c7c57be0277b7670bbd933f51e4bcfc64580b962c
+size 1434

--- a/test/baseline/databases/lines/mesh_plot_01.png
+++ b/test/baseline/databases/lines/mesh_plot_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc77dc981d59a4f0c4f67c87a69250e8109aa9a20122566b6aaa17e452172b4e
+size 1723

--- a/test/baseline/databases/lines/mesh_plot_02.png
+++ b/test/baseline/databases/lines/mesh_plot_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a50f644a567ebdb9897c8abd41c18a51b6ef965985528e3aafa5f811e97c9fb
+size 1745


### PR DESCRIPTION
### Description

Resolves #4508 

This resolves 2 issues with the lines file reader:
1. 2D vs 3D is now recognized. 
2. Identical consecutive points are only removed if they exist on the same line. 

I've also changed the extension of the single lines example that we had in testdata—the extension it had was apparently wrong (VisIt had no idea how to open it), and it wasn't being used in any of our tests—and I've added 2 new datasets. There was also no tests for this reader, so I've added a test file.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?
I added lines.py to the test suite. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [x] I have added debugging support to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
