### PR TITLE
apply @mathstuf patches to _export files.

### DIFF
--- a/src/avt/DBAtts/MetaData/dbatts_exports.h
+++ b/src/avt/DBAtts/MetaData/dbatts_exports.h
@@ -6,10 +6,14 @@
 #define DBATTS_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTDBATTS_EXPORTS) || defined(avtdbatts_EXPORTS)
 #define DBATTS_API __declspec(dllexport)
 #else
 #define DBATTS_API __declspec(dllimport)
+#endif
+#else
+#define DBATTS_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about signed/unsigned comparison.

--- a/src/avt/DataBinning/dbin_exports.h
+++ b/src/avt/DataBinning/dbin_exports.h
@@ -6,10 +6,14 @@
 #define AVTDBIN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTDBIN_EXPORTS) || defined(avtdbin_ser_EXPORTS) || defined(avtdbin_par_EXPORTS) 
 #define AVTDBIN_API __declspec(dllexport)
 #else
 #define AVTDBIN_API __declspec(dllimport)
+#endif
+#else
+#define AVTDBIN_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/Database/Database/database_exports.h
+++ b/src/avt/Database/Database/database_exports.h
@@ -6,10 +6,14 @@
 #define DATABASE_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTDATABASE_EXPORTS) || defined(avtdatabase_ser_EXPORTS) || defined(avtdatabase_par_EXPORTS)
 #define DATABASE_API __declspec(dllexport)
 #else
 #define DATABASE_API __declspec(dllimport)
+#endif
+#else
+#define DATABASE_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about possible loss of data

--- a/src/avt/Expressions/Abstract/expression_exports.h
+++ b/src/avt/Expressions/Abstract/expression_exports.h
@@ -6,10 +6,14 @@
 #define EXPRESSION_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTEXPRESSION_EXPORTS) || defined(avtexpressions_ser_EXPORTS) || defined(avtexpressions_par_EXPORTS)
 #define EXPRESSION_API __declspec(dllexport)
 #else
 #define EXPRESSION_API __declspec(dllimport)
+#endif
+#else
+#define EXPRESSION_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about inheritance by dominance.

--- a/src/avt/FileWriter/file_writer_exports.h
+++ b/src/avt/FileWriter/file_writer_exports.h
@@ -6,10 +6,14 @@
 #define AVTFILEWRITER_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTWRITER_EXPORTS) || defined(avtwriter_ser_EXPORTS) || defined(avtwriter_par_EXPORTS)
 #define AVTFILEWRITER_API __declspec(dllexport)
 #else
 #define AVTFILEWRITER_API __declspec(dllimport)
+#endif
+#else
+#define AVTFILEWRITER_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/Filters/filters_exports.h
+++ b/src/avt/Filters/filters_exports.h
@@ -6,10 +6,14 @@
 #define AVTFILTERS_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTFILTERS_EXPORTS) || defined(avtfilters_ser_EXPORTS) || defined(avtfilters_par_EXPORTS)
 #define AVTFILTERS_API __declspec(dllexport)
 #else
 #define AVTFILTERS_API __declspec(dllimport)
+#endif
+#else
+#define AVTFILTERS_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/IVP/ivp_exports.h
+++ b/src/avt/IVP/ivp_exports.h
@@ -6,10 +6,14 @@
 #define IVP_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTIVP_EXPORTS) || defined(avtivp_ser_EXPORTS) || defined(avtivp_par_EXPORTS)
 #define IVP_API __declspec(dllexport)
 #else
 #define IVP_API __declspec(dllimport)
+#endif
+#else
+#define IVP_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/MIR/Base/mir_exports.h
+++ b/src/avt/MIR/Base/mir_exports.h
@@ -6,10 +6,14 @@
 #define MIR_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTMIR_EXPORTS) || defined(avtmir_ser_EXPORTS) || defined(avtmir_par_EXPORTS)
 #define MIR_API __declspec(dllexport)
 #else
 #define MIR_API __declspec(dllimport)
+#endif
+#else
+#define MIR_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about possible loss of data

--- a/src/avt/Math/math_exports.h
+++ b/src/avt/Math/math_exports.h
@@ -6,10 +6,14 @@
 #define MATH_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTMATH_EXPORTS) || defined(avtmath_EXPORTS)
 #define MATH_API __declspec(dllexport)
 #else
 #define MATH_API __declspec(dllimport)
+#endif
+#else
+#define MATH_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/Pipeline/Data/pipeline_exports.h
+++ b/src/avt/Pipeline/Data/pipeline_exports.h
@@ -6,10 +6,14 @@
 #define PIPELINE_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTPIPELINE_EXPORTS) || defined(avtpipeline_ser_EXPORTS) || defined(avtpipeline_par_EXPORTS)
 #define PIPELINE_API __declspec(dllexport)
 #else
 #define PIPELINE_API __declspec(dllimport)
+#endif
+#else
+#define PIPELINE_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about inheritance by dominance.

--- a/src/avt/Plotter/plotter_exports.h
+++ b/src/avt/Plotter/plotter_exports.h
@@ -6,10 +6,14 @@
 #define PLOTTER_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTPLOTTER_EXPORTS) || defined(avtplotter_ser_EXPORTS) || defined(avtplotter_par_EXPORTS)
 #define PLOTTER_API __declspec(dllexport)
 #else
 #define PLOTTER_API __declspec(dllimport)
+#endif
+#else
+#define PLOTTER_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about inheritance by dominance.

--- a/src/avt/Preprocessor/prep_exports.h
+++ b/src/avt/Preprocessor/prep_exports.h
@@ -6,10 +6,14 @@
 #define PREP_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #ifdef PREP_EXPORTS
 #define PREP_API __declspec(dllexport)
 #else
 #define PREP_API __declspec(dllimport)
+#endif
+#else
+#define PREP_API
 #endif
 #else
 # if __GNUC__ >= 4 && defined(PREP_EXPORTS)

--- a/src/avt/PythonFilters/python_filters_exports.h
+++ b/src/avt/PythonFilters/python_filters_exports.h
@@ -6,10 +6,14 @@
 #define AVTPYTHON_FILTERS_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTPYTHONFILTERS_EXPORTS) || defined(avtpythonfilters_ser_EXPORTS) || defined(avtpythonfilters_par_EXPORTS) 
 #define AVTPYTHON_FILTERS_API __declspec(dllexport)
 #else
 #define AVTPYTHON_FILTERS_API __declspec(dllimport)
+#endif
+#else
+#define AVTPYTHON_FILTERS_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/QtVisWindow/qtviswindow_exports.h
+++ b/src/avt/QtVisWindow/qtviswindow_exports.h
@@ -6,10 +6,14 @@
 #define QTVISWINDOW_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTQTVISWINDOW_EXPORTS) || defined (avtqtviswindow_EXPORTS)
 #define QTVISWINDOW_API __declspec(dllexport)
 #else
 #define QTVISWINDOW_API __declspec(dllimport)
+#endif
+#else
+#define QTVISWINDOW_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/Queries/Abstract/query_exports.h
+++ b/src/avt/Queries/Abstract/query_exports.h
@@ -6,10 +6,14 @@
 #define QUERY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTQUERY_EXPORTS) || defined(avtquery_ser_EXPORTS) || defined(avtquery_par_EXPORTS)
 #define QUERY_API __declspec(dllexport)
 #else
 #define QUERY_API __declspec(dllimport)
+#endif
+#else
+#define QUERY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about inheritance by dominance.

--- a/src/avt/Shapelets/shapelets_exports.h
+++ b/src/avt/Shapelets/shapelets_exports.h
@@ -6,10 +6,14 @@
 #define AVTSHAPELETS_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTSHAPELETS_EXPORTS) || defined(avtshapelets_EXPORTS)
 #define AVTSHAPELETS_API __declspec(dllexport)
 #else
 #define AVTSHAPELETS_API __declspec(dllimport)
+#endif
+#else
+#define AVTSHAPELETS_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/View/view_exports.h
+++ b/src/avt/View/view_exports.h
@@ -6,10 +6,14 @@
 #define AVTVIEW_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(AVTVIEW_EXPORTS) || defined(avtview_EXPORTS)
 #define AVTVIEW_API __declspec(dllexport)
 #else
 #define AVTVIEW_API __declspec(dllimport)
+#endif
+#else
+#define AVTVIEW_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/avt/VisWindow/VisWindow/viswindow_exports.h
+++ b/src/avt/VisWindow/VisWindow/viswindow_exports.h
@@ -6,12 +6,17 @@
 #define VISWINDOW_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VISWINDOW_EXPORTS) || defined(avtviswindow_ser_EXPORTS) || defined(avtviswindow_par_EXPORTS)
 #define VISWINDOW_API  __declspec(dllexport)
 #define VISWINDOW_API2 __declspec(dllexport)
 #else
 #define VISWINDOW_API  __declspec(dllimport)
 #define VISWINDOW_API2 __declspec(dllimport)
+#endif
+#else
+#define VISWINDOW_API
+#define VISWINDOW_API2
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/common/Exceptions/Pipeline/avtexception_exports.h
+++ b/src/common/Exceptions/Pipeline/avtexception_exports.h
@@ -6,10 +6,14 @@
 #define AVTEXCEPTION_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(AVTEXCEPTION_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define AVTEXCEPTION_API __declspec(dllexport)
 # else
 #   define AVTEXCEPTION_API __declspec(dllimport)
+#endif
+#else
+#define AVTEXCEPTION_API
 # endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/common/comm/comm_exports.h
+++ b/src/common/comm/comm_exports.h
@@ -7,6 +7,7 @@
 
 #if defined(_WIN32)
 # define DESCRIPTOR unsigned int
+#if !defined(VISIT_STATIC)
 # if defined(COMM_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define COMM_API  __declspec(dllexport)
 #   define COMM_API2 __declspec(dllexport)
@@ -14,6 +15,10 @@
 #   define COMM_API  __declspec(dllimport)
 #   define COMM_API2 __declspec(dllimport)
 # endif
+#else
+#define COMM_API
+#define COMM_API2
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/common/expr/expr_exports.h
+++ b/src/common/expr/expr_exports.h
@@ -6,6 +6,7 @@
 #define EXPR_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(EXPR_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define EXPR_API  __declspec(dllexport)
 #   define EXPR_API2 __declspec(dllexport)
@@ -13,6 +14,10 @@
 #   define EXPR_API  __declspec(dllimport)
 #   define EXPR_API2 __declspec(dllimport)
 # endif
+#else
+#define EXPR_API
+#define EXPR_API2
+#endif
 # ifdef _MSC_VER
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/common/misc/misc_exports.h
+++ b/src/common/misc/misc_exports.h
@@ -6,6 +6,7 @@
 #define MISC_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(MISC_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define MISC_API  __declspec(dllexport)
 #   define MISC_API2 __declspec(dllexport)
@@ -13,6 +14,10 @@
 #   define MISC_API  __declspec(dllimport)
 #   define MISC_API2 __declspec(dllimport)
 # endif
+#else
+#define MISC_API
+#define MISC_API2
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/common/parser/parser_exports.h
+++ b/src/common/parser/parser_exports.h
@@ -6,6 +6,7 @@
 #define PARSER_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(PARSER_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define PARSER_API  __declspec(dllexport)
 #   define PARSER_API2 __declspec(dllexport)
@@ -13,6 +14,10 @@
 #   define PARSER_API  __declspec(dllimport)
 #   define PARSER_API2 __declspec(dllimport)
 # endif
+#else
+#define PARSER_API
+#define PARSER_API2
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/common/plugin/database_plugin_exports.h
+++ b/src/common/plugin/database_plugin_exports.h
@@ -6,7 +6,11 @@
 #define DATABASE_PLUGIN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # define DBP_EXPORT __declspec(dllexport)
+#else
+#define DBP_EXPORT
+#endif
 #else
 # if __GNUC__ >= 4
 #   define DBP_EXPORT __attribute__((visibility("default")))

--- a/src/common/plugin/operator_plugin_exports.h
+++ b/src/common/plugin/operator_plugin_exports.h
@@ -6,7 +6,11 @@
 #define Operator_PLUGIN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # define OP_EXPORT __declspec(dllexport)
+#else
+#define OP_EXPORT
+#endif
 #else
 # if __GNUC__ >= 4
 #   define OP_EXPORT __attribute__((visibility("default")))

--- a/src/common/plugin/plot_plugin_exports.h
+++ b/src/common/plugin/plot_plugin_exports.h
@@ -6,7 +6,11 @@
 #define PLOT_PLUGIN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # define PLOT_EXPORT __declspec(dllexport)
+#else
+#define PLOT_EXPORT
+#endif
 #else
 # if __GNUC__ >= 4
 #   define PLOT_EXPORT __attribute__((visibility("default")))

--- a/src/common/plugin/plugin_exports.h
+++ b/src/common/plugin/plugin_exports.h
@@ -6,6 +6,7 @@
 #define PLUGIN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(PLUGIN_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define PLUGIN_API  __declspec(dllexport)
 #   define PLUGIN_API2 __declspec(dllexport)
@@ -13,6 +14,10 @@
 #   define PLUGIN_API  __declspec(dllimport)
 #   define PLUGIN_API2 __declspec(dllimport)
 # endif
+#else
+#define PLUGIN_API
+#define PLUGIN_API2
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about inheritance by dominance.
 #   pragma warning(disable:4250)

--- a/src/common/proxybase/proxybase_exports.h
+++ b/src/common/proxybase/proxybase_exports.h
@@ -6,11 +6,15 @@
 #define PROXYBASE_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(PROXYBASE_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define PROXYBASE_API __declspec(dllexport)
 # else
 #   define PROXYBASE_API __declspec(dllimport)
 # endif
+#else
+#define PROXYBASE_API
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/common/state/state_exports.h
+++ b/src/common/state/state_exports.h
@@ -6,11 +6,15 @@
 #define STATE_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(STATE_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define STATE_API __declspec(dllexport)
 # else
 #   define STATE_API __declspec(dllimport)
 # endif
+#else
+#define STATE_API
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/common/utility/utility_exports.h
+++ b/src/common/utility/utility_exports.h
@@ -6,11 +6,15 @@
 #define UTILITY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 # if defined(UTILITY_EXPORTS) || defined(visitcommon_EXPORTS)
 #   define UTILITY_API __declspec(dllexport)
 # else
 #   define UTILITY_API __declspec(dllimport)
 # endif
+#else
+#define UTILITY_API
+#endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface
 #   pragma warning(disable:4251)

--- a/src/databases/FieldViewXDB/include/VXDB_exports.h
+++ b/src/databases/FieldViewXDB/include/VXDB_exports.h
@@ -8,10 +8,14 @@
 #define VXDB_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VXDB_ser_EXPORTS) || defined(VXDB_par_EXPORTS)
 #define VXDB_API __declspec(dllexport)
 #else
 #define VXDB_API __declspec(dllimport)
+#endif
+#else
+#define VXDB_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/engine/main/engine_main_exports.h
+++ b/src/engine/main/engine_main_exports.h
@@ -6,10 +6,14 @@
 #define ENGINE_MAIN_EXPORTS_H
 
 #if defined(_WIN32)
-#  if defined(ENGINE_MAIN_EXPORTS) || defined(engine_ser_EXPORTS) || defined(engine_par_EXPORTS)
-#    define ENGINE_MAIN_API __declspec(dllexport)
+#  if !defined(VISIT_STATIC)
+#    if defined(ENGINE_MAIN_EXPORTS) || defined(engine_ser_EXPORTS) || defined(engine_par_EXPORTS)
+#      define ENGINE_MAIN_API __declspec(dllexport)
+#    else
+#      define ENGINE_MAIN_API __declspec(dllimport)
+#    endif
 #  else
-#    define ENGINE_MAIN_API __declspec(dllimport)
+#    define ENGINE_MAIN_API
 #  endif
 #  if defined(_MSC_VER)
 //   Turn off warning about lack of DLL interface

--- a/src/engine/proxy/engine_proxy_exports.h
+++ b/src/engine/proxy/engine_proxy_exports.h
@@ -6,10 +6,14 @@
 #define ENGINE_PROXY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(ENGINE_PROXY_EXPORTS) || defined(engineproxy_EXPORTS)
 #define ENGINE_PROXY_API __declspec(dllexport)
 #else
 #define ENGINE_PROXY_API __declspec(dllimport)
+#endif
+#else
+#define ENGINE_PROXY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/engine/rpc/engine_rpc_exports.h
+++ b/src/engine/rpc/engine_rpc_exports.h
@@ -6,10 +6,14 @@
 #define ENGINE_RPC_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(ENGINE_RPC_EXPORTS) || defined (enginerpc_EXPORTS)
 #define ENGINE_RPC_API __declspec(dllexport)
 #else
 #define ENGINE_RPC_API __declspec(dllimport)
+#endif
+#else
+#define ENGINE_RPC_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/gui/gui_exports.h
+++ b/src/gui/gui_exports.h
@@ -6,10 +6,14 @@
 #define GUI_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(GUI_EXPORTS) || defined(gui_EXPORTS)
 #define GUI_API __declspec(dllexport)
 #else
 #define GUI_API __declspec(dllimport)
+#endif
+#else
+#define GUI_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/launcher/proxy/vclproxy_exports.h
+++ b/src/launcher/proxy/vclproxy_exports.h
@@ -6,10 +6,14 @@
 #define LAUNCHER_PROXY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(LAUNCHER_PROXY_EXPORTS) || defined(vclproxy_EXPORTS)
 #define LAUNCHER_PROXY_API __declspec(dllexport)
 #else
 #define LAUNCHER_PROXY_API __declspec(dllimport)
+#endif
+#else
+#define LAUNCHER_PROXY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/launcher/rpc/vclrpc_exports.h
+++ b/src/launcher/rpc/vclrpc_exports.h
@@ -6,10 +6,14 @@
 #define LAUNCHER_RPC_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(LAUNCHER_RPC_EXPORTS) || defined(vclrpc_EXPORTS)
 #define LAUNCHER_RPC_API __declspec(dllexport)
 #else
 #define LAUNCHER_RPC_API __declspec(dllimport)
+#endif
+#else
+#define LAUNCHER_RPC_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/mdserver/main/mdsmain_exports.h
+++ b/src/mdserver/main/mdsmain_exports.h
@@ -6,10 +6,14 @@
 #define MDSERVER_MAIN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(MDSMAIN_EXPORTS) || defined(mdserverproxy_EXPORTS)
 #define MDSERVER_MAIN_API __declspec(dllexport)
 #else
 #define MDSERVER_MAIN_API __declspec(dllimport)
+#endif
+#else
+#define MDSERVER_MAIN_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/mdserver/proxy/mdsproxy_exports.h
+++ b/src/mdserver/proxy/mdsproxy_exports.h
@@ -6,10 +6,14 @@
 #define MDSERVER_PROXY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(MDSPROXY_EXPORTS) || defined(mdserverproxy_EXPORTS)
 #define MDSERVER_PROXY_API __declspec(dllexport)
 #else
 #define MDSERVER_PROXY_API __declspec(dllimport)
+#endif
+#else
+#define MDSERVER_PROXY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/mdserver/rpc/mdsrpc_exports.h
+++ b/src/mdserver/rpc/mdsrpc_exports.h
@@ -6,12 +6,17 @@
 #define MDSERVER_RPC_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(MDSERVER_RPC_EXPORTS) || defined(mdserverrpc_EXPORTS)
 #define MDSERVER_RPC_API  __declspec(dllexport)
 #define MDSERVER_RPC_API2 __declspec(dllexport)
 #else
 #define MDSERVER_RPC_API  __declspec(dllimport)
 #define MDSERVER_RPC_API2 __declspec(dllimport)
+#endif
+#else
+#define MDSERVER_RPC_API
+#define MDSERVER_RPC_API2
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/third_party_builtin/bow/bow_exports.h
+++ b/src/third_party_builtin/bow/bow_exports.h
@@ -6,10 +6,14 @@
 #define BOW_EXPORTS_H
 
 #if defined(_WIN32)
-# if defined(bow_EXPORTS)
+# if !defined(VISIT_STATIC)
+#  if defined(bow_EXPORTS)
 #   define BOW_API __declspec(dllexport)
-# else
+#  else
 #   define BOW_API __declspec(dllimport)
+#  endif
+# else
+#  define BOW_API
 # endif
 # if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/third_party_builtin/nek5000/nek5000_exports.h
+++ b/src/third_party_builtin/nek5000/nek5000_exports.h
@@ -6,10 +6,14 @@
 #define NEK5000_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(nek5000_interp_EXPORTS)
 #define NEK5000_API __declspec(dllexport)
 #else
 #define NEK5000_API __declspec(dllimport)
+#endif
+#else
+#define NEK5000_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/third_party_builtin/tess2/tess_exports.h
+++ b/src/third_party_builtin/tess2/tess_exports.h
@@ -3,10 +3,14 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 #if defined(_WIN32)
-  #if defined(tess2_EXPORTS)
-    #define TESS2_API __declspec(dllexport)
+  #if !defined(VISIT_STATIC)
+    #if defined(tess2_EXPORTS)
+      #define TESS2_API __declspec(dllexport)
+    #else
+      #define TESS2_API __declspec(dllimport)
+    #endif
   #else
-    #define TESS2_API __declspec(dllimport)
+    #define TESS2_API
   #endif
 #else
   #ifdef __cplusplus

--- a/src/viewer/core/viewercore_exports.h
+++ b/src/viewer/core/viewercore_exports.h
@@ -6,10 +6,14 @@
 #define VIEWERCORE_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VIEWERCORE_EXPORTS) || defined(viewercore_ser_EXPORTS) || defined(viewercore_par_EXPORTS)
 #define VIEWERCORE_API __declspec(dllexport)
 #else
 #define VIEWERCORE_API __declspec(dllimport)
+#endif
+#else
+#define VIEWERCORE_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/viewer/main/viewer_exports.h
+++ b/src/viewer/main/viewer_exports.h
@@ -6,10 +6,14 @@
 #define VIEWER_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VIEWER_EXPORTS) || defined(viewer_EXPORTS)
 #define VIEWER_API __declspec(dllexport)
 #else
 #define VIEWER_API __declspec(dllimport)
+#endif
+#else
+#define VIEWER_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/viewer/proxy/viewerproxy_exports.h
+++ b/src/viewer/proxy/viewerproxy_exports.h
@@ -6,10 +6,14 @@
 #define VIEWER_PROXY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VIEWER_PROXY_EXPORTS) || defined(viewerproxy_EXPORTS)
 #define VIEWER_PROXY_API __declspec(dllexport)
 #else
 #define VIEWER_PROXY_API __declspec(dllimport)
+#endif
+#else
+#define VIEWER_PROXY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/viewer/rpc/viewerrpc_exports.h
+++ b/src/viewer/rpc/viewerrpc_exports.h
@@ -6,10 +6,14 @@
 #define VIEWER_RPC_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VIEWER_RPC_EXPORTS) || defined(viewerrpc_EXPORTS)
 #define VIEWER_RPC_API __declspec(dllexport)
 #else
 #define VIEWER_RPC_API __declspec(dllimport)
+#endif
+#else
+#define VIEWER_RPC_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/viewer/subjectproxy/viewersubjectproxy_exports.h
+++ b/src/viewer/subjectproxy/viewersubjectproxy_exports.h
@@ -6,10 +6,14 @@
 #define VIEWER_SUBJECT_PROXY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VIEWER_SUBJECT_PROXY_EXPORTS)||defined(viewersubjectproxy_EXPORTS)
 #define VIEWER_SUBJECT_PROXY_API __declspec(dllexport)
 #else
 #define VIEWER_SUBJECT_PROXY_API __declspec(dllimport)
+#endif
+#else
+#define VIEWER_SUBJECT_PROXY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/visit_vtk/full/visit_vtk_exports.h
+++ b/src/visit_vtk/full/visit_vtk_exports.h
@@ -6,10 +6,14 @@
 #define VISIT_VTK_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VISIT_VTK_EXPORTS) || defined(visit_vtk_EXPORTS)
 #define VISIT_VTK_API __declspec(dllexport)
 #else
 #define VISIT_VTK_API __declspec(dllimport)
+#endif
+#else
+#define VISIT_VTK_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/visit_vtk/lightweight/visit_vtk_light_exports.h
+++ b/src/visit_vtk/lightweight/visit_vtk_light_exports.h
@@ -6,10 +6,14 @@
 #define VISIT_VTK_LIGHT_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VISIT_VTK_LIGHT_EXPORTS) || defined(lightweight_visit_vtk_EXPORTS)
 #define VISIT_VTK_LIGHT_API __declspec(dllexport)
 #else
 #define VISIT_VTK_LIGHT_API __declspec(dllimport)
+#endif
+#else
+#define VISIT_VTK_LIGHT_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/visit_vtk/offscreen/visit_vtk_offscreen_exports.h
+++ b/src/visit_vtk/offscreen/visit_vtk_offscreen_exports.h
@@ -6,10 +6,14 @@
 #define VISIT_VTK_OFFSCREEN_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VISIT_VTK_OFFSCREEN_EXPORTS) || defined(visit_vtk_offscreen_EXPORTS)
 #define VISIT_VTK_OFFSCREEN_API __declspec(dllexport)
 #else
 #define VISIT_VTK_OFFSCREEN_API __declspec(dllimport)
+#endif
+#else
+#define VISIT_VTK_OFFSCREEN_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/visitpy/pyui/common/guiwrapper_exports.h
+++ b/src/visitpy/pyui/common/guiwrapper_exports.h
@@ -6,10 +6,14 @@
 #define GUIWRAPPER_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(GUIWRAPPER_EXPORTS) || defined(guiwrapper_EXPORTS)
 #define GUIWRAPPER_API __declspec(dllexport)
 #else
 #define GUIWRAPPER_API __declspec(dllimport)
+#endif
+#else
+#define GUIWRAPPER_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/visitpy/visitpy/visitpy_exports.h
+++ b/src/visitpy/visitpy/visitpy_exports.h
@@ -6,10 +6,14 @@
 #define VISITPY_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VISITPY_EXPORTS) || defined(visitpy_EXPORTS)
 #define VISITPY_API __declspec(dllexport)
 #else
 #define VISITPY_API __declspec(dllimport)
+#endif
+#else
+#define VISITPY_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface

--- a/src/vtkqt/vtkqt_exports.h
+++ b/src/vtkqt/vtkqt_exports.h
@@ -6,10 +6,14 @@
 #define VTKQT_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(VTKQT_EXPORTS) || defined(vtkqt_EXPORTS)
 #define VTKQT_API __declspec(dllexport)
 #else
 #define VTKQT_API __declspec(dllimport)
+#endif
+#else
+#define VTKQT_API
 #endif
 #else
 # if __GNUC__ >= 4 && (defined(VTKQT_EXPORTS) || defined(vtkqt_EXPORTS))

--- a/src/winutil/winutil_exports.h
+++ b/src/winutil/winutil_exports.h
@@ -6,10 +6,14 @@
 #define WINUTIL_EXPORTS_H
 
 #if defined(_WIN32)
+#if !defined(VISIT_STATIC)
 #if defined(WINUTIL_EXPORTS) || defined(winutil_EXPORTS)
 #define WINUTIL_API __declspec(dllexport)
 #else
 #define WINUTIL_API __declspec(dllimport)
+#endif
+#else
+#define WINUTIL_API
 #endif
 #if defined(_MSC_VER)
 // Turn off warning about lack of DLL interface


### PR DESCRIPTION
@mathstuf I've begun applying some of your patches to VisIt's latest version. 
This PR is just for the _exports.h files.
Can you please take a look and verify my changes are in line with your original intent?
I changed #if defined(VISIT_BUILD_SHARED_LIBS) to #if !defined(VISIT_STATIC)

Also, there are other _exports.h in VisIt that didn't seem to be touched by your original patch.
Is this PR sufficient?