### PR TITLE
Task/maguire7/triangle strip normals rc

### DIFF
--- a/data/vtk_test_data.7z
+++ b/data/vtk_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2111bf0cc3d983e8b79a8bb6ca60eeb2ae6297a27074d4a64e2c1de7365414d
-size 885892
+oid sha256:2e31772b658343ee2247d5bb523172360e3c8105fc3f57e07262811bd2b7687f
+size 887114

--- a/src/avt/Filters/avtVertexNormalsFilter.C
+++ b/src/avt/Filters/avtVertexNormalsFilter.C
@@ -139,6 +139,9 @@ avtVertexNormalsFilter::~avtVertexNormalsFilter()
 //    and in fact removes them from the output, don't process the input if
 //    they are present.
 //
+//    Alister Maguire, Wed Mar 18 15:16:33 PDT 2020
+//    Updated vtkVisItPolyDataNormals filter to handle triangle strips.
+//
 // ****************************************************************************
 
 avtDataRepresentation *
@@ -169,10 +172,6 @@ avtVertexNormalsFilter::ExecuteData(avtDataRepresentation *in_dr)
     if (in_ds->GetDataObjectType() == VTK_POLY_DATA)
     {
         vtkPolyData *pd = (vtkPolyData *)in_ds;
-        // The polydata normals filter doesn't handle triangle strips, in fact
-        // it removes them, so don't process a dataset that contains them.
-        if (pd->GetNumberOfStrips() > 0)
-            return in_dr;
 
         bool pointNormals = true;
         if (atts.ValidActiveVariable())

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed bugs with the Blueprint plugin for cases where domain data also exists in the root file.</li>
   <li>Fixed ability to save a movie template via the Save Movie Wizard on Windows.</li>
   <li>Fixed bugs with the avtLinesFileFormat reader. The reader can now distinguish 2D from 3D, and it will not remove identical consecutive points that exist on different lines.</li>
+  <li>Fixed a bug that was preventing VisIt from correctly generating normals for triangle strips.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/rendering/lighting.py
+++ b/src/test/tests/rendering/lighting.py
@@ -17,51 +17,84 @@
 #
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #    Added ability to swtich between Silo's HDF5 and PDB data.
+#
+#    Alister Maguire, Wed Mar 18 16:45:02 PDT 2020
+#    Moved previous two tests into a function called TestBasicLighting and
+#    added TestNormals.
+#
 # ----------------------------------------------------------------------------
 
 
-OpenDatabase(silo_data_path("rect3d.silo"))
+def TestBasicLighting():
+    OpenDatabase(silo_data_path("rect3d.silo"))
 
-AddPlot("Pseudocolor", "d")
-AddOperator("Slice")
-AddOperator("Elevate")
-DrawPlots()
+    AddPlot("Pseudocolor", "d")
+    AddOperator("Slice")
+    AddOperator("Elevate")
+    DrawPlots()
 
-View3DAtts = View3DAttributes()
-View3DAtts.viewNormal = (-0.58136, 0.782415, -0.223267)
-View3DAtts.focus = (0.5, 0.5, 0.66382)
-View3DAtts.viewUp = (0.259676, -0.0816327, -0.962239)
-View3DAtts.viewAngle = 30
-View3DAtts.parallelScale = 0.728621
-View3DAtts.nearPlane = -1.45724
-View3DAtts.farPlane = 1.45724
-View3DAtts.imagePan = (0, 0)
-View3DAtts.imageZoom = 1
-View3DAtts.perspective = 1
-View3DAtts.eyeAngle = 2
-View3DAtts.centerOfRotationSet = 0
-View3DAtts.centerOfRotation = (0.5, 0.5, 0.66382)
-SetView3D(View3DAtts)
+    View3DAtts = View3DAttributes()
+    View3DAtts.viewNormal = (-0.58136, 0.782415, -0.223267)
+    View3DAtts.focus = (0.5, 0.5, 0.66382)
+    View3DAtts.viewUp = (0.259676, -0.0816327, -0.962239)
+    View3DAtts.viewAngle = 30
+    View3DAtts.parallelScale = 0.728621
+    View3DAtts.nearPlane = -1.45724
+    View3DAtts.farPlane = 1.45724
+    View3DAtts.imagePan = (0, 0)
+    View3DAtts.imageZoom = 1
+    View3DAtts.perspective = 1
+    View3DAtts.eyeAngle = 2
+    View3DAtts.centerOfRotationSet = 0
+    View3DAtts.centerOfRotation = (0.5, 0.5, 0.66382)
+    SetView3D(View3DAtts)
 
-light0 = GetLight(0)
-light0.enabledFlag = 1
-light0.type = light0.Camera  # Ambient, Object, Camera
-light0.direction = (0, 0, -1)
-light0.color = (255, 255, 255, 255)
-light0.brightness = 1
-SetLight(0, light0)
-light1 = GetLight(1)
-light1.enabledFlag = 1
-light1.type = light1.Ambient  # Ambient, Object, Camera
-light1.direction = (0, 0, -1)
-light1.color = (255, 255, 255, 255)
-light1.brightness = 0.47
-SetLight(1, light1)
+    light0 = GetLight(0)
+    light0.enabledFlag = 1
+    light0.type = light0.Camera  # Ambient, Object, Camera
+    light0.direction = (0, 0, -1)
+    light0.color = (255, 255, 255, 255)
+    light0.brightness = 1
+    SetLight(0, light0)
+    light1 = GetLight(1)
+    light1.enabledFlag = 1
+    light1.type = light1.Ambient  # Ambient, Object, Camera
+    light1.direction = (0, 0, -1)
+    light1.color = (255, 255, 255, 255)
+    light1.brightness = 0.47
+    SetLight(1, light1)
 
-# In SR mode, bug '8017 was that the ambient would get turned off on
-# the second save.
-Test("lighting_01")
-Test("lighting_02")
+    # In SR mode, bug '8017 was that the ambient would get turned off on
+    # the second save.
+    Test("lighting_01")
+    Test("lighting_02")
 
-Exit()
+    DeleteAllPlots()
+    CloseDatabase(silo_data_path("rect3d.silo"))
+
+
+def TestNormals():
+
+    v = GetView3D()
+    v.viewNormal = (-0.03622833898009251, 0.7402344653499199, 0.6713720606063838)
+    SetView3D(v)
+
+    #
+    # In the past, our normals filter wasn't able to handle triangle strips.
+    # This test ensures that we now can.
+    #
+    OpenDatabase(data_path("vtk_test_data/polyWithStrips.vtk"))
+    AddPlot("Pseudocolor", "fooData")
+    DrawPlots()
+    Test("normals_00")
+    DeleteAllPlots()
+    CloseDatabase(data_path("vtk_test_data/polyWithStrips.vtk"))
+
+
+def main():
+    TestBasicLighting()
+    TestNormals()
+    Exit()
+
+main()
 

--- a/test/baseline/rendering/lighting/normals_00.png
+++ b/test/baseline/rendering/lighting/normals_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29c844e84738e20b23d42127ac3bbfd4694416bc092a9a963a12e1f85496a40e
+size 8762


### PR DESCRIPTION
### Description

Resolves #3711 

I've updated vtkVisItPolyDataNormals to handle triangle strips when computing point normals, and I've updated vtkVertexNormalsFilter to allow datasets with triangle strips to be processed with the poly data normals filter.


### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New Documentation
- [ ] Other (please describe below)

### How Has This Been Tested?

I've added a new test that makes sure the triangle strip normals are being processed correctly, and I've run the test suite. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
