### PR TITLE
Fix a bug copying too many baselines to the dashboard.

### DIFF
--- a/src/tools/dev/scripts/visit-copy-test-results.py
+++ b/src/tools/dev/scripts/visit-copy-test-results.py
@@ -106,7 +106,7 @@ def copy_new_baselines(cur_dir):
             found = False
             ibase = 0
             while (ibase < nbase and not found):
-                base_file = os.path.join(base_dirs[ibase], mode_dirs[imode], file)
+                base_file = os.path.join(out_dir, "baselines", mode_dirs[imode], base_dirs[ibase], file)
                 if (os.path.exists(base_file)):
                     found = True
                     #


### PR DESCRIPTION
### Description

I corrected a bug with visit-copy-test-results.py that caused it to copy more baselines to the dashboard than necessary. Nothing in the dashboard is incorrect, it's just that there are redundant copies of baseline results taking up more space than necessary.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

I posted the results from last nights test run and it behaved properly not copying over any new baselines, since none of the baselines changed last night.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code