### PR TITLE
A couple of test suite fixes.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -243,6 +243,7 @@ fi
 # Update the repository.
 cd visit
 rm -f .git/index.lock >> ../buildlog 2>&1
+git checkout develop >> ../buildlog 2>&1
 git pull >> ../buildlog 2>&1
 git lfs pull >> ../buildlog 2>&1
 

--- a/src/tools/dev/scripts/visit-notify-test-failure
+++ b/src/tools/dev/scripts/visit-notify-test-failure
@@ -133,7 +133,7 @@ is...
 EOF
 echo $modifiersEmails | tr ' ' '\n' | sort >> mailmsg
 echo "" >> mailmsg
-echo "The test suite results are at http://portal.nersc.gov/project/visit/" >> mailmsg
+echo "The test suite results are at https://visit-dav.github.io/dashboard/" >> mailmsg
 echo "" >> mailmsg
 
 if test -n "$testEmail"; then


### PR DESCRIPTION
### Description

Changed the address of the regression suite results to the GitHub dashboard in the failure e-mail. Added a "git checkout develop" to regressiontest_pascal to handle the case where the git clone used for running the test suite is accidentally left on a different branch or on a specific checkout hash.

### Type of change

- [X] Bug fix

### How Has This Been Tested?

These are pretty simple changes and don't need testing. If there is a problem it is easily fixed and of low consequence.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code