### PR TITLE
Task/biagas/add const db options

### DIFF
--- a/src/databases/ADIOS/avtADIOSBasicFileFormat.C
+++ b/src/databases/ADIOS/avtADIOSBasicFileFormat.C
@@ -22,7 +22,6 @@
 #include <vtkUnsignedCharArray.h>
 
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <DebugStream.h>

--- a/src/databases/ADIOS/avtADIOSSchemaFileFormat.C
+++ b/src/databases/ADIOS/avtADIOSSchemaFileFormat.C
@@ -13,7 +13,6 @@
 #include <vtkFloatArray.h>
 #include <vtkPointData.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <DebugStream.h>

--- a/src/databases/ADIOS/avtLAMMPSFileFormat.C
+++ b/src/databases/ADIOS/avtLAMMPSFileFormat.C
@@ -14,7 +14,6 @@
 #include <vtkPolyData.h>
 #include <vtkCellArray.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <InvalidVariableException.h>
 

--- a/src/databases/ADIOS/avtPIConGPUFileFormat.C
+++ b/src/databases/ADIOS/avtPIConGPUFileFormat.C
@@ -22,7 +22,6 @@
 #include <vtkGenericCell.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <avtIntervalTree.h>

--- a/src/databases/ADIOS/avtPixieFileFormat.C
+++ b/src/databases/ADIOS/avtPixieFileFormat.C
@@ -13,7 +13,6 @@
 #include <vtkFloatArray.h>
 #include <vtkPointData.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <DebugStream.h>

--- a/src/databases/ADIOS/avtSpecFEMFileFormat.C
+++ b/src/databases/ADIOS/avtSpecFEMFileFormat.C
@@ -13,7 +13,6 @@
 #include <vtkFloatArray.h>
 #include <vtkPointData.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <DebugStream.h>

--- a/src/databases/ADIOS/avtXGCFileFormat.C
+++ b/src/databases/ADIOS/avtXGCFileFormat.C
@@ -14,7 +14,6 @@
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <DebugStream.h>

--- a/src/databases/ADIOS2/avtADIOS2BaseFileFormat.C
+++ b/src/databases/ADIOS2/avtADIOS2BaseFileFormat.C
@@ -21,7 +21,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/ADIOS2/avtADIOS2SSTFileFormat.C
+++ b/src/databases/ADIOS2/avtADIOS2SSTFileFormat.C
@@ -20,7 +20,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/ADIOS2/avtGTCFileFormat.C
+++ b/src/databases/ADIOS2/avtGTCFileFormat.C
@@ -18,7 +18,6 @@
 #include <vtkGenericCell.h>
 
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <Utility.h>
 #include <VisItStreamUtil.h>

--- a/src/databases/ADIOS2/avtLAMMPSFileFormat.C
+++ b/src/databases/ADIOS2/avtLAMMPSFileFormat.C
@@ -18,7 +18,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/ADIOS2/avtMEUMMAPSFileFormat.C
+++ b/src/databases/ADIOS2/avtMEUMMAPSFileFormat.C
@@ -19,7 +19,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/ADIOS2/avtSpecFEMFileFormat.C
+++ b/src/databases/ADIOS2/avtSpecFEMFileFormat.C
@@ -13,7 +13,6 @@
 #include <vtkDoubleArray.h>
 #include <vtkPointData.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <InvalidDBTypeException.h>
 #include <InvalidVariableException.h>
 #include <DebugStream.h>

--- a/src/databases/ALS/avtALSFileFormat.C
+++ b/src/databases/ALS/avtALSFileFormat.C
@@ -17,7 +17,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Adventure/avtAdventureFileFormat.C
+++ b/src/databases/Adventure/avtAdventureFileFormat.C
@@ -17,7 +17,6 @@
 #include <vtkDataSet.h>
 #include <vtkPointData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/AugDecomp/avtAugDecompFileFormat.C
+++ b/src/databases/AugDecomp/avtAugDecompFileFormat.C
@@ -24,7 +24,6 @@
 #include <InvalidFilesException.h>
 #include <DatabasePluginInfo.h>
 #include <DatabasePluginManager.h>
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/BATL/avtBATLFileFormat.C
+++ b/src/databases/BATL/avtBATLFileFormat.C
@@ -176,7 +176,7 @@ avtBATLFileFormat::FinalizeHDF5(void)
 // ****************************************************************************
 
 avtBATLFileFormat::avtBATLFileFormat(const char *cfilename,
-                                     DBOptionsAttributes *&opts)
+                                     const DBOptionsAttributes *opts)
     : avtSTMDFileFormat(&cfilename, 1)
 {
     debug5 << "avtBATLFileFormat Marker 1" << endl;

--- a/src/databases/BATL/avtBATLFileFormat.h
+++ b/src/databases/BATL/avtBATLFileFormat.h
@@ -82,7 +82,7 @@ class     DBOptionsAttributes;
 class avtBATLFileFormat : public avtSTMDFileFormat
 {
 public:
-    avtBATLFileFormat(const char *, DBOptionsAttributes *&);
+    avtBATLFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtBATLFileFormat();
 
     virtual bool           HasInvariantMetaData(void) const

--- a/src/databases/BOV/avtBOVFileFormat.C
+++ b/src/databases/BOV/avtBOVFileFormat.C
@@ -110,7 +110,7 @@ static bool fillSpace = true;
 // ****************************************************************************
  
 avtBOVFileFormat::avtBOVFileFormat(const char *fname, 
-    DBOptionsAttributes *opts)
+    const DBOptionsAttributes *opts)
     : avtSTMDFileFormat(&fname, 1)
 {
     //

--- a/src/databases/BOV/avtBOVFileFormat.h
+++ b/src/databases/BOV/avtBOVFileFormat.h
@@ -66,7 +66,7 @@ class avtBOVFileFormat : public avtSTMDFileFormat
 {
   public:
                                avtBOVFileFormat(const char *, 
-                                   DBOptionsAttributes *);
+                                   const DBOptionsAttributes *);
     virtual                   ~avtBOVFileFormat();
 
     virtual const char        *GetType(void) { return "Brick of values"; };

--- a/src/databases/BOV/avtBOVWriter.C
+++ b/src/databases/BOV/avtBOVWriter.C
@@ -46,7 +46,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtBOVWriter::avtBOVWriter(DBOptionsAttributes *atts)
+avtBOVWriter::avtBOVWriter(const DBOptionsAttributes *atts)
 {
     switch(atts->GetEnum("Compression"))
     {

--- a/src/databases/BOV/avtBOVWriter.h
+++ b/src/databases/BOV/avtBOVWriter.h
@@ -45,7 +45,7 @@ class
 avtBOVWriter : public virtual avtDatabaseWriter
 {
   public:
-                   avtBOVWriter(DBOptionsAttributes *);
+                   avtBOVWriter(const DBOptionsAttributes *);
     virtual       ~avtBOVWriter();
 
   protected:

--- a/src/databases/Blueprint/avtBlueprintFileFormat.C
+++ b/src/databases/Blueprint/avtBlueprintFileFormat.C
@@ -18,7 +18,6 @@
 #include "StringHelpers.h"
 #include "TimingsManager.h"
 
-#include "DBOptionsAttributes.h"
 #include "Expression.h"
 #include "FileFunctions.h"
 #include "InvalidVariableException.h"

--- a/src/databases/Blueprint/avtBlueprintWriter.C
+++ b/src/databases/Blueprint/avtBlueprintWriter.C
@@ -29,7 +29,6 @@
 #include <avtParallelContext.h>
 #include <FileFunctions.h>
 
-#include <DBOptionsAttributes.h>
 #include <DebugStream.h>
 #include <ImproperUseException.h>
 

--- a/src/databases/Blueprint/avtBlueprintWriter.h
+++ b/src/databases/Blueprint/avtBlueprintWriter.h
@@ -16,7 +16,6 @@
 
 #include "conduit.hpp"
 
-class DBOptionsAttributes;
 
 // ****************************************************************************
 //  Class: avtBlueprintWriter

--- a/src/databases/CEAucd/avtCEAucdFileFormat.C
+++ b/src/databases/CEAucd/avtCEAucdFileFormat.C
@@ -28,7 +28,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtMaterial.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidFilesException.h>

--- a/src/databases/Chombo/avtChomboFileFormat.C
+++ b/src/databases/Chombo/avtChomboFileFormat.C
@@ -97,7 +97,7 @@ using     std::string;
 // ****************************************************************************
 
 avtChomboFileFormat::avtChomboFileFormat(const char *filename,
-                                         DBOptionsAttributes *atts)
+                                         const DBOptionsAttributes *atts)
     : avtSTMDFileFormat(&filename, 1)
 {
     initializedReader = false;

--- a/src/databases/Chombo/avtChomboFileFormat.h
+++ b/src/databases/Chombo/avtChomboFileFormat.h
@@ -152,7 +152,7 @@ class DBOptionsAttributes;
 class avtChomboFileFormat : public avtSTMDFileFormat
 {
   public:
-                       avtChomboFileFormat(const char *, DBOptionsAttributes*);
+                       avtChomboFileFormat(const char *, const DBOptionsAttributes*);
     virtual           ~avtChomboFileFormat();
 
     virtual const char    *GetType(void)   { return "Chombo"; };

--- a/src/databases/CosmosPP/avtCosmosPPFileFormat.C
+++ b/src/databases/CosmosPP/avtCosmosPPFileFormat.C
@@ -31,7 +31,6 @@
 #include <avtGhostData.h>
 
 #include <BadIndexException.h>
-#include <DBOptionsAttributes.h>
 #include <DebugStream.h>
 #include <Expression.h>
 #include <ImproperUseException.h>

--- a/src/databases/Cube/avtCubeFileFormat.C
+++ b/src/databases/Cube/avtCubeFileFormat.C
@@ -43,7 +43,7 @@ using std::stringstream;
 //  Modified:   Fri Apr 26 11:12:38 CEST 2013
 // ****************************************************************************
 
-avtCubeFileFormat::avtCubeFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtCubeFileFormat::avtCubeFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
     : avtMTSDFileFormat(&filename, 1)
 {
   ExtendVolumeByOneCell = readOpts->GetBool("ExtendVolumeByOneCell");

--- a/src/databases/Cube/avtCubeFileFormat.h
+++ b/src/databases/Cube/avtCubeFileFormat.h
@@ -37,7 +37,7 @@ class DBOptionsAttributes;
 class avtCubeFileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtCubeFileFormat(const char *, DBOptionsAttributes *);
+                       avtCubeFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtCubeFileFormat() {;};
 
     //

--- a/src/databases/Curve2D/avtCurve2DFileFormat.C
+++ b/src/databases/Curve2D/avtCurve2DFileFormat.C
@@ -57,7 +57,7 @@ using std::string;
 //
 // ****************************************************************************
 
-avtCurve2DFileFormat::avtCurve2DFileFormat(const char *fname, DBOptionsAttributes *)
+avtCurve2DFileFormat::avtCurve2DFileFormat(const char *fname, const DBOptionsAttributes *)
     : avtSTSDFileFormat(fname)
 {
     filename = fname;

--- a/src/databases/Curve2D/avtCurve2DFileFormat.h
+++ b/src/databases/Curve2D/avtCurve2DFileFormat.h
@@ -70,7 +70,7 @@ typedef enum
 class avtCurve2DFileFormat : public avtSTSDFileFormat
 {
   public:
-                          avtCurve2DFileFormat(const char *, DBOptionsAttributes *);
+                          avtCurve2DFileFormat(const char *, const DBOptionsAttributes *);
     virtual              ~avtCurve2DFileFormat();
     
     virtual const char   *GetType(void) { return "Curve File Format"; };

--- a/src/databases/Curve2D/avtCurve2DWriter.C
+++ b/src/databases/Curve2D/avtCurve2DWriter.C
@@ -35,7 +35,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtCurve2DWriter::avtCurve2DWriter(DBOptionsAttributes *atts) : commentStyle("#")
+avtCurve2DWriter::avtCurve2DWriter(const DBOptionsAttributes *atts) : commentStyle("#")
 {
     nBlocks = 0;
     if (atts->GetEnum("CommentStyle") == 1)

--- a/src/databases/Curve2D/avtCurve2DWriter.h
+++ b/src/databases/Curve2D/avtCurve2DWriter.h
@@ -34,7 +34,7 @@ class
 avtCurve2DWriter : public avtDatabaseWriter
 {
   public:
-                   avtCurve2DWriter(DBOptionsAttributes *);
+                   avtCurve2DWriter(const DBOptionsAttributes *);
     virtual       ~avtCurve2DWriter() {;}
 
   protected:

--- a/src/databases/Denovo/avtDenovoFileFormat.C
+++ b/src/databases/Denovo/avtDenovoFileFormat.C
@@ -18,7 +18,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtMaterial.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <InvalidFilesException.h>
 #include <InvalidVariableException.h>

--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -1447,7 +1447,7 @@ avtExodusFileFormat::RegisterFileList(const char *const *list, int nlist)
 //    detection.
 // ****************************************************************************
 
-avtExodusFileFormat::avtExodusFileFormat(const char *name, DBOptionsAttributes *rdatts)
+avtExodusFileFormat::avtExodusFileFormat(const char *name, const DBOptionsAttributes *rdatts)
    : avtMTSDFileFormat(&name, 1)
 {
     fileList = -1;

--- a/src/databases/Exodus/avtExodusFileFormat.h
+++ b/src/databases/Exodus/avtExodusFileFormat.h
@@ -63,7 +63,7 @@ class     DBOptionsAttributes;
 class avtExodusFileFormat : public avtMTSDFileFormat
 {
   public:
-                                avtExodusFileFormat(const char *, DBOptionsAttributes *rdatts);
+                                avtExodusFileFormat(const char *, const DBOptionsAttributes *rdatts);
     virtual                    ~avtExodusFileFormat();
  
     virtual void                FreeUpResources(void);

--- a/src/databases/ExtrudedVol/avtExtrudedVolFileFormat.C
+++ b/src/databases/ExtrudedVol/avtExtrudedVolFileFormat.C
@@ -37,7 +37,7 @@ using     std::string;
 //
 // ****************************************************************************
 
-avtExtrudedVolFileFormat::avtExtrudedVolFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtExtrudedVolFileFormat::avtExtrudedVolFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
     : avtSTMDFileFormat(&filename, 1)
 {
     ifstream ifile(filename);

--- a/src/databases/ExtrudedVol/avtExtrudedVolFileFormat.h
+++ b/src/databases/ExtrudedVol/avtExtrudedVolFileFormat.h
@@ -32,7 +32,7 @@ class avtExtrudedVolFileFormat : public avtSTMDFileFormat
 {
   public:
                        avtExtrudedVolFileFormat(const char *, 
-                                                DBOptionsAttributes *);
+                                                const DBOptionsAttributes *);
     virtual           ~avtExtrudedVolFileFormat() {;};
 
     //

--- a/src/databases/ExtrudedVol/avtExtrudedVolWriter.C
+++ b/src/databases/ExtrudedVol/avtExtrudedVolWriter.C
@@ -34,7 +34,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtExtrudedVolWriter::avtExtrudedVolWriter(DBOptionsAttributes *atts)
+avtExtrudedVolWriter::avtExtrudedVolWriter(const DBOptionsAttributes *atts)
 {
     timestep   = atts->GetInt("Time");
     nTimesteps = atts->GetInt("nTimes");

--- a/src/databases/ExtrudedVol/avtExtrudedVolWriter.h
+++ b/src/databases/ExtrudedVol/avtExtrudedVolWriter.h
@@ -31,7 +31,7 @@ class
 avtExtrudedVolWriter : public avtDatabaseWriter
 {
   public:
-                   avtExtrudedVolWriter(DBOptionsAttributes *);
+                   avtExtrudedVolWriter(const DBOptionsAttributes *);
     virtual       ~avtExtrudedVolWriter() {;};
 
   protected:

--- a/src/databases/FLASH/avtFLASHFileFormat.C
+++ b/src/databases/FLASH/avtFLASHFileFormat.C
@@ -212,7 +212,7 @@ avtFLASHFileFormat::FinalizeHDF5(void)
 // ****************************************************************************
 
 avtFLASHFileFormat::avtFLASHFileFormat(const char *cfilename, 
-                                       DBOptionsAttributes *opts)
+                                       const DBOptionsAttributes *opts)
     : avtSTMDFileFormat(&cfilename, 1)
 {
     filename  = cfilename;

--- a/src/databases/FLASH/avtFLASHFileFormat.h
+++ b/src/databases/FLASH/avtFLASHFileFormat.h
@@ -88,7 +88,7 @@ class     DBOptionsAttributes;
 class avtFLASHFileFormat : public avtSTMDFileFormat
 {
   public:
-                       avtFLASHFileFormat(const char *, DBOptionsAttributes *);
+                       avtFLASHFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtFLASHFileFormat();
 
     virtual bool           HasInvariantMetaData(void) const { return false; };

--- a/src/databases/FT2/avtFT2FileFormat.C
+++ b/src/databases/FT2/avtFT2FileFormat.C
@@ -19,7 +19,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/GGCM/avtGGCMFileFormat.C
+++ b/src/databases/GGCM/avtGGCMFileFormat.C
@@ -44,7 +44,7 @@ static void *xmalloc(size_t size);
  *  Creation:   Thu Jun 1 13:38:54 PST 2006 */
 avtGGCMFileFormat::avtGGCMFileFormat(
         const char *filename,
-        DBOptionsAttributes *db)
+        const DBOptionsAttributes *db)
                 :
         avtMTSDFileFormat(&filename,1),
         fn_grid(NULL),

--- a/src/databases/GGCM/avtGGCMFileFormat.h
+++ b/src/databases/GGCM/avtGGCMFileFormat.h
@@ -30,7 +30,7 @@ class vtkRectilinearGrid;
 class avtGGCMFileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtGGCMFileFormat(const char *, DBOptionsAttributes *);
+                       avtGGCMFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtGGCMFileFormat();
 
     //

--- a/src/databases/GMV/avtGMVFileFormat.C
+++ b/src/databases/GMV/avtGMVFileFormat.C
@@ -29,7 +29,6 @@
 #include <avtPolygonToTrianglesTesselator.h>
 #include <avtPolyhedralSplit.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/GULP/avtGULPFileFormat.C
+++ b/src/databases/GULP/avtGULPFileFormat.C
@@ -21,7 +21,6 @@
 #include <avtCallback.h>
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Gadget/avtGadgetFileFormat.C
+++ b/src/databases/Gadget/avtGadgetFileFormat.C
@@ -17,7 +17,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Geqdsk/avtGeqdskFileFormat.C
+++ b/src/databases/Geqdsk/avtGeqdskFileFormat.C
@@ -45,7 +45,7 @@ using     std::string;
 //
 // ****************************************************************************
 
-avtGeqdskFileFormat::avtGeqdskFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtGeqdskFileFormat::avtGeqdskFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
   : avtMTSDFileFormat(&filename, 1), nw(0), nh(0)
 {
     if (std::string(filename) == "")

--- a/src/databases/Geqdsk/avtGeqdskFileFormat.h
+++ b/src/databases/Geqdsk/avtGeqdskFileFormat.h
@@ -30,7 +30,7 @@ class DBOptionsAttributes;
 class avtGeqdskFileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtGeqdskFileFormat(const char *, DBOptionsAttributes *);
+                       avtGeqdskFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtGeqdskFileFormat() {;};
 
     //

--- a/src/databases/H5Part/avtH5PartFileFormat.C
+++ b/src/databases/H5Part/avtH5PartFileFormat.C
@@ -87,7 +87,7 @@
 // ****************************************************************************
 
 avtH5PartFileFormat::avtH5PartFileFormat(const char *filename,
-        DBOptionsAttributes *readOpts) : avtMTSDFileFormat(&filename, 1)
+        const DBOptionsAttributes *readOpts) : avtMTSDFileFormat(&filename, 1)
 {
     // ibis::gVerbose = 1000;
     

--- a/src/databases/H5Part/avtH5PartFileFormat.h
+++ b/src/databases/H5Part/avtH5PartFileFormat.h
@@ -72,7 +72,7 @@ class avtHistogramSpecification;
 class avtH5PartFileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtH5PartFileFormat(const char *, DBOptionsAttributes *);
+                       avtH5PartFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtH5PartFileFormat();
 
 #ifdef HAVE_LIBFASTQUERY

--- a/src/databases/H5Part/avtH5PartWriter.C
+++ b/src/databases/H5Part/avtH5PartWriter.C
@@ -85,7 +85,7 @@ double avtH5PartWriter::INVALID_TIME = -DBL_MAX;
 //
 // ****************************************************************************
 
-avtH5PartWriter::avtH5PartWriter(DBOptionsAttributes *writeOpts)
+avtH5PartWriter::avtH5PartWriter(const DBOptionsAttributes *writeOpts)
 {
     // Defaults
     variablePathPrefix = std::string("Step#");

--- a/src/databases/H5Part/avtH5PartWriter.h
+++ b/src/databases/H5Part/avtH5PartWriter.h
@@ -48,7 +48,7 @@ struct H5PartFile;
 class avtH5PartWriter : public virtual avtDatabaseWriter
 {
   public:
-                   avtH5PartWriter(DBOptionsAttributes *);
+                   avtH5PartWriter(const DBOptionsAttributes *);
     virtual       ~avtH5PartWriter();
 
   protected:

--- a/src/databases/HDFS/avtHDFSFileFormat.C
+++ b/src/databases/HDFS/avtHDFSFileFormat.C
@@ -23,7 +23,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtMaterial.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <FileFunctions.h>

--- a/src/databases/IDX/avtIDXFileFormat.C
+++ b/src/databases/IDX/avtIDXFileFormat.C
@@ -529,7 +529,7 @@ void avtIDXFileFormat::createTimeIndex()
 //
 // ****************************************************************************
 
-avtIDXFileFormat::avtIDXFileFormat(const char *filename, DBOptionsAttributes* attrs)
+avtIDXFileFormat::avtIDXFileFormat(const char *filename, const DBOptionsAttributes* attrs)
 : avtMTMDFileFormat(filename)
 {
 

--- a/src/databases/IDX/avtIDXFileFormat.h
+++ b/src/databases/IDX/avtIDXFileFormat.h
@@ -45,7 +45,7 @@ struct gidx_info{
 class avtIDXFileFormat : public avtMTMDFileFormat
 {
   public:
-                       avtIDXFileFormat(const char *, DBOptionsAttributes* attrs);
+                       avtIDXFileFormat(const char *, const DBOptionsAttributes* attrs);
     virtual           ~avtIDXFileFormat();
 
     //

--- a/src/databases/Image/avtImageFileFormat.C
+++ b/src/databases/Image/avtImageFileFormat.C
@@ -73,7 +73,7 @@ using     std::string;
 //
 // ****************************************************************************
 
-avtImageFileFormat::avtImageFileFormat(const char *filename, DBOptionsAttributes *)
+avtImageFileFormat::avtImageFileFormat(const char *filename, const DBOptionsAttributes *)
     : avtSTSDFileFormat(filename)
 {
     fname = filename;

--- a/src/databases/Image/avtImageFileFormat.h
+++ b/src/databases/Image/avtImageFileFormat.h
@@ -50,7 +50,7 @@ class DBOptionsAttributes;
 class avtImageFileFormat : public avtSTSDFileFormat
 {
   public:
-                       avtImageFileFormat(const char *filename, DBOptionsAttributes *);
+                       avtImageFileFormat(const char *filename, const DBOptionsAttributes *);
     virtual           ~avtImageFileFormat();
 
     virtual const char    *GetType(void)   { return "Image"; };

--- a/src/databases/Image/avtImagePluginWriter.C
+++ b/src/databases/Image/avtImagePluginWriter.C
@@ -44,7 +44,7 @@ using     std::vector;
 //  Creation:   November 28, 2007 
 //
 // ****************************************************************************
-avtImagePluginWriter::avtImagePluginWriter(DBOptionsAttributes *dbOpts)
+avtImagePluginWriter::avtImagePluginWriter(const DBOptionsAttributes *dbOpts)
 {
     format = dbOpts->GetEnum("Format");
     normalize = dbOpts->GetBool("Normalize [0,255]");

--- a/src/databases/Image/avtImagePluginWriter.h
+++ b/src/databases/Image/avtImagePluginWriter.h
@@ -30,7 +30,7 @@ class
 avtImagePluginWriter : public virtual avtDatabaseWriter
 {
   public:
-                   avtImagePluginWriter(DBOptionsAttributes *);
+                   avtImagePluginWriter(const DBOptionsAttributes *);
     virtual       ~avtImagePluginWriter() {;};
 
   protected:

--- a/src/databases/M3DC1/avtM3DC1FileFormat.C
+++ b/src/databases/M3DC1/avtM3DC1FileFormat.C
@@ -50,7 +50,7 @@
 // ****************************************************************************
 
 avtM3DC1FileFormat::avtM3DC1FileFormat(const char *filename,
-                                       DBOptionsAttributes *readOpts)
+                                       const DBOptionsAttributes *readOpts)
   : avtMTSDFileFormat(&filename, 1),
     processDataSelections(false), haveReadWholeData(true),
     m_filename(filename),

--- a/src/databases/M3DC1/avtM3DC1FileFormat.h
+++ b/src/databases/M3DC1/avtM3DC1FileFormat.h
@@ -32,7 +32,7 @@ class vtkPoints;
 class avtM3DC1FileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtM3DC1FileFormat(const char *, DBOptionsAttributes *);
+                       avtM3DC1FileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtM3DC1FileFormat() {;};
 
     //

--- a/src/databases/MDSplus/avtMDSplusFileFormat.C
+++ b/src/databases/MDSplus/avtMDSplusFileFormat.C
@@ -37,7 +37,7 @@ using namespace std;
 //
 // ****************************************************************************
 
-avtMDSplusFileFormat::avtMDSplusFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtMDSplusFileFormat::avtMDSplusFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
   : avtMTSDFileFormat(&filename, 1), m_socket(-1)
 {
     if (readOpts != NULL) {

--- a/src/databases/MDSplus/avtMDSplusFileFormat.h
+++ b/src/databases/MDSplus/avtMDSplusFileFormat.h
@@ -32,7 +32,7 @@ class DBOptionsAttributes;
 class avtMDSplusFileFormat : public avtMTSDFileFormat
 {
   public:
-               avtMDSplusFileFormat(const char *, DBOptionsAttributes *);
+               avtMDSplusFileFormat(const char *, const DBOptionsAttributes *);
     virtual   ~avtMDSplusFileFormat() {;};
 
     //

--- a/src/databases/MFEM/avtMFEMFileFormat.C
+++ b/src/databases/MFEM/avtMFEMFileFormat.C
@@ -20,7 +20,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <DebugStream.h>
 #include <Expression.h>
 #include <FileFunctions.h>

--- a/src/databases/MFIX/avtMFIXFileFormat.C
+++ b/src/databases/MFIX/avtMFIXFileFormat.C
@@ -63,7 +63,7 @@
 // ****************************************************************************
 
 avtMFIXFileFormat::avtMFIXFileFormat(const char *filename,
-    DBOptionsAttributes *rdopts)
+    const DBOptionsAttributes *rdopts)
 : avtMTMDFileFormat(filename)
 {
     strncpy(this->RestartFileName, filename, MFIX_NAME_MAX);

--- a/src/databases/MFIX/avtMFIXFileFormat.h
+++ b/src/databases/MFIX/avtMFIXFileFormat.h
@@ -57,7 +57,7 @@ class vtkUnstructuredGrid;
 class avtMFIXFileFormat : public avtMTMDFileFormat
 {
  public:
-     avtMFIXFileFormat(const char *, DBOptionsAttributes *);
+     avtMFIXFileFormat(const char *, const DBOptionsAttributes *);
      virtual               ~avtMFIXFileFormat();
 
      virtual int            GetNTimesteps(void);

--- a/src/databases/MFIXCDF/avtMFIXCDFFileFormat.C
+++ b/src/databases/MFIXCDF/avtMFIXCDFFileFormat.C
@@ -204,7 +204,7 @@ int openFile( const char* filename )
 //
 // ****************************************************************************
 
-avtMFIXCDFFileFormat::avtMFIXCDFFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtMFIXCDFFileFormat::avtMFIXCDFFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
     : avtSTMDFileFormat(&filename, 1)
 {
     // INITIALIZE DATA MEMBERS

--- a/src/databases/MFIXCDF/avtMFIXCDFFileFormat.h
+++ b/src/databases/MFIXCDF/avtMFIXCDFFileFormat.h
@@ -41,7 +41,7 @@ class vtkUnsignedCharArray;
 class avtMFIXCDFFileFormat : public avtSTMDFileFormat
 {
 public:
-    avtMFIXCDFFileFormat(const char *, DBOptionsAttributes *);
+    avtMFIXCDFFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtMFIXCDFFileFormat();
 
     virtual double GetTime(void);

--- a/src/databases/MOAB/avtMOABFileFormat.C
+++ b/src/databases/MOAB/avtMOABFileFormat.C
@@ -61,7 +61,7 @@ using     std::string;
 //
 // ****************************************************************************
 
-avtMOABFileFormat::avtMOABFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtMOABFileFormat::avtMOABFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
     : avtSTMDFileFormat(&filename, 1), readOptions(readOpts), fileLoaded(false), file_descriptor(NULL), pcomm(NULL)
 {
     // INITIALIZE DATA MEMBERS

--- a/src/databases/MOAB/avtMOABFileFormat.h
+++ b/src/databases/MOAB/avtMOABFileFormat.h
@@ -36,7 +36,7 @@ struct mhdf_FileDesc ;
 class avtMOABFileFormat : public avtSTMDFileFormat
 {
   public:
-                       avtMOABFileFormat(const char *, DBOptionsAttributes *);
+                       avtMOABFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtMOABFileFormat() {;};
 
     //

--- a/src/databases/MOAB/avtMOABWriter.C
+++ b/src/databases/MOAB/avtMOABWriter.C
@@ -30,7 +30,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtMOABWriter::avtMOABWriter(DBOptionsAttributes *)
+avtMOABWriter::avtMOABWriter(const DBOptionsAttributes *)
 {
 }
 

--- a/src/databases/MOAB/avtMOABWriter.h
+++ b/src/databases/MOAB/avtMOABWriter.h
@@ -36,7 +36,7 @@ class
 avtMOABWriter : public avtDatabaseWriter
 {
   public:
-                   avtMOABWriter(DBOptionsAttributes *);
+                   avtMOABWriter(const DBOptionsAttributes *);
     virtual       ~avtMOABWriter() {;};
 
   protected:

--- a/src/databases/MatrixMarket/avtMatrixMarketFileFormat.C
+++ b/src/databases/MatrixMarket/avtMatrixMarketFileFormat.C
@@ -19,7 +19,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtDatabase.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Miranda/avtMirandaFileFormat.C
+++ b/src/databases/Miranda/avtMirandaFileFormat.C
@@ -215,7 +215,7 @@ private:
 //    Updated to read curvilinear or rectilinear data.
 // ****************************************************************************
 
-avtMirandaFileFormat::avtMirandaFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtMirandaFileFormat::avtMirandaFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
   : avtMTMDFileFormat(filename)
 {
   string tag, buf1;

--- a/src/databases/Miranda/avtMirandaFileFormat.h
+++ b/src/databases/Miranda/avtMirandaFileFormat.h
@@ -44,7 +44,7 @@ class DBOptionsAttributes;
 class avtMirandaFileFormat : public avtMTMDFileFormat
 {
   public:
-                           avtMirandaFileFormat(const char *, DBOptionsAttributes *);
+                           avtMirandaFileFormat(const char *, const DBOptionsAttributes *);
     virtual               ~avtMirandaFileFormat() {;};
 
     virtual void          *GetAuxiliaryData(const char *var, int timestate, 

--- a/src/databases/NASTRAN/avtNASTRANFileFormat.C
+++ b/src/databases/NASTRAN/avtNASTRANFileFormat.C
@@ -73,7 +73,7 @@ using std::vector;
 // ****************************************************************************
 
 avtNASTRANFileFormat::avtNASTRANFileFormat(const char *filename,
-    DBOptionsAttributes *rdatts) : avtSTSDFileFormat(filename), title()
+    const DBOptionsAttributes *rdatts) : avtSTSDFileFormat(filename), title()
 {
     meshDS = 0;
     matCountOpt = 0;

--- a/src/databases/NASTRAN/avtNASTRANFileFormat.h
+++ b/src/databases/NASTRAN/avtNASTRANFileFormat.h
@@ -36,7 +36,7 @@ class avtMaterial;
 class avtNASTRANFileFormat : public avtSTSDFileFormat
 {
 public:
-                       avtNASTRANFileFormat(const char *filename, DBOptionsAttributes*);
+                       avtNASTRANFileFormat(const char *filename, const DBOptionsAttributes*);
     virtual           ~avtNASTRANFileFormat();
 
     virtual void         *GetAuxiliaryData(const char *var,

--- a/src/databases/Nek5000/avtNek5000FileFormat.C
+++ b/src/databases/Nek5000/avtNek5000FileFormat.C
@@ -247,7 +247,7 @@ using std::vector;
 // ****************************************************************************
 
 avtNek5000FileFormat::avtNek5000FileFormat(const char *filename,
-                                           DBOptionsAttributes *atts)
+                                           const DBOptionsAttributes *atts)
     : avtMTMDFileFormat(filename)
 {
     int t0 = visitTimer->StartTimer();

--- a/src/databases/Nek5000/avtNek5000FileFormat.h
+++ b/src/databases/Nek5000/avtNek5000FileFormat.h
@@ -110,7 +110,7 @@ class KeyCompare {
 class avtNek5000FileFormat : public avtMTMDFileFormat
 {
   public:
-                       avtNek5000FileFormat(const char *, DBOptionsAttributes *);
+                       avtNek5000FileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtNek5000FileFormat();
 
     virtual void       RegisterDataSelections(

--- a/src/databases/Nektar++/avtNektarPPFileFormat.C
+++ b/src/databases/Nektar++/avtNektarPPFileFormat.C
@@ -76,7 +76,7 @@ using namespace Nektar;
 //
 // ****************************************************************************
 
-avtNektarPPFileFormat::avtNektarPPFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtNektarPPFileFormat::avtNektarPPFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
   : avtMTSDFileFormat(&filename, 1),
     m_refinement(0), m_ignoreCurvedElements(1), refinedDataSet(0)
 {

--- a/src/databases/Nektar++/avtNektarPPFileFormat.h
+++ b/src/databases/Nektar++/avtNektarPPFileFormat.h
@@ -38,7 +38,7 @@ class DBOptionsAttributes;
 class avtNektarPPFileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtNektarPPFileFormat(const char *, DBOptionsAttributes *);
+                       avtNektarPPFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtNektarPPFileFormat() {;};
 
     virtual void       Initialize();

--- a/src/databases/OpenFOAM/avtOpenFOAMFileFormat.C
+++ b/src/databases/OpenFOAM/avtOpenFOAMFileFormat.C
@@ -53,7 +53,7 @@ using     std::map;
 // ****************************************************************************
 
 avtOpenFOAMFileFormat::avtOpenFOAMFileFormat(const char *filename, 
-    DBOptionsAttributes *readOpts) : avtMTMDFileFormat(filename), timeSteps()
+    const DBOptionsAttributes *readOpts) : avtMTMDFileFormat(filename), timeSteps()
 {
     convertCellToPoint = false;
     readZones = false;

--- a/src/databases/OpenFOAM/avtOpenFOAMFileFormat.h
+++ b/src/databases/OpenFOAM/avtOpenFOAMFileFormat.h
@@ -36,7 +36,7 @@ class vtkMultiBlockDataSet;
 class avtOpenFOAMFileFormat : public avtMTMDFileFormat
 {
   public:
-                           avtOpenFOAMFileFormat(const char *, DBOptionsAttributes *);
+                           avtOpenFOAMFileFormat(const char *, const DBOptionsAttributes *);
     virtual               ~avtOpenFOAMFileFormat() {;};
 
     virtual void           GetTimes(std::vector<double> &);

--- a/src/databases/OpenPMD/avtOpenPMDFileFormat.C
+++ b/src/databases/OpenPMD/avtOpenPMDFileFormat.C
@@ -64,7 +64,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <DebugStream.h>
 

--- a/src/databases/PFLOTRAN/avtPFLOTRANFileFormat.C
+++ b/src/databases/PFLOTRAN/avtPFLOTRANFileFormat.C
@@ -27,7 +27,6 @@
 
 #include <InvalidDBTypeException.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/PICS_Tester/avtPICS_TesterFileFormat.C
+++ b/src/databases/PICS_Tester/avtPICS_TesterFileFormat.C
@@ -25,7 +25,6 @@
 
 #include <avtParallel.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <DebugStream.h>

--- a/src/databases/PLOT3D/avtPLOT3DFileFormat.C
+++ b/src/databases/PLOT3D/avtPLOT3DFileFormat.C
@@ -74,7 +74,7 @@ using std::string;
 // ****************************************************************************
 
 avtPLOT3DFileFormat::avtPLOT3DFileFormat(const char *fname,
-    DBOptionsAttributes *readOpts)
+    const DBOptionsAttributes *readOpts)
     : avtMTMDFileFormat(fname),
        visitMetaFile(),
        xFileName(),

--- a/src/databases/PLOT3D/avtPLOT3DFileFormat.h
+++ b/src/databases/PLOT3D/avtPLOT3DFileFormat.h
@@ -44,7 +44,7 @@ class     vtkPLOT3DReader;
 class avtPLOT3DFileFormat : public avtMTMDFileFormat
 {
   public:
-                          avtPLOT3DFileFormat(const char *, DBOptionsAttributes *);
+                          avtPLOT3DFileFormat(const char *, const DBOptionsAttributes *);
     virtual              ~avtPLOT3DFileFormat();
     
     virtual int            GetNTimesteps(void);

--- a/src/databases/PLY/avtPLYFileFormat.C
+++ b/src/databases/PLY/avtPLYFileFormat.C
@@ -29,7 +29,7 @@ using     std::string;
 //
 // ****************************************************************************
 
-avtPLYFileFormat::avtPLYFileFormat(const char *filename, DBOptionsAttributes*&)
+avtPLYFileFormat::avtPLYFileFormat(const char *filename, const DBOptionsAttributes*)
     : avtSTSDFileFormat(filename)
 {
     dataset = NULL;

--- a/src/databases/PLY/avtPLYFileFormat.h
+++ b/src/databases/PLY/avtPLYFileFormat.h
@@ -27,7 +27,7 @@ class DBOptionsAttributes;
 class avtPLYFileFormat : public avtSTSDFileFormat
 {
   public:
-    avtPLYFileFormat(const char *filename, DBOptionsAttributes*&);
+    avtPLYFileFormat(const char *filename, const DBOptionsAttributes*);
     virtual           ~avtPLYFileFormat();
 
 

--- a/src/databases/PLY/avtPLYWriter.C
+++ b/src/databases/PLY/avtPLYWriter.C
@@ -46,7 +46,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtPLYWriter::avtPLYWriter(DBOptionsAttributes *atts)
+avtPLYWriter::avtPLYWriter(const DBOptionsAttributes *atts)
 {
     doBinary = atts->GetBool("Binary format");
     doColor = atts->GetBool("Output colors");

--- a/src/databases/PLY/avtPLYWriter.h
+++ b/src/databases/PLY/avtPLYWriter.h
@@ -39,7 +39,7 @@ class
 avtPLYWriter : public avtDatabaseWriter
 {
   public:
-                   avtPLYWriter(DBOptionsAttributes *);
+                   avtPLYWriter(const DBOptionsAttributes *);
     virtual       ~avtPLYWriter() {}
 
   protected:

--- a/src/databases/PVLD/avtPVLDFileFormat.C
+++ b/src/databases/PVLD/avtPVLDFileFormat.C
@@ -23,7 +23,6 @@
 #include <avtMaterial.h>
 #include <avtVariableCache.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Pixie/avtPixieFileFormat.C
+++ b/src/databases/Pixie/avtPixieFileFormat.C
@@ -187,7 +187,7 @@ static void DetectTyphonIO(int fileId)
 //
 // ****************************************************************************
 
-avtPixieFileFormat::avtPixieFileFormat(const char *filename, DBOptionsAttributes *readOpts)
+avtPixieFileFormat::avtPixieFileFormat(const char *filename, const DBOptionsAttributes *readOpts)
     : avtMTSDFileFormat(&filename, 1), variables(), meshes(),
       timeStatePrefix("/Timestep ")
 {

--- a/src/databases/Pixie/avtPixieFileFormat.h
+++ b/src/databases/Pixie/avtPixieFileFormat.h
@@ -102,7 +102,7 @@ class avtPixieFileFormat : public avtMTSDFileFormat
 
     typedef std::map<std::string, VarInfo> VarInfoMap;
 public:
-                       avtPixieFileFormat(const char *, DBOptionsAttributes *);
+                       avtPixieFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtPixieFileFormat();
 
     virtual void           GetCycles(std::vector<int> &);

--- a/src/databases/PlainText/avtPlainTextFileFormat.C
+++ b/src/databases/PlainText/avtPlainTextFileFormat.C
@@ -52,7 +52,7 @@ using     std::vector;
 // ****************************************************************************
 
 avtPlainTextFileFormat::avtPlainTextFileFormat(const char *fn,
-                                               DBOptionsAttributes *readOpts)
+                                               const DBOptionsAttributes *readOpts)
     : avtSTSDFileFormat(fn)
 {
     fileRead = false;

--- a/src/databases/PlainText/avtPlainTextFileFormat.h
+++ b/src/databases/PlainText/avtPlainTextFileFormat.h
@@ -31,7 +31,7 @@ class DBOptionsAttributes;
 class avtPlainTextFileFormat : public avtSTSDFileFormat
 {
   public:
-                       avtPlainTextFileFormat(const char *filename, DBOptionsAttributes *);
+                       avtPlainTextFileFormat(const char *filename, const DBOptionsAttributes *);
     virtual           ~avtPlainTextFileFormat() {;};
 
     //

--- a/src/databases/ProteinDataBank/avtProteinDataBankFileFormat.C
+++ b/src/databases/ProteinDataBank/avtProteinDataBankFileFormat.C
@@ -58,7 +58,7 @@ TrimTrailingSpaces(char *s)
 // ****************************************************************************
 
 avtProteinDataBankFileFormat::avtProteinDataBankFileFormat(const char *fn,
-                                                DBOptionsAttributes *readOpts)
+                                                const DBOptionsAttributes *readOpts)
     : avtSTSDFileFormat(fn)
 {
     filename = fn;

--- a/src/databases/ProteinDataBank/avtProteinDataBankFileFormat.h
+++ b/src/databases/ProteinDataBank/avtProteinDataBankFileFormat.h
@@ -101,7 +101,7 @@ struct ConnectRecord
 class avtProteinDataBankFileFormat : public avtSTSDFileFormat
 {
   public:
-                       avtProteinDataBankFileFormat(const char *, DBOptionsAttributes *);
+                       avtProteinDataBankFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtProteinDataBankFileFormat() {;};
 
     virtual const char    *GetType(void)   { return "ProteinDataBank"; };

--- a/src/databases/PuReMD/avtPuReMDFileFormat.C
+++ b/src/databases/PuReMD/avtPuReMDFileFormat.C
@@ -21,7 +21,6 @@
 #include <avtDatabaseMetaData.h>
 #include <AtomicProperties.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <vtkTriangulationTables.h>
 

--- a/src/databases/RAGE/avtRAGEFileFormat.C
+++ b/src/databases/RAGE/avtRAGEFileFormat.C
@@ -16,7 +16,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <ImproperUseException.h>

--- a/src/databases/SPCTH/avtSPCTHFileFormat.C
+++ b/src/databases/SPCTH/avtSPCTHFileFormat.C
@@ -28,7 +28,6 @@
 #include <avtCallback.h>
 #include <avtMixedVariable.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <InvalidVariableException.h>
 #include <InvalidDBTypeException.h>

--- a/src/databases/STAR/avtSTARFileFormat.C
+++ b/src/databases/STAR/avtSTARFileFormat.C
@@ -41,7 +41,6 @@
 #include <avtSTARFileFormat.h>
 #include <avtDatabaseMetaData.h>
 #include <avtMeshMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <DebugStream.h>
 #include <Expression.h>
 #include <ImproperUseException.h>

--- a/src/databases/STL/avtSTLFileFormat.C
+++ b/src/databases/STL/avtSTLFileFormat.C
@@ -44,7 +44,7 @@ const char   *avtSTLFileFormat::MESHNAME = "STL_mesh";
 //    Added DBOptionsAttributes
 // ****************************************************************************
 
-avtSTLFileFormat::avtSTLFileFormat(const char *fname, DBOptionsAttributes*&) 
+avtSTLFileFormat::avtSTLFileFormat(const char *fname, const DBOptionsAttributes*) 
     : avtSTSDFileFormat(fname)
 {
     dataset = NULL;

--- a/src/databases/STL/avtSTLFileFormat.h
+++ b/src/databases/STL/avtSTLFileFormat.h
@@ -34,7 +34,7 @@ class     DBOptionsAttributes;
 class avtSTLFileFormat : public avtSTSDFileFormat
 {
   public:
-                          avtSTLFileFormat(const char *, const DBOptionsAttributes*&);
+                          avtSTLFileFormat(const char *, const DBOptionsAttributes*);
     virtual              ~avtSTLFileFormat();
 
     virtual vtkDataSet   *GetMesh(const char *);

--- a/src/databases/STL/avtSTLFileFormat.h
+++ b/src/databases/STL/avtSTLFileFormat.h
@@ -34,7 +34,7 @@ class     DBOptionsAttributes;
 class avtSTLFileFormat : public avtSTSDFileFormat
 {
   public:
-                          avtSTLFileFormat(const char *, DBOptionsAttributes*&);
+                          avtSTLFileFormat(const char *, const DBOptionsAttributes*&);
     virtual              ~avtSTLFileFormat();
 
     virtual vtkDataSet   *GetMesh(const char *);

--- a/src/databases/STL/avtSTLWriter.C
+++ b/src/databases/STL/avtSTLWriter.C
@@ -44,7 +44,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtSTLWriter::avtSTLWriter(DBOptionsAttributes *atts) : avtDatabaseWriter()
+avtSTLWriter::avtSTLWriter(const DBOptionsAttributes *atts) : avtDatabaseWriter()
 {
     doBinary = atts->GetBool("Binary format");
 }

--- a/src/databases/STL/avtSTLWriter.h
+++ b/src/databases/STL/avtSTLWriter.h
@@ -35,7 +35,7 @@ class
 avtSTLWriter : public avtDatabaseWriter
 {
   public:
-                   avtSTLWriter(DBOptionsAttributes *);
+                   avtSTLWriter(const DBOptionsAttributes *);
     virtual       ~avtSTLWriter() {}
 
   protected:

--- a/src/databases/SXRIS/avtSXRISFileFormat.C
+++ b/src/databases/SXRIS/avtSXRISFileFormat.C
@@ -15,7 +15,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -262,7 +262,7 @@ static int db_get_index(DBnamescheme const *ns, int natnum);
 // ****************************************************************************
 
 avtSiloFileFormat::avtSiloFileFormat(const char *toc_name,
-                                     DBOptionsAttributes *rdatts)
+                                     const DBOptionsAttributes *rdatts)
     : avtSTMDFileFormat(&toc_name, 1)
 {
     //

--- a/src/databases/Silo/avtSiloFileFormat.h
+++ b/src/databases/Silo/avtSiloFileFormat.h
@@ -267,7 +267,7 @@ typedef struct _GroupInfo
 class avtSiloFileFormat : public avtSTMDFileFormat
 {
   public:
-                          avtSiloFileFormat(const char *, DBOptionsAttributes*);
+                          avtSiloFileFormat(const char *, const DBOptionsAttributes*);
     virtual              ~avtSiloFileFormat();
 
     virtual void          FreeUpResources(void);

--- a/src/databases/Silo/avtSiloWriter.C
+++ b/src/databases/Silo/avtSiloWriter.C
@@ -313,7 +313,7 @@ RestoreSiloLibState()
 //
 // ****************************************************************************
 
-avtSiloWriter::avtSiloWriter(DBOptionsAttributes *dbopts)
+avtSiloWriter::avtSiloWriter(const DBOptionsAttributes *dbopts)
 {
     headerDbMd = 0;
     optlist = 0;

--- a/src/databases/Silo/avtSiloWriter.h
+++ b/src/databases/Silo/avtSiloWriter.h
@@ -89,7 +89,7 @@ class
 avtSiloWriter : public virtual avtDatabaseWriter
 {
   public:
-                   avtSiloWriter(DBOptionsAttributes *);
+                   avtSiloWriter(const DBOptionsAttributes *);
     virtual       ~avtSiloWriter();
 
   protected:

--- a/src/databases/StreamGhostTest/avtStreamGhostTestFileFormat.C
+++ b/src/databases/StreamGhostTest/avtStreamGhostTestFileFormat.C
@@ -19,7 +19,6 @@
 #include <avtIsenburgSGG.h>
 #include <avtVariableCache.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/TCGA/avtTCGAFileFormat.C
+++ b/src/databases/TCGA/avtTCGAFileFormat.C
@@ -18,7 +18,6 @@
 #include <vtkVertex.h>
 
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Tecplot/avtTecplotBinaryFileFormat.C
+++ b/src/databases/Tecplot/avtTecplotBinaryFileFormat.C
@@ -152,7 +152,7 @@ FilterTecplotNamesForVisIt(const std::string &input)
 // ****************************************************************************
 
 avtTecplotBinaryFileFormat::avtTecplotBinaryFileFormat(const char *filename,
-                                                 DBOptionsAttributes *readOpts)
+                                                 const DBOptionsAttributes *readOpts)
     : avtSTMDFileFormat(&filename, 1), zoneNameToZoneList(), scalarToZone()
 {
     tec = 0;

--- a/src/databases/Tecplot/avtTecplotBinaryFileFormat.h
+++ b/src/databases/Tecplot/avtTecplotBinaryFileFormat.h
@@ -37,7 +37,7 @@ class vtkPoints;
 class avtTecplotBinaryFileFormat : public avtSTMDFileFormat
 {
 public:
-    avtTecplotBinaryFileFormat(const char *, DBOptionsAttributes *);
+    avtTecplotBinaryFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtTecplotBinaryFileFormat() {;};
 
     //

--- a/src/databases/Tecplot/avtTecplotFileFormat.C
+++ b/src/databases/Tecplot/avtTecplotFileFormat.C
@@ -1737,7 +1737,7 @@ avtTecplotFileFormat::ReadFile()
 // ****************************************************************************
 
 avtTecplotFileFormat::avtTecplotFileFormat(const char *fname,
-                                           DBOptionsAttributes *readOpts)
+                                           const DBOptionsAttributes *readOpts)
     : avtSTMDFileFormat(&fname, 1), expressions()
 {
     file_read = false;

--- a/src/databases/Tecplot/avtTecplotFileFormat.h
+++ b/src/databases/Tecplot/avtTecplotFileFormat.h
@@ -55,7 +55,7 @@ class vtkUnstructuredGrid;
 class avtTecplotFileFormat : public avtSTMDFileFormat
 {
   public:
-                       avtTecplotFileFormat(const char *, DBOptionsAttributes *);
+                       avtTecplotFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtTecplotFileFormat();
 
     virtual const char    *GetType(void)   { return "Tecplot"; };

--- a/src/databases/Tecplot/avtTecplotWriter.C
+++ b/src/databases/Tecplot/avtTecplotWriter.C
@@ -12,6 +12,7 @@
 
 #include <avtDatabaseMetaData.h>
 
+#include <DBOptionsAttributes.h>
 #include <DebugStream.h>
 #include <ImproperUseException.h>
 #include <visit_gzstream.h>
@@ -38,7 +39,7 @@ using     std::vector;
 #define FLOAT_COLUMN_WIDTH 14
 #define INT_COLUMN_WIDTH   11
 
-avtTecplotWriter::avtTecplotWriter(DBOptionsAttributes *writeOpts)
+avtTecplotWriter::avtTecplotWriter(const DBOptionsAttributes *writeOpts)
 {
     variablesWritten = false;
     gzipLevel = 0;

--- a/src/databases/Tecplot/avtTecplotWriter.h
+++ b/src/databases/Tecplot/avtTecplotWriter.h
@@ -10,13 +10,13 @@
 #define AVT_TECPLOT_WRITER_H
 
 #include <avtDatabaseWriter.h>
-#include <DBOptionsAttributes.h>
 
 #include <string>
 #include <vector>
 #include <visitstream.h>
 #include <visit_gzstream.h>
 
+class DBOptionsAttributes;
 class vtkPoints;
 class vtkPolyData;
 class vtkRectilinearGrid;
@@ -48,7 +48,7 @@ class vtkUnstructuredGrid;
 class avtTecplotWriter : public virtual avtDatabaseWriter
 {
   public:
-                   avtTecplotWriter(DBOptionsAttributes *);
+                   avtTecplotWriter(const DBOptionsAttributes *);
     virtual       ~avtTecplotWriter();
 
   protected:

--- a/src/databases/UNIC/avtUNICFileFormat.C
+++ b/src/databases/UNIC/avtUNICFileFormat.C
@@ -20,7 +20,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidDBTypeException.h>

--- a/src/databases/Uintah/avtUintahFileFormat.C
+++ b/src/databases/Uintah/avtUintahFileFormat.C
@@ -60,7 +60,7 @@ const double NAN_REPLACE_VAL = 1.0E9;
 //
 // ****************************************************************************
 avtUintahFileFormat::avtUintahFileFormat(const char *filename,
-                                         DBOptionsAttributes* attrs) :
+                                         const DBOptionsAttributes* attrs) :
   avtMTMDFileFormat(filename)
 {
   // int t1 = visitTimer->StartTimer();

--- a/src/databases/Uintah/avtUintahFileFormat.h
+++ b/src/databases/Uintah/avtUintahFileFormat.h
@@ -49,7 +49,7 @@ class TimeStepInfo;
 class avtUintahFileFormat : public avtMTMDFileFormat
 {
 public:
-  avtUintahFileFormat( const char * filename, DBOptionsAttributes* attrs);
+  avtUintahFileFormat( const char * filename, const DBOptionsAttributes* attrs);
   virtual           ~avtUintahFileFormat();
 
   virtual double        GetTime( int timestep );

--- a/src/databases/VTK/avtVTKFileFormat.C
+++ b/src/databases/VTK/avtVTKFileFormat.C
@@ -4,7 +4,7 @@
 
 #include <avtVTKFileFormat.h>
 
-avtVTK_STSDFileFormat::avtVTK_STSDFileFormat(const char *filename, DBOptionsAttributes *opts) : 
+avtVTK_STSDFileFormat::avtVTK_STSDFileFormat(const char *filename, const DBOptionsAttributes *opts) : 
     avtSTSDFileFormat(filename)
 {
     GetCycleFromFilename(filename);
@@ -12,7 +12,7 @@ avtVTK_STSDFileFormat::avtVTK_STSDFileFormat(const char *filename, DBOptionsAttr
 }
 
 avtVTK_STSDFileFormat::avtVTK_STSDFileFormat(const char *filename, 
-    DBOptionsAttributes *opts, avtVTKFileReader *r) : 
+    const DBOptionsAttributes *opts, avtVTKFileReader *r) : 
     avtSTSDFileFormat(filename)
 {
     GetCycleFromFilename(filename);
@@ -142,7 +142,7 @@ avtVTK_STSDFileFormat::IsEmpty()
 // ****************************************************************************
 // ****************************************************************************
 
-avtVTK_STMDFileFormat::avtVTK_STMDFileFormat(const char *filename, DBOptionsAttributes *opts) : 
+avtVTK_STMDFileFormat::avtVTK_STMDFileFormat(const char *filename, const DBOptionsAttributes *opts) : 
     avtSTMDFileFormat(&filename, 1)
 {
     GetCycleFromFilename(filename);
@@ -150,7 +150,7 @@ avtVTK_STMDFileFormat::avtVTK_STMDFileFormat(const char *filename, DBOptionsAttr
 }
 
 avtVTK_STMDFileFormat::avtVTK_STMDFileFormat(const char *filename,
-    DBOptionsAttributes *opts, avtVTKFileReader *r) : 
+    const DBOptionsAttributes *opts, avtVTKFileReader *r) : 
     avtSTMDFileFormat(&filename, 1)
 {
     GetCycleFromFilename(filename);

--- a/src/databases/VTK/avtVTKFileFormat.h
+++ b/src/databases/VTK/avtVTKFileFormat.h
@@ -35,9 +35,9 @@ class avtVTK_STSDFileFormat : public avtSTSDFileFormat
 {
 public:
                        avtVTK_STSDFileFormat(const char *filename, 
-                                             DBOptionsAttributes *);
+                                             const DBOptionsAttributes *);
                        avtVTK_STSDFileFormat(const char *filename, 
-                                             DBOptionsAttributes *,
+                                             const DBOptionsAttributes *,
                                              avtVTKFileReader *r);
     virtual           ~avtVTK_STSDFileFormat();
 
@@ -82,9 +82,9 @@ class avtVTK_STMDFileFormat : public avtSTMDFileFormat
 {
 public:
                        avtVTK_STMDFileFormat(const char *filename,
-                                             DBOptionsAttributes *);
+                                             const DBOptionsAttributes *);
                        avtVTK_STMDFileFormat(const char *filename, 
-                                             DBOptionsAttributes *,
+                                             const DBOptionsAttributes *,
                                              avtVTKFileReader *r);
     virtual           ~avtVTK_STMDFileFormat();
 

--- a/src/databases/VTK/avtVTKFileReader.C
+++ b/src/databases/VTK/avtVTKFileReader.C
@@ -114,7 +114,7 @@ double avtVTKFileReader::INVALID_TIME = -DBL_MAX;
 //
 // ****************************************************************************
 
-avtVTKFileReader::avtVTKFileReader(const char *fname, DBOptionsAttributes *) :
+avtVTKFileReader::avtVTKFileReader(const char *fname, const DBOptionsAttributes *) :
     vtk_meshname()
 {
     filename = new char[strlen(fname)+1];

--- a/src/databases/VTK/avtVTKFileReader.h
+++ b/src/databases/VTK/avtVTKFileReader.h
@@ -92,7 +92,7 @@ class DBOptionsAttributes;
 class avtVTKFileReader
 {
   public:
-    avtVTKFileReader(const char *,const DBOptionsAttributes *);
+    avtVTKFileReader(const char *, const DBOptionsAttributes *);
     ~avtVTKFileReader();
 
     int           GetNumberOfDomains();

--- a/src/databases/VTK/avtVTKFileReader.h
+++ b/src/databases/VTK/avtVTKFileReader.h
@@ -92,7 +92,7 @@ class DBOptionsAttributes;
 class avtVTKFileReader
 {
   public:
-    avtVTKFileReader(const char *,DBOptionsAttributes *);
+    avtVTKFileReader(const char *,const DBOptionsAttributes *);
     ~avtVTKFileReader();
 
     int           GetNumberOfDomains();

--- a/src/databases/VTK/avtVTKWriter.C
+++ b/src/databases/VTK/avtVTKWriter.C
@@ -71,7 +71,7 @@ double avtVTKWriter::INVALID_TIME = -DBL_MAX;
 //    Add tetrahedralize option.
 // ****************************************************************************
 
-avtVTKWriter::avtVTKWriter(DBOptionsAttributes *atts) :stem(), meshName(), fileNames()
+avtVTKWriter::avtVTKWriter(const DBOptionsAttributes *atts) :stem(), meshName(), fileNames()
 {
     doBinary = false;
     doXML = false;

--- a/src/databases/VTK/avtVTKWriter.h
+++ b/src/databases/VTK/avtVTKWriter.h
@@ -59,7 +59,7 @@ class
 avtVTKWriter : public virtual avtDatabaseWriter
 {
   public:
-                   avtVTKWriter(DBOptionsAttributes *);
+                   avtVTKWriter(const DBOptionsAttributes *);
     virtual       ~avtVTKWriter() {;};
 
   protected:

--- a/src/databases/Velodyne/avtVelodyneFileFormat.C
+++ b/src/databases/Velodyne/avtVelodyneFileFormat.C
@@ -19,7 +19,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtMaterial.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidDBTypeException.h>

--- a/src/databases/Vs/avtVsFileFormat.C
+++ b/src/databases/Vs/avtVsFileFormat.C
@@ -104,7 +104,7 @@ int avtVsFileFormat::instanceCounter = 0;
 //  Modifications:
 //
 avtVsFileFormat::avtVsFileFormat(const char* filename,
-                                 DBOptionsAttributes *readOpts) :
+                                 const DBOptionsAttributes *readOpts) :
   avtSTMDFileFormat(&filename, 1), dataFileName(filename),
   processDataSelections(false)
 {

--- a/src/databases/Vs/avtVsFileFormat.h
+++ b/src/databases/Vs/avtVsFileFormat.h
@@ -60,7 +60,7 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  *
  * @param dfnm the name of the data file
  */
-    avtVsFileFormat(const char*, DBOptionsAttributes *);
+    avtVsFileFormat(const char*, const DBOptionsAttributes *);
 
 /**
  * Destructor

--- a/src/databases/WPPImage/avtWPPImageFileFormat.C
+++ b/src/databases/WPPImage/avtWPPImageFileFormat.C
@@ -18,7 +18,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -21,7 +21,6 @@
 #include <vtkPolyData.h>
 #include <vtkTriangleFilter.h>
 #include <avtDatabaseMetaData.h>
-#include <DBOptionsAttributes.h>
 #include <vtkOBJWriter.h>
 
 #include <avtDatabaseMetaData.h>

--- a/src/databases/WellLogs/avtWellLogsFileFormat.C
+++ b/src/databases/WellLogs/avtWellLogsFileFormat.C
@@ -23,7 +23,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtMaterial.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/XSF/avtXSFFileFormat.C
+++ b/src/databases/XSF/avtXSFFileFormat.C
@@ -21,7 +21,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/Xdmf/avtXdmfFileFormat.C
+++ b/src/databases/Xdmf/avtXdmfFileFormat.C
@@ -32,7 +32,6 @@
 #include <avtDatabaseMetaData.h>
 #include <avtGhostData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidDBTypeException.h>

--- a/src/databases/Xmdv/avtXmdvFileFormat.C
+++ b/src/databases/Xmdv/avtXmdvFileFormat.C
@@ -47,7 +47,7 @@ ifstream &operator >> (ifstream &s, string &str)
 // ****************************************************************************
 
 avtXmdvFileFormat::avtXmdvFileFormat(const char *filename, 
-                                     DBOptionsAttributes *)
+                                     const DBOptionsAttributes *)
     : avtSTSDFileFormat(filename)
 {
     readInData = false;

--- a/src/databases/Xmdv/avtXmdvFileFormat.h
+++ b/src/databases/Xmdv/avtXmdvFileFormat.h
@@ -38,7 +38,7 @@ class avtXmdvFileFormat : public avtSTSDFileFormat
 {
   public:
                        avtXmdvFileFormat(const char *filename, 
-                                         DBOptionsAttributes *);
+                                         const DBOptionsAttributes *);
     virtual           ~avtXmdvFileFormat() {;};
 
     virtual const char    *GetType(void)   { return "Xmdv"; };

--- a/src/databases/Xmdv/avtXmdvWriter.C
+++ b/src/databases/Xmdv/avtXmdvWriter.C
@@ -38,7 +38,7 @@ using     std::vector;
 //
 // ****************************************************************************
 
-avtXmdvWriter::avtXmdvWriter(DBOptionsAttributes *atts)
+avtXmdvWriter::avtXmdvWriter(const DBOptionsAttributes *atts)
 {
     writeOutCoordinates = atts->GetBool("Export coordinates?");
 }

--- a/src/databases/Xmdv/avtXmdvWriter.h
+++ b/src/databases/Xmdv/avtXmdvWriter.h
@@ -46,7 +46,7 @@ class
 avtXmdvWriter : virtual public avtDatabaseWriter
 {
   public:
-                   avtXmdvWriter(DBOptionsAttributes *);
+                   avtXmdvWriter(const DBOptionsAttributes *);
     virtual       ~avtXmdvWriter() {;};
 
   protected:

--- a/src/databases/Xolotl/avtXolotlFileFormat.C
+++ b/src/databases/Xolotl/avtXolotlFileFormat.C
@@ -50,7 +50,7 @@ typedef struct {
 //  Creation:   March 22, 2016
 //
 // ****************************************************************************
-avtXolotlFileFormat::avtXolotlFileFormat(const char *fn, DBOptionsAttributes *readOpts)
+avtXolotlFileFormat::avtXolotlFileFormat(const char *fn, const DBOptionsAttributes *readOpts)
     : avtMTSDFileFormat(&fn, 1)
 {
     fileId = -1;

--- a/src/databases/Xolotl/avtXolotlFileFormat.h
+++ b/src/databases/Xolotl/avtXolotlFileFormat.h
@@ -31,7 +31,7 @@ class DBOptionsAttributes;
 class avtXolotlFileFormat : public avtMTSDFileFormat
 {
   public:
-                       avtXolotlFileFormat(const char *, DBOptionsAttributes *);
+                       avtXolotlFileFormat(const char *, const DBOptionsAttributes *);
     virtual           ~avtXolotlFileFormat();
 
     void               Initialize();

--- a/src/databases/ffp/avtffpFileFormat.C
+++ b/src/databases/ffp/avtffpFileFormat.C
@@ -39,7 +39,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Environment.h>
 #include <Expression.h>
 

--- a/src/databases/paraDIS/Dumpfile.C
+++ b/src/databases/paraDIS/Dumpfile.C
@@ -25,7 +25,7 @@ using namespace std;
 
 int burgersTypes[18] = {-2,-1, 0, 10,11,12,13, 20,21,22, 30,31,32, 40,41,42, 50, 60};
 
-Dumpfile::Dumpfile(const char* filename, DBOptionsAttributes *rdatts) {
+Dumpfile::Dumpfile(const char* filename, const DBOptionsAttributes *rdatts) {
 
   this->Clear(); 
 

--- a/src/databases/paraDIS/Dumpfile.h
+++ b/src/databases/paraDIS/Dumpfile.h
@@ -17,11 +17,11 @@
 struct Dumpfile: public ParaDISFileSet {
  public:
  
-  Dumpfile(const char *filename, DBOptionsAttributes *rdatts); 
+  Dumpfile(const char *filename, const DBOptionsAttributes *rdatts); 
   ~Dumpfile(); 
 
   void Clear(void); 
-  //void Init(std::string filename, DBOptionsAttributes *rdatts); 
+  //void Init(std::string filename, const DBOptionsAttributes *rdatts); 
   bool FileIsValid(void);
   virtual vtkDataSet *GetMesh(std::string meshname);
   virtual vtkDataArray *GetVar(std::string varname); 

--- a/src/databases/paraDIS/avtparaDISFileFormat.C
+++ b/src/databases/paraDIS/avtparaDISFileFormat.C
@@ -43,7 +43,7 @@ using     rclib::Point;
 // ****************************************************************************
  
 avtparaDISFileFormat::avtparaDISFileFormat(const char *filename,
-                                           DBOptionsAttributes *rdatts)
+                                           const DBOptionsAttributes *rdatts)
   : avtSTSDFileFormat(filename), mParallelData(filename), mDumpfile(filename, rdatts) {
 
   if (filename) {

--- a/src/databases/paraDIS/avtparaDISFileFormat.h
+++ b/src/databases/paraDIS/avtparaDISFileFormat.h
@@ -38,7 +38,7 @@ class avtparaDISFileFormat : public avtSTSDFileFormat
 {
   public:
                        avtparaDISFileFormat(const char *filename,
-                                            DBOptionsAttributes *rdatts);
+                                            const DBOptionsAttributes *rdatts);
     virtual           ~avtparaDISFileFormat() {;};
 
 

--- a/src/databases/paraDIS_tecplot/avtparaDIS_tecplotFileFormat.C
+++ b/src/databases/paraDIS_tecplot/avtparaDIS_tecplotFileFormat.C
@@ -21,7 +21,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 #include <DebugStream.h>
 

--- a/src/databases/unv/avtunvFileFormat.C
+++ b/src/databases/unv/avtunvFileFormat.C
@@ -34,7 +34,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/databases/volimage/avtvolimageFileFormat.C
+++ b/src/databases/volimage/avtvolimageFileFormat.C
@@ -17,7 +17,6 @@
 
 #include <avtDatabaseMetaData.h>
 
-#include <DBOptionsAttributes.h>
 #include <Expression.h>
 
 #include <InvalidVariableException.h>

--- a/src/tools/dev/xml/GenerateAVT.h
+++ b/src/tools/dev/xml/GenerateAVT.h
@@ -844,7 +844,7 @@ class AVTGeneratorPlugin : public PluginBase
             h << "{" << Endl;
             h << "  public:" << Endl;
             if (hasoptions)
-                h << "                       avt"<<name<<"FileFormat(const char *filename, DBOptionsAttributes *);" << Endl;
+                h << "                       avt"<<name<<"FileFormat(const char *filename, const DBOptionsAttributes *);" << Endl;
             else
                 h << "                       avt"<<name<<"FileFormat(const char *filename);" << Endl;
             h << "    virtual           ~avt"<<name<<"FileFormat() {;};" << Endl;
@@ -917,7 +917,7 @@ class AVTGeneratorPlugin : public PluginBase
             h << "{" << Endl;
             h << "  public:" << Endl;
             if (hasoptions)
-                h << "                       avt"<<name<<"FileFormat(const char *, DBOptionsAttributes *);" << Endl;
+                h << "                       avt"<<name<<"FileFormat(const char *, const DBOptionsAttributes *);" << Endl;
             else
                 h << "                       avt"<<name<<"FileFormat(const char *);" << Endl;
             h << "    virtual           ~avt"<<name<<"FileFormat() {;};" << Endl;
@@ -989,7 +989,7 @@ class AVTGeneratorPlugin : public PluginBase
             h << "{" << Endl;
             h << "  public:" << Endl;
             if (hasoptions)
-                h << "                       avt"<<name<<"FileFormat(const char *, DBOptionsAttributes *);" << Endl;
+                h << "                       avt"<<name<<"FileFormat(const char *, const DBOptionsAttributes *);" << Endl;
             else
                 h << "                       avt"<<name<<"FileFormat(const char *);" << Endl;
             h << "    virtual           ~avt"<<name<<"FileFormat() {;};" << Endl;
@@ -1058,7 +1058,7 @@ class AVTGeneratorPlugin : public PluginBase
             h << "{" << Endl;
             h << "  public:" << Endl;
             if (hasoptions)
-                h << "                       avt"<<name<<"FileFormat(const char *, DBOptionsAttributes *);" << Endl;
+                h << "                       avt"<<name<<"FileFormat(const char *, const DBOptionsAttributes *);" << Endl;
             else
                 h << "                       avt"<<name<<"FileFormat(const char *);" << Endl;
             h << "    virtual           ~avt"<<name<<"FileFormat() {;};" << Endl;
@@ -1137,7 +1137,7 @@ class AVTGeneratorPlugin : public PluginBase
             c << "// ****************************************************************************" << Endl;
             c << "" << Endl;
             if (hasoptions)
-                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, DBOptionsAttributes *readOpts)" << Endl;
+                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, const DBOptionsAttributes *readOpts)" << Endl;
             else
                 c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename)" << Endl;
             c << "    : avtSTSDFileFormat(filename)" << Endl;
@@ -1444,7 +1444,7 @@ class AVTGeneratorPlugin : public PluginBase
             c << "// ****************************************************************************" << Endl;
             c << "" << Endl;
             if (hasoptions)
-                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, DBOptionsAttributes *readOpts)" << Endl;
+                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, const DBOptionsAttributes *readOpts)" << Endl;
             else
                 c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename)" << Endl;
             c << "    : avtMTSDFileFormat(&filename, 1)" << Endl;
@@ -1775,7 +1775,7 @@ class AVTGeneratorPlugin : public PluginBase
             c << "// ****************************************************************************" << Endl;
             c << "" << Endl;
             if (hasoptions)
-                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, DBOptionsAttributes *readOpts)" << Endl;
+                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, const DBOptionsAttributes *readOpts)" << Endl;
             else
                 c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename)" << Endl;
             c << "    : avtSTMDFileFormat(&filename, 1)" << Endl;
@@ -2091,7 +2091,7 @@ class AVTGeneratorPlugin : public PluginBase
             c << "// ****************************************************************************" << Endl;
             c << "" << Endl;
             if (hasoptions)
-                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, DBOptionsAttributes *readOpts)" << Endl;
+                c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename, const DBOptionsAttributes *readOpts)" << Endl;
             else
                 c << "avt"<<name<<"FileFormat::avt"<<name<<"FileFormat(const char *filename)" << Endl;
             c << "    : avtMTMDFileFormat(filename)" << Endl;
@@ -2537,7 +2537,7 @@ class AVTGeneratorPlugin : public PluginBase
         h << "{" << Endl;
         h << "  public:" << Endl;
         if (hasoptions)
-            h << "                   avt"<<name<<"Writer(DBOptionsAttributes *);" << Endl;
+            h << "                   avt"<<name<<"Writer(const DBOptionsAttributes *);" << Endl;
         else
             h << "                   avt"<<name<<"Writer();" << Endl;
         h << "    virtual       ~avt"<<name<<"Writer() {;};" << Endl;
@@ -2587,7 +2587,7 @@ class AVTGeneratorPlugin : public PluginBase
         c << "// ****************************************************************************" << Endl;
         c << "" << Endl;
         if (hasoptions)
-            c << "avt"<<name<<"Writer::avt"<<name<<"Writer(DBOptionsAttributes *)" << Endl;
+            c << "avt"<<name<<"Writer::avt"<<name<<"Writer(const DBOptionsAttributes *)" << Endl;
         else
             c << "avt"<<name<<"Writer::avt"<<name<<"Writer(void)" << Endl;
         c << "{" << Endl;


### PR DESCRIPTION
Add const to DBOptionsAttributes in avtXXXFileFormat and avtXXXWriter constructors.

Resolves #4550.

Also removed DBOptionsAttributes references from readers that don't use them.
