### PR TITLE
Fix importing of host profiles.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed bugs with the avtLinesFileFormat reader. The reader can now distinguish 2D from 3D, and it will not remove identical consecutive points that exist on different lines.</li>
   <li>Fixed a crash with the generation of ghost zones using global node ids where there were NULL domains.</li>
   <li>Fixed a bug that caused trilinear ray casting to have very harsh lighting.</li>
+  <li>Fixed a bug importing remote hosts.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #4596.

URL's were being created with '//' as part of the path.
Evidently that causes a redirect (seems like new behavior
since it worked when I originally fixed the code to work with
github), and redirects aren't (currently) allowed when importing
host profiles.
I removed the extra '/' from urls and added error checking
and error messages to aid in fixing future problems.
Updated release notes.

This is a merge from 3.1RC
