### PR TITLE
Fix Exodus reader bug for files generated with newer exodus libraries.

### DIFF
--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -129,6 +129,12 @@ static int CompareStrings(void const *_a, void const *_b)
 // optionally, sort it.
 //
 // Programmer: Mark C. Miller, Fri Dec 19 11:05:11 PST 2014
+//
+//  Modifications:
+//    Kathleen Biagas, Wed Apr 29 11:19:52 PDT 2020
+//    Don't err out if len_string isn't present. Files created with newer
+//    versions of exodus libraries don't have this dim.
+//
 // ****************************************************************************
 
 char **GetStringListFromExodusIINCvar(int exfid, char const *var_name, bool sort_results = false)
@@ -137,9 +143,9 @@ char **GetStringListFromExodusIINCvar(int exfid, char const *var_name, bool sort
     char **retval = (char**) malloc(1 * sizeof(char*));
     retval[0] = 0;
 
-    int len_string_dimid;
+    int len_string_dimid = -1;
     ncerr = nc_inq_dimid(exfid, "len_string", &len_string_dimid);
-    if (ncerr != NC_NOERR) return retval;
+    if (ncerr != NC_NOERR) len_string_dimid = -1;
 
     int len_name_dimid = -1;
     ncerr = nc_inq_dimid(exfid, "len_name", &len_name_dimid);

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a crash with the generation of ghost zones using global node ids where there were NULL domains.</li>
   <li>Fixed a bug that caused trilinear ray casting to have very harsh lighting.</li>
   <li>Fixed a bug importing remote hosts.</li>
+  <li>Fixed a bug reading files generated with newer Exodus libraries.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #4658 
At least, this fix allows us to read the data provided in the ticket.

I changed the reader to not err_out if 'len_string' dim isn't available in the file.

I tested with the provided data, ran our regression tests for the exodus reader, and also tried some exodus files from VTK.


### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] New and existing unit tests pass locally with my changes

