### PR TITLE
Correct a bug handling !TIME and !ENSEMBLE in ".visit" files.

### DIFF
--- a/src/avt/Database/Database/avtDatabase.C
+++ b/src/avt/Database/Database/avtDatabase.C
@@ -2374,6 +2374,9 @@ avtDatabase::NumStagesForFetch(avtDataRequest_p)
 //    Don't count key words when determining if the file count evenly divides
 //    the block count.
 //
+//    Eric Brugger, Fri May  1 12:39:32 PDT 2020
+//    Added logic to skip lines that start with !TIME and !ENSEMBLE.
+//
 // ****************************************************************************
 
 bool
@@ -2448,6 +2451,20 @@ avtDatabase::GetFileListFromTextFile(const char *textfile,
                 if (bang_nBlocksp)
                     *bang_nBlocksp = bang_nBlocks;
 
+                continue;
+            }
+
+            //
+            // Skip !TIME and !ENSEMBLE.
+            //
+            bnbp = strstr(str_auto, "!TIME ");
+            if (bnbp && bnbp == str_auto)
+            {
+                continue;
+            }
+            bnbp = strstr(str_auto, "!ENSEMBLE");
+            if (bnbp && bnbp == str_auto)
+            {
                 continue;
             }
 

--- a/src/avt/Database/Database/avtDatabaseFactory.C
+++ b/src/avt/Database/Database/avtDatabaseFactory.C
@@ -338,6 +338,9 @@ avtDatabaseFactory::SetBackendType(const int bType)
 //    Allow file permission check to be bypassed. We don't want it for batch
 //    in situ.
 //
+//    Eric Brugger, Fri May  1 12:39:32 PDT 2020
+//    Correct the parsing of !TIME when the time was 0.
+//
 // ****************************************************************************
 
 avtDatabase *
@@ -396,7 +399,7 @@ avtDatabaseFactory::FileList(DatabasePluginManager *dbmgr,
              char *endptr = 0;
              errno = 0;
              double time = strtod(filelist[fileIndex] + strlen("!TIME "), &endptr);
-             if (errno != 0 || (time == 0.0 || endptr == filelist[fileIndex] + strlen("!TIME ")))
+             if (errno != 0 || (time == 0.0 && endptr == filelist[fileIndex] + strlen("!TIME ")))
              {
                  debug1 << "BAD SYNTAX FOR !TIME, \"" << filelist[fileIndex] << "\", RESETTING TO ";
                  if (times.size())

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -38,6 +38,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug reading files generated with newer Exodus libraries.</li>
   <li>Fixed a bug preventing full removal of the axes when using OSPRay rendering.</li>
   <li>Fixed a bug where 2D axes annotation font settings weren't always saved to config files.</li>
+  <li>Fixed a bug where lines starting with !TIME and !ENSEMBLE ".visit" files weren't being processed properly and were interpreted as file names.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #4672

I corrected a bug where lines starting with !TIME and !ENSEMBLE weren't being handled properly in ".visit" files. They were essentially being handled as filenames.

### Type of change

This is a bug fix.

### How Has This Been Tested?

I open dbA00.pdb from our standard data files and exported "mesh/ireg" for all the time states. I then created the following ".visit" file:

!NBLOCKS 1
!TIME 0.0
visit_ex_db_0000.vts
!TIME 1.0
visit_ex_db_0001.vts
!TIME 2.0
visit_ex_db_0002.vts
!TIME 3.0
visit_ex_db_0003.vts
!TIME 4.0
visit_ex_db_0004.vts
!TIME 5.0
visit_ex_db_0005.vts
!TIME 6.0
visit_ex_db_0006.vts
!TIME 7.0
visit_ex_db_0007.vts
!TIME 8.0
visit_ex_db_0008.vts
!TIME 9.0
visit_ex_db_0009.vts

I then opened this file in VisIt and it plotted properly. I will note that the vts files had times associated with them and that the times specified in the ".visit" file didn't override the times in the vts files. I didn't fix this and filed ticker #4674. I did remove the times from the first 2 vts files and for those 2 time states it used the time in the ".visit" file.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers