### PR TITLE
Correct a bug handling TIME and ENSEMBLE in ".visit" files. (#4675)

### DIFF
--- a/src/avt/Database/Database/avtDatabase.C
+++ b/src/avt/Database/Database/avtDatabase.C
@@ -2374,6 +2374,9 @@ avtDatabase::NumStagesForFetch(avtDataRequest_p)
 //    Don't count key words when determining if the file count evenly divides
 //    the block count.
 //
+//    Eric Brugger, Fri May  1 12:39:32 PDT 2020
+//    Added logic to skip lines that start with !TIME and !ENSEMBLE.
+//
 // ****************************************************************************
 
 bool
@@ -2448,6 +2451,20 @@ avtDatabase::GetFileListFromTextFile(const char *textfile,
                 if (bang_nBlocksp)
                     *bang_nBlocksp = bang_nBlocks;
 
+                continue;
+            }
+
+            //
+            // Skip !TIME and !ENSEMBLE.
+            //
+            bnbp = strstr(str_auto, "!TIME ");
+            if (bnbp && bnbp == str_auto)
+            {
+                continue;
+            }
+            bnbp = strstr(str_auto, "!ENSEMBLE");
+            if (bnbp && bnbp == str_auto)
+            {
                 continue;
             }
 

--- a/src/avt/Database/Database/avtDatabaseFactory.C
+++ b/src/avt/Database/Database/avtDatabaseFactory.C
@@ -338,6 +338,9 @@ avtDatabaseFactory::SetBackendType(const int bType)
 //    Allow file permission check to be bypassed. We don't want it for batch
 //    in situ.
 //
+//    Eric Brugger, Fri May  1 12:39:32 PDT 2020
+//    Correct the parsing of !TIME when the time was 0.
+//
 // ****************************************************************************
 
 avtDatabase *
@@ -396,7 +399,7 @@ avtDatabaseFactory::FileList(DatabasePluginManager *dbmgr,
              char *endptr = 0;
              errno = 0;
              double time = strtod(filelist[fileIndex] + strlen("!TIME "), &endptr);
-             if (errno != 0 || (time == 0.0 || endptr == filelist[fileIndex] + strlen("!TIME ")))
+             if (errno != 0 || (time == 0.0 && endptr == filelist[fileIndex] + strlen("!TIME ")))
              {
                  debug1 << "BAD SYNTAX FOR !TIME, \"" << filelist[fileIndex] << "\", RESETTING TO ";
                  if (times.size())

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug that was preventing VisIt from correctly generating normals for triangle strips.</li>
   <li>Fixed a bug reading files generated with newer Exodus libraries.</li>
   <li>Fixed a bug where 2D axes annotation font settings weren't always saved to config files.</li>
+  <li>Fixed a bug where lines starting with !TIME and !ENSEMBLE ".visit" files weren't being processed properly and were interpreted as file names.</li>
   <li>Reduced amount of '.' written to log files while waiting for processes to connect.</li>
 </ul>
 


### PR DESCRIPTION
Merge from the 3.1RC to develop.