### PR TITLE
Updates stock host profile for rhea.ccs.ornl.gov

### DIFF
--- a/src/resources/hosts/ornl/host_ornl_rhea.xml
+++ b/src/resources/hosts/ornl/host_ornl_rhea.xml
@@ -4,7 +4,7 @@
     <Field name="host" type="string">rhea.ccs.ornl.gov</Field>
     <Field name="userName" type="string">notset</Field>
     <Field name="hostAliases" type="string">rhea-login#g</Field>
-    <Field name="directory" type="string">/sw/redhat6/visit</Field>
+    <Field name="directory" type="string">/sw/rhea/visit</Field>
     <Field name="shareOneBatchJob" type="bool">false</Field>
     <Field name="sshPortSpecified" type="bool">false</Field>
     <Field name="sshPort" type="int">22</Field>
@@ -24,14 +24,14 @@
         <Field name="numProcessors" type="int">16</Field>
         <Field name="numNodesSet" type="bool">true</Field>
         <Field name="numNodes" type="int">1</Field>
-        <Field name="partitionSet" type="bool">false</Field>
-        <Field name="partition" type="string"></Field>
-        <Field name="bankSet" type="bool">false</Field>
-        <Field name="bank" type="string"></Field>
+        <Field name="partitionSet" type="bool">true</Field>
+        <Field name="partition" type="string">batch</Field>
+        <Field name="bankSet" type="bool">true</Field>
+        <Field name="bank" type="string">PROJECT-ID</Field>
         <Field name="timeLimitSet" type="bool">true</Field>
         <Field name="timeLimit" type="string">1:00:00</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">qsub/mpirun</Field>
+        <Field name="launchMethod" type="string">sbatch/srun</Field>
         <Field name="forceStatic" type="bool">true</Field>
         <Field name="forceDynamic" type="bool">false</Field>
         <Field name="active" type="bool">false</Field>


### PR DESCRIPTION
### Description

ORNL's Rhea cluster migrated to using slurm for scheduling over a year ago. And the location of the facility-installed VisIT binaries changed at the same time. This commit updates the stock host profile for Rhea to use sbatch/srun as the default launch method and sets the default path to VisIT to the new, correct location.

Since it's not possible to start jobs without specifying an project ID for allocation accounting on Rhea, this commit also sets the default `bankSet` boolean checkbox to `true` and adds a suggestive placeholder value for the default project ID (`bank` field).

### Type of change

Bug fix

### How Has This Been Tested?

This change is based on live tests with a custom host profile for Rhea which I have been using for the past year.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
