### PR TITLE
blueprint plugin: add support for a multi domain per file scheme

### DIFF
--- a/src/databases/Blueprint/avtBlueprintTreeCache.C
+++ b/src/databases/Blueprint/avtBlueprintTreeCache.C
@@ -1031,13 +1031,82 @@ avtBlueprintTreeCache::SetProtocol(const std::string &protocol)
     m_protocol = protocol;
 }
 
+//-----------------------------------------------------------------------------
+// This uses a mapping scheme created by ascent + conduit
+// Note: We will support explicit maps from the bp index in the future.
+// TODO: We should cache this, not regen every fetch
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+void gen_domain_to_file_map(int num_domains,
+                            int num_files,
+                            Node &out)
+{
+    int num_domains_per_file = num_domains / num_files;
+    int left_overs = num_domains % num_files;
+
+    out["global_domains_per_file"].set(DataType::int32(num_files));
+    out["global_domain_offsets"].set(DataType::int32(num_files));
+    out["global_domain_to_file"].set(DataType::int32(num_domains));
+    
+    int32_array v_domains_per_file = out["global_domains_per_file"].value();
+    int32_array v_domains_offsets  = out["global_domain_offsets"].value();
+    int32_array v_domain_to_file   = out["global_domain_to_file"].value();
+    
+    // setup domains per file
+    for(int f=0; f < num_files; f++)
+    {
+        v_domains_per_file[f] = num_domains_per_file;
+        if( f < left_overs)
+            v_domains_per_file[f]+=1;
+    }
+
+    // prefix sum to calc offsets
+    for(int f=0; f < num_files; f++)
+    {
+        v_domains_offsets[f] = v_domains_per_file[f];
+        if(f > 0)
+            v_domains_offsets[f] += v_domains_offsets[f-1];
+    }
+    
+    // do assignment, create simple map
+    int f_idx = 0;
+    for(int d=0; d < num_domains; d++)
+    {
+        if(d >= v_domains_offsets[f_idx])
+            f_idx++;
+        v_domain_to_file[d] = f_idx;
+    }
+}
 
 //-------------------------------------------------------------------//
 std::string
 avtBlueprintTreeCache::GenerateFilePath(int tree_id) const
 {
-    // for now, we only support 1 tree per file.
-    int file_id = tree_id;
+    int file_id = -1;
+
+    if(m_num_trees == m_num_files)
+    {
+        file_id = tree_id;
+    }
+    else if(m_num_files == 1)
+    {
+        file_id = 0;
+    }
+    else
+    {
+        Node d2f_map;
+        gen_domain_to_file_map(m_num_trees,
+                                m_num_files,
+                                d2f_map);
+        int num_domains_per_file = m_num_trees / m_num_files;
+        int left_overs = m_num_trees % m_num_files;
+        int32_array v_domain_to_file = d2f_map["global_domain_to_file"].value();
+        file_id = v_domain_to_file[tree_id];
+    }
+
+    BP_PLUGIN_INFO( "tree_id: " << tree_id 
+                    << " ==> file_id: " << file_id);
+
     return Expand(m_file_pattern,file_id);
 }
 

--- a/src/databases/Blueprint/avtBlueprintTreeCache.C
+++ b/src/databases/Blueprint/avtBlueprintTreeCache.C
@@ -1037,9 +1037,10 @@ avtBlueprintTreeCache::SetProtocol(const std::string &protocol)
 // TODO: We should cache this, not regen every fetch
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-void gen_domain_to_file_map(int num_domains,
-                            int num_files,
-                            Node &out)
+static void
+gen_domain_to_file_map(int num_domains,
+                       int num_files,
+                       Node &out)
 {
     int num_domains_per_file = num_domains / num_files;
     int left_overs = num_domains % num_files;

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -53,6 +53,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Enhanced the Pick Through Time to use a substantially faster algorithm by default. This algorithm will be enabled when preserving the picked element id. When preserving the picked coordinate, the original algorithm will be used instead.</li>
   <li>Enhanced the new default Pick Through Time algorithm to handle vectors, tensors, and arrays. For vectors, the magnitude is used. For tensors and arrays, the major eigenvalue is used.</li>
   <li>Expressions in the GUI Expression window will now appear alphabetically sorted.</li>
+  <li>The Blueprint Plugin now supports Ascent outputs with multiple domains per file.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Adds support for reading Ascent outputs that save multiple files per domain.


### Type of change

New feature, minor change to the plugin.

### How Has This Been Tested?

Tested on my mac with outputs from ascent's test suite.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [x] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
