### PR TITLE
Scalable rendering instead of remote rendering in the interactor gui window

### DIFF
--- a/src/gui/QvisInteractorWindow.C
+++ b/src/gui/QvisInteractorWindow.C
@@ -166,7 +166,7 @@ QvisInteractorWindow::CreateWindowContents()
     QRadioButton *never = new QRadioButton(tr("Never"), boundingBoxGroup);
     boundingBoxMode->addButton(never,1);
     boundingBoxLayout->addWidget(never, 1, 2);
-    QRadioButton *autorb = new QRadioButton(tr("Auto (remote rendering only)"), boundingBoxGroup);
+    QRadioButton *autorb = new QRadioButton(tr("Auto (scalable rendering only)"), boundingBoxGroup);
     boundingBoxMode->addButton(autorb,2);
     boundingBoxLayout->addWidget(autorb, 1, 3);
 


### PR DESCRIPTION
### Description

Resolves #4559 

Interactor settings now uses the phrase "scalable rendering" instead of "remote rendering"

### Type of change

Bug fix

### How Has This Been Tested?

Confirmed in the gui

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
