### PR TITLE
Fix a crash when choosing center and in scalable rendering mode.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -41,6 +41,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where lines starting with !TIME and !ENSEMBLE ".visit" files weren't being processed properly and were interpreted as file names.</li>
   <li>Fixed a bug that was producing bad volumes on datasets with cells of multiple dimensions.</li>
   <li>Reduced amount of '.' written to log files while waiting for processes to connect.</li>
+  <li>Fixed a crash when performing a choose center operation when there weren't any non-hidden active plots while in scalable rendering mode. It now prints an error message requesting that the user select a non-hidden plot.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/viewer/core/ViewerWindow.C
+++ b/src/viewer/core/ViewerWindow.C
@@ -6629,6 +6629,11 @@ ViewerWindow::Pick(int x, int y, const INTERACTION_MODE pickMode)
 //    Brad Whitlock, Wed Apr 30 09:37:27 PDT 2008
 //    Support for internationalization.
 //
+//    Eric Brugger, Wed May  6 10:57:35 PDT 2020
+//    Add a check for no active non-hidden plots and return false if
+//    there aren't any. This fixes a crash. Add some error and warning
+//    messages if the operation failed.
+//
 // ****************************************************************************
 
 bool
@@ -6644,25 +6649,45 @@ ViewerWindow::GetPickAttributesForScreenPoint(double sx, double sy,
         ViewerPlotList *plist = GetPlotList();
         intVector plotIds;
         plist->GetActivePlotIDs(plotIds);
-        EngineKey key = plist->GetPlot(plotIds[0])->GetEngineKey();
-        if (GetViewerEngineManager()->EngineExists(key))
+
+        //
+        // Its an error if there aren't any active non-hidden plot.
+        //
+        if (plotIds.size() == 0)
         {
-            intVector netIds;
-            for (size_t i = 0; i < plotIds.size(); i++)
+            GetViewerMessaging()->Error(
+                TR("Choose center requires an active non-hidden plot. "
+                   "Please select a plot and try again."));
+            retval = false;
+        }
+        else
+        {
+            EngineKey key = plist->GetPlot(plotIds[0])->GetEngineKey();
+            if (GetViewerEngineManager()->EngineExists(key))
             {
-                netIds.push_back(plist->GetPlot(plotIds[i])->GetNetworkID());
+                intVector netIds;
+                for (size_t i = 0; i < plotIds.size(); i++)
+                {
+                    netIds.push_back(plist->GetPlot(plotIds[i])->GetNetworkID());
+                }
+                PickAttributes pick;
+                pick.SetIncidentElements(netIds);
+                double sc[3];
+                sc[0] = sx;
+                sc[1] = sy;
+                sc[2] = 0.; 
+                pick.SetRayPoint1(sc);
+                GetViewerEngineManager()->Pick(key, -1, GetWindowId(),
+                                               &pick, pick);
+                pa = pick;
+                retval = pick.GetFulfilled();
+                if (retval == false)
+                {
+                    GetViewerMessaging()->Warning(
+                        TR("VisIt could not set the center of rotation. "
+                           "You might not have clicked on a plot."));
+                }
             }
-            PickAttributes pick;
-            pick.SetIncidentElements(netIds);
-            double sc[3];
-            sc[0] = sx;
-            sc[1] = sy;
-            sc[2] = 0.; 
-            pick.SetRayPoint1(sc);
-            GetViewerEngineManager()->Pick(key, -1, GetWindowId(),
-                                           &pick, pick);
-            pa = pick;
-            retval = pick.GetFulfilled();
         }
     }
     CATCH2(VisItException, e)

--- a/src/viewer/core/actions/ViewActions.C
+++ b/src/viewer/core/actions/ViewActions.C
@@ -971,6 +971,10 @@ ChooseCenterOfRotationAction::FinishCB(void *data, bool success,
 //   Brad Whitlock, Tue Apr 29 11:54:47 PDT 2008
 //   Support for internationalization.
 //
+//   Eric Brugger, Wed May  6 10:57:35 PDT 2020
+//   Moved a warning message to ViewerWindow::GetPickAttributesForScreenPoint
+//   to eliminate the possiblity of getting multiple error messages.
+//
 // ****************************************************************************
 
 void
@@ -1013,12 +1017,6 @@ ChooseCenterOfRotationAction::FinishExecute(bool success,
         // Set the new center of rotation.
         windowMgr->SetCenterOfRotation(window->GetWindowId(),
                                        pt[0], pt[1], pt[2]);
-    }
-    else 
-    {
-        GetViewerMessaging()->Warning(
-            TR("VisIt could not set the center of rotation. "
-               "You might not have clicked on a plot."));
     }
 
      //

--- a/src/viewer/core/actions/ViewActions.C
+++ b/src/viewer/core/actions/ViewActions.C
@@ -972,8 +972,9 @@ ChooseCenterOfRotationAction::FinishCB(void *data, bool success,
 //   Support for internationalization.
 //
 //   Eric Brugger, Wed May  6 10:57:35 PDT 2020
-//   Moved a warning message to ViewerWindow::GetPickAttributesForScreenPoint
-//   to eliminate the possiblity of getting multiple error messages.
+//   Made the warning message conditional on not being in scalable
+//   rendering mode, since the warning message will put out in
+//   ViewerWindow::GetPickAttributesForScreenPoint in that case.
 //
 // ****************************************************************************
 
@@ -1017,6 +1018,12 @@ ChooseCenterOfRotationAction::FinishExecute(bool success,
         // Set the new center of rotation.
         windowMgr->SetCenterOfRotation(window->GetWindowId(),
                                        pt[0], pt[1], pt[2]);
+    }
+    else if (!window->GetScalableRendering())
+    {
+        GetViewerMessaging()->Warning(
+            TR("VisIt could not set the center of rotation. "
+               "You might not have clicked on a plot."));
     }
 
      //


### PR DESCRIPTION
### Description

VisIt would crash when you tried to do a choose center when there weren't any non-hidden active plots when in scalable rendering mode. I put in a check to put out an error in that case recommending that the make a non-hidden plot active.

### Type of change

Bug fix.

### How Has This Been Tested?

I ran VisIt with 8 nodes on quartz and did the following:
- Set scalable rendering to always.
- Open multi_ucd3d.silo.
- Create a Filled boundary plot and a Mesh plot.
- Hide the Mesh plot.
- Enter choose center mode and click on the object.
- You get an error message to make a non-hidden plot active and try again.
- Make the Filled boundary plot active.
- Enter choose center mode and click on the object.
- It now works.
- Enter choose center mode and click on an empty area.
- You get a warning message that you probably didn't pick on an object and should try again.

I also checked similar things without scalable rendering set to always.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [x] I have assigned reviewers