### PR TITLE
openPMD: fix Database Name in Test

### DIFF
--- a/src/test/tests/databases/OpenPMD.py
+++ b/src/test/tests/databases/OpenPMD.py
@@ -9,7 +9,7 @@
 #  Date:       Mon Oct 28 13:00:15 EDT 2019
 #
 # ----------------------------------------------------------------------------
-RequiredDatabasePlugin("OpenPMD")
+RequiredDatabasePlugin("openPMD")
 
 openPMDFile = 'openpmd_test_data/data00000500.opmd'
 


### PR DESCRIPTION
Update the database name of the openPMD test.

### Description

Follow-up to #4696

I forgot to update the database name in the unit test as well, caught by the nightly test.

cc @dpugmire @xxirii @cyrush 

### Type of change

Use new database name.

### How Has This Been Tested?

Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
