### PR TITLE
python logging -- capture db export options

### DIFF
--- a/src/common/state/ExportDBAttributes.code
+++ b/src/common/state/ExportDBAttributes.code
@@ -65,7 +65,7 @@ PyExportDBAttributes_ToString(const ExportDBAttributes *atts, const char *prefix
     if((!db_opts_dict_str.empty()) && // make sure its not an empty string
        (db_opts_dict_str.find("{}") != 0) ) // and not an empty dict
     {
-        str += "db_export_opts = ";
+        str += "DBExportOpts = ";
         str += db_opts_dict_str;
         str += "\n";
     }

--- a/src/common/state/ExportDBAttributes.code
+++ b/src/common/state/ExportDBAttributes.code
@@ -1,0 +1,75 @@
+Target: xml2python
+Function: PyExportDBAttributes_ToString
+Declaration: std::string PyExportDBAttributes_ToString(const ExportDBAttributes *atts, const char *prefix);
+Definition:
+
+
+// ****************************************************************************
+// Module: PyExportDBAttributes_ToString
+//
+// Purpose: 
+//   Custom to string method. Custom b/c of handled for opts dict.
+//
+//
+//  Programmer: Cyrus Harrison
+//  Creation:   Mon May 11 14:14:38 PDT 2020
+//
+// ****************************************************************************
+std::string
+PyExportDBAttributes_ToString(const ExportDBAttributes *atts, const char *prefix)
+{
+    std::string str;
+    char tmpStr[1000];
+
+    if(atts->GetAllTimes())
+        snprintf(tmpStr, 1000, "%sallTimes = 1\n", prefix);
+    else
+        snprintf(tmpStr, 1000, "%sallTimes = 0\n", prefix);
+    str += tmpStr;
+    snprintf(tmpStr, 1000, "%sdirname = \"%s\"\n", prefix, atts->GetDirname().c_str());
+    str += tmpStr;
+    snprintf(tmpStr, 1000, "%sfilename = \"%s\"\n", prefix, atts->GetFilename().c_str());
+    str += tmpStr;
+    snprintf(tmpStr, 1000, "%stimeStateFormat = \"%s\"\n", prefix, atts->GetTimeStateFormat().c_str());
+    str += tmpStr;
+    snprintf(tmpStr, 1000, "%sdb_type = \"%s\"\n", prefix, atts->GetDb_type().c_str());
+    str += tmpStr;
+    snprintf(tmpStr, 1000, "%sdb_type_fullname = \"%s\"\n", prefix, atts->GetDb_type_fullname().c_str());
+    str += tmpStr;
+    {   const stringVector &variables = atts->GetVariables();
+        snprintf(tmpStr, 1000, "%svariables = (", prefix);
+        str += tmpStr;
+        for(size_t i = 0; i < variables.size(); ++i)
+        {
+            snprintf(tmpStr, 1000, "\"%s\"", variables[i].c_str());
+            str += tmpStr;
+            if(i < variables.size() - 1)
+            {
+                snprintf(tmpStr, 1000, ", ");
+                str += tmpStr;
+            }
+        }
+        snprintf(tmpStr, 1000, ")\n");
+        str += tmpStr;
+    }
+    if(atts->GetWriteUsingGroups())
+        snprintf(tmpStr, 1000, "%swriteUsingGroups = 1\n", prefix);
+    else
+        snprintf(tmpStr, 1000, "%swriteUsingGroups = 0\n", prefix);
+    str += tmpStr;
+    snprintf(tmpStr, 1000, "%sgroupSize = %d\n", prefix, atts->GetGroupSize());
+    str += tmpStr;
+
+    std::string db_opts_dict_str = PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(atts->GetOpts(),
+                                                                                     false);
+    if((!db_opts_dict_str.empty()) && // make sure its not an empty string
+       (db_opts_dict_str.find("{}") != 0) ) // and not an empty dict
+    {
+        str += "db_export_opts = ";
+        str += db_opts_dict_str;
+        str += "\n";
+    }
+
+    return str;
+}
+

--- a/src/common/state/ExportDBAttributes.xml
+++ b/src/common/state/ExportDBAttributes.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-  <Attribute name="ExportDBAttributes" purpose="The attributes for export a database" persistent="true" exportAPI="STATE_API" exportInclude="state_exports.h">
+  <Attribute name="ExportDBAttributes" purpose="The attributes for export a database" persistent="true" keyframe="true" exportAPI="STATE_API" exportInclude="state_exports.h" codefile="ExportDBAttributes.code">
     <Field name="allTimes" label="All time steps" type="bool">
       false
     </Field>
     <Field name="dirname" label="dirname" type="string">
-      "."
+      .
     </Field>
     <Field name="filename" label="filename" type="string">
       visit_ex_db
@@ -26,4 +26,9 @@
     </Field>
     <Field name="opts" label="opts" type="att" subtype="DBOptionsAttributes">
     </Field>
+    <Function name="PyExportDBAttributes_ToString" user="false" member="false">
+    </Function>
+    <Include file="source" quoted="true" target="xml2python">
+      PyDBOptionsAttributes_Helpers.h
+    </Include>
   </Attribute>

--- a/src/visitpy/CMakeLists.txt
+++ b/src/visitpy/CMakeLists.txt
@@ -106,6 +106,7 @@ visitpy/PyColorTableAttributes.C
 visitpy/PyConstructDataBinningAttributes.C 
 visitpy/PyDatabaseCorrelation.C 
 visitpy/PyDBOptionsAttributes.C
+visitpy/PyDBOptionsAttributes_Helpers.C
 visitpy/PyEngineProperties.C 
 visitpy/PyExportDBAttributes.C 
 visitpy/PyExpression.C 

--- a/src/visitpy/common/Logging.C
+++ b/src/visitpy/common/Logging.C
@@ -18,6 +18,7 @@
 #include <PyAnnotationAttributes.h>
 #include <PyConstructDataBinningAttributes.h>
 #include <PyExportDBAttributes.h>
+#include <PyDBOptionsAttributes.h>
 #include <PyGlobalLineoutAttributes.h>
 #include <PyInteractorAttributes.h>
 #include <PyKeyframeAttributes.h>
@@ -1783,7 +1784,17 @@ static std::string log_ConstructDataBinningRPC(ViewerRPC *rpc)
 static std::string log_ExportDBRPC(ViewerRPC *rpc)
 {
     std::string s(constructor(PyExportDBAttributes_GetLogString()));
-    s += "ExportDatabase(ExportDBAtts)\n";
+
+    // if ops were included, we need to call differently 
+    if(s.find("db_export_opts =") !=std::string::npos )
+    {
+        s += "ExportDatabase(ExportDBAtts, db_export_opts)\n";
+    }
+    else // export w/o opts
+    {
+        s += "ExportDatabase(ExportDBAtts)\n";
+    }
+
     return visitmodule() + s;
 }
 

--- a/src/visitpy/common/Logging.C
+++ b/src/visitpy/common/Logging.C
@@ -1786,9 +1786,9 @@ static std::string log_ExportDBRPC(ViewerRPC *rpc)
     std::string s(constructor(PyExportDBAttributes_GetLogString()));
 
     // if ops were included, we need to call differently 
-    if(s.find("db_export_opts =") !=std::string::npos )
+    if(s.find("DBExportOpts =") !=std::string::npos )
     {
-        s += "ExportDatabase(ExportDBAtts, db_export_opts)\n";
+        s += "ExportDatabase(ExportDBAtts, DBExportOpts)\n";
     }
     else // export w/o opts
     {

--- a/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
@@ -1,0 +1,101 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#include <PyDBOptionsAttributes.h>
+#include <ObserverToCallback.h>
+#include <stdio.h>
+
+// ****************************************************************************
+//  Method: PyDBOptionsAttributes_CreateDictionaryFromDBOptions
+//
+//  Purpose:
+//     Helper that creates a Python dict of the DB options.
+//
+//  Programmer: Cyrus Harrison
+//  Creation:   Mon May 11 14:14:38 PDT 2020
+//
+// ****************************************************************************
+// Note: (cyrush) This would ideally be in PyDBOptionsAttributes but I
+//       hit snags generating defs in headers to expose via xmltools
+// **************************************************************************** 
+PyObject *
+PyDBOptionsAttributes_CreateDictionaryFromDBOptions(const DBOptionsAttributes &opts, 
+                                                    bool show_enum_opts)
+{
+    PyObject *dict = PyDict_New();
+    for (int j=0; j<opts.GetNumberOfOptions(); j++)
+    {
+        // Older pythons don't support const char* in the PyDict routines,
+        // so we have to copy this into a non-const string.
+        char *name = new char[opts.GetName(j).length()+1];
+        strcpy(name, opts.GetName(j).c_str());
+        switch (opts.GetType(j))
+        {
+          case DBOptionsAttributes::Bool:
+            PyDict_SetItemString(dict,name,PyInt_FromLong(opts.GetBool(name)));
+            break;
+          case DBOptionsAttributes::Int:
+            PyDict_SetItemString(dict,name,PyInt_FromLong(opts.GetInt(name)));
+            break;
+          case DBOptionsAttributes::Float:
+            PyDict_SetItemString(dict,name,PyFloat_FromDouble(opts.GetFloat(name)));
+            break;
+          case DBOptionsAttributes::Double:
+            PyDict_SetItemString(dict,name,PyFloat_FromDouble(opts.GetDouble(name)));
+            break;
+          case DBOptionsAttributes::String:
+            PyDict_SetItemString(dict,name,PyString_FromString(opts.GetString(name).c_str()));
+            break;
+          case DBOptionsAttributes::Enum:
+            // If you modify this section, also check the Enum case in
+            // FillDBOptionsFromDictionary
+            int enumIndex = opts.GetEnum(name);
+            stringVector enumStrings = opts.GetEnumStrings(name);
+            std::string itemString(enumStrings[enumIndex]);
+            if (show_enum_opts && enumStrings.size() > 1)
+            {
+                itemString += " # Options are: ";
+                for (size_t i = 0; i < enumStrings.size(); ++i)
+                {
+                    itemString += enumStrings[i];
+                    if (i != enumStrings.size()-1)
+                        itemString += ", ";
+                }
+            }
+            PyDict_SetItemString(dict,name,PyString_FromString(itemString.c_str()));
+            break;
+        }
+        delete[] name;
+    }
+    return dict;
+}
+
+// ****************************************************************************
+//  Method: PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions
+//
+//  Purpose:
+//     Create a string rep of the Python Dictionary of our opts.
+//
+//  Programmer: Cyrus Harrison
+//  Creation:   Mon May 11 14:14:38 PDT 2020
+//
+// ****************************************************************************
+// Note: (cyrush) This would ideally be in PyDBOptionsAttributes but I
+//       hit snags generating defs in headers to expose via xmltools
+// **************************************************************************** 
+std::string
+PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(const DBOptionsAttributes &opts,
+                                                          bool show_enum_opts)
+{
+    PyObject *py_opts_dict = PyDBOptionsAttributes_CreateDictionaryFromDBOptions(opts,
+                                                                           show_enum_opts);
+    PyObject *py_opts_repr = PyObject_Repr(py_opts_dict);
+    const char *opts_repr_cstr = PyString_AsString(py_opts_repr);
+    std::string res = std::string(opts_repr_cstr);
+
+    Py_DECREF(py_opts_dict);
+    Py_DECREF(py_opts_repr);
+    return res;
+}
+

--- a/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.h
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.h
@@ -1,0 +1,18 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#ifndef PY_DBOPTIONSATTRIBUTES_HELPERS_H
+#define PY_DBOPTIONSATTRIBUTES_HELPERS_H
+#include <Python.h>
+#include <DBOptionsAttributes.h>
+#include <visitpy_exports.h>
+
+//
+// Helpers for dealing with dict reps of our DB Options
+//
+PyObject * VISITPY_API  PyDBOptionsAttributes_CreateDictionaryFromDBOptions(const DBOptionsAttributes &opts, bool show_enum_opts);
+std::string VISITPY_API PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(const DBOptionsAttributes &opts, bool show_enum_opts);
+
+#endif
+

--- a/src/visitpy/visitpy/PyExportDBAttributes.C
+++ b/src/visitpy/visitpy/PyExportDBAttributes.C
@@ -100,7 +100,7 @@ PyExportDBAttributes_ToString(const ExportDBAttributes *atts, const char *prefix
     if((!db_opts_dict_str.empty()) && // make sure its not an empty string
        (db_opts_dict_str.find("{}") != 0) ) // and not an empty dict
     {
-        str += "db_export_opts = ";
+        str += "DBExportOpts = ";
         str += db_opts_dict_str;
         str += "\n";
     }

--- a/src/visitpy/visitpy/PyExportDBAttributes.C
+++ b/src/visitpy/visitpy/PyExportDBAttributes.C
@@ -5,6 +5,7 @@
 #include <PyExportDBAttributes.h>
 #include <ObserverToCallback.h>
 #include <stdio.h>
+#include "PyDBOptionsAttributes_Helpers.h"
 #include <PyDBOptionsAttributes.h>
 
 // ****************************************************************************
@@ -36,6 +37,19 @@ struct ExportDBAttributesObject
 //
 static PyObject *NewExportDBAttributes(int);
 
+
+
+// ****************************************************************************
+// Module: PyExportDBAttributes_ToString
+//
+// Purpose: 
+//   Custom to string method. Custom b/c of handled for opts dict.
+//
+//
+//  Programmer: Cyrus Harrison
+//  Creation:   Mon May 11 14:14:38 PDT 2020
+//
+// ****************************************************************************
 std::string
 PyExportDBAttributes_ToString(const ExportDBAttributes *atts, const char *prefix)
 {
@@ -80,11 +94,17 @@ PyExportDBAttributes_ToString(const ExportDBAttributes *atts, const char *prefix
     str += tmpStr;
     snprintf(tmpStr, 1000, "%sgroupSize = %d\n", prefix, atts->GetGroupSize());
     str += tmpStr;
-    { // new scope
-        std::string objPrefix(prefix);
-        objPrefix += "opts.";
-        str += PyDBOptionsAttributes_ToString(&atts->GetOpts(), objPrefix.c_str());
+
+    std::string db_opts_dict_str = PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(atts->GetOpts(),
+                                                                                     false);
+    if((!db_opts_dict_str.empty()) && // make sure its not an empty string
+       (db_opts_dict_str.find("{}") != 0) ) // and not an empty dict
+    {
+        str += "db_export_opts = ";
+        str += db_opts_dict_str;
+        str += "\n";
     }
+
     return str;
 }
 


### PR DESCRIPTION
### Description

Resolves #3878  (almost)

Here is an example of recording of an export that includes options:

```
ExportDBAtts = ExportDBAttributes()
ExportDBAtts.allTimes = 0
ExportDBAtts.dirname = "."
ExportDBAtts.filename = "visit_ex_db"
ExportDBAtts.timeStateFormat = "_%04d"
ExportDBAtts.db_type = "Silo"
ExportDBAtts.db_type_fullname = "Silo_1.0"
ExportDBAtts.variables = ()
ExportDBAtts.writeUsingGroups = 0
ExportDBAtts.groupSize = 48
db_export_opts = {'Checksums': 1, 'Driver': 'HDF5', 'DBSetCompression()': ''}
ExportDatabase(ExportDBAtts, db_export_opts)

```

And here is an example of of an export that does not include options:

```
ExportDBAtts = ExportDBAttributes()
ExportDBAtts.allTimes = 0
ExportDBAtts.dirname = "."
ExportDBAtts.filename = "visit_ex_db"
ExportDBAtts.timeStateFormat = "_%04d"
ExportDBAtts.db_type = "Blueprint"
ExportDBAtts.db_type_fullname = "Blueprint_1.0"
ExportDBAtts.variables = ()
ExportDBAtts.writeUsingGroups = 0
ExportDBAtts.groupSize = 48
ExportDatabase(ExportDBAtts)

```

There is an unrelated issue with the Metadata server not being inited right in the CLI, so any attempt to use the export fails b/c it doesn't know valid plugin names.

(verified it was unrelated b/c I see the same problem with or without my changes)

```
VisIt: Message - Exported database
Traceback (most recent call last):
  File "<string>", line 12, in <module>
visit.VisItException: "Silo" is not a valid plugin type.  Make sure the Metadata Server is running.
```


