### PR TITLE
Fix a bug in OpenPMD reader possibly causing a hang.

### DIFF
--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -151,8 +151,7 @@ void PMDFile::OpenFile(char * PMDFilePath)
 //
 // Modifications:
 // Nov. 9 2017 - M. Lobet - add buffer + `\0` for a correct reading
-// May 12 2020 - E. Brugger - add check for group open failure and existence
-//                            of attribute openPMD.
+// May 12 2020 - E. Brugger - add check for existence of attribute openPMD
 //
 // ***************************************************************************
 void PMDFile::ScanFileAttributes()
@@ -171,9 +170,6 @@ void PMDFile::ScanFileAttributes()
     hid_t    aspace;
     size_t   size;
     int      nPoints;
-
-    // is this a valid openPMD file with an "openPMD" attribute in / ?
-    bool     isValid = false;
 
     // OpenPMD files always contain a data group at the root
     groupId = H5Gopen(fileId, "/",H5P_DEFAULT);
@@ -217,7 +213,6 @@ void PMDFile::ScanFileAttributes()
             this->version = buffer;
 
             delete [] buffer;
-            isValid = true;
         }
         else if (strcmp(attrName,"meshesPath")==0)
         {
@@ -243,18 +238,6 @@ void PMDFile::ScanFileAttributes()
 
             delete [] buffer;
         }
-    }
-
-    // missing self-identification as openPMD file
-    if (!isValid)
-    {
-        char format_error[1024];
-        snprintf(format_error, 1024,
-                 "Not an openPMD file: Missing 'openPMD' identifier in /");
-        debug5 << "The current file ID '" << fileId
-               << "' is not an openPMD file" << endl;
-        CloseFile();
-        EXCEPTION1(InvalidDBTypeException, format_error);
     }
 }
 

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -166,7 +166,6 @@ void PMDFile::ScanFileAttributes()
     char     attrName[64];
     hsize_t  nbAttr;
     hid_t    groupId;
-    hid_t    opmdId;
     hid_t    attrId;
     hid_t    atype;
     hid_t    aspace;
@@ -177,14 +176,12 @@ void PMDFile::ScanFileAttributes()
     groupId = H5Gopen(fileId, "/",H5P_DEFAULT);
 
     // Check for openPMD attr in the root group
-    opmdId = H5Aopen_by_name(groupId, ".", "openPMD", H5P_DEFAULT, H5P_DEFAULT);
-    if (opmdId < 0)
+    if (H5Aexists(groupId, "openPMD") <= 0)
     {
         CloseFile();
         EXCEPTION1(InvalidDBTypeException,
             "Not an openPMD file: Missing \"openPMD\" attribute in root group");
     }
-    H5Aclose(opmdId);
 
     // Number of attributes
     nbAttr = H5Aget_num_attrs(groupId);

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -111,6 +111,7 @@ PMDFile::~PMDFile()
 // Creation: Fri Oct 14 2016
 //
 // Modifications:
+// May 12 2020 - E. Brugger - add check for file open failure
 //
 // ***************************************************************************
 void PMDFile::OpenFile(char * PMDFilePath)
@@ -128,6 +129,14 @@ void PMDFile::OpenFile(char * PMDFilePath)
 
     H5Pclose(fileAccessPropListID);
 
+    // Check for error opening the file
+    if (fileId < 0)
+    {
+        debug5 << "The current file is not an openPMD file" << endl;
+        EXCEPTION1(InvalidDBTypeException,
+                   "Not an openPMD file: Error opening the file");
+    }
+
     // The path is copied in this->filePath if the file was well opened.
     strcpy(this->filePath,PMDFilePath);
 }
@@ -143,6 +152,7 @@ void PMDFile::OpenFile(char * PMDFilePath)
 //
 // Modifications:
 // Nov. 9 2017 - M. Lobet - add buffer + `\0` for a correct reading
+// May 12 2020 - E. Brugger - add check for group open failure
 //
 // ***************************************************************************
 void PMDFile::ScanFileAttributes()
@@ -164,6 +174,16 @@ void PMDFile::ScanFileAttributes()
 
     // OpenPMD files always contain a data group at the root
     groupId = H5Gopen(fileId, "/",H5P_DEFAULT);
+
+    // Check for error opening the group
+    if (groupId < 0)
+    {
+        debug5 << "The current file ID '" << fileId
+               << "' is not an openPMD file" << endl;
+        CloseFile();
+        EXCEPTION1(InvalidDBTypeException,
+                   "Not an openPMD file: Missing data group at root");
+    }
 
     // Number of attributes
     nbAttr = H5Aget_num_attrs(groupId);

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -166,6 +166,7 @@ void PMDFile::ScanFileAttributes()
     char     attrName[64];
     hsize_t  nbAttr;
     hid_t    groupId;
+    hid_t    opmdId;
     hid_t    attrId;
     hid_t    atype;
     hid_t    aspace;
@@ -175,15 +176,15 @@ void PMDFile::ScanFileAttributes()
     // OpenPMD files always contain a data group at the root
     groupId = H5Gopen(fileId, "/",H5P_DEFAULT);
 
-    // Check for error opening the group
-    if (groupId < 0)
+    // Check for openPMD attr in the root group
+    opmdId = H5Aopen_by_name(groupId, ".", "openPMD", H5P_DEFAULT, H5P_DEFAULT);
+    if (opmdId < 0)
     {
-        debug5 << "The current file ID '" << fileId
-               << "' is not an openPMD file" << endl;
         CloseFile();
         EXCEPTION1(InvalidDBTypeException,
-                   "Not an openPMD file: Missing data group at root");
+            "Not an openPMD file: Missing \"openPMD\" attribute in root group");
     }
+    H5Aclose(opmdId);
 
     // Number of attributes
     nbAttr = H5Aget_num_attrs(groupId);

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -152,7 +152,7 @@ void PMDFile::OpenFile(char * PMDFilePath)
 //
 // Modifications:
 // Nov. 9 2017 - M. Lobet - add buffer + `\0` for a correct reading
-// May 12 2020 - E. Brugger - add check for group open failure
+// May 12 2020 - E. Brugger - add check for openPMD attr on root group.
 //
 // ***************************************************************************
 void PMDFile::ScanFileAttributes()

--- a/src/resources/help/en_US/relnotes3.1.2.html
+++ b/src/resources/help/en_US/relnotes3.1.2.html
@@ -43,6 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Reduced amount of '.' written to log files while waiting for processes to connect.</li>
   <li>Fixed a crash when performing a choose center operation when there weren't any non-hidden active plots while in scalable rendering mode. It now prints an error message requesting that the user select a non-hidden plot.</li>
   <li>Forced VisIt to always use 'Light Mode' on macOS until 'Dark Mode' is supported for Qt.</li>
+  <li>Fixed a bug where the OpenPMD reader might cause opening an HDF5 file to hang.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

The OpenPMD reader didn't check the error codes from HDF5 when opening the file, possibly causing the reader to read unitialized memory for a loop count. If this number was small, no real harm other than some unnecessary loop iterations. If the number was large this effectively caused a hang, as was the case with the test suite when the unitialized memory gave a count with 20 digits. The bad thing is that this could occur with non OpenPMD files, since VisIt will try all the readers that match the file extension, which in this case was "h5" for a pixie file.

### Type of change

Bug fix.

### How Has This Been Tested?

I made the fix on develop and tested opening a Pixie file that previously hung. Now it detected the file open error and moved past the OpenPMD reader. I then back ported this to the 3.1RC.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers