### PR TITLE
Fix comile errors on WIndows.

### DIFF
--- a/src/databases/Blueprint/avtBlueprintFileFormat.C
+++ b/src/databases/Blueprint/avtBlueprintFileFormat.C
@@ -58,6 +58,9 @@
 #include "avtBlueprintTreeCache.h"
 #include "avtBlueprintDataAdaptor.h"
 
+#ifdef _WIN32
+#define strcasecmp stricmp
+#endif
 
 using std::string;
 using namespace conduit;

--- a/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.h
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.h
@@ -11,8 +11,8 @@
 //
 // Helpers for dealing with dict reps of our DB Options
 //
-PyObject * VISITPY_API  PyDBOptionsAttributes_CreateDictionaryFromDBOptions(const DBOptionsAttributes &opts, bool show_enum_opts);
-std::string VISITPY_API PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(const DBOptionsAttributes &opts, bool show_enum_opts);
+VISITPY_API PyObject *  PyDBOptionsAttributes_CreateDictionaryFromDBOptions(const DBOptionsAttributes &opts, bool show_enum_opts);
+VISITPY_API std::string PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(const DBOptionsAttributes &opts, bool show_enum_opts);
 
 #endif
 


### PR DESCRIPTION
stcasecmp not defined on  Windows, #define it as stricmp
Change location of VISITPY_API.

