### PR TITLE
Update the create checksum script for the 3.1.2 release.

### DIFF
--- a/src/tools/dev/scripts/visit-create-chksums
+++ b/src/tools/dev/scripts/visit-create-chksums
@@ -113,10 +113,9 @@ do
    $cmd jvisit$version.tar.gz                             >> $output
    $cmd visit$version.darwin-x86_64-10_14.dmg             >> $output
    $cmd visit$version.darwin-x86_64-10_14.tar.gz          >> $output
-   $cmd visit$version.darwin-x86_64-10.13.dmg             >> $output
-   $cmd visit$version.darwin-x86_64-10.13.tar.gz          >> $output
    $cmd visit$version2.linux-x86_64-centos8.tar.gz        >> $output
    $cmd visit$version2.linux-x86_64-debian9.tar.gz        >> $output
+   $cmd visit$version2.linux-x86_64-debian10.tar.gz       >> $output
    $cmd visit$version2.linux-x86_64-fedora27.tar.gz       >> $output
    $cmd visit$version2.linux-x86_64-rhel7.tar.gz          >> $output
    $cmd visit$version2.linux-x86_64-rhel7-wmesa.tar.gz    >> $output


### PR DESCRIPTION
### Description

I updated the visit-create-chksums script for 3.1.2. I removed the mac 10.13 binaries and added one for debian 10.

### Type of change

New feature.

### How Has This Been Tested?

I used the new script to generate the checksums for the 3.1.2 release and it worked fine.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code