### PR TITLE
Bugfix/biagas/crash creating ghosts from globalids

### DIFF
--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -287,8 +287,8 @@ DebugDumpDatasetCollection(avtDatasetCollection &dsc, int ndoms,
             << ".proc" << std::setfill('0') << std::setw(4) << PAR_Rank() << ".vtk";
 #else
         oss << dumpDir << "/gdb." << std::setfill('0') << std::setw(4)
-                       << call_count << "." << phaseName << ".dom"
-                       << std::setfill('0') << std::setw(4) << i << ".vtk";
+            << call_count << "." << phaseName << ".dom"
+            << std::setfill('0') << std::setw(4) << i << ".vtk";
 #endif
         dsw->SetFileName(oss.str().c_str());
         dsw->SetInputData(dsc.GetDataset(i, 0));

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -253,14 +253,21 @@ avtGenericDatabase::SetCycleTimeInDatabaseMetaData(avtDatabaseMetaData *md, int 
 //      during a -dump run.
 //
 //  Created: Mark C. Miller, Wed Dec 12 04:58:26 PST 2018
+//
+//  Modifications:
+//    Kathleen Biagas, Wed May 20 14:27:24 PDT 2020
+//    Modified to dump out every domain.
+//
+//    Kathleen Biagas, Fri May 22 15:21:19 PDT 2020
+//    Handle parallel.
+//
 // ****************************************************************************
+
 static void
 DebugDumpDatasetCollection(avtDatasetCollection &dsc, int ndoms,
     string phaseName)
-
 {
     static int call_count = 0;
-    std::ostringstream oss;
 
     if (!avtDebugDumpOptions::DumpEnabled())
         return;
@@ -268,18 +275,25 @@ DebugDumpDatasetCollection(avtDatasetCollection &dsc, int ndoms,
     string dumpDir = avtDebugDumpOptions::GetDumpDirectory();
     if (dumpDir == "")
         dumpDir = ".";
-    oss << dumpDir << "/gdb." << std::setfill('0') << std::setw(4) << call_count << "." << phaseName << ".vtk";
-    string dumpFile = oss.str();
-    vtkDataSetWriter *dsw = vtkDataSetWriter::New();
+    vtkNew<vtkDataSetWriter> dsw;
     dsw->SetFileTypeToASCII();
-    dsw->SetFileName(dumpFile.c_str());
     for (int i = 0 ; i < ndoms; i++)
     {
-        vtkDataSet *ds = dsc.GetDataset(i, 0);
-        dsw->SetInputData(i, ds);
+        std::ostringstream oss;
+#ifdef PARALLEL
+        oss << dumpDir << "/gdb." << std::setfill('0') << std::setw(4)
+            << call_count << "." << phaseName << ".dom"
+            << std::setfill('0') << std::setw(4) << i
+            << ".proc" << std::setfill('0') << std::setw(4) << PAR_Rank() << ".vtk";
+#else
+        oss << dumpDir << "/gdb." << std::setfill('0') << std::setw(4)
+                       << call_count << "." << phaseName << ".dom"
+                       << std::setfill('0') << std::setw(4) << i << ".vtk";
+#endif
+        dsw->SetFileName(oss.str().c_str());
+        dsw->SetInputData(dsc.GetDataset(i, 0));
+        dsw->Write();
     }
-    dsw->Write();
-    dsw->Delete();
     call_count++;
 }
 
@@ -8355,6 +8369,9 @@ avtGenericDatabase::CommunicateGhostNodesFromDomainBoundariesFromFile(
 //    Eric Brugger, Fri Mar 13 15:20:08 PDT 2020
 //    Modify to handle NULL meshes.
 //
+//    Kathleen Biagas, Fri May 22 15:41:44 PDT 2020
+//    Test for myMin > myMax.
+//
 // ****************************************************************************
 
 bool
@@ -8483,6 +8500,8 @@ avtGenericDatabase::CommunicateGhostZonesFromGlobalNodeIds(
     int myMax = numIdsPerProc * (rank+1);
     if (myMax > maxId)
         myMax = maxId;
+    if (myMin > myMax)
+        myMin = myMax;
 
     //
     // We will do the bookkeeping for this processor's range.  Set up
@@ -8957,6 +8976,9 @@ avtGenericDatabase::CommunicateGhostZonesWhileStreaming(
 //    Burlen Loring, Fri Oct  2 17:02:27 PDT 2015
 //    clean up a warning
 //
+//    Kathleen Biagas, Fri May 22 15:41:44 PDT 2020
+//    Test for myMin > myMax.
+//
 // ****************************************************************************
 
 bool
@@ -9002,6 +9024,8 @@ avtGenericDatabase::CommunicateGhostNodesFromGlobalNodeIds(
     int myMax = numIdsPerProc * (rank+1);
     if (myMax > maxId)
         myMax = maxId;
+    if (myMin > myMax)
+        myMin = myMax;
 
     //
     // We will do the bookkeeping for this processor's range.  Set up

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.1.3</font></b></p>
 <ul>
   <li>Fixed a bug preventing SaveWindow from saving OSPRay rendered images.</li>
+  <li>Fixed parallel engine crash when creating ghosts from global ids.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #4761

Fixed flawed logic where a negative value being use to allocate a std::vector during
creation of ghosts from global ids.

Port change from develop to DebugDump all domains in avtGenericDatabase,
and add support for parallel to same.


I ran the data from the bug ticket with multiple processors, and the engine no longer crashes.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes

