### PR TITLE
Modify build_visit to build on Ubuntu 20.

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu19.10
+++ b/scripts/docker/Dockerfile-ubuntu19.10
@@ -1,0 +1,61 @@
+FROM ubuntu:eoan
+MAINTAINER Eric Brugger <brugger1@llnl.gov>
+
+# fetch build env
+RUN apt-get update && apt-get install -y \
+    git \
+    wget \
+    curl \
+    p7zip \
+    unzip \
+    subversion \
+    build-essential \
+    gcc \
+    g++ \
+    gfortran \
+    zlib1g-dev \
+    python \
+    libsm-dev \
+    libice-dev \
+    libssl-dev \
+    libx11-xcb-dev \
+    libxcb-dri2-0-dev \
+    libxcb-xfixes0-dev \
+    xutils-dev \
+    xorg-dev \
+    libfreetype6-dev \
+    autoconf \
+    libtool \
+    m4 \
+    automake \
+    libxml2 \
+    libxml2-dev \
+    vim \
+    emacs \
+    bison \
+    flex \
+    cpio \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y libffi-dev && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+RUN cd /usr/include && ln -s freetype2 freetype
+
+RUN groupadd -r visit && useradd -ms /bin/bash --no-log-init -r -g visit visit
+USER visit
+WORKDIR /home/visit
+
+# Create the third-party directory
+RUN mkdir third-party
+# Copy build_visit and the script to run it
+COPY build_visit3_1_2 /home/visit
+COPY run_build_visit.sh /home/visit
+COPY build_visit_docker_cleanup.py /home/visit
+COPY build_test_visit.sh /home/visit
+COPY test_visit.py /home/visit
+# Build the third party libraries.
+RUN /bin/bash run_build_visit.sh

--- a/scripts/docker/Dockerfile-ubuntu20
+++ b/scripts/docker/Dockerfile-ubuntu20
@@ -1,0 +1,63 @@
+FROM ubuntu:focal
+MAINTAINER Eric Brugger <brugger1@llnl.gov>
+
+# fetch build env
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+RUN apt-get update && apt-get install -y \
+    git \
+    wget \
+    curl \
+    p7zip \
+    unzip \
+    subversion \
+    build-essential \
+    gcc \
+    g++ \
+    gfortran \
+    zlib1g-dev \
+    python \
+    libsm-dev \
+    libice-dev \
+    libssl-dev \
+    libx11-xcb-dev \
+    libxcb-dri2-0-dev \
+    libxcb-xfixes0-dev \
+    xutils-dev \
+    xorg-dev \
+    libfreetype6-dev \
+    autoconf \
+    libtool \
+    m4 \
+    automake \
+    libxml2 \
+    libxml2-dev \
+    vim \
+    emacs \
+    bison \
+    flex \
+    cpio \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y libffi-dev && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+RUN cd /usr/include && ln -s freetype2 freetype
+
+RUN groupadd -r visit && useradd -ms /bin/bash --no-log-init -r -g visit visit
+USER visit
+WORKDIR /home/visit
+
+# Create the third-party directory
+RUN mkdir third-party
+# Copy build_visit and the script to run it
+COPY build_visit3_1_2 /home/visit
+COPY run_build_visit.sh /home/visit
+COPY build_visit_docker_cleanup.py /home/visit
+COPY build_test_visit.sh /home/visit
+COPY test_visit.py /home/visit
+# Build the third party libraries.
+RUN /bin/bash run_build_visit.sh

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -36,7 +36,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.3</font></b></p>
 <ul>
-  <li></li>
+  <li>The build_visit script was enhanced to allow VisIt to build on Ubuntu 20.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -225,7 +225,7 @@ function apply_qt_patch
             fi
         elif [[ -f /etc/lsb-release ]] ; then
             VER=`cat /etc/lsb-release | grep "DISTRIB_RELEASE" | cut -d'=' -f 2`
-            if [[ "${VER:0:3}" == "19." ]] ; then
+            if [[ "${VER:0:3}" == "19." || "${VER:0:3}" == "20." ]] ; then
                 apply_qt_5101_centos8_patch
                 if [[ $? != 0 ]] ; then
                     return 1


### PR DESCRIPTION
### Description

Resolves #4757

Modified build_visit to build on Ubuntu 20. I also added a Docker file for Ubuntu 20. While I was at it I also added the Docker file for Ubuntu 19.10, which I created a while back.

### Type of change

New feature.

### How Has This Been Tested?

I created a Docker container with the Docker file for Ubuntu 20. I then used the modified build_visit to build the third party libraries and then VisIt. I tested the CLI and it worked properly.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers.