### PR TITLE
Remove bad baseline image CGNS_0_07

### DIFF
--- a/test/baseline/databases/CGNS/CGNS_0_07.png
+++ b/test/baseline/databases/CGNS/CGNS_0_07.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b310e64aad206a3d4813022534a6f0412503c89bcd919ecedc3534b60c00517
-size 271


### PR DESCRIPTION
CGNS_0_07.png baseline is bad, but it isn't being used by the regression test, so I have removed it.
