### PR TITLE
Improve the CLI manual quick recipe for launching a compute engine.

### DIFF
--- a/src/doc/cli_manual/quickrecipes.rst
+++ b/src/doc/cli_manual/quickrecipes.rst
@@ -231,10 +231,10 @@ launch the engine such as the number of processors.
 
 ::
 
-    # Open a remote, parallel compute engine before opening a database 
+    # Open a local, parallel compute engine before opening a database 
     # Use 4 processors on 2 nodes
-    OpenComputeEngine("quartz", ("-np", "4", "-nn", "2")) 
-    OpenDatabase("quartz:/usr/gapps/visit/data/multi_ucd3d.silo") 
+    OpenComputeEngine("localhost", ("-np", "4", "-nn", "2"))
+    OpenDatabase("/usr/gapps/visit/data/multi_ucd3d.silo") 
 
 The options for starting the compute engine are the same as the ones used
 on the command line. Here are the most common options for launching a

--- a/src/doc/cli_manual/quickrecipes.rst
+++ b/src/doc/cli_manual/quickrecipes.rst
@@ -234,7 +234,7 @@ launch the engine such as the number of processors.
     # Open a local, parallel compute engine before opening a database 
     # Use 4 processors on 2 nodes
     OpenComputeEngine("localhost", ("-np", "4", "-nn", "2"))
-    OpenDatabase("/usr/gapps/visit/data/multi_ucd3d.silo") 
+    OpenDatabase("/usr/local/visit/data/multi_ucd3d.silo") 
 
 The options for starting the compute engine are the same as the ones used
 on the command line. Here are the most common options for launching a
@@ -252,16 +252,13 @@ compute engine.
 
 
 The full list of parallel launch options can be obtained by typing
-'visit --fullhelp'. Here is a more complex example of launching a compute
+``visit --fullhelp``. Here is a more complex example of launching a compute
 engine.
-jjjgfullThe following example launches a compute engine using
-the "srun" job launcher in the "batch" partition, charging the "mybank"
-bank, using 72 processors on 2 nodes, and using a time limit of 1 hour.
 
 ::
 
-    # Use the "srun" job launcher, the "batch" partition, the "mybank" bank
-    # Use 72 processors on 2 nodes and a time limit of 1 hour
+    # Use the "srun" job launcher, the "batch" partition, the "mybank" bank,
+    # 72 processors on 2 nodes and a time limit of 1 hour
     OpenComputeEngine("localhost",("-l", "srun",
                                    "-p", "batch",
                                    "-b", "mybank",
@@ -276,8 +273,8 @@ didn't know this you could print "p" to get all the properties.
 
 ::
 
-    # Set the user name to "user1" and use the third profile
-    # Override a few properties of the third profile.
+    # Set the user name to "user1" and use the third profile,
+    # overriding a few of its properties
     p = GetMachineProfile("quartz.llnl.gov")
     p.userName="user1"
     p.activeProfile = 2

--- a/src/doc/cli_manual/quickrecipes.rst
+++ b/src/doc/cli_manual/quickrecipes.rst
@@ -214,7 +214,7 @@ name.
     OpenDatabase("thunder:/usr/local/visit/data/wave.visit", 17)
 
 Opening a compute engine
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 Sometimes it is advantageous to open a compute engine before opening a
 database. When you tell VisIt to open a database using the OpenDatabase
@@ -232,8 +232,59 @@ launch the engine such as the number of processors.
 ::
 
     # Open a remote, parallel compute engine before opening a database 
-    OpenComputeEngine("mcr", ("-np", "4", "-nn", "2")) 
-    OpenDatabase("mcr:/usr/local/visit/data/multi_ucd3d.silo") 
+    # Use 4 processors on 2 nodes
+    OpenComputeEngine("quartz", ("-np", "4", "-nn", "2")) 
+    OpenDatabase("quartz:/usr/gapps/visit/data/multi_ucd3d.silo") 
+
+The options for starting the compute engine are the same as the ones used
+on the command line. Here are the most common options for launching a
+compute engine.
+
+::
+
+    -l    <method>       Launch in parallel using the given method.
+    -np   <# procs>      The number of processors to use.
+    -nn   <# nodes>      The number of nodes to allocate.
+    -p    <part>         Partition to run in.
+    -b    <bank>         Bank from which to draw resources.
+    -t    <time>         Maximum job run time.
+    -machinefile <file>  Machine file.
+
+
+The full list of parallel launch options can be obtained by typing
+'visit --fullhelp'. Here is a more complex example of launching a compute
+engine.
+jjjgfullThe following example launches a compute engine using
+the "srun" job launcher in the "batch" partition, charging the "mybank"
+bank, using 72 processors on 2 nodes, and using a time limit of 1 hour.
+
+::
+
+    # Use the "srun" job launcher, the "batch" partition, the "mybank" bank
+    # Use 72 processors on 2 nodes and a time limit of 1 hour
+    OpenComputeEngine("localhost",("-l", "srun",
+                                   "-p", "batch",
+                                   "-b", "mybank",
+                                   "-np", "72",
+                                   "-nn", "2",
+                                   "-t", "1:00:00"))
+
+You can also launch a compute engine using one of the existing host
+profiles defined for your system. In this particular case we know that
+the third profile is for the "parallel batch pbatch" profile. If you
+didn't know this you could print "p" to get all the properties.
+
+::
+
+    # Set the user name to "user1" and use the third profile
+    # Override a few properties of the third profile.
+    p = GetMachineProfile("quartz.llnl.gov")
+    p.userName="user1"
+    p.activeProfile = 2
+    p.GetLaunchProfiles(2).numProcessors = 72
+    p.GetLaunchProfiles(2).numNodes = 2
+    p.GetLaunchProfiles(2).timeLimit = "00:30:00"
+    OpenComputeEngine(p)
 
 Working with plots
 ------------------


### PR DESCRIPTION
### Description

I added more content the quick recipe for launching a compute engine in the CLI manual. I believe it is pretty complete at this point. I also moved it up 1 level in the hierarchy so that it would be more obvious.

### Type of change

New documentation.

### How Has This Been Tested?

I generated the html and proof read it.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code