### PR TITLE
Correct a bug with the Pixie reader reading curvilinear meshes in parallel. (#4771)

### DIFF
--- a/src/databases/Pixie/avtPixieFileFormat.C
+++ b/src/databases/Pixie/avtPixieFileFormat.C
@@ -424,6 +424,10 @@ avtPixieFileFormat::FreeUpResources(void)
 //   Satheesh Maheswaran, Thu Oct 26 14:14:53 PDT 2012
 //   Added static function for detecting TyphonIO function
 //
+//   Eric Brugger, Fri May 22 13:37:44 PDT 2020
+//   Corrected a bug reading curvilinear meshes in parallel. I added
+//   isCoord to TraversalInfo and VarInfo to track if a variable is a
+//   coordinate array so that the decomposition can be done correctly.
 //
 // ****************************************************************************
 
@@ -483,6 +487,7 @@ avtPixieFileFormat::Initialize()
         info.level = 0;
         info.path = "/";
         info.hasCoords = false;
+        info.isCoord = false;
         info.coordX = "";
         info.coordY = "";
         info.coordZ = "";
@@ -496,6 +501,21 @@ avtPixieFileFormat::Initialize()
         H5Giterate(fileId, "/", NULL, GetVariableList, (void*)&info);
 //      H5Literate(fileId, H5_INDEX_NAME, H5_ITER_INC, 0, VisitLinks, (void*)&info);
         H5Gclose(gid);
+
+        // Tag any coordinates as isCoord.
+        for(VarInfoMap::const_iterator it = variables.begin();
+            it != variables.end(); ++it)
+        {
+            if (it->second.hasCoords)
+            {
+                if (variables.count(it->second.coordX) == 1)
+                    variables[it->second.coordX].isCoord = true;
+                if (variables.count(it->second.coordY) == 1)
+                    variables[it->second.coordY].isCoord = true;
+                if (variables.count(it->second.coordZ) == 1)
+                    variables[it->second.coordZ].isCoord = true;
+            }
+        }
 
         // Determine the names of the meshes that we'll need.
         for(VarInfoMap::const_iterator it = variables.begin();
@@ -572,6 +592,12 @@ avtPixieFileFormat::Initialize()
 //    Jean Favre, Wed Sep  9 14:11:03 CEST 2015
 //    Added a switch between PieceToExtent and PieceToExtentByPoints to
 //    correctly handle cell-based data ghosting
+//
+//    Eric Brugger, Fri May 22 13:37:44 PDT 2020
+//    Corrected a bug reading curvilinear meshes in parallel. I added
+//    isCoord to TraversalInfo and VarInfo to track if a variable is a
+//    coordinate array so that the decomposition can be done correctly.
+//
 // ****************************************************************************
 
 void
@@ -633,7 +659,7 @@ avtPixieFileFormat::PartitionDims()
         globalExtents[4] = 0;
         globalExtents[5] = it->second.dims[2] - 1;
         extTran->SetWholeExtent(globalExtents);
-        if (it->second.hasCoords)
+        if (it->second.hasCoords || it->second.isCoord)
             extTran->PieceToExtent();
         else
             extTran->PieceToExtentByPoints();
@@ -647,7 +673,7 @@ avtPixieFileFormat::PartitionDims()
         it->second.count[2] = extents[5] - extents[4] + 1;
 // redo without ghost to get the strict bounds
         extTran->SetGhostLevel(0);
-        if (it->second.hasCoords)
+        if (it->second.hasCoords || it->second.isCoord)
             extTran->PieceToExtent();
         else
             extTran->PieceToExtentByPoints();
@@ -2086,6 +2112,11 @@ avtPixieFileFormat::VisitLinks(hid_t locId, const char* name,
 //   Luis Chacon, Tue Mar 2 10:02:00 EST 2010
 //   Added code to read time value attributes
 //
+//   Eric Brugger, Fri May 22 13:37:44 PDT 2020
+//   Corrected a bug reading curvilinear meshes in parallel. I added
+//   isCoord to TraversalInfo and VarInfo to track if a variable is a
+//   coordinate array so that the decomposition can be done correctly.
+//
 // ****************************************************************************
 
 herr_t
@@ -2128,6 +2159,7 @@ avtPixieFileFormat::GetVariableList(hid_t group, const char *name,
             varInfo.fileVarName = varName;
             varInfo.timeVarying = false;
             varInfo.hasCoords = info->hasCoords;
+            varInfo.isCoord = info->isCoord;
             varInfo.coordX = info->coordX;
             varInfo.coordY = info->coordY;
             varInfo.coordZ = info->coordZ;
@@ -2296,6 +2328,7 @@ avtPixieFileFormat::GetVariableList(hid_t group, const char *name,
             info2.level = info->level + 1;
             info2.path = varName;
             info2.hasCoords = false;
+            info2.isCoord = false;
             info2.coordX = "";
             info2.coordY = "";
             info2.coordZ = "";

--- a/src/databases/Pixie/avtPixieFileFormat.h
+++ b/src/databases/Pixie/avtPixieFileFormat.h
@@ -69,6 +69,11 @@ class DBOptionsAttributes;
 //    Added a start_no_ghost[3], count_no_ghost[3]
 //    Added reading options to select hyperslab cutting method
 //
+//    Eric Brugger, Fri May 22 13:37:44 PDT 2020
+//    Corrected a bug reading curvilinear meshes in parallel. I added
+//    isCoord to TraversalInfo and VarInfo to track if a variable is a
+//    coordinate array so that the decomposition can be done correctly.
+//
 // ****************************************************************************
 
 class avtPixieFileFormat : public avtMTSDFileFormat
@@ -79,6 +84,7 @@ class avtPixieFileFormat : public avtMTSDFileFormat
         int                level;
         std::string        path;
         bool               hasCoords;
+        bool               isCoord;
         std::string        coordX;
         std::string        coordY;
         std::string        coordZ;
@@ -95,6 +101,7 @@ class avtPixieFileFormat : public avtMTSDFileFormat
         hid_t       nativeVarType;
         std::string fileVarName;
         bool        hasCoords;
+        bool        isCoord;
         std::string coordX;
         std::string coordY;
         std::string coordZ;

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.1.3</font></b></p>
 <ul>
   <li>Fixed a bug preventing SaveWindow from saving OSPRay rendered images.</li>
+  <li>Fixed a bug with the Pixie reader when it read 3D curvilinear meshes in parallel.</li>
   <li>Fixed parallel engine crash when creating ghosts from global ids.</li>
 </ul>
 

--- a/src/test/tests/databases/pixie.py
+++ b/src/test/tests/databases/pixie.py
@@ -128,5 +128,33 @@ v=GetView2D()
 v.windowCoords=(-0.241119, 0.241119, -0.162714, 0.162714)
 SetView2D(v)
 Test("pixie_08")
+DeleteAllPlots()
+
+# test a pseudocolor plot of a 3D curvilinear mesh
+OpenDatabase(data_path("pixie_test_data/pixie3d6.h5"))
+
+AddPlot("Mesh", "curvemesh_8x8x8")
+AddPlot("Pseudocolor","Curvilinear/temperature")
+DrawPlots()
+v = GetView3D()
+v.viewNormal = (0.465617, -0.587141, 0.662168)
+v.focus = (0.5, 1, 1.5)
+v.viewUp = (0.884708, 0.327576, -0.33164)
+v.viewAngle = 30
+v.parallelScale = 1.63698
+v.nearPlane = -3.27395
+v.farPlane = 3.27395
+v.imagePan = (0, 0)
+v.imageZoom = 0.9
+v.perspective = 1
+v.eyeAngle = 2
+v.centerOfRotationSet = 0
+v.centerOfRotation = (0.5, 1, 1.5)
+v.axis3DScaleFlag = 0
+v.axis3DScales = (1, 1, 1)
+v.shear = (0, 0, 1)
+v.windowValid = 1
+SetView3D(v)
+Test("pixie_09")
 
 Exit()

--- a/test/baseline/databases/pixie/pixie_09.png
+++ b/test/baseline/databases/pixie/pixie_09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2f278df769aa067d067d59e6506fb4a28474c2087746a273cccd36f2b6497b8
+size 15473


### PR DESCRIPTION
Resolves #4749 
Merge from the 3.1RC to develop.