### PR TITLE
Add 3d curvilinear pixie file to pixie test data.

### DIFF
--- a/data/pixie_test_data.7z
+++ b/data/pixie_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a2c6aa1c7d5314236dbf5dd7042cda5c98414769a440601bee19f894f1106a6
-size 7431678
+oid sha256:067d324ae25481c6e3fa41f8799553cb2f1cb78b1a0e89dbee9de453c1bfa9c8
+size 7431242


### PR DESCRIPTION
### Description

Added a 3d curvilinear pixie file to the pixie test data. I forgot to add it with my pixie reader changes that added a test that depended on the file.

### Type of change

Bug fix.

### How Has This Been Tested?

I checked that the pixie test data file had the new pixie file.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code