### PR TITLE
Fix file globbing for test suite when run from the build dir.

### DIFF
--- a/src/test/visit_test_suite.py
+++ b/src/test/visit_test_suite.py
@@ -108,7 +108,7 @@ def parse_test_specific_vargs(test_file):
 # ----------------------------------------------------------------------------
 #  Method: parse_test_specific_limit
 #
-#  Programmer: Kathleen Biagas 
+#  Programmer: Kathleen Biagas
 #  Date:       Thu Nov 8, 2018
 # ----------------------------------------------------------------------------
 def parse_test_specific_limit(test_file):
@@ -411,7 +411,7 @@ def log_test_result(result_dir,result):
 #    Added sessionfiles option to rigoursly test session files
 #
 #    Kathleen Biagas, Thu Nov  8 10:33:45 PST 2018
-#    Added src_dir and cmake_cmd.  
+#    Added src_dir and cmake_cmd.
 #
 #    Eric Brugger, Wed Dec  5 13:05:18 PST 2018
 #    Changed the definition of tests_dir_def to the new location of the
@@ -431,7 +431,7 @@ def default_suite_options():
     skip_def        = pjoin(test_path(),"skip.json")
     # Set nprocs_def to 1, since multi-proc test mode seems to result in
     # crossed streams. In the past we have used: multiprocessing.cpu_count()
-    nprocs_def      = 1 
+    nprocs_def      = 1
     opts_full_defs = {
                       "use_pil":True,
                       "threshold_diff":False,
@@ -990,6 +990,12 @@ def rsync_post(src_dir,rsync_dest):
 #   Kathleen Biagas, Wed Dec 18 17:22:59 MST 2019
 #   On windows, glob any '*.py' tests names.
 #
+#   Kathleen Biagas, Wed Jun  3 09:28:11 PDT 2020
+#   Test for '*' on all platforms not just windows. Allows globbing from
+#   batch scripts (where the command-line-glob won't necessarily be expanded).
+#   And allows out-of-source testing to use file glob as well (surrounded by
+#   quotes).
+#
 # ----------------------------------------------------------------------------
 def main(opts,tests):
     """
@@ -1007,19 +1013,18 @@ def main(opts,tests):
         ridx  = pjoin(opts["result_dir"],"results.json")
         tests = load_test_cases_from_index(opts["tests_dir"],ridx,True)
     elif len(tests) == 0:
-        tests = find_test_cases(opts["tests_dir"],opts["classes"]) 
+        tests = find_test_cases(opts["tests_dir"],opts["classes"])
     tests = [ abs_path(pjoin(opts["tests_dir"], "..",t)) for t in tests]
-    if sys.platform.startswith("win"):
-        # use glob to match any *.py
-        expandedtests = []
-        for t in tests:
-           if not '*' in t:
-              expandedtests.append(t)
-           else:
-              for match in glob.iglob(t):
-                 expandedtests.append(match)
-        if len(expandedtests) > 0:
-            tests = expandedtests
+    # use glob to match any *.py
+    expandedtests = []
+    for t in tests:
+       if not '*' in t:
+          expandedtests.append(t)
+       else:
+          for match in glob.iglob(t):
+             expandedtests.append(match)
+    if len(expandedtests) > 0:
+        tests = expandedtests
     prepare_result_dirs(opts["result_dir"])
     ststamp = timestamp(sep=":")
     stime   = time.time()


### PR DESCRIPTION
We lost the ability to specify tests via globbing like so:
"tests/plots/*.py" when run out-of-source.  The shell attempts the file expansion, which fails yielding this error message (on linux).

/run_visit_test_suite.sh: No match.

This commit allows expansion of '*' for all platforms, not just
windows. On linux, this requires surrounding the glob in quotes
to prevent the shell from attempting the expansion.

### How Has This Been Tested?

I have run the test suite from a build dir (not from src) in batch on pascal using 'tests/plots/*.py' and on my local linux using same, and the test suite runs the correct tests.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
