### PR TITLE
Properly dismissed progress dialog when launching client fails

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug preventing SaveWindow from saving OSPRay rendered images.</li>
   <li>Fixed a bug with the Pixie reader when it read 3D curvilinear meshes in parallel.</li>
   <li>Fixed parallel engine crash when creating ghosts from global ids.</li>
+  <li>Fixed the issue with the progress dialog staying visible when a client connection fails.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/viewer/main/ViewerClientConnection.h
+++ b/src/viewer/main/ViewerClientConnection.h
@@ -44,6 +44,10 @@ class ViewerState;
 //   I added a slot that we can use to trickle state objects out to the client
 //   that we launch.
 //
+//   Kevin Griffin, Wed Jun 17 15:08:15 PDT 2020
+//   Changed the return type of LaunchClient from void to bool to determine
+//   if the client was successfully launched.
+//
 // ****************************************************************************
 
 class ViewerClientConnection : public ViewerBaseUI, public SimpleObserver
@@ -56,7 +60,7 @@ public:
                            QObject *parent, const QString &name, const bool _allState = false);
     virtual ~ViewerClientConnection();
 
-    void LaunchClient(const std::string &program,
+    bool LaunchClient(const std::string &program,
                       const stringVector &args,
                       void (*)(const std::string &, const stringVector &, void *),
                       void *,


### PR DESCRIPTION
Resolves #3754.
* Added check for successful launching of client and propagated results to the original caller.
* Also checked that the progress dialog was dismissed.
* Switched to a CATCHALL to ensure that dynamically allocated memory was deleted.

### How Has This Been Tested?

Built and ran on Linux box.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
