### PR TITLE
Add menu indicator to color table button.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Pixie reader when it read 3D curvilinear meshes in parallel.</li>
   <li>Fixed parallel engine crash when creating ghosts from global ids.</li>
   <li>Fixed the issue with the progress dialog staying visible when a client connection fails.</li>
+  <li>Added a menu indicator icon to Color Table buttons so it is more obvious the button can be pushed to see available options.<li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/winutil/QvisColorTableButton.C
+++ b/src/winutil/QvisColorTableButton.C
@@ -72,8 +72,8 @@ QvisColorTableButton::QvisColorTableButton(QWidget *parent) :
         colorTableMenu = new QMenu(0);
         colorTableMenuActionGroup->addAction(colorTableMenu->addAction("Default"));
         colorTableMenu->addSeparator();
-        setMenu(colorTableMenu);
     }
+    setMenu(colorTableMenu);
     buttons.push_back(this);
 
     // Make the popup active when this button is clicked.

--- a/src/winutil/QvisColorTableButton.C
+++ b/src/winutil/QvisColorTableButton.C
@@ -50,6 +50,12 @@ ColorTableAttributes *QvisColorTableButton::colorTableAtts = NULL;
 //   Brad Whitlock, Fri May  9 11:23:57 PDT 2008
 //   Qt 4.
 //
+//   Kathleen Biagas, Thu Jun 18 11:42:47 PDT 2020
+//   Call 'setMenu' to allow QPushButton to control showing and placment of
+//   colorTableMenu.  This will add an arrow to the button to indicate a menu
+//   is attached. Connect QMenu's 'aboutToShow' instead of QPushButton's
+//   'pressed' signal.
+//
 // ****************************************************************************
 
 QvisColorTableButton::QvisColorTableButton(QWidget *parent) :
@@ -66,11 +72,12 @@ QvisColorTableButton::QvisColorTableButton(QWidget *parent) :
         colorTableMenu = new QMenu(0);
         colorTableMenuActionGroup->addAction(colorTableMenu->addAction("Default"));
         colorTableMenu->addSeparator();
+        setMenu(colorTableMenu);
     }
     buttons.push_back(this);
 
     // Make the popup active when this button is clicked.
-    connect(this, SIGNAL(pressed()), this, SLOT(popupPressed()));
+    connect(colorTableMenu, SIGNAL(aboutToShow()), this, SLOT(popupPressed()));
 
     setText(colorTable);
     setIconSize(QSize(ICON_NX,ICON_NY));
@@ -281,22 +288,21 @@ QvisColorTableButton::getColorTable() const
 // Creation:   Sat Jun 16 20:10:16 PST 2001
 //
 // Modifications:
-//   
+//    Kathleen Biagas, Thu Jun 18 11:39:24 PDT 2020
+//    Menu is now connected to this pushbutton via setMenu method, so it will
+//    control placement. This slot is now called when aboutToShow signal is
+//    triggered, so don't need to test for 'isDown'.
+//
 // ****************************************************************************
 
 void
 QvisColorTableButton::popupPressed()
 {
-    if(isDown() && colorTableMenu)
+    if(colorTableMenu)
     {
         // If the popup menu does not have anything in it, fill it up.
         if(!popupHasEntries)
             regeneratePopupMenu();
-
-        QPoint p1(mapToGlobal(rect().bottomLeft()));
-        QPoint p2(mapToGlobal(rect().topRight()));
-        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
-                            p1.y() + ((p2.y() - p1.y()) >> 1));
 
         // Disconnect all other color table buttons.
         for(size_t i = 0; i < buttons.size(); ++i)
@@ -308,28 +314,6 @@ QvisColorTableButton::popupPressed()
         // Connect this colorbutton to the popup menu.
         connect(colorTableMenuActionGroup, SIGNAL(triggered(QAction *)),
                 this, SLOT(colorTableSelected(QAction *)));
-
-        // Figure out a good place to popup the menu.
-        int menuW = colorTableMenu->sizeHint().width();
-        int menuH = colorTableMenu->sizeHint().height();
-        int menuX = buttonMiddle.x();
-        int menuY = buttonMiddle.y() - (menuH >> 1);
-
-        // Fix the X dimension.
-        if(menuX < 0)
-           menuX = 0;
-        else if(menuX + menuW > QApplication::desktop()->width())
-           menuX -= (menuW + 5);
-
-        // Fix the Y dimension.
-        if(menuY < 0)
-           menuY = 0;
-        else if(menuY + menuH > QApplication::desktop()->height())
-           menuY -= ((menuY + menuH) - QApplication::desktop()->height());
-
-        // Show the popup menu.         
-        colorTableMenu->exec(QPoint(menuX, menuY));
-        setDown(false);
     }
 }
 


### PR DESCRIPTION
Use setMenu, which adds the indicator icon (down arrow) and controls placment and showing of the menu. Connect to QMenu's 'aboutToShow' signal instead of QPushButton's 'pressed' signal.
Removed logic for determining placement and showing of the menu as it is now automatically handled.

Resolves #4810
I looked at several plots and verified their color table buttons have the menu indicator.
I've attached a screen shot of Molecule plot which uses multiple color table buttons, showing before and after.

![ColorTableButton](https://user-images.githubusercontent.com/17075318/85062672-baaa0180-b15d-11ea-9267-ad10d09f82ff.png)
