### PR TITLE
Fix a couple of color table issues.

### DIFF
--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -156,6 +156,10 @@ QvisColorTableWindow::~QvisColorTableWindow()
 //
 //   Mark C. Miller, Wed Feb 28 14:27:38 PST 2018
 //   Handle "smoothing" label correctly.
+//
+//   Kathleen Biagas, Mon Jun 22 10:08:41 PDT 2020
+//   Change colorNumColors spin box max to 256.
+//
 // ****************************************************************************
 
 void
@@ -244,7 +248,7 @@ QvisColorTableWindow::CreateWindowContents()
     innerColorLayout->addLayout(colorInfoLayout);
     colorNumColors = new QSpinBox(colorWidgetGroup);
     colorNumColors->setKeyboardTracking(false);
-    colorNumColors->setRange(2,200);
+    colorNumColors->setRange(2,256);
     colorNumColors->setSingleStep(1);
     connect(colorNumColors, SIGNAL(valueChanged(int)),
             this, SLOT(resizeColorTable(int)));

--- a/src/resources/colortables/Accent.ct
+++ b/src/resources/colortables/Accent.ct
@@ -1,37 +1,38 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">127 201 127 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">190 174 212 255 </Field>
-        <Field name="position" type="float">0.142857</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 192 134 255 </Field>
-        <Field name="position" type="float">0.285714</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 153 255 </Field>
-        <Field name="position" type="float">0.428571</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">56 108 176 255 </Field>
-        <Field name="position" type="float">0.571429</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">240 2 127 255 </Field>
-        <Field name="position" type="float">0.714286</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">191 91 23 255 </Field>
-        <Field name="position" type="float">0.857143</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 102 102 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">127 201 127 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">190 174 212 255 </Field>
+            <Field name="position" type="float">0.142857</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 192 134 255 </Field>
+            <Field name="position" type="float">0.285714</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 153 255 </Field>
+            <Field name="position" type="float">0.428571</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">56 108 176 255 </Field>
+            <Field name="position" type="float">0.571429</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">240 2 127 255 </Field>
+            <Field name="position" type="float">0.714286</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">191 91 23 255 </Field>
+            <Field name="position" type="float">0.857143</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 102 102 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Blues.ct
+++ b/src/resources/colortables/Blues.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 251 255 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">222 235 247 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">198 219 239 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">158 202 225 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">107 174 214 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">66 146 198 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">33 113 181 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">8 81 156 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">8 48 107 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 251 255 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">222 235 247 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">198 219 239 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">158 202 225 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">107 174 214 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">66 146 198 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">33 113 181 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">8 81 156 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">8 48 107 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/BrBG.ct
+++ b/src/resources/colortables/BrBG.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">84 48 5 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">140 81 10 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">191 129 45 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">223 194 125 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">246 232 195 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">245 245 245 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">199 234 229 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">128 205 193 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">53 151 143 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">1 102 94 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 60 48 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">84 48 5 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">140 81 10 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">191 129 45 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">223 194 125 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">246 232 195 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">245 245 245 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">199 234 229 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">128 205 193 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">53 151 143 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">1 102 94 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 60 48 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/BuGn.ct
+++ b/src/resources/colortables/BuGn.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 252 253 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">229 245 249 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">204 236 230 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">153 216 201 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 194 164 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 174 118 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">35 139 69 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 109 44 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 68 27 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 252 253 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">229 245 249 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">204 236 230 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">153 216 201 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 194 164 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 174 118 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">35 139 69 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 109 44 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 68 27 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/BuPu.ct
+++ b/src/resources/colortables/BuPu.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 252 253 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">224 236 244 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">191 211 230 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">158 188 218 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">140 150 198 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">140 107 177 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">136 65 157 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">129 15 124 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">77 0 75 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 252 253 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">224 236 244 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">191 211 230 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">158 188 218 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">140 150 198 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">140 107 177 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">136 65 157 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">129 15 124 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">77 0 75 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Dark2.ct
+++ b/src/resources/colortables/Dark2.ct
@@ -1,37 +1,38 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">27 158 119 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 95 2 255 </Field>
-        <Field name="position" type="float">0.142857</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">117 112 179 255 </Field>
-        <Field name="position" type="float">0.285714</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">231 41 138 255 </Field>
-        <Field name="position" type="float">0.428571</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 166 30 255 </Field>
-        <Field name="position" type="float">0.571429</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">230 171 2 255 </Field>
-        <Field name="position" type="float">0.714286</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 118 29 255 </Field>
-        <Field name="position" type="float">0.857143</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 102 102 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">27 158 119 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 95 2 255 </Field>
+            <Field name="position" type="float">0.142857</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">117 112 179 255 </Field>
+            <Field name="position" type="float">0.285714</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">231 41 138 255 </Field>
+            <Field name="position" type="float">0.428571</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 166 30 255 </Field>
+            <Field name="position" type="float">0.571429</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">230 171 2 255 </Field>
+            <Field name="position" type="float">0.714286</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 118 29 255 </Field>
+            <Field name="position" type="float">0.857143</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 102 102 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/GnBu.ct
+++ b/src/resources/colortables/GnBu.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 252 240 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">224 243 219 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">204 235 197 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">168 221 181 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">123 204 196 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">78 179 211 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">43 140 190 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">8 104 172 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">8 64 129 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 252 240 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">224 243 219 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">204 235 197 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">168 221 181 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">123 204 196 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">78 179 211 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">43 140 190 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">8 104 172 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">8 64 129 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Greens.ct
+++ b/src/resources/colortables/Greens.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 252 245 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">229 245 224 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">199 233 192 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">161 217 155 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">116 196 118 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 171 93 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">35 139 69 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 109 44 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 68 27 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 252 245 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">229 245 224 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">199 233 192 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">161 217 155 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">116 196 118 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 171 93 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">35 139 69 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 109 44 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 68 27 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Greys.ct
+++ b/src/resources/colortables/Greys.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 255 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">240 240 240 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 217 217 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">189 189 189 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">150 150 150 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">115 115 115 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">82 82 82 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">37 37 37 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 0 0 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 255 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">240 240 240 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 217 217 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">189 189 189 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">150 150 150 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">115 115 115 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">82 82 82 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">37 37 37 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 0 0 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/OrRd.ct
+++ b/src/resources/colortables/OrRd.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 247 236 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 232 200 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 212 158 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 187 132 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 141 89 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">239 101 72 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">215 48 31 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 0 0 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">127 0 0 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 247 236 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 232 200 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 212 158 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 187 132 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 141 89 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">239 101 72 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">215 48 31 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 0 0 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">127 0 0 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Oranges.ct
+++ b/src/resources/colortables/Oranges.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 245 235 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 230 206 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 208 162 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 174 107 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 141 60 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">241 105 19 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 72 1 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 54 3 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">127 39 4 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 245 235 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 230 206 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 208 162 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 174 107 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 141 60 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">241 105 19 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 72 1 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 54 3 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">127 39 4 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/PRGn.ct
+++ b/src/resources/colortables/PRGn.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">64 0 75 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">118 42 131 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">153 112 171 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">194 165 207 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">231 212 232 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 240 211 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 219 160 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">90 174 97 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">27 120 55 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 68 27 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">64 0 75 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">118 42 131 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">153 112 171 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">194 165 207 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">231 212 232 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 240 211 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 219 160 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">90 174 97 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">27 120 55 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 68 27 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Paired.ct
+++ b/src/resources/colortables/Paired.ct
@@ -1,53 +1,54 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 206 227 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">31 120 180 255 </Field>
-        <Field name="position" type="float">0.090909</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">178 223 138 255 </Field>
-        <Field name="position" type="float">0.181818</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">51 160 44 255 </Field>
-        <Field name="position" type="float">0.272727</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 154 153 255 </Field>
-        <Field name="position" type="float">0.363636</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">227 26 28 255 </Field>
-        <Field name="position" type="float">0.454545</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 191 111 255 </Field>
-        <Field name="position" type="float">0.545455</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 127 0 255 </Field>
-        <Field name="position" type="float">0.636364</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">202 178 214 255 </Field>
-        <Field name="position" type="float">0.727273</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">106 61 154 255 </Field>
-        <Field name="position" type="float">0.818182</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 153 255 </Field>
-        <Field name="position" type="float">0.909091</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">177 89 40 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 206 227 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">31 120 180 255 </Field>
+            <Field name="position" type="float">0.090909</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">178 223 138 255 </Field>
+            <Field name="position" type="float">0.181818</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">51 160 44 255 </Field>
+            <Field name="position" type="float">0.272727</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 154 153 255 </Field>
+            <Field name="position" type="float">0.363636</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">227 26 28 255 </Field>
+            <Field name="position" type="float">0.454545</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 191 111 255 </Field>
+            <Field name="position" type="float">0.545455</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 127 0 255 </Field>
+            <Field name="position" type="float">0.636364</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">202 178 214 255 </Field>
+            <Field name="position" type="float">0.727273</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">106 61 154 255 </Field>
+            <Field name="position" type="float">0.818182</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 153 255 </Field>
+            <Field name="position" type="float">0.909091</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">177 89 40 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Pastel1.ct
+++ b/src/resources/colortables/Pastel1.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 180 174 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 205 227 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">204 235 197 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">222 203 228 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 217 166 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 204 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">229 216 189 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 218 236 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">242 242 242 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 180 174 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 205 227 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">204 235 197 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">222 203 228 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 217 166 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 204 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">229 216 189 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 218 236 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">242 242 242 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Pastel2.ct
+++ b/src/resources/colortables/Pastel2.ct
@@ -1,37 +1,38 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 226 205 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 205 172 255 </Field>
-        <Field name="position" type="float">0.142857</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">203 213 232 255 </Field>
-        <Field name="position" type="float">0.285714</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 202 228 255 </Field>
-        <Field name="position" type="float">0.428571</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">230 245 201 255 </Field>
-        <Field name="position" type="float">0.571429</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 242 174 255 </Field>
-        <Field name="position" type="float">0.714286</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">241 226 204 255 </Field>
-        <Field name="position" type="float">0.857143</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">204 204 204 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 226 205 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 205 172 255 </Field>
+            <Field name="position" type="float">0.142857</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">203 213 232 255 </Field>
+            <Field name="position" type="float">0.285714</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 202 228 255 </Field>
+            <Field name="position" type="float">0.428571</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">230 245 201 255 </Field>
+            <Field name="position" type="float">0.571429</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 242 174 255 </Field>
+            <Field name="position" type="float">0.714286</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">241 226 204 255 </Field>
+            <Field name="position" type="float">0.857143</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">204 204 204 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/PiYG.ct
+++ b/src/resources/colortables/PiYG.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">142 1 82 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">197 27 125 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">222 119 174 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">241 182 218 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 224 239 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">230 245 208 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">184 225 134 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">127 188 65 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">77 146 33 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">39 100 25 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">142 1 82 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">197 27 125 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">222 119 174 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">241 182 218 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 224 239 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">230 245 208 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">184 225 134 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">127 188 65 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">77 146 33 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">39 100 25 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/PuBu.ct
+++ b/src/resources/colortables/PuBu.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 247 251 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">236 231 242 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">208 209 230 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 189 219 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">116 169 207 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">54 144 192 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">5 112 176 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">4 90 141 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">2 56 88 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 247 251 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">236 231 242 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">208 209 230 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 189 219 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">116 169 207 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">54 144 192 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">5 112 176 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">4 90 141 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">2 56 88 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/PuBuGn.ct
+++ b/src/resources/colortables/PuBuGn.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 247 251 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">236 226 240 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">208 209 230 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 189 219 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">103 169 207 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">54 144 192 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">2 129 138 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">1 108 89 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">1 70 54 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 247 251 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">236 226 240 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">208 209 230 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 189 219 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">103 169 207 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">54 144 192 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">2 129 138 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">1 108 89 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">1 70 54 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/PuOr.ct
+++ b/src/resources/colortables/PuOr.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">127 59 8 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 88 6 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">224 130 20 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 184 99 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 224 182 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">216 218 235 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">178 171 210 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">128 115 172 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">84 39 136 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">45 0 75 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">127 59 8 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 88 6 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">224 130 20 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 184 99 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 224 182 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">216 218 235 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">178 171 210 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">128 115 172 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">84 39 136 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">45 0 75 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/PuRd.ct
+++ b/src/resources/colortables/PuRd.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 244 249 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">231 225 239 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">212 185 218 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">201 148 199 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">223 101 176 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">231 41 138 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">206 18 86 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">152 0 67 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">103 0 31 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 244 249 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">231 225 239 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">212 185 218 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">201 148 199 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">223 101 176 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">231 41 138 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">206 18 86 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">152 0 67 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">103 0 31 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Purples.ct
+++ b/src/resources/colortables/Purples.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 251 253 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">239 237 245 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">218 218 235 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">188 189 220 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">158 154 200 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">128 125 186 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">106 81 163 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">84 39 143 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">63 0 125 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 251 253 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">239 237 245 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">218 218 235 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">188 189 220 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">158 154 200 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">128 125 186 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">106 81 163 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">84 39 143 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">63 0 125 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/RdBu.ct
+++ b/src/resources/colortables/RdBu.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">103 0 31 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">178 24 43 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">214 96 77 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 165 130 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 219 199 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">209 229 240 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">146 197 222 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">67 147 195 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">33 102 172 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">5 48 97 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">103 0 31 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">178 24 43 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">214 96 77 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 165 130 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 219 199 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 247 247 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">209 229 240 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">146 197 222 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">67 147 195 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">33 102 172 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">5 48 97 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/RdGy.ct
+++ b/src/resources/colortables/RdGy.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">103 0 31 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">178 24 43 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">214 96 77 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 165 130 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 219 199 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 255 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">224 224 224 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">186 186 186 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">135 135 135 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">77 77 77 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">26 26 26 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">103 0 31 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">178 24 43 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">214 96 77 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 165 130 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 219 199 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 255 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">224 224 224 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">186 186 186 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">135 135 135 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">77 77 77 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">26 26 26 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/RdPu.ct
+++ b/src/resources/colortables/RdPu.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 247 243 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 224 221 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 197 192 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">250 159 181 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 104 161 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">221 52 151 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">174 1 126 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">122 1 119 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">73 0 106 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 247 243 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 224 221 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 197 192 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">250 159 181 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 104 161 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">221 52 151 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">174 1 126 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">122 1 119 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">73 0 106 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/RdYlBu.ct
+++ b/src/resources/colortables/RdYlBu.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">165 0 38 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">215 48 39 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 109 67 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 174 97 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 224 144 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 191 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">224 243 248 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">171 217 233 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">116 173 209 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 117 180 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">49 54 149 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">165 0 38 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">215 48 39 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 109 67 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 174 97 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 224 144 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 191 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">224 243 248 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">171 217 233 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">116 173 209 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 117 180 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">49 54 149 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/RdYlGn.ct
+++ b/src/resources/colortables/RdYlGn.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">165 0 38 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">215 48 39 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 109 67 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 174 97 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 224 139 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 191 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 239 139 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 217 106 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 189 99 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">26 152 80 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 104 55 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">165 0 38 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">215 48 39 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 109 67 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 174 97 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 224 139 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 191 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 239 139 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 217 106 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 189 99 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">26 152 80 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 104 55 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Reds.ct
+++ b/src/resources/colortables/Reds.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 245 240 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 224 210 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 187 161 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 146 114 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 106 74 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">239 59 44 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">203 24 29 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">165 15 21 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">103 0 13 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 245 240 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 224 210 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 187 161 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 146 114 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 106 74 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">239 59 44 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">203 24 29 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">165 15 21 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">103 0 13 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Set1.ct
+++ b/src/resources/colortables/Set1.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">228 26 28 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">55 126 184 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">77 175 74 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">152 78 163 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 127 0 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 51 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 86 40 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 129 191 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">153 153 153 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">228 26 28 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">55 126 184 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">77 175 74 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">152 78 163 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 127 0 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 51 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 86 40 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 129 191 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">153 153 153 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Set2.ct
+++ b/src/resources/colortables/Set2.ct
@@ -1,37 +1,38 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 194 165 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 141 98 255 </Field>
-        <Field name="position" type="float">0.142857</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">141 160 203 255 </Field>
-        <Field name="position" type="float">0.285714</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">231 138 195 255 </Field>
-        <Field name="position" type="float">0.428571</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 216 84 255 </Field>
-        <Field name="position" type="float">0.571429</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 217 47 255 </Field>
-        <Field name="position" type="float">0.714286</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">229 196 148 255 </Field>
-        <Field name="position" type="float">0.857143</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 179 179 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 194 165 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 141 98 255 </Field>
+            <Field name="position" type="float">0.142857</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">141 160 203 255 </Field>
+            <Field name="position" type="float">0.285714</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">231 138 195 255 </Field>
+            <Field name="position" type="float">0.428571</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 216 84 255 </Field>
+            <Field name="position" type="float">0.571429</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 217 47 255 </Field>
+            <Field name="position" type="float">0.714286</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">229 196 148 255 </Field>
+            <Field name="position" type="float">0.857143</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 179 179 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Set3.ct
+++ b/src/resources/colortables/Set3.ct
@@ -1,53 +1,54 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">141 211 199 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 179 255 </Field>
-        <Field name="position" type="float">0.090909</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">190 186 218 255 </Field>
-        <Field name="position" type="float">0.181818</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 128 114 255 </Field>
-        <Field name="position" type="float">0.272727</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">128 177 211 255 </Field>
-        <Field name="position" type="float">0.363636</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 180 98 255 </Field>
-        <Field name="position" type="float">0.454545</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 222 105 255 </Field>
-        <Field name="position" type="float">0.545455</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 205 229 255 </Field>
-        <Field name="position" type="float">0.636364</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 217 217 255 </Field>
-        <Field name="position" type="float">0.727273</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">188 128 189 255 </Field>
-        <Field name="position" type="float">0.818182</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">204 235 197 255 </Field>
-        <Field name="position" type="float">0.909091</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 237 111 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">141 211 199 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 179 255 </Field>
+            <Field name="position" type="float">0.090909</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">190 186 218 255 </Field>
+            <Field name="position" type="float">0.181818</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 128 114 255 </Field>
+            <Field name="position" type="float">0.272727</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">128 177 211 255 </Field>
+            <Field name="position" type="float">0.363636</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 180 98 255 </Field>
+            <Field name="position" type="float">0.454545</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 222 105 255 </Field>
+            <Field name="position" type="float">0.545455</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 205 229 255 </Field>
+            <Field name="position" type="float">0.636364</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 217 217 255 </Field>
+            <Field name="position" type="float">0.727273</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">188 128 189 255 </Field>
+            <Field name="position" type="float">0.818182</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">204 235 197 255 </Field>
+            <Field name="position" type="float">0.909091</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 237 111 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/Spectral.ct
+++ b/src/resources/colortables/Spectral.ct
@@ -1,49 +1,50 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">158 1 66 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">213 62 79 255 </Field>
-        <Field name="position" type="float">0.100000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 109 67 255 </Field>
-        <Field name="position" type="float">0.200000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 174 97 255 </Field>
-        <Field name="position" type="float">0.300000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 224 139 255 </Field>
-        <Field name="position" type="float">0.400000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 191 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">230 245 152 255 </Field>
-        <Field name="position" type="float">0.600000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">171 221 164 255 </Field>
-        <Field name="position" type="float">0.700000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 194 165 255 </Field>
-        <Field name="position" type="float">0.800000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">50 136 189 255 </Field>
-        <Field name="position" type="float">0.900000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">94 79 162 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">158 1 66 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">213 62 79 255 </Field>
+            <Field name="position" type="float">0.100000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 109 67 255 </Field>
+            <Field name="position" type="float">0.200000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 174 97 255 </Field>
+            <Field name="position" type="float">0.300000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 224 139 255 </Field>
+            <Field name="position" type="float">0.400000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 191 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">230 245 152 255 </Field>
+            <Field name="position" type="float">0.600000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">171 221 164 255 </Field>
+            <Field name="position" type="float">0.700000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 194 165 255 </Field>
+            <Field name="position" type="float">0.800000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">50 136 189 255 </Field>
+            <Field name="position" type="float">0.900000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">94 79 162 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/YlGn.ct
+++ b/src/resources/colortables/YlGn.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 229 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 252 185 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 240 163 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">173 221 142 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">120 198 121 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 171 93 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">35 132 67 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 104 55 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">0 69 41 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 229 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 252 185 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 240 163 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">173 221 142 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">120 198 121 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 171 93 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">35 132 67 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 104 55 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">0 69 41 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/YlGnBu.ct
+++ b/src/resources/colortables/YlGnBu.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 217 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">237 248 177 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">199 233 180 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">127 205 187 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 182 196 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">29 145 192 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">34 94 168 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">37 52 148 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">8 29 88 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 217 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">237 248 177 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">199 233 180 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">127 205 187 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 182 196 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">29 145 192 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">34 94 168 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">37 52 148 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">8 29 88 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/YlOrBr.ct
+++ b/src/resources/colortables/YlOrBr.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 229 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 247 188 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 227 145 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 196 79 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 153 41 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">236 112 20 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">204 76 2 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">153 52 4 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">102 37 6 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 229 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 247 188 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 227 145 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 196 79 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 153 41 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">236 112 20 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">204 76 2 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">153 52 4 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">102 37 6 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/YlOrRd.ct
+++ b/src/resources/colortables/YlOrRd.ct
@@ -1,41 +1,42 @@
 <?xml version="1.0"?>
 <Object name="ColorTable">
-<Field name="Version" type="string">2.0.1</Field>
-<Object name="ColorControlPointList">
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 255 204 255 </Field>
-        <Field name="position" type="float">0.000000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">255 237 160 255 </Field>
-        <Field name="position" type="float">0.125000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 217 118 255 </Field>
-        <Field name="position" type="float">0.250000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 178 76 255 </Field>
-        <Field name="position" type="float">0.375000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 141 60 255 </Field>
-        <Field name="position" type="float">0.500000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 78 42 255 </Field>
-        <Field name="position" type="float">0.625000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">227 26 28 255 </Field>
-        <Field name="position" type="float">0.750000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">189 0 38 255 </Field>
-        <Field name="position" type="float">0.875000</Field>
-    </Object>
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">128 0 38 255 </Field>
-        <Field name="position" type="float">1.000000</Field>
+    <Field name="Version" type="string">2.0.1</Field>
+    <Object name="ColorControlPointList">
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 255 204 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">255 237 160 255 </Field>
+            <Field name="position" type="float">0.125000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 217 118 255 </Field>
+            <Field name="position" type="float">0.250000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 178 76 255 </Field>
+            <Field name="position" type="float">0.375000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 141 60 255 </Field>
+            <Field name="position" type="float">0.500000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 78 42 255 </Field>
+            <Field name="position" type="float">0.625000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">227 26 28 255 </Field>
+            <Field name="position" type="float">0.750000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">189 0 38 255 </Field>
+            <Field name="position" type="float">0.875000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">128 0 38 255 </Field>
+            <Field name="position" type="float">1.000000</Field>
+        </Object>
     </Object>
 </Object>

--- a/src/resources/colortables/inferno.ct
+++ b/src/resources/colortables/inferno.ct
@@ -4,6 +4,7 @@
     <Object name="ColorControlPointList">
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">0 0 3 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
         </Object>
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">0 0 4 255 </Field>

--- a/src/resources/colortables/magma.ct
+++ b/src/resources/colortables/magma.ct
@@ -4,6 +4,7 @@
     <Object name="ColorControlPointList">
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">0 0 3 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
         </Object>
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">0 0 4 255 </Field>

--- a/src/resources/colortables/plasma.ct
+++ b/src/resources/colortables/plasma.ct
@@ -4,6 +4,7 @@
     <Object name="ColorControlPointList">
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">12 7 134 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
         </Object>
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">16 7 135 255 </Field>

--- a/src/resources/colortables/turbo.ct
+++ b/src/resources/colortables/turbo.ct
@@ -1,1288 +1,1031 @@
-
 <?xml version="1.0"?>
 <Object name="ColorTable">
     <Field name="Version" type="string">3.0.2</Field>
     <Object name="ColorControlPointList">
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">48 18 59 255</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">49 21 66 255</Field>
-        <Field name="position" type="float">0.00392156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">50 24 74 255</Field>
-        <Field name="position" type="float">0.0078431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">52 27 81 255</Field>
-        <Field name="position" type="float">0.0117647058824</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">53 30 88 255</Field>
-        <Field name="position" type="float">0.0156862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">54 33 95 255</Field>
-        <Field name="position" type="float">0.0196078431373</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">55 35 101 255</Field>
-        <Field name="position" type="float">0.0235294117647</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">56 38 108 255</Field>
-        <Field name="position" type="float">0.0274509803922</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">57 41 114 255</Field>
-        <Field name="position" type="float">0.0313725490196</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">58 44 121 255</Field>
-        <Field name="position" type="float">0.0352941176471</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">59 47 127 255</Field>
-        <Field name="position" type="float">0.0392156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">60 50 133 255</Field>
-        <Field name="position" type="float">0.043137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">60 53 139 255</Field>
-        <Field name="position" type="float">0.0470588235294</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">61 55 145 255</Field>
-        <Field name="position" type="float">0.0509803921569</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">62 58 150 255</Field>
-        <Field name="position" type="float">0.0549019607843</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">63 61 156 255</Field>
-        <Field name="position" type="float">0.0588235294118</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">64 64 161 255</Field>
-        <Field name="position" type="float">0.0627450980392</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">64 67 166 255</Field>
-        <Field name="position" type="float">0.0666666666667</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 69 171 255</Field>
-        <Field name="position" type="float">0.0705882352941</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 72 176 255</Field>
-        <Field name="position" type="float">0.0745098039216</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">66 75 181 255</Field>
-        <Field name="position" type="float">0.078431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">67 78 186 255</Field>
-        <Field name="position" type="float">0.0823529411765</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">67 80 190 255</Field>
-        <Field name="position" type="float">0.0862745098039</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">67 83 194 255</Field>
-        <Field name="position" type="float">0.0901960784314</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">68 86 199 255</Field>
-        <Field name="position" type="float">0.0941176470588</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">68 88 203 255</Field>
-        <Field name="position" type="float">0.0980392156863</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 91 206 255</Field>
-        <Field name="position" type="float">0.101960784314</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 94 210 255</Field>
-        <Field name="position" type="float">0.105882352941</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 96 214 255</Field>
-        <Field name="position" type="float">0.109803921569</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 99 217 255</Field>
-        <Field name="position" type="float">0.113725490196</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 102 221 255</Field>
-        <Field name="position" type="float">0.117647058824</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 104 224 255</Field>
-        <Field name="position" type="float">0.121568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 107 227 255</Field>
-        <Field name="position" type="float">0.125490196078</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 109 230 255</Field>
-        <Field name="position" type="float">0.129411764706</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 112 232 255</Field>
-        <Field name="position" type="float">0.133333333333</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 115 235 255</Field>
-        <Field name="position" type="float">0.137254901961</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 117 237 255</Field>
-        <Field name="position" type="float">0.141176470588</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 120 240 255</Field>
-        <Field name="position" type="float">0.145098039216</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 122 242 255</Field>
-        <Field name="position" type="float">0.149019607843</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 125 244 255</Field>
-        <Field name="position" type="float">0.152941176471</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 127 246 255</Field>
-        <Field name="position" type="float">0.156862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 130 248 255</Field>
-        <Field name="position" type="float">0.160784313725</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 132 249 255</Field>
-        <Field name="position" type="float">0.164705882353</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 135 251 255</Field>
-        <Field name="position" type="float">0.16862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">69 137 252 255</Field>
-        <Field name="position" type="float">0.172549019608</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">68 140 253 255</Field>
-        <Field name="position" type="float">0.176470588235</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">67 142 253 255</Field>
-        <Field name="position" type="float">0.180392156863</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">66 145 254 255</Field>
-        <Field name="position" type="float">0.18431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">65 147 254 255</Field>
-        <Field name="position" type="float">0.188235294118</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">64 150 254 255</Field>
-        <Field name="position" type="float">0.192156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">63 152 254 255</Field>
-        <Field name="position" type="float">0.196078431373</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">62 155 254 255</Field>
-        <Field name="position" type="float">0.2</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">60 157 253 255</Field>
-        <Field name="position" type="float">0.203921568627</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">59 160 252 255</Field>
-        <Field name="position" type="float">0.207843137255</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">57 162 252 255</Field>
-        <Field name="position" type="float">0.211764705882</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">56 165 251 255</Field>
-        <Field name="position" type="float">0.21568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">54 168 249 255</Field>
-        <Field name="position" type="float">0.219607843137</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">52 170 248 255</Field>
-        <Field name="position" type="float">0.223529411765</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">51 172 246 255</Field>
-        <Field name="position" type="float">0.227450980392</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">49 175 245 255</Field>
-        <Field name="position" type="float">0.23137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">47 177 243 255</Field>
-        <Field name="position" type="float">0.235294117647</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">45 180 241 255</Field>
-        <Field name="position" type="float">0.239215686275</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">43 182 239 255</Field>
-        <Field name="position" type="float">0.243137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">42 185 237 255</Field>
-        <Field name="position" type="float">0.247058823529</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">40 187 235 255</Field>
-        <Field name="position" type="float">0.250980392157</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">38 189 233 255</Field>
-        <Field name="position" type="float">0.254901960784</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">37 192 230 255</Field>
-        <Field name="position" type="float">0.258823529412</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">35 194 228 255</Field>
-        <Field name="position" type="float">0.262745098039</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">33 196 225 255</Field>
-        <Field name="position" type="float">0.266666666667</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">32 198 223 255</Field>
-        <Field name="position" type="float">0.270588235294</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">30 201 220 255</Field>
-        <Field name="position" type="float">0.274509803922</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">29 203 218 255</Field>
-        <Field name="position" type="float">0.278431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">28 205 215 255</Field>
-        <Field name="position" type="float">0.282352941176</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">27 207 212 255</Field>
-        <Field name="position" type="float">0.286274509804</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">26 209 210 255</Field>
-        <Field name="position" type="float">0.290196078431</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">25 211 207 255</Field>
-        <Field name="position" type="float">0.294117647059</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">24 213 204 255</Field>
-        <Field name="position" type="float">0.298039215686</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">24 215 202 255</Field>
-        <Field name="position" type="float">0.301960784314</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">23 217 199 255</Field>
-        <Field name="position" type="float">0.305882352941</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">23 218 196 255</Field>
-        <Field name="position" type="float">0.309803921569</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">23 220 194 255</Field>
-        <Field name="position" type="float">0.313725490196</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">23 222 191 255</Field>
-        <Field name="position" type="float">0.317647058824</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">24 224 189 255</Field>
-        <Field name="position" type="float">0.321568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">24 225 186 255</Field>
-        <Field name="position" type="float">0.325490196078</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">25 227 184 255</Field>
-        <Field name="position" type="float">0.329411764706</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">26 228 182 255</Field>
-        <Field name="position" type="float">0.333333333333</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">27 229 180 255</Field>
-        <Field name="position" type="float">0.337254901961</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">29 231 177 255</Field>
-        <Field name="position" type="float">0.341176470588</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">30 232 175 255</Field>
-        <Field name="position" type="float">0.345098039216</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">32 233 172 255</Field>
-        <Field name="position" type="float">0.349019607843</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">34 235 169 255</Field>
-        <Field name="position" type="float">0.352941176471</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">36 236 166 255</Field>
-        <Field name="position" type="float">0.356862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">39 237 163 255</Field>
-        <Field name="position" type="float">0.360784313725</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">41 238 160 255</Field>
-        <Field name="position" type="float">0.364705882353</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">44 239 157 255</Field>
-        <Field name="position" type="float">0.36862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">47 240 154 255</Field>
-        <Field name="position" type="float">0.372549019608</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">50 241 151 255</Field>
-        <Field name="position" type="float">0.376470588235</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">53 243 148 255</Field>
-        <Field name="position" type="float">0.380392156863</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">56 244 145 255</Field>
-        <Field name="position" type="float">0.38431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">59 244 141 255</Field>
-        <Field name="position" type="float">0.388235294118</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">63 245 138 255</Field>
-        <Field name="position" type="float">0.392156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">66 246 135 255</Field>
-        <Field name="position" type="float">0.396078431373</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">70 247 131 255</Field>
-        <Field name="position" type="float">0.4</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">74 248 128 255</Field>
-        <Field name="position" type="float">0.403921568627</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">77 249 124 255</Field>
-        <Field name="position" type="float">0.407843137255</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">81 249 121 255</Field>
-        <Field name="position" type="float">0.411764705882</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">85 250 118 255</Field>
-        <Field name="position" type="float">0.41568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">89 251 114 255</Field>
-        <Field name="position" type="float">0.419607843137</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">93 251 111 255</Field>
-        <Field name="position" type="float">0.423529411765</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">97 252 108 255</Field>
-        <Field name="position" type="float">0.427450980392</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">101 252 104 255</Field>
-        <Field name="position" type="float">0.43137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">105 253 101 255</Field>
-        <Field name="position" type="float">0.435294117647</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">109 253 98 255</Field>
-        <Field name="position" type="float">0.439215686275</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">113 253 95 255</Field>
-        <Field name="position" type="float">0.443137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">116 254 92 255</Field>
-        <Field name="position" type="float">0.447058823529</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">120 254 89 255</Field>
-        <Field name="position" type="float">0.450980392157</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">124 254 86 255</Field>
-        <Field name="position" type="float">0.454901960784</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">128 254 83 255</Field>
-        <Field name="position" type="float">0.458823529412</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">132 254 80 255</Field>
-        <Field name="position" type="float">0.462745098039</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">135 254 77 255</Field>
-        <Field name="position" type="float">0.466666666667</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">139 254 75 255</Field>
-        <Field name="position" type="float">0.470588235294</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">142 254 72 255</Field>
-        <Field name="position" type="float">0.474509803922</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">146 254 70 255</Field>
-        <Field name="position" type="float">0.478431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">149 254 68 255</Field>
-        <Field name="position" type="float">0.482352941176</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">152 254 66 255</Field>
-        <Field name="position" type="float">0.486274509804</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">155 253 64 255</Field>
-        <Field name="position" type="float">0.490196078431</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">158 253 62 255</Field>
-        <Field name="position" type="float">0.494117647059</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">161 252 61 255</Field>
-        <Field name="position" type="float">0.498039215686</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">164 252 59 255</Field>
-        <Field name="position" type="float">0.501960784314</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 251 58 255</Field>
-        <Field name="position" type="float">0.505882352941</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">169 251 57 255</Field>
-        <Field name="position" type="float">0.509803921569</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">172 250 55 255</Field>
-        <Field name="position" type="float">0.513725490196</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">174 249 55 255</Field>
-        <Field name="position" type="float">0.517647058824</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">177 248 54 255</Field>
-        <Field name="position" type="float">0.521568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">179 248 53 255</Field>
-        <Field name="position" type="float">0.525490196078</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">182 247 53 255</Field>
-        <Field name="position" type="float">0.529411764706</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">185 245 52 255</Field>
-        <Field name="position" type="float">0.533333333333</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">187 244 52 255</Field>
-        <Field name="position" type="float">0.537254901961</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">190 243 52 255</Field>
-        <Field name="position" type="float">0.541176470588</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">192 242 51 255</Field>
-        <Field name="position" type="float">0.545098039216</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">195 241 51 255</Field>
-        <Field name="position" type="float">0.549019607843</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">197 239 51 255</Field>
-        <Field name="position" type="float">0.552941176471</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">200 238 51 255</Field>
-        <Field name="position" type="float">0.556862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">202 237 51 255</Field>
-        <Field name="position" type="float">0.560784313725</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">205 235 52 255</Field>
-        <Field name="position" type="float">0.564705882353</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">207 234 52 255</Field>
-        <Field name="position" type="float">0.56862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">209 232 52 255</Field>
-        <Field name="position" type="float">0.572549019608</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">212 231 53 255</Field>
-        <Field name="position" type="float">0.576470588235</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">214 229 53 255</Field>
-        <Field name="position" type="float">0.580392156863</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">216 227 53 255</Field>
-        <Field name="position" type="float">0.58431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">218 226 54 255</Field>
-        <Field name="position" type="float">0.588235294118</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">221 224 54 255</Field>
-        <Field name="position" type="float">0.592156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">223 222 54 255</Field>
-        <Field name="position" type="float">0.596078431373</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">225 220 55 255</Field>
-        <Field name="position" type="float">0.6</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">227 218 55 255</Field>
-        <Field name="position" type="float">0.603921568627</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">229 216 56 255</Field>
-        <Field name="position" type="float">0.607843137255</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">231 215 56 255</Field>
-        <Field name="position" type="float">0.611764705882</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">232 213 56 255</Field>
-        <Field name="position" type="float">0.61568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">234 211 57 255</Field>
-        <Field name="position" type="float">0.619607843137</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">236 209 57 255</Field>
-        <Field name="position" type="float">0.623529411765</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">237 207 57 255</Field>
-        <Field name="position" type="float">0.627450980392</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">239 205 57 255</Field>
-        <Field name="position" type="float">0.63137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">240 203 58 255</Field>
-        <Field name="position" type="float">0.635294117647</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">242 200 58 255</Field>
-        <Field name="position" type="float">0.639215686275</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">243 198 58 255</Field>
-        <Field name="position" type="float">0.643137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 196 58 255</Field>
-        <Field name="position" type="float">0.647058823529</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">246 194 58 255</Field>
-        <Field name="position" type="float">0.650980392157</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 192 57 255</Field>
-        <Field name="position" type="float">0.654901960784</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">248 190 57 255</Field>
-        <Field name="position" type="float">0.658823529412</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">249 188 57 255</Field>
-        <Field name="position" type="float">0.662745098039</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">249 186 56 255</Field>
-        <Field name="position" type="float">0.666666666667</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">250 183 55 255</Field>
-        <Field name="position" type="float">0.670588235294</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 181 55 255</Field>
-        <Field name="position" type="float">0.674509803922</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 179 54 255</Field>
-        <Field name="position" type="float">0.678431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 176 53 255</Field>
-        <Field name="position" type="float">0.682352941176</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 174 52 255</Field>
-        <Field name="position" type="float">0.686274509804</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 171 51 255</Field>
-        <Field name="position" type="float">0.690196078431</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 169 50 255</Field>
-        <Field name="position" type="float">0.694117647059</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 166 49 255</Field>
-        <Field name="position" type="float">0.698039215686</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 163 48 255</Field>
-        <Field name="position" type="float">0.701960784314</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 161 47 255</Field>
-        <Field name="position" type="float">0.705882352941</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 158 46 255</Field>
-        <Field name="position" type="float">0.709803921569</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 155 45 255</Field>
-        <Field name="position" type="float">0.713725490196</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">254 152 44 255</Field>
-        <Field name="position" type="float">0.717647058824</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 149 43 255</Field>
-        <Field name="position" type="float">0.721568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 146 41 255</Field>
-        <Field name="position" type="float">0.725490196078</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 143 40 255</Field>
-        <Field name="position" type="float">0.729411764706</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">253 140 39 255</Field>
-        <Field name="position" type="float">0.733333333333</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 137 38 255</Field>
-        <Field name="position" type="float">0.737254901961</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">252 134 36 255</Field>
-        <Field name="position" type="float">0.741176470588</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 131 35 255</Field>
-        <Field name="position" type="float">0.745098039216</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">251 128 34 255</Field>
-        <Field name="position" type="float">0.749019607843</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">250 125 32 255</Field>
-        <Field name="position" type="float">0.752941176471</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">250 122 31 255</Field>
-        <Field name="position" type="float">0.756862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">249 119 30 255</Field>
-        <Field name="position" type="float">0.760784313725</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">248 116 28 255</Field>
-        <Field name="position" type="float">0.764705882353</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 113 27 255</Field>
-        <Field name="position" type="float">0.76862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">247 110 26 255</Field>
-        <Field name="position" type="float">0.772549019608</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">246 107 24 255</Field>
-        <Field name="position" type="float">0.776470588235</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">245 104 23 255</Field>
-        <Field name="position" type="float">0.780392156863</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">244 101 22 255</Field>
-        <Field name="position" type="float">0.78431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">243 99 21 255</Field>
-        <Field name="position" type="float">0.788235294118</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">242 96 20 255</Field>
-        <Field name="position" type="float">0.792156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">241 93 19 255</Field>
-        <Field name="position" type="float">0.796078431373</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">239 90 17 255</Field>
-        <Field name="position" type="float">0.8</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">238 88 16 255</Field>
-        <Field name="position" type="float">0.803921568627</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">237 85 15 255</Field>
-        <Field name="position" type="float">0.807843137255</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">236 82 14 255</Field>
-        <Field name="position" type="float">0.811764705882</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">234 80 13 255</Field>
-        <Field name="position" type="float">0.81568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">233 77 13 255</Field>
-        <Field name="position" type="float">0.819607843137</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">232 75 12 255</Field>
-        <Field name="position" type="float">0.823529411765</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">230 73 11 255</Field>
-        <Field name="position" type="float">0.827450980392</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">229 70 10 255</Field>
-        <Field name="position" type="float">0.83137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">227 68 10 255</Field>
-        <Field name="position" type="float">0.835294117647</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">226 66 9 255</Field>
-        <Field name="position" type="float">0.839215686275</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">224 64 8 255</Field>
-        <Field name="position" type="float">0.843137254902</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">222 62 8 255</Field>
-        <Field name="position" type="float">0.847058823529</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">221 60 7 255</Field>
-        <Field name="position" type="float">0.850980392157</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">219 58 7 255</Field>
-        <Field name="position" type="float">0.854901960784</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">217 56 6 255</Field>
-        <Field name="position" type="float">0.858823529412</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">215 54 6 255</Field>
-        <Field name="position" type="float">0.862745098039</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">214 52 5 255</Field>
-        <Field name="position" type="float">0.866666666667</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">212 50 5 255</Field>
-        <Field name="position" type="float">0.870588235294</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">210 48 5 255</Field>
-        <Field name="position" type="float">0.874509803922</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">208 47 4 255</Field>
-        <Field name="position" type="float">0.878431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">206 45 4 255</Field>
-        <Field name="position" type="float">0.882352941176</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">203 43 3 255</Field>
-        <Field name="position" type="float">0.886274509804</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">201 41 3 255</Field>
-        <Field name="position" type="float">0.890196078431</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">199 40 3 255</Field>
-        <Field name="position" type="float">0.894117647059</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">197 38 2 255</Field>
-        <Field name="position" type="float">0.898039215686</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">195 36 2 255</Field>
-        <Field name="position" type="float">0.901960784314</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">192 35 2 255</Field>
-        <Field name="position" type="float">0.905882352941</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">190 33 2 255</Field>
-        <Field name="position" type="float">0.909803921569</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">187 31 1 255</Field>
-        <Field name="position" type="float">0.913725490196</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">185 30 1 255</Field>
-        <Field name="position" type="float">0.917647058824</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">182 28 1 255</Field>
-        <Field name="position" type="float">0.921568627451</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">180 27 1 255</Field>
-        <Field name="position" type="float">0.925490196078</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">177 25 1 255</Field>
-        <Field name="position" type="float">0.929411764706</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">174 24 1 255</Field>
-        <Field name="position" type="float">0.933333333333</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">172 22 1 255</Field>
-        <Field name="position" type="float">0.937254901961</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">169 21 1 255</Field>
-        <Field name="position" type="float">0.941176470588</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">166 20 1 255</Field>
-        <Field name="position" type="float">0.945098039216</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">163 18 1 255</Field>
-        <Field name="position" type="float">0.949019607843</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">160 17 1 255</Field>
-        <Field name="position" type="float">0.952941176471</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">157 16 1 255</Field>
-        <Field name="position" type="float">0.956862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">154 14 1 255</Field>
-        <Field name="position" type="float">0.960784313725</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">151 13 1 255</Field>
-        <Field name="position" type="float">0.964705882353</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">148 12 1 255</Field>
-        <Field name="position" type="float">0.96862745098</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">145 11 1 255</Field>
-        <Field name="position" type="float">0.972549019608</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">142 10 1 255</Field>
-        <Field name="position" type="float">0.976470588235</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">139 9 1 255</Field>
-        <Field name="position" type="float">0.980392156863</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">135 8 1 255</Field>
-        <Field name="position" type="float">0.98431372549</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">132 7 1 255</Field>
-        <Field name="position" type="float">0.988235294118</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">129 6 2 255</Field>
-        <Field name="position" type="float">0.992156862745</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">125 5 2 255</Field>
-        <Field name="position" type="float">0.996078431373</Field>
-    </Object>
-
-    <Object name="ColorControlPoint">
-        <Field name="colors" type="unsignedCharArray" length="4">122 4 2 255</Field>
-        <Field name="position" type="float">1.0</Field>
-    </Object>
-
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">48 18 59 255</Field>
+            <Field name="position" type="float">0.000000</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">49 21 66 255</Field>
+            <Field name="position" type="float">0.00392156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">50 24 74 255</Field>
+            <Field name="position" type="float">0.0078431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">52 27 81 255</Field>
+            <Field name="position" type="float">0.0117647058824</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">53 30 88 255</Field>
+            <Field name="position" type="float">0.0156862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">54 33 95 255</Field>
+            <Field name="position" type="float">0.0196078431373</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">55 35 101 255</Field>
+            <Field name="position" type="float">0.0235294117647</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">56 38 108 255</Field>
+            <Field name="position" type="float">0.0274509803922</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">57 41 114 255</Field>
+            <Field name="position" type="float">0.0313725490196</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">58 44 121 255</Field>
+            <Field name="position" type="float">0.0352941176471</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">59 47 127 255</Field>
+            <Field name="position" type="float">0.0392156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">60 50 133 255</Field>
+            <Field name="position" type="float">0.043137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">60 53 139 255</Field>
+            <Field name="position" type="float">0.0470588235294</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">61 55 145 255</Field>
+            <Field name="position" type="float">0.0509803921569</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">62 58 150 255</Field>
+            <Field name="position" type="float">0.0549019607843</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">63 61 156 255</Field>
+            <Field name="position" type="float">0.0588235294118</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">64 64 161 255</Field>
+            <Field name="position" type="float">0.0627450980392</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">64 67 166 255</Field>
+            <Field name="position" type="float">0.0666666666667</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 69 171 255</Field>
+            <Field name="position" type="float">0.0705882352941</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 72 176 255</Field>
+            <Field name="position" type="float">0.0745098039216</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">66 75 181 255</Field>
+            <Field name="position" type="float">0.078431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">67 78 186 255</Field>
+            <Field name="position" type="float">0.0823529411765</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">67 80 190 255</Field>
+            <Field name="position" type="float">0.0862745098039</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">67 83 194 255</Field>
+            <Field name="position" type="float">0.0901960784314</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">68 86 199 255</Field>
+            <Field name="position" type="float">0.0941176470588</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">68 88 203 255</Field>
+            <Field name="position" type="float">0.0980392156863</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 91 206 255</Field>
+            <Field name="position" type="float">0.101960784314</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 94 210 255</Field>
+            <Field name="position" type="float">0.105882352941</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 96 214 255</Field>
+            <Field name="position" type="float">0.109803921569</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 99 217 255</Field>
+            <Field name="position" type="float">0.113725490196</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 102 221 255</Field>
+            <Field name="position" type="float">0.117647058824</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 104 224 255</Field>
+            <Field name="position" type="float">0.121568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 107 227 255</Field>
+            <Field name="position" type="float">0.125490196078</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 109 230 255</Field>
+            <Field name="position" type="float">0.129411764706</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 112 232 255</Field>
+            <Field name="position" type="float">0.133333333333</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 115 235 255</Field>
+            <Field name="position" type="float">0.137254901961</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 117 237 255</Field>
+            <Field name="position" type="float">0.141176470588</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 120 240 255</Field>
+            <Field name="position" type="float">0.145098039216</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 122 242 255</Field>
+            <Field name="position" type="float">0.149019607843</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 125 244 255</Field>
+            <Field name="position" type="float">0.152941176471</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 127 246 255</Field>
+            <Field name="position" type="float">0.156862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 130 248 255</Field>
+            <Field name="position" type="float">0.160784313725</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 132 249 255</Field>
+            <Field name="position" type="float">0.164705882353</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 135 251 255</Field>
+            <Field name="position" type="float">0.16862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">69 137 252 255</Field>
+            <Field name="position" type="float">0.172549019608</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">68 140 253 255</Field>
+            <Field name="position" type="float">0.176470588235</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">67 142 253 255</Field>
+            <Field name="position" type="float">0.180392156863</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">66 145 254 255</Field>
+            <Field name="position" type="float">0.18431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">65 147 254 255</Field>
+            <Field name="position" type="float">0.188235294118</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">64 150 254 255</Field>
+            <Field name="position" type="float">0.192156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">63 152 254 255</Field>
+            <Field name="position" type="float">0.196078431373</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">62 155 254 255</Field>
+            <Field name="position" type="float">0.2</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">60 157 253 255</Field>
+            <Field name="position" type="float">0.203921568627</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">59 160 252 255</Field>
+            <Field name="position" type="float">0.207843137255</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">57 162 252 255</Field>
+            <Field name="position" type="float">0.211764705882</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">56 165 251 255</Field>
+            <Field name="position" type="float">0.21568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">54 168 249 255</Field>
+            <Field name="position" type="float">0.219607843137</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">52 170 248 255</Field>
+            <Field name="position" type="float">0.223529411765</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">51 172 246 255</Field>
+            <Field name="position" type="float">0.227450980392</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">49 175 245 255</Field>
+            <Field name="position" type="float">0.23137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">47 177 243 255</Field>
+            <Field name="position" type="float">0.235294117647</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">45 180 241 255</Field>
+            <Field name="position" type="float">0.239215686275</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">43 182 239 255</Field>
+            <Field name="position" type="float">0.243137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">42 185 237 255</Field>
+            <Field name="position" type="float">0.247058823529</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">40 187 235 255</Field>
+            <Field name="position" type="float">0.250980392157</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">38 189 233 255</Field>
+            <Field name="position" type="float">0.254901960784</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">37 192 230 255</Field>
+            <Field name="position" type="float">0.258823529412</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">35 194 228 255</Field>
+            <Field name="position" type="float">0.262745098039</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">33 196 225 255</Field>
+            <Field name="position" type="float">0.266666666667</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">32 198 223 255</Field>
+            <Field name="position" type="float">0.270588235294</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">30 201 220 255</Field>
+            <Field name="position" type="float">0.274509803922</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">29 203 218 255</Field>
+            <Field name="position" type="float">0.278431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">28 205 215 255</Field>
+            <Field name="position" type="float">0.282352941176</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">27 207 212 255</Field>
+            <Field name="position" type="float">0.286274509804</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">26 209 210 255</Field>
+            <Field name="position" type="float">0.290196078431</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">25 211 207 255</Field>
+            <Field name="position" type="float">0.294117647059</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">24 213 204 255</Field>
+            <Field name="position" type="float">0.298039215686</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">24 215 202 255</Field>
+            <Field name="position" type="float">0.301960784314</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">23 217 199 255</Field>
+            <Field name="position" type="float">0.305882352941</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">23 218 196 255</Field>
+            <Field name="position" type="float">0.309803921569</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">23 220 194 255</Field>
+            <Field name="position" type="float">0.313725490196</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">23 222 191 255</Field>
+            <Field name="position" type="float">0.317647058824</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">24 224 189 255</Field>
+            <Field name="position" type="float">0.321568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">24 225 186 255</Field>
+            <Field name="position" type="float">0.325490196078</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">25 227 184 255</Field>
+            <Field name="position" type="float">0.329411764706</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">26 228 182 255</Field>
+            <Field name="position" type="float">0.333333333333</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">27 229 180 255</Field>
+            <Field name="position" type="float">0.337254901961</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">29 231 177 255</Field>
+            <Field name="position" type="float">0.341176470588</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">30 232 175 255</Field>
+            <Field name="position" type="float">0.345098039216</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">32 233 172 255</Field>
+            <Field name="position" type="float">0.349019607843</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">34 235 169 255</Field>
+            <Field name="position" type="float">0.352941176471</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">36 236 166 255</Field>
+            <Field name="position" type="float">0.356862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">39 237 163 255</Field>
+            <Field name="position" type="float">0.360784313725</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">41 238 160 255</Field>
+            <Field name="position" type="float">0.364705882353</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">44 239 157 255</Field>
+            <Field name="position" type="float">0.36862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">47 240 154 255</Field>
+            <Field name="position" type="float">0.372549019608</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">50 241 151 255</Field>
+            <Field name="position" type="float">0.376470588235</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">53 243 148 255</Field>
+            <Field name="position" type="float">0.380392156863</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">56 244 145 255</Field>
+            <Field name="position" type="float">0.38431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">59 244 141 255</Field>
+            <Field name="position" type="float">0.388235294118</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">63 245 138 255</Field>
+            <Field name="position" type="float">0.392156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">66 246 135 255</Field>
+            <Field name="position" type="float">0.396078431373</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">70 247 131 255</Field>
+            <Field name="position" type="float">0.4</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">74 248 128 255</Field>
+            <Field name="position" type="float">0.403921568627</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">77 249 124 255</Field>
+            <Field name="position" type="float">0.407843137255</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">81 249 121 255</Field>
+            <Field name="position" type="float">0.411764705882</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">85 250 118 255</Field>
+            <Field name="position" type="float">0.41568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">89 251 114 255</Field>
+            <Field name="position" type="float">0.419607843137</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">93 251 111 255</Field>
+            <Field name="position" type="float">0.423529411765</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">97 252 108 255</Field>
+            <Field name="position" type="float">0.427450980392</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">101 252 104 255</Field>
+            <Field name="position" type="float">0.43137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">105 253 101 255</Field>
+            <Field name="position" type="float">0.435294117647</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">109 253 98 255</Field>
+            <Field name="position" type="float">0.439215686275</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">113 253 95 255</Field>
+            <Field name="position" type="float">0.443137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">116 254 92 255</Field>
+            <Field name="position" type="float">0.447058823529</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">120 254 89 255</Field>
+            <Field name="position" type="float">0.450980392157</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">124 254 86 255</Field>
+            <Field name="position" type="float">0.454901960784</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">128 254 83 255</Field>
+            <Field name="position" type="float">0.458823529412</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">132 254 80 255</Field>
+            <Field name="position" type="float">0.462745098039</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">135 254 77 255</Field>
+            <Field name="position" type="float">0.466666666667</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">139 254 75 255</Field>
+            <Field name="position" type="float">0.470588235294</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">142 254 72 255</Field>
+            <Field name="position" type="float">0.474509803922</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">146 254 70 255</Field>
+            <Field name="position" type="float">0.478431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">149 254 68 255</Field>
+            <Field name="position" type="float">0.482352941176</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">152 254 66 255</Field>
+            <Field name="position" type="float">0.486274509804</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">155 253 64 255</Field>
+            <Field name="position" type="float">0.490196078431</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">158 253 62 255</Field>
+            <Field name="position" type="float">0.494117647059</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">161 252 61 255</Field>
+            <Field name="position" type="float">0.498039215686</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">164 252 59 255</Field>
+            <Field name="position" type="float">0.501960784314</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 251 58 255</Field>
+            <Field name="position" type="float">0.505882352941</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">169 251 57 255</Field>
+            <Field name="position" type="float">0.509803921569</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">172 250 55 255</Field>
+            <Field name="position" type="float">0.513725490196</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">174 249 55 255</Field>
+            <Field name="position" type="float">0.517647058824</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">177 248 54 255</Field>
+            <Field name="position" type="float">0.521568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">179 248 53 255</Field>
+            <Field name="position" type="float">0.525490196078</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">182 247 53 255</Field>
+            <Field name="position" type="float">0.529411764706</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">185 245 52 255</Field>
+            <Field name="position" type="float">0.533333333333</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">187 244 52 255</Field>
+            <Field name="position" type="float">0.537254901961</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">190 243 52 255</Field>
+            <Field name="position" type="float">0.541176470588</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">192 242 51 255</Field>
+            <Field name="position" type="float">0.545098039216</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">195 241 51 255</Field>
+            <Field name="position" type="float">0.549019607843</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">197 239 51 255</Field>
+            <Field name="position" type="float">0.552941176471</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">200 238 51 255</Field>
+            <Field name="position" type="float">0.556862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">202 237 51 255</Field>
+            <Field name="position" type="float">0.560784313725</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">205 235 52 255</Field>
+            <Field name="position" type="float">0.564705882353</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">207 234 52 255</Field>
+            <Field name="position" type="float">0.56862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">209 232 52 255</Field>
+            <Field name="position" type="float">0.572549019608</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">212 231 53 255</Field>
+            <Field name="position" type="float">0.576470588235</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">214 229 53 255</Field>
+            <Field name="position" type="float">0.580392156863</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">216 227 53 255</Field>
+            <Field name="position" type="float">0.58431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">218 226 54 255</Field>
+            <Field name="position" type="float">0.588235294118</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">221 224 54 255</Field>
+            <Field name="position" type="float">0.592156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">223 222 54 255</Field>
+            <Field name="position" type="float">0.596078431373</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">225 220 55 255</Field>
+            <Field name="position" type="float">0.6</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">227 218 55 255</Field>
+            <Field name="position" type="float">0.603921568627</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">229 216 56 255</Field>
+            <Field name="position" type="float">0.607843137255</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">231 215 56 255</Field>
+            <Field name="position" type="float">0.611764705882</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">232 213 56 255</Field>
+            <Field name="position" type="float">0.61568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">234 211 57 255</Field>
+            <Field name="position" type="float">0.619607843137</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">236 209 57 255</Field>
+            <Field name="position" type="float">0.623529411765</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">237 207 57 255</Field>
+            <Field name="position" type="float">0.627450980392</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">239 205 57 255</Field>
+            <Field name="position" type="float">0.63137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">240 203 58 255</Field>
+            <Field name="position" type="float">0.635294117647</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">242 200 58 255</Field>
+            <Field name="position" type="float">0.639215686275</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">243 198 58 255</Field>
+            <Field name="position" type="float">0.643137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 196 58 255</Field>
+            <Field name="position" type="float">0.647058823529</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">246 194 58 255</Field>
+            <Field name="position" type="float">0.650980392157</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 192 57 255</Field>
+            <Field name="position" type="float">0.654901960784</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">248 190 57 255</Field>
+            <Field name="position" type="float">0.658823529412</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">249 188 57 255</Field>
+            <Field name="position" type="float">0.662745098039</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">249 186 56 255</Field>
+            <Field name="position" type="float">0.666666666667</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">250 183 55 255</Field>
+            <Field name="position" type="float">0.670588235294</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 181 55 255</Field>
+            <Field name="position" type="float">0.674509803922</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 179 54 255</Field>
+            <Field name="position" type="float">0.678431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 176 53 255</Field>
+            <Field name="position" type="float">0.682352941176</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 174 52 255</Field>
+            <Field name="position" type="float">0.686274509804</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 171 51 255</Field>
+            <Field name="position" type="float">0.690196078431</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 169 50 255</Field>
+            <Field name="position" type="float">0.694117647059</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 166 49 255</Field>
+            <Field name="position" type="float">0.698039215686</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 163 48 255</Field>
+            <Field name="position" type="float">0.701960784314</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 161 47 255</Field>
+            <Field name="position" type="float">0.705882352941</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 158 46 255</Field>
+            <Field name="position" type="float">0.709803921569</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 155 45 255</Field>
+            <Field name="position" type="float">0.713725490196</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">254 152 44 255</Field>
+            <Field name="position" type="float">0.717647058824</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 149 43 255</Field>
+            <Field name="position" type="float">0.721568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 146 41 255</Field>
+            <Field name="position" type="float">0.725490196078</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 143 40 255</Field>
+            <Field name="position" type="float">0.729411764706</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">253 140 39 255</Field>
+            <Field name="position" type="float">0.733333333333</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 137 38 255</Field>
+            <Field name="position" type="float">0.737254901961</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">252 134 36 255</Field>
+            <Field name="position" type="float">0.741176470588</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 131 35 255</Field>
+            <Field name="position" type="float">0.745098039216</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">251 128 34 255</Field>
+            <Field name="position" type="float">0.749019607843</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">250 125 32 255</Field>
+            <Field name="position" type="float">0.752941176471</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">250 122 31 255</Field>
+            <Field name="position" type="float">0.756862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">249 119 30 255</Field>
+            <Field name="position" type="float">0.760784313725</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">248 116 28 255</Field>
+            <Field name="position" type="float">0.764705882353</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 113 27 255</Field>
+            <Field name="position" type="float">0.76862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">247 110 26 255</Field>
+            <Field name="position" type="float">0.772549019608</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">246 107 24 255</Field>
+            <Field name="position" type="float">0.776470588235</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">245 104 23 255</Field>
+            <Field name="position" type="float">0.780392156863</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">244 101 22 255</Field>
+            <Field name="position" type="float">0.78431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">243 99 21 255</Field>
+            <Field name="position" type="float">0.788235294118</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">242 96 20 255</Field>
+            <Field name="position" type="float">0.792156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">241 93 19 255</Field>
+            <Field name="position" type="float">0.796078431373</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">239 90 17 255</Field>
+            <Field name="position" type="float">0.8</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">238 88 16 255</Field>
+            <Field name="position" type="float">0.803921568627</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">237 85 15 255</Field>
+            <Field name="position" type="float">0.807843137255</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">236 82 14 255</Field>
+            <Field name="position" type="float">0.811764705882</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">234 80 13 255</Field>
+            <Field name="position" type="float">0.81568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">233 77 13 255</Field>
+            <Field name="position" type="float">0.819607843137</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">232 75 12 255</Field>
+            <Field name="position" type="float">0.823529411765</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">230 73 11 255</Field>
+            <Field name="position" type="float">0.827450980392</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">229 70 10 255</Field>
+            <Field name="position" type="float">0.83137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">227 68 10 255</Field>
+            <Field name="position" type="float">0.835294117647</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">226 66 9 255</Field>
+            <Field name="position" type="float">0.839215686275</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">224 64 8 255</Field>
+            <Field name="position" type="float">0.843137254902</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">222 62 8 255</Field>
+            <Field name="position" type="float">0.847058823529</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">221 60 7 255</Field>
+            <Field name="position" type="float">0.850980392157</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">219 58 7 255</Field>
+            <Field name="position" type="float">0.854901960784</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">217 56 6 255</Field>
+            <Field name="position" type="float">0.858823529412</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">215 54 6 255</Field>
+            <Field name="position" type="float">0.862745098039</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">214 52 5 255</Field>
+            <Field name="position" type="float">0.866666666667</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">212 50 5 255</Field>
+            <Field name="position" type="float">0.870588235294</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">210 48 5 255</Field>
+            <Field name="position" type="float">0.874509803922</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">208 47 4 255</Field>
+            <Field name="position" type="float">0.878431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">206 45 4 255</Field>
+            <Field name="position" type="float">0.882352941176</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">203 43 3 255</Field>
+            <Field name="position" type="float">0.886274509804</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">201 41 3 255</Field>
+            <Field name="position" type="float">0.890196078431</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">199 40 3 255</Field>
+            <Field name="position" type="float">0.894117647059</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">197 38 2 255</Field>
+            <Field name="position" type="float">0.898039215686</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">195 36 2 255</Field>
+            <Field name="position" type="float">0.901960784314</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">192 35 2 255</Field>
+            <Field name="position" type="float">0.905882352941</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">190 33 2 255</Field>
+            <Field name="position" type="float">0.909803921569</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">187 31 1 255</Field>
+            <Field name="position" type="float">0.913725490196</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">185 30 1 255</Field>
+            <Field name="position" type="float">0.917647058824</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">182 28 1 255</Field>
+            <Field name="position" type="float">0.921568627451</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">180 27 1 255</Field>
+            <Field name="position" type="float">0.925490196078</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">177 25 1 255</Field>
+            <Field name="position" type="float">0.929411764706</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">174 24 1 255</Field>
+            <Field name="position" type="float">0.933333333333</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">172 22 1 255</Field>
+            <Field name="position" type="float">0.937254901961</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">169 21 1 255</Field>
+            <Field name="position" type="float">0.941176470588</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">166 20 1 255</Field>
+            <Field name="position" type="float">0.945098039216</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">163 18 1 255</Field>
+            <Field name="position" type="float">0.949019607843</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">160 17 1 255</Field>
+            <Field name="position" type="float">0.952941176471</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">157 16 1 255</Field>
+            <Field name="position" type="float">0.956862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">154 14 1 255</Field>
+            <Field name="position" type="float">0.960784313725</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">151 13 1 255</Field>
+            <Field name="position" type="float">0.964705882353</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">148 12 1 255</Field>
+            <Field name="position" type="float">0.96862745098</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">145 11 1 255</Field>
+            <Field name="position" type="float">0.972549019608</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">142 10 1 255</Field>
+            <Field name="position" type="float">0.976470588235</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">139 9 1 255</Field>
+            <Field name="position" type="float">0.980392156863</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">135 8 1 255</Field>
+            <Field name="position" type="float">0.98431372549</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">132 7 1 255</Field>
+            <Field name="position" type="float">0.988235294118</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">129 6 2 255</Field>
+            <Field name="position" type="float">0.992156862745</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">125 5 2 255</Field>
+            <Field name="position" type="float">0.996078431373</Field>
+        </Object>
+        <Object name="ColorControlPoint">
+            <Field name="colors" type="unsignedCharArray" length="4">122 4 2 255</Field>
+            <Field name="position" type="float">1.0</Field>
+        </Object>
         <Field name="category" type="string">UserDefined</Field>
     </Object>
 </Object>

--- a/src/resources/colortables/viridis.ct
+++ b/src/resources/colortables/viridis.ct
@@ -4,6 +4,7 @@
     <Object name="ColorControlPointList">
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">68 1 84 255 </Field>
+            <Field name="position" type="float">0.000000</Field>
         </Object>
         <Object name="ColorControlPoint">
             <Field name="colors" type="unsignedCharArray" length="4">68 2 85 255 </Field>

--- a/src/resources/colortables/viridis_light.ct
+++ b/src/resources/colortables/viridis_light.ct
@@ -1,1 +1,1030 @@
-<?xml version="1.0"?><Object name="ColorTable"><Field name="Version" type="string">1.0.0</Field><Object name="ColorControlPointList">    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">113 48 193 255 </Field>      <Field name="position" type="float">0.000000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">113 50 194 255 </Field>      <Field name="position" type="float">0.003906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">112 51 194 255 </Field>      <Field name="position" type="float">0.007812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">111 53 195 255 </Field>      <Field name="position" type="float">0.011719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">111 55 195 255 </Field>      <Field name="position" type="float">0.015625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">110 56 196 255 </Field>      <Field name="position" type="float">0.019531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">110 58 196 255 </Field>      <Field name="position" type="float">0.023438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">109 60 196 255 </Field>      <Field name="position" type="float">0.027344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">108 61 197 255 </Field>      <Field name="position" type="float">0.031250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">108 63 197 255 </Field>      <Field name="position" type="float">0.035156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">107 64 198 255 </Field>      <Field name="position" type="float">0.039062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">106 66 198 255 </Field>      <Field name="position" type="float">0.042969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">106 67 198 255 </Field>      <Field name="position" type="float">0.046875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">105 69 198 255 </Field>      <Field name="position" type="float">0.050781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">104 70 199 255 </Field>      <Field name="position" type="float">0.054688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">103 72 199 255 </Field>      <Field name="position" type="float">0.058594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">103 73 199 255 </Field>      <Field name="position" type="float">0.062500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">102 75 199 255 </Field>      <Field name="position" type="float">0.066406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">101 76 199 255 </Field>      <Field name="position" type="float">0.070312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">100 77 199 255 </Field>      <Field name="position" type="float">0.074219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">100 79 199 255 </Field>      <Field name="position" type="float">0.078125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">99 80 199 255 </Field>      <Field name="position" type="float">0.082031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">98 81 199 255 </Field>      <Field name="position" type="float">0.085938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">97 83 199 255 </Field>      <Field name="position" type="float">0.089844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">96 84 199 255 </Field>      <Field name="position" type="float">0.093750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">96 85 199 255 </Field>      <Field name="position" type="float">0.097656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">95 87 199 255 </Field>      <Field name="position" type="float">0.101562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">94 88 199 255 </Field>      <Field name="position" type="float">0.105469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">93 89 199 255 </Field>      <Field name="position" type="float">0.109375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">92 91 199 255 </Field>      <Field name="position" type="float">0.113281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">92 92 199 255 </Field>      <Field name="position" type="float">0.117188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">91 93 198 255 </Field>      <Field name="position" type="float">0.121094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">90 94 198 255 </Field>      <Field name="position" type="float">0.125000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">89 95 198 255 </Field>      <Field name="position" type="float">0.128906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">88 97 198 255 </Field>      <Field name="position" type="float">0.132812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">88 98 197 255 </Field>      <Field name="position" type="float">0.136719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">87 99 197 255 </Field>      <Field name="position" type="float">0.140625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">86 100 197 255 </Field>      <Field name="position" type="float">0.144531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">85 101 196 255 </Field>      <Field name="position" type="float">0.148438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">84 102 196 255 </Field>      <Field name="position" type="float">0.152344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">84 104 196 255 </Field>      <Field name="position" type="float">0.156250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">83 105 195 255 </Field>      <Field name="position" type="float">0.160156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">82 106 195 255 </Field>      <Field name="position" type="float">0.164062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">81 107 195 255 </Field>      <Field name="position" type="float">0.167969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">81 108 194 255 </Field>      <Field name="position" type="float">0.171875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">80 109 194 255 </Field>      <Field name="position" type="float">0.175781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">79 110 193 255 </Field>      <Field name="position" type="float">0.179688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">78 111 193 255 </Field>      <Field name="position" type="float">0.183594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">78 112 193 255 </Field>      <Field name="position" type="float">0.187500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">77 113 192 255 </Field>      <Field name="position" type="float">0.191406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">76 114 192 255 </Field>      <Field name="position" type="float">0.195312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">76 115 191 255 </Field>      <Field name="position" type="float">0.199219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">75 116 191 255 </Field>      <Field name="position" type="float">0.203125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">75 117 190 255 </Field>      <Field name="position" type="float">0.207031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">74 118 190 255 </Field>      <Field name="position" type="float">0.210938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">74 119 189 255 </Field>      <Field name="position" type="float">0.214844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">73 120 189 255 </Field>      <Field name="position" type="float">0.218750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">73 121 188 255 </Field>      <Field name="position" type="float">0.222656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">72 122 188 255 </Field>      <Field name="position" type="float">0.226562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">72 123 187 255 </Field>      <Field name="position" type="float">0.230469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">71 124 187 255 </Field>      <Field name="position" type="float">0.234375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">71 125 187 255 </Field>      <Field name="position" type="float">0.238281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">70 125 186 255 </Field>      <Field name="position" type="float">0.242188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">70 126 186 255 </Field>      <Field name="position" type="float">0.246094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">70 127 185 255 </Field>      <Field name="position" type="float">0.250000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">69 128 185 255 </Field>      <Field name="position" type="float">0.253906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">69 129 184 255 </Field>      <Field name="position" type="float">0.257812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">69 130 184 255 </Field>      <Field name="position" type="float">0.261719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">68 131 183 255 </Field>      <Field name="position" type="float">0.265625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">68 132 183 255 </Field>      <Field name="position" type="float">0.269531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">68 132 182 255 </Field>      <Field name="position" type="float">0.273438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">67 133 182 255 </Field>      <Field name="position" type="float">0.277344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">67 134 182 255 </Field>      <Field name="position" type="float">0.281250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">67 135 181 255 </Field>      <Field name="position" type="float">0.285156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">67 136 181 255 </Field>      <Field name="position" type="float">0.289062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">67 136 180 255 </Field>      <Field name="position" type="float">0.292969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">67 137 180 255 </Field>      <Field name="position" type="float">0.296875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 138 179 255 </Field>      <Field name="position" type="float">0.300781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 139 179 255 </Field>      <Field name="position" type="float">0.304688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 140 179 255 </Field>      <Field name="position" type="float">0.308594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 140 178 255 </Field>      <Field name="position" type="float">0.312500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 141 178 255 </Field>      <Field name="position" type="float">0.316406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 142 178 255 </Field>      <Field name="position" type="float">0.320312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 143 177 255 </Field>      <Field name="position" type="float">0.324219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 144 177 255 </Field>      <Field name="position" type="float">0.328125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 144 176 255 </Field>      <Field name="position" type="float">0.332031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 145 176 255 </Field>      <Field name="position" type="float">0.335938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 146 176 255 </Field>      <Field name="position" type="float">0.339844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 147 175 255 </Field>      <Field name="position" type="float">0.343750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 147 175 255 </Field>      <Field name="position" type="float">0.347656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 148 175 255 </Field>      <Field name="position" type="float">0.351562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 149 174 255 </Field>      <Field name="position" type="float">0.355469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 150 174 255 </Field>      <Field name="position" type="float">0.359375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 151 174 255 </Field>      <Field name="position" type="float">0.363281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 151 173 255 </Field>      <Field name="position" type="float">0.367188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 152 173 255 </Field>      <Field name="position" type="float">0.371094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 153 173 255 </Field>      <Field name="position" type="float">0.375000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 154 172 255 </Field>      <Field name="position" type="float">0.378906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 154 172 255 </Field>      <Field name="position" type="float">0.382812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 155 172 255 </Field>      <Field name="position" type="float">0.386719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 156 171 255 </Field>      <Field name="position" type="float">0.390625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 157 171 255 </Field>      <Field name="position" type="float">0.394531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">65 157 171 255 </Field>      <Field name="position" type="float">0.398438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 158 170 255 </Field>      <Field name="position" type="float">0.402344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 159 170 255 </Field>      <Field name="position" type="float">0.406250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 160 170 255 </Field>      <Field name="position" type="float">0.410156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 161 169 255 </Field>      <Field name="position" type="float">0.414062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 161 169 255 </Field>      <Field name="position" type="float">0.417969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 162 169 255 </Field>      <Field name="position" type="float">0.421875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 163 168 255 </Field>      <Field name="position" type="float">0.425781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 164 168 255 </Field>      <Field name="position" type="float">0.429688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">63 164 168 255 </Field>      <Field name="position" type="float">0.433594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">63 165 167 255 </Field>      <Field name="position" type="float">0.437500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">63 166 167 255 </Field>      <Field name="position" type="float">0.441406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">63 167 167 255 </Field>      <Field name="position" type="float">0.445312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">63 168 166 255 </Field>      <Field name="position" type="float">0.449219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">62 168 166 255 </Field>      <Field name="position" type="float">0.453125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">62 169 166 255 </Field>      <Field name="position" type="float">0.457031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">62 170 165 255 </Field>      <Field name="position" type="float">0.460938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">62 171 165 255 </Field>      <Field name="position" type="float">0.464844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">61 171 164 255 </Field>      <Field name="position" type="float">0.468750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">61 172 164 255 </Field>      <Field name="position" type="float">0.472656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">61 173 164 255 </Field>      <Field name="position" type="float">0.476562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">60 174 163 255 </Field>      <Field name="position" type="float">0.480469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">60 175 163 255 </Field>      <Field name="position" type="float">0.484375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">59 176 162 255 </Field>      <Field name="position" type="float">0.488281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">59 176 162 255 </Field>      <Field name="position" type="float">0.492188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">59 177 161 255 </Field>      <Field name="position" type="float">0.496094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">58 178 161 255 </Field>      <Field name="position" type="float">0.500000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">58 179 161 255 </Field>      <Field name="position" type="float">0.503906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">57 180 160 255 </Field>      <Field name="position" type="float">0.507812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">57 180 159 255 </Field>      <Field name="position" type="float">0.511719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">57 181 159 255 </Field>      <Field name="position" type="float">0.515625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">56 182 158 255 </Field>      <Field name="position" type="float">0.519531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">56 183 158 255 </Field>      <Field name="position" type="float">0.523438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">55 184 157 255 </Field>      <Field name="position" type="float">0.527344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">55 184 157 255 </Field>      <Field name="position" type="float">0.531250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">54 185 156 255 </Field>      <Field name="position" type="float">0.535156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">53 186 155 255 </Field>      <Field name="position" type="float">0.539062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">53 187 155 255 </Field>      <Field name="position" type="float">0.542969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">52 188 154 255 </Field>      <Field name="position" type="float">0.546875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">52 189 154 255 </Field>      <Field name="position" type="float">0.550781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">51 189 153 255 </Field>      <Field name="position" type="float">0.554688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">51 190 152 255 </Field>      <Field name="position" type="float">0.558594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">50 191 151 255 </Field>      <Field name="position" type="float">0.562500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">50 192 151 255 </Field>      <Field name="position" type="float">0.566406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">49 193 150 255 </Field>      <Field name="position" type="float">0.570312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">48 194 149 255 </Field>      <Field name="position" type="float">0.574219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">48 194 148 255 </Field>      <Field name="position" type="float">0.578125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">47 195 148 255 </Field>      <Field name="position" type="float">0.582031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">47 196 147 255 </Field>      <Field name="position" type="float">0.585938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">46 197 146 255 </Field>      <Field name="position" type="float">0.589844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">46 198 145 255 </Field>      <Field name="position" type="float">0.593750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">45 199 144 255 </Field>      <Field name="position" type="float">0.597656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">45 199 143 255 </Field>      <Field name="position" type="float">0.601562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">44 200 142 255 </Field>      <Field name="position" type="float">0.605469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">44 201 141 255 </Field>      <Field name="position" type="float">0.609375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">43 202 140 255 </Field>      <Field name="position" type="float">0.613281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">43 203 139 255 </Field>      <Field name="position" type="float">0.617188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">43 204 138 255 </Field>      <Field name="position" type="float">0.621094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 204 137 255 </Field>      <Field name="position" type="float">0.625000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 205 136 255 </Field>      <Field name="position" type="float">0.628906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 206 135 255 </Field>      <Field name="position" type="float">0.632812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 207 134 255 </Field>      <Field name="position" type="float">0.636719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">41 208 133 255 </Field>      <Field name="position" type="float">0.640625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">41 209 131 255 </Field>      <Field name="position" type="float">0.644531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">41 209 130 255 </Field>      <Field name="position" type="float">0.648438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">41 210 129 255 </Field>      <Field name="position" type="float">0.652344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">41 211 128 255 </Field>      <Field name="position" type="float">0.656250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 212 126 255 </Field>      <Field name="position" type="float">0.660156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 213 125 255 </Field>      <Field name="position" type="float">0.664062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">42 213 124 255 </Field>      <Field name="position" type="float">0.667969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">43 214 122 255 </Field>      <Field name="position" type="float">0.671875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">43 215 121 255 </Field>      <Field name="position" type="float">0.675781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">44 216 119 255 </Field>      <Field name="position" type="float">0.679688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">44 217 118 255 </Field>      <Field name="position" type="float">0.683594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">45 217 116 255 </Field>      <Field name="position" type="float">0.687500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">46 218 115 255 </Field>      <Field name="position" type="float">0.691406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">47 219 113 255 </Field>      <Field name="position" type="float">0.695312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">48 220 112 255 </Field>      <Field name="position" type="float">0.699219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">49 221 110 255 </Field>      <Field name="position" type="float">0.703125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">50 221 108 255 </Field>      <Field name="position" type="float">0.707031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">51 222 107 255 </Field>      <Field name="position" type="float">0.710938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">53 223 105 255 </Field>      <Field name="position" type="float">0.714844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">54 224 103 255 </Field>      <Field name="position" type="float">0.718750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">56 224 101 255 </Field>      <Field name="position" type="float">0.722656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">57 225 99 255 </Field>      <Field name="position" type="float">0.726562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">59 226 97 255 </Field>      <Field name="position" type="float">0.730469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">61 226 95 255 </Field>      <Field name="position" type="float">0.734375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">63 227 93 255 </Field>      <Field name="position" type="float">0.738281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">64 228 91 255 </Field>      <Field name="position" type="float">0.742188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">66 229 89 255 </Field>      <Field name="position" type="float">0.746094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">69 229 87 255 </Field>      <Field name="position" type="float">0.750000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">71 230 85 255 </Field>      <Field name="position" type="float">0.753906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">73 231 82 255 </Field>      <Field name="position" type="float">0.757812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">75 231 80 255 </Field>      <Field name="position" type="float">0.761719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">78 232 78 255 </Field>      <Field name="position" type="float">0.765625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">80 232 75 255 </Field>      <Field name="position" type="float">0.769531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">83 233 73 255 </Field>      <Field name="position" type="float">0.773438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">86 234 70 255 </Field>      <Field name="position" type="float">0.777344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">89 234 68 255 </Field>      <Field name="position" type="float">0.781250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">91 235 65 255 </Field>      <Field name="position" type="float">0.785156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">94 235 62 255 </Field>      <Field name="position" type="float">0.789062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">98 236 59 255 </Field>      <Field name="position" type="float">0.792969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">101 236 57 255 </Field>      <Field name="position" type="float">0.796875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">104 236 54 255 </Field>      <Field name="position" type="float">0.800781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">108 237 51 255 </Field>      <Field name="position" type="float">0.804688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">111 237 48 255 </Field>      <Field name="position" type="float">0.808594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">115 237 46 255 </Field>      <Field name="position" type="float">0.812500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">119 238 43 255 </Field>      <Field name="position" type="float">0.816406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">123 238 41 255 </Field>      <Field name="position" type="float">0.820312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">126 238 40 255 </Field>      <Field name="position" type="float">0.824219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">130 238 38 255 </Field>      <Field name="position" type="float">0.828125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">134 238 37 255 </Field>      <Field name="position" type="float">0.832031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">138 239 37 255 </Field>      <Field name="position" type="float">0.835938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">141 239 37 255 </Field>      <Field name="position" type="float">0.839844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">145 239 37 255 </Field>      <Field name="position" type="float">0.843750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">149 239 38 255 </Field>      <Field name="position" type="float">0.847656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">152 239 39 255 </Field>      <Field name="position" type="float">0.851562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">155 239 40 255 </Field>      <Field name="position" type="float">0.855469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">159 239 41 255 </Field>      <Field name="position" type="float">0.859375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">162 239 42 255 </Field>      <Field name="position" type="float">0.863281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">165 239 43 255 </Field>      <Field name="position" type="float">0.867188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">168 240 45 255 </Field>      <Field name="position" type="float">0.871094</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">171 240 46 255 </Field>      <Field name="position" type="float">0.875000</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">174 240 48 255 </Field>      <Field name="position" type="float">0.878906</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">177 240 49 255 </Field>      <Field name="position" type="float">0.882812</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">180 240 50 255 </Field>      <Field name="position" type="float">0.886719</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">182 240 51 255 </Field>      <Field name="position" type="float">0.890625</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">185 240 52 255 </Field>      <Field name="position" type="float">0.894531</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">188 240 53 255 </Field>      <Field name="position" type="float">0.898438</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">191 241 54 255 </Field>      <Field name="position" type="float">0.902344</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">193 241 55 255 </Field>      <Field name="position" type="float">0.906250</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">196 241 56 255 </Field>      <Field name="position" type="float">0.910156</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">199 241 56 255 </Field>      <Field name="position" type="float">0.914062</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">201 241 57 255 </Field>      <Field name="position" type="float">0.917969</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">204 241 57 255 </Field>      <Field name="position" type="float">0.921875</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">206 241 57 255 </Field>      <Field name="position" type="float">0.925781</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">209 241 57 255 </Field>      <Field name="position" type="float">0.929688</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">212 242 57 255 </Field>      <Field name="position" type="float">0.933594</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">214 242 57 255 </Field>      <Field name="position" type="float">0.937500</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">217 242 57 255 </Field>      <Field name="position" type="float">0.941406</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">219 242 56 255 </Field>      <Field name="position" type="float">0.945312</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">222 242 56 255 </Field>      <Field name="position" type="float">0.949219</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">224 242 55 255 </Field>      <Field name="position" type="float">0.953125</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">227 242 54 255 </Field>      <Field name="position" type="float">0.957031</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">229 242 53 255 </Field>      <Field name="position" type="float">0.960938</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">232 243 51 255 </Field>      <Field name="position" type="float">0.964844</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">234 243 50 255 </Field>      <Field name="position" type="float">0.968750</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">237 243 48 255 </Field>      <Field name="position" type="float">0.972656</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">239 243 46 255 </Field>      <Field name="position" type="float">0.976562</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">241 243 44 255 </Field>      <Field name="position" type="float">0.980469</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">244 243 42 255 </Field>      <Field name="position" type="float">0.984375</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">246 243 39 255 </Field>      <Field name="position" type="float">0.988281</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">249 243 36 255 </Field>      <Field name="position" type="float">0.992188</Field>    </Object>    <Object name="ColorControlPoint">      <Field name="colors" type="unsignedCharArray" length="4">251 244 32 255 </Field>      <Field name="position" type="float">0.996094</Field>    </Object></Object>
+<?xml version="1.0"?>
+<Object name="ColorTable">
+    <Field name="Version" type="string">1.0.0 </Field>
+    <Object name="ColorControlPointList">    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">113 48 193 255 </Field>
+            <Field name="position" type="float">0.000000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">113 50 194 255 </Field>      
+            <Field name="position" type="float">0.003906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">112 51 194 255 </Field>      
+            <Field name="position" type="float">0.007812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">111 53 195 255 </Field>      
+            <Field name="position" type="float">0.011719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">111 55 195 255 </Field>      
+            <Field name="position" type="float">0.015625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">110 56 196 255 </Field>      
+            <Field name="position" type="float">0.019531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">110 58 196 255 </Field>      
+            <Field name="position" type="float">0.023438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">109 60 196 255 </Field>      
+            <Field name="position" type="float">0.027344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">108 61 197 255 </Field>      
+            <Field name="position" type="float">0.031250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">108 63 197 255 </Field>      
+            <Field name="position" type="float">0.035156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">107 64 198 255 </Field>      
+            <Field name="position" type="float">0.039062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">106 66 198 255 </Field>      
+            <Field name="position" type="float">0.042969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">106 67 198 255 </Field>      
+            <Field name="position" type="float">0.046875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">105 69 198 255 </Field>      
+            <Field name="position" type="float">0.050781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">104 70 199 255 </Field>      
+            <Field name="position" type="float">0.054688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">103 72 199 255 </Field>      
+            <Field name="position" type="float">0.058594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">103 73 199 255 </Field>      
+            <Field name="position" type="float">0.062500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">102 75 199 255 </Field>      
+            <Field name="position" type="float">0.066406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">101 76 199 255 </Field>      
+            <Field name="position" type="float">0.070312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">100 77 199 255 </Field>      
+            <Field name="position" type="float">0.074219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">100 79 199 255 </Field>      
+            <Field name="position" type="float">0.078125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">99 80 199 255 </Field>      
+            <Field name="position" type="float">0.082031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">98 81 199 255 </Field>      
+            <Field name="position" type="float">0.085938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">97 83 199 255 </Field>      
+            <Field name="position" type="float">0.089844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">96 84 199 255 </Field>      
+            <Field name="position" type="float">0.093750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">96 85 199 255 </Field>      
+            <Field name="position" type="float">0.097656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">95 87 199 255 </Field>      
+            <Field name="position" type="float">0.101562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">94 88 199 255 </Field>      
+            <Field name="position" type="float">0.105469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">93 89 199 255 </Field>      
+            <Field name="position" type="float">0.109375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">92 91 199 255 </Field>      
+            <Field name="position" type="float">0.113281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">92 92 199 255 </Field>      
+            <Field name="position" type="float">0.117188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">91 93 198 255 </Field>      
+            <Field name="position" type="float">0.121094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">90 94 198 255 </Field>      
+            <Field name="position" type="float">0.125000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">89 95 198 255 </Field>      
+            <Field name="position" type="float">0.128906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">88 97 198 255 </Field>      
+            <Field name="position" type="float">0.132812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">88 98 197 255 </Field>      
+            <Field name="position" type="float">0.136719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">87 99 197 255 </Field>      
+            <Field name="position" type="float">0.140625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">86 100 197 255 </Field>      
+            <Field name="position" type="float">0.144531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">85 101 196 255 </Field>      
+            <Field name="position" type="float">0.148438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">84 102 196 255 </Field>      
+            <Field name="position" type="float">0.152344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">84 104 196 255 </Field>      
+            <Field name="position" type="float">0.156250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">83 105 195 255 </Field>      
+            <Field name="position" type="float">0.160156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">82 106 195 255 </Field>      
+            <Field name="position" type="float">0.164062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">81 107 195 255 </Field>      
+            <Field name="position" type="float">0.167969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">81 108 194 255 </Field>      
+            <Field name="position" type="float">0.171875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">80 109 194 255 </Field>      
+            <Field name="position" type="float">0.175781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">79 110 193 255 </Field>      
+            <Field name="position" type="float">0.179688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">78 111 193 255 </Field>      
+            <Field name="position" type="float">0.183594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">78 112 193 255 </Field>      
+            <Field name="position" type="float">0.187500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">77 113 192 255 </Field>      
+            <Field name="position" type="float">0.191406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">76 114 192 255 </Field>      
+            <Field name="position" type="float">0.195312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">76 115 191 255 </Field>      
+            <Field name="position" type="float">0.199219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">75 116 191 255 </Field>      
+            <Field name="position" type="float">0.203125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">75 117 190 255 </Field>      
+            <Field name="position" type="float">0.207031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">74 118 190 255 </Field>      
+            <Field name="position" type="float">0.210938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">74 119 189 255 </Field>      
+            <Field name="position" type="float">0.214844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">73 120 189 255 </Field>      
+            <Field name="position" type="float">0.218750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">73 121 188 255 </Field>      
+            <Field name="position" type="float">0.222656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">72 122 188 255 </Field>      
+            <Field name="position" type="float">0.226562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">72 123 187 255 </Field>      
+            <Field name="position" type="float">0.230469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">71 124 187 255 </Field>      
+            <Field name="position" type="float">0.234375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">71 125 187 255 </Field>      
+            <Field name="position" type="float">0.238281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">70 125 186 255 </Field>      
+            <Field name="position" type="float">0.242188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">70 126 186 255 </Field>      
+            <Field name="position" type="float">0.246094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">70 127 185 255 </Field>      
+            <Field name="position" type="float">0.250000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">69 128 185 255 </Field>      
+            <Field name="position" type="float">0.253906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">69 129 184 255 </Field>      
+            <Field name="position" type="float">0.257812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">69 130 184 255 </Field>      
+            <Field name="position" type="float">0.261719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">68 131 183 255 </Field>      
+            <Field name="position" type="float">0.265625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">68 132 183 255 </Field>      
+            <Field name="position" type="float">0.269531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">68 132 182 255 </Field>      
+            <Field name="position" type="float">0.273438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">67 133 182 255 </Field>      
+            <Field name="position" type="float">0.277344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">67 134 182 255 </Field>      
+            <Field name="position" type="float">0.281250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">67 135 181 255 </Field>      
+            <Field name="position" type="float">0.285156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">67 136 181 255 </Field>      
+            <Field name="position" type="float">0.289062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">67 136 180 255 </Field>      
+            <Field name="position" type="float">0.292969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">67 137 180 255 </Field>      
+            <Field name="position" type="float">0.296875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 138 179 255 </Field>      
+            <Field name="position" type="float">0.300781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 139 179 255 </Field>      
+            <Field name="position" type="float">0.304688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 140 179 255 </Field>      
+            <Field name="position" type="float">0.308594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 140 178 255 </Field>      
+            <Field name="position" type="float">0.312500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 141 178 255 </Field>      
+            <Field name="position" type="float">0.316406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 142 178 255 </Field>      
+            <Field name="position" type="float">0.320312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 143 177 255 </Field>      
+            <Field name="position" type="float">0.324219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 144 177 255 </Field>      
+            <Field name="position" type="float">0.328125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 144 176 255 </Field>      
+            <Field name="position" type="float">0.332031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 145 176 255 </Field>      
+            <Field name="position" type="float">0.335938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 146 176 255 </Field>      
+            <Field name="position" type="float">0.339844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 147 175 255 </Field>      
+            <Field name="position" type="float">0.343750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 147 175 255 </Field>      
+            <Field name="position" type="float">0.347656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 148 175 255 </Field>      
+            <Field name="position" type="float">0.351562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 149 174 255 </Field>      
+            <Field name="position" type="float">0.355469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 150 174 255 </Field>      
+            <Field name="position" type="float">0.359375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 151 174 255 </Field>      
+            <Field name="position" type="float">0.363281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 151 173 255 </Field>      
+            <Field name="position" type="float">0.367188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 152 173 255 </Field>      
+            <Field name="position" type="float">0.371094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 153 173 255 </Field>      
+            <Field name="position" type="float">0.375000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 154 172 255 </Field>      
+            <Field name="position" type="float">0.378906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 154 172 255 </Field>      
+            <Field name="position" type="float">0.382812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 155 172 255 </Field>      
+            <Field name="position" type="float">0.386719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 156 171 255 </Field>      
+            <Field name="position" type="float">0.390625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 157 171 255 </Field>      
+            <Field name="position" type="float">0.394531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">65 157 171 255 </Field>      
+            <Field name="position" type="float">0.398438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 158 170 255 </Field>      
+            <Field name="position" type="float">0.402344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 159 170 255 </Field>      
+            <Field name="position" type="float">0.406250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 160 170 255 </Field>      
+            <Field name="position" type="float">0.410156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 161 169 255 </Field>      
+            <Field name="position" type="float">0.414062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 161 169 255 </Field>      
+            <Field name="position" type="float">0.417969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 162 169 255 </Field>      
+            <Field name="position" type="float">0.421875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 163 168 255 </Field>      
+            <Field name="position" type="float">0.425781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 164 168 255 </Field>      
+            <Field name="position" type="float">0.429688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">63 164 168 255 </Field>      
+            <Field name="position" type="float">0.433594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">63 165 167 255 </Field>      
+            <Field name="position" type="float">0.437500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">63 166 167 255 </Field>      
+            <Field name="position" type="float">0.441406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">63 167 167 255 </Field>      
+            <Field name="position" type="float">0.445312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">63 168 166 255 </Field>      
+            <Field name="position" type="float">0.449219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">62 168 166 255 </Field>      
+            <Field name="position" type="float">0.453125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">62 169 166 255 </Field>      
+            <Field name="position" type="float">0.457031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">62 170 165 255 </Field>      
+            <Field name="position" type="float">0.460938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">62 171 165 255 </Field>      
+            <Field name="position" type="float">0.464844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">61 171 164 255 </Field>      
+            <Field name="position" type="float">0.468750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">61 172 164 255 </Field>      
+            <Field name="position" type="float">0.472656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">61 173 164 255 </Field>      
+            <Field name="position" type="float">0.476562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">60 174 163 255 </Field>      
+            <Field name="position" type="float">0.480469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">60 175 163 255 </Field>      
+            <Field name="position" type="float">0.484375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">59 176 162 255 </Field>      
+            <Field name="position" type="float">0.488281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">59 176 162 255 </Field>      
+            <Field name="position" type="float">0.492188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">59 177 161 255 </Field>      
+            <Field name="position" type="float">0.496094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">58 178 161 255 </Field>      
+            <Field name="position" type="float">0.500000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">58 179 161 255 </Field>      
+            <Field name="position" type="float">0.503906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">57 180 160 255 </Field>      
+            <Field name="position" type="float">0.507812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">57 180 159 255 </Field>      
+            <Field name="position" type="float">0.511719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">57 181 159 255 </Field>      
+            <Field name="position" type="float">0.515625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">56 182 158 255 </Field>      
+            <Field name="position" type="float">0.519531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">56 183 158 255 </Field>      
+            <Field name="position" type="float">0.523438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">55 184 157 255 </Field>      
+            <Field name="position" type="float">0.527344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">55 184 157 255 </Field>      
+            <Field name="position" type="float">0.531250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">54 185 156 255 </Field>      
+            <Field name="position" type="float">0.535156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">53 186 155 255 </Field>      
+            <Field name="position" type="float">0.539062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">53 187 155 255 </Field>      
+            <Field name="position" type="float">0.542969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">52 188 154 255 </Field>      
+            <Field name="position" type="float">0.546875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">52 189 154 255 </Field>      
+            <Field name="position" type="float">0.550781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">51 189 153 255 </Field>      
+            <Field name="position" type="float">0.554688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">51 190 152 255 </Field>      
+            <Field name="position" type="float">0.558594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">50 191 151 255 </Field>      
+            <Field name="position" type="float">0.562500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">50 192 151 255 </Field>      
+            <Field name="position" type="float">0.566406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">49 193 150 255 </Field>      
+            <Field name="position" type="float">0.570312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">48 194 149 255 </Field>      
+            <Field name="position" type="float">0.574219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">48 194 148 255 </Field>      
+            <Field name="position" type="float">0.578125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">47 195 148 255 </Field>      
+            <Field name="position" type="float">0.582031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">47 196 147 255 </Field>      
+            <Field name="position" type="float">0.585938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">46 197 146 255 </Field>      
+            <Field name="position" type="float">0.589844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">46 198 145 255 </Field>      
+            <Field name="position" type="float">0.593750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">45 199 144 255 </Field>      
+            <Field name="position" type="float">0.597656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">45 199 143 255 </Field>      
+            <Field name="position" type="float">0.601562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">44 200 142 255 </Field>      
+            <Field name="position" type="float">0.605469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">44 201 141 255 </Field>      
+            <Field name="position" type="float">0.609375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">43 202 140 255 </Field>      
+            <Field name="position" type="float">0.613281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">43 203 139 255 </Field>      
+            <Field name="position" type="float">0.617188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">43 204 138 255 </Field>      
+            <Field name="position" type="float">0.621094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 204 137 255 </Field>      
+            <Field name="position" type="float">0.625000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 205 136 255 </Field>      
+            <Field name="position" type="float">0.628906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 206 135 255 </Field>      
+            <Field name="position" type="float">0.632812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 207 134 255 </Field>      
+            <Field name="position" type="float">0.636719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">41 208 133 255 </Field>      
+            <Field name="position" type="float">0.640625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">41 209 131 255 </Field>      
+            <Field name="position" type="float">0.644531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">41 209 130 255 </Field>      
+            <Field name="position" type="float">0.648438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">41 210 129 255 </Field>      
+            <Field name="position" type="float">0.652344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">41 211 128 255 </Field>      
+            <Field name="position" type="float">0.656250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 212 126 255 </Field>      
+            <Field name="position" type="float">0.660156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 213 125 255 </Field>      
+            <Field name="position" type="float">0.664062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">42 213 124 255 </Field>      
+            <Field name="position" type="float">0.667969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">43 214 122 255 </Field>      
+            <Field name="position" type="float">0.671875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">43 215 121 255 </Field>      
+            <Field name="position" type="float">0.675781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">44 216 119 255 </Field>      
+            <Field name="position" type="float">0.679688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">44 217 118 255 </Field>      
+            <Field name="position" type="float">0.683594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">45 217 116 255 </Field>      
+            <Field name="position" type="float">0.687500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">46 218 115 255 </Field>      
+            <Field name="position" type="float">0.691406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">47 219 113 255 </Field>      
+            <Field name="position" type="float">0.695312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">48 220 112 255 </Field>      
+            <Field name="position" type="float">0.699219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">49 221 110 255 </Field>      
+            <Field name="position" type="float">0.703125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">50 221 108 255 </Field>      
+            <Field name="position" type="float">0.707031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">51 222 107 255 </Field>      
+            <Field name="position" type="float">0.710938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">53 223 105 255 </Field>      
+            <Field name="position" type="float">0.714844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">54 224 103 255 </Field>      
+            <Field name="position" type="float">0.718750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">56 224 101 255 </Field>      
+            <Field name="position" type="float">0.722656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">57 225 99 255 </Field>      
+            <Field name="position" type="float">0.726562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">59 226 97 255 </Field>      
+            <Field name="position" type="float">0.730469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">61 226 95 255 </Field>      
+            <Field name="position" type="float">0.734375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">63 227 93 255 </Field>      
+            <Field name="position" type="float">0.738281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">64 228 91 255 </Field>      
+            <Field name="position" type="float">0.742188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">66 229 89 255 </Field>      
+            <Field name="position" type="float">0.746094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">69 229 87 255 </Field>      
+            <Field name="position" type="float">0.750000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">71 230 85 255 </Field>      
+            <Field name="position" type="float">0.753906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">73 231 82 255 </Field>      
+            <Field name="position" type="float">0.757812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">75 231 80 255 </Field>      
+            <Field name="position" type="float">0.761719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">78 232 78 255 </Field>      
+            <Field name="position" type="float">0.765625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">80 232 75 255 </Field>      
+            <Field name="position" type="float">0.769531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">83 233 73 255 </Field>      
+            <Field name="position" type="float">0.773438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">86 234 70 255 </Field>      
+            <Field name="position" type="float">0.777344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">89 234 68 255 </Field>      
+            <Field name="position" type="float">0.781250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">91 235 65 255 </Field>      
+            <Field name="position" type="float">0.785156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">94 235 62 255 </Field>      
+            <Field name="position" type="float">0.789062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">98 236 59 255 </Field>      
+            <Field name="position" type="float">0.792969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">101 236 57 255 </Field>      
+            <Field name="position" type="float">0.796875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">104 236 54 255 </Field>      
+            <Field name="position" type="float">0.800781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">108 237 51 255 </Field>      
+            <Field name="position" type="float">0.804688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">111 237 48 255 </Field>      
+            <Field name="position" type="float">0.808594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">115 237 46 255 </Field>      
+            <Field name="position" type="float">0.812500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">119 238 43 255 </Field>      
+            <Field name="position" type="float">0.816406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">123 238 41 255 </Field>      
+            <Field name="position" type="float">0.820312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">126 238 40 255 </Field>      
+            <Field name="position" type="float">0.824219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">130 238 38 255 </Field>      
+            <Field name="position" type="float">0.828125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">134 238 37 255 </Field>      
+            <Field name="position" type="float">0.832031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">138 239 37 255 </Field>      
+            <Field name="position" type="float">0.835938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">141 239 37 255 </Field>      
+            <Field name="position" type="float">0.839844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">145 239 37 255 </Field>      
+            <Field name="position" type="float">0.843750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">149 239 38 255 </Field>      
+            <Field name="position" type="float">0.847656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">152 239 39 255 </Field>      
+            <Field name="position" type="float">0.851562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">155 239 40 255 </Field>      
+            <Field name="position" type="float">0.855469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">159 239 41 255 </Field>      
+            <Field name="position" type="float">0.859375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">162 239 42 255 </Field>      
+            <Field name="position" type="float">0.863281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">165 239 43 255 </Field>      
+            <Field name="position" type="float">0.867188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">168 240 45 255 </Field>      
+            <Field name="position" type="float">0.871094 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">171 240 46 255 </Field>      
+            <Field name="position" type="float">0.875000 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">174 240 48 255 </Field>      
+            <Field name="position" type="float">0.878906 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">177 240 49 255 </Field>      
+            <Field name="position" type="float">0.882812 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">180 240 50 255 </Field>      
+            <Field name="position" type="float">0.886719 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">182 240 51 255 </Field>      
+            <Field name="position" type="float">0.890625 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">185 240 52 255 </Field>      
+            <Field name="position" type="float">0.894531 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">188 240 53 255 </Field>      
+            <Field name="position" type="float">0.898438 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">191 241 54 255 </Field>      
+            <Field name="position" type="float">0.902344 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">193 241 55 255 </Field>      
+            <Field name="position" type="float">0.906250 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">196 241 56 255 </Field>      
+            <Field name="position" type="float">0.910156 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">199 241 56 255 </Field>      
+            <Field name="position" type="float">0.914062 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">201 241 57 255 </Field>      
+            <Field name="position" type="float">0.917969 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">204 241 57 255 </Field>      
+            <Field name="position" type="float">0.921875 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">206 241 57 255 </Field>      
+            <Field name="position" type="float">0.925781 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">209 241 57 255 </Field>      
+            <Field name="position" type="float">0.929688 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">212 242 57 255 </Field>      
+            <Field name="position" type="float">0.933594 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">214 242 57 255 </Field>      
+            <Field name="position" type="float">0.937500 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">217 242 57 255 </Field>      
+            <Field name="position" type="float">0.941406 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">219 242 56 255 </Field>      
+            <Field name="position" type="float">0.945312 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">222 242 56 255 </Field>      
+            <Field name="position" type="float">0.949219 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">224 242 55 255 </Field>      
+            <Field name="position" type="float">0.953125 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">227 242 54 255 </Field>      
+            <Field name="position" type="float">0.957031 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">229 242 53 255 </Field>      
+            <Field name="position" type="float">0.960938 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">232 243 51 255 </Field>      
+            <Field name="position" type="float">0.964844 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">234 243 50 255 </Field>      
+            <Field name="position" type="float">0.968750 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">237 243 48 255 </Field>      
+            <Field name="position" type="float">0.972656 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">239 243 46 255 </Field>      
+            <Field name="position" type="float">0.976562 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">241 243 44 255 </Field>      
+            <Field name="position" type="float">0.980469 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">244 243 42 255 </Field>      
+            <Field name="position" type="float">0.984375 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">246 243 39 255 </Field>      
+            <Field name="position" type="float">0.988281 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">249 243 36 255 </Field>      
+            <Field name="position" type="float">0.992188 </Field>    
+        </Object>    
+        <Object name="ColorControlPoint">      
+            <Field name="colors" type="unsignedCharArray" length="4">251 244 32 255 </Field>      
+            <Field name="position" type="float">0.996094 </Field>    
+        </Object>
+    </Object>
+</Object>

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed the issue with the progress dialog staying visible when a client connection fails.</li>
   <li>Added a menu indicator icon to Color Table buttons so it is more obvious the button can be pushed to see available options.<li>
   <li>Fixed a bug preventing the ability to Pick Through Time using mesh quality metrics.</li>
+  <li>Fixed a bug in ColorTable window that limited number of color control points to 200.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #1555
Modified the ColorTable controls window to allow up to 256 color control points.
This jives with the maximum allowed by avtColorTables.
This resolves part 1 of the ticket.

I added the final </Object> tag to all the color tables stored in resources/colortables.
This resolves part 2 of the ticket.

I couldn't duplicate Part 3 with version 3.x of VisIt, so I think it was resolved previously.

### How Has This Been Tested?

I looked at all the color tables via the color table window and verified that those with > 200 color controls points showed the correct number of colors, and that I could create a new color table with > 200 color control points.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have updated the release notes
