### PR TITLE
Added Philip Blakely's code to fix memory leak in Lines

### DIFF
--- a/src/databases/Lines/avtLinesFileFormat.C
+++ b/src/databases/Lines/avtLinesFileFormat.C
@@ -61,6 +61,8 @@ avtLinesFileFormat::~avtLinesFileFormat()
     {
         lines[i]->Delete();
     }
+    
+    lines.clear();
 }
 
 // ****************************************************************************

--- a/src/databases/Lines/avtLinesFileFormat.C
+++ b/src/databases/Lines/avtLinesFileFormat.C
@@ -61,8 +61,6 @@ avtLinesFileFormat::~avtLinesFileFormat()
     {
         lines[i]->Delete();
     }
-    
-    lines.clear();
 }
 
 // ****************************************************************************
@@ -87,6 +85,7 @@ avtLinesFileFormat::FreeUpResources(void)
         lines[i]->Delete();
     }
     
+    lines.clear();
     readInFile = false;
 }
 

--- a/src/databases/Lines/avtLinesFileFormat.C
+++ b/src/databases/Lines/avtLinesFileFormat.C
@@ -44,11 +44,7 @@ using std::string;
 // ****************************************************************************
 
 avtLinesFileFormat::avtLinesFileFormat(const char *fname)
-    : avtSTMDFileFormat(&fname, 1)
-{
-    filename = fname;
-    readInFile = false;
-}
+: avtSTMDFileFormat(&fname, 1), filename(fname), readInFile(false) { }
 
 
 // ****************************************************************************
@@ -65,6 +61,31 @@ avtLinesFileFormat::~avtLinesFileFormat()
     {
         lines[i]->Delete();
     }
+}
+
+// ****************************************************************************
+//  Method: avtLinesFileFormat::FreeUpResources
+//
+//  Purpose:
+//      When VisIt is done focusing on a particular timestep, it asks that
+//      timestep to free up any resources (memory, file descriptors) that
+//      it has associated with it.  This method is the mechanism for doing
+//      that.
+//
+//  Programmer: Philip Blakely
+//  Creation:   Mon Jun 22 15:29:05 PDT 2020
+//
+// ****************************************************************************
+
+void
+avtLinesFileFormat::FreeUpResources(void)
+{
+    for (size_t i = 0 ; i < lines.size() ; i++)
+    {
+        lines[i]->Delete();
+    }
+    
+    readInFile = false;
 }
 
 

--- a/src/databases/Lines/avtLinesFileFormat.h
+++ b/src/databases/Lines/avtLinesFileFormat.h
@@ -37,6 +37,9 @@ class     vtkPolyData;
 //    Alister Maguire, Tue Mar 17 08:50:32 PDT 2020
 //    Added GetDimensionality.
 //
+//    Kevin Griffin, Mon Jun 22 15:29:05 PDT 2020
+//    Added FreeUpResources() from Philip Blakely's code to fix memory leak.
+//
 // ****************************************************************************
 
 class avtLinesFileFormat : public avtSTMDFileFormat
@@ -45,6 +48,7 @@ class avtLinesFileFormat : public avtSTMDFileFormat
                           avtLinesFileFormat(const char *);
     virtual              ~avtLinesFileFormat();
     
+    virtual void          FreeUpResources(void);    
     virtual const char   *GetType(void) { return "Lines File Format"; };
     
     virtual vtkDataSet   *GetMesh(int, const char *);

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug preventing the ability to Pick Through Time using mesh quality metrics.</li>
   <li>Fixed a couple of bugs with the MutilCurve plot. Fixed a bug where portions of the axes were missing or incomplete after switching the orientation. Fixed a bug where there were no tickmarks when displaying 16 curves.</li>
   <li>Fixed a bug in ColorTable window that limited number of color control points to 200.</li>
+  <li>Added Philip Blakely's code to fix the memory leak in the Lines Database.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #4805. Added Philip Blakely's code to fix memory leak in Lines database. Used Initializer list to initialize class data members.

### How Has This Been Tested?
Ran the sample lines dataset and verified that memory was correctly deleted and not leaking.

Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
