### PR TITLE
Fix bug where 'equal' color control points in color table window

### DIFF
--- a/src/gui/QvisSpectrumBar.C
+++ b/src/gui/QvisSpectrumBar.C
@@ -3146,7 +3146,10 @@ ControlPointList::DeleteHighestRank()
 // Creation:   Wed Jan 3 11:42:16 PDT 2001
 //
 // Modifications:
-//   
+//    Kathleen Biagas, Mon Jun 22 16:28:50 PDT 2020
+//    Modified how position is determined in the equal case, to fix selection
+//    of control points.  Was: (index*(1.-offset))+(offset*0.5)
+//
 // ****************************************************************************
 
 int
@@ -3167,7 +3170,7 @@ ControlPointList::ChangeSelectedIndex(float pos, float width, int equal)
         index = Rank(i);
 
         if(equal)
-            position = (index *(1. - offset)) +(offset * 0.5);
+            position = (index *offset) +(offset * 0.5);
         else
             position = list[index].position;
 

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a couple of bugs with the MutilCurve plot. Fixed a bug where portions of the axes were missing or incomplete after switching the orientation. Fixed a bug where there were no tickmarks when displaying 16 curves.</li>
   <li>Fixed a bug in ColorTable window that limited number of color control points to 200.</li>
   <li>Added Philip Blakely's code to fix the memory leak in the Lines Database.</li>
+  <li>Fixed a bug in ColorTable window that prevented colors on 'equal' control points from being changed.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
could not have their colors changed via right-mouse-click.
Resolves #1197.

This is a merge from 3.1RC.