### PR TITLE
update setlocale for Ubuntu compatibility

### DIFF
--- a/src/common/state/ConfigManager.C
+++ b/src/common/state/ConfigManager.C
@@ -14,6 +14,7 @@
 #include <clocale>
 #include <iomanip>
 #include <visit-config.h>
+#include <DebugStream.h>
 
 // ****************************************************************************
 // Method: ConfigManager::ConfigManager
@@ -1131,6 +1132,11 @@ ConfigManager::ReadFieldData(std::istream& in,
 //    Mark C. Miller, Tue Mar 31 18:54:53 PDT 2015
 //    Incorporate changes as per Brad's guidance to force locale to en_US
 //    when reading.
+//
+//    Alister Maguire, Wed Jun 24 15:37:46 PDT 2020
+//    Changed setlocale from en_US to en_US.UTF-8 for Ubuntu compatibility,
+//    and added a check to see if it succeeded or not.
+//
 // ****************************************************************************
 
 bool
@@ -1140,7 +1146,14 @@ ConfigManager::ReadObject(std::istream& in, DataNode *parentNode)
     std::string current_locale = setlocale(LC_ALL, 0);
 
     // Force US locale.
-    setlocale(LC_ALL, "en_US");
+    const char * result = setlocale(LC_ALL, "en_US.UTF-8");
+
+    // Did we succeed?
+    if (result == NULL)
+    {
+        debug1 << "setlocale failed! This may result in erroneous reads..."
+            << endl;
+    }
 
     // Read the settings.
     bool te = false;

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in ColorTable window that limited number of color control points to 200.</li>
   <li>Added Philip Blakely's code to fix the memory leak in the Lines Database.</li>
   <li>Fixed a bug in ColorTable window that prevented colors on 'equal' control points from being changed.</li>
+  <li>Fixed a bug preventing VisIt from correctly reading some types of files on Ubuntu when using non-English language settings.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description
I've updated a bugfix for VisIt's ability to handle non-English language settings. The previous bugfix seemed to work for all systems other than Ubuntu, which required a small tweak in the fix. 

Resolves #2198 

### Type of change

Bug fix.

### How Has This Been Tested?
I've built and tested on Ubuntu and Mac to make sure that the fix works for both systems.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [x] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
