### PR TITLE
Fixed a CGNS reader crash with a Subset plot of zones from decomposed data. (#4870)

### DIFF
--- a/src/databases/CGNS/avtCGNSFileFormat.C
+++ b/src/databases/CGNS/avtCGNSFileFormat.C
@@ -22,13 +22,16 @@
 //  Creation:   Fri Feb 28 13:48:04 PST 2020
 //
 //  Modifications:
+//    Eric Brugger, Thu Jul  2 10:56:36 PDT 2020
+//    Corrected a bug that caused a crash when doing a Subset plot of "zones"
+//    when reading data decomposed across multiple CGNS files.
 //
 // ****************************************************************************
 
 avtCGNS_MTMDFileFormat::avtCGNS_MTMDFileFormat(const char *filename) :
     avtMTMDFileFormat(filename)
 {
-    reader = new avtCGNSFileReader(filename);
+    reader = new avtCGNSFileReader(filename, true);
 }
 
 // ****************************************************************************
@@ -251,6 +254,9 @@ avtCGNS_MTMDFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md,
 //  Creation:   Fri Feb 28 13:48:04 PST 2020
 //
 //  Modifications:
+//    Eric Brugger, Thu Jul  2 10:56:36 PDT 2020
+//    Corrected a bug that caused a crash when doing a Subset plot of "zones"
+//    when reading data decomposed across multiple CGNS files.
 //
 // ****************************************************************************
 
@@ -260,7 +266,7 @@ avtCGNS_MTSDFileFormat::avtCGNS_MTSDFileFormat(const char *filename) :
     cgnsFileName = new char[strlen(filename) + 1];
     strcpy(cgnsFileName, filename);
 
-    reader = new avtCGNSFileReader(filename);
+    reader = new avtCGNSFileReader(filename, false);
 }
 
 // ****************************************************************************

--- a/src/databases/CGNS/avtCGNSFileReader.h
+++ b/src/databases/CGNS/avtCGNSFileReader.h
@@ -47,12 +47,16 @@ using namespace std;
 //    Pulled out all the CGNS specific code from avtCGNSFileFormat into
 //    this class.
 //
+//    Eric Brugger, Thu Jul  2 10:56:36 PDT 2020
+//    Corrected a bug that caused a crash when doing a Subset plot of "zones"
+//    when reading data decomposed across multiple CGNS files.
+//
 // ****************************************************************************
 
 class avtCGNSFileReader
 {
 public:
-                           avtCGNSFileReader(const char *);
+                           avtCGNSFileReader(const char *, bool);
                           ~avtCGNSFileReader();
 
     virtual void           GetCycles(std::vector<int> &);
@@ -137,6 +141,7 @@ protected:
     std::map<std::string, int>             BaseNameToIndices;
     std::map<std::string, std::string>     VisItNameToCGNSName;
     bool                                   initializedMaps;
+    bool                                   cgnsIsMTMD;
 };
 
 #endif

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Duplicate expressions in the gui are now handled gracefully with an automatic name change.</li>
   <li>Fixed a bug preventing VisIt from correctly reading some types of files on Ubuntu when using non-English language settings.</li>
   <li>Adding and deleting expressions in the expressions window now only takes effect when actually clicking the apply button.</li>
+  <li>Fixed a bug with the CGNS reader that caused VisIt to crash when doing a Subset plot of "zones" when reading data decomposed across multiple CGNS files.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Merge from the 3.1RC to develop.