### PR TITLE
Add ability to create ghost nodes for collections of structured grids.

### DIFF
--- a/src/avt/Database/CMakeLists.txt
+++ b/src/avt/Database/CMakeLists.txt
@@ -42,6 +42,7 @@ Formats/avtSTSDFileFormatInterface.C
 SET(GHOST_SOURCES
 Ghost/StructuredBoundary.C
 Ghost/avtDomainBoundaries.C
+Ghost/avtGhostNodeGenerator.C
 Ghost/avtIsenburgSGG.C
 Ghost/avtStreamingGhostGenerator.C
 Ghost/avtStructuredDomainBoundaries.C

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7243,31 +7243,35 @@ avtGenericDatabase::CommunicateGhosts(avtGhostDataType ghostType,
     // proper subroutine to do it.
     //
     int portion2 = visitTimer->StartTimer();
-    bool s = false;
+    bool madeGhosts = false;
     if (ghostType == GHOST_NODE_DATA)
     {
         if (hasDomainBoundaryInfo)
-            s = CommunicateGhostNodesFromDomainBoundariesFromFile(ds, doms,
-                                                       spec, src, allDomains);
+            madeGhosts = CommunicateGhostNodesFromDomainBoundariesFromFile
+               (ds, doms, spec, src, allDomains);
         else if (canUseGlobalNodeIds)
-            s = CommunicateGhostNodesFromGlobalNodeIds(ds, doms, spec, src);
+            madeGhosts = CommunicateGhostNodesFromGlobalNodeIds
+                (ds, doms, spec, src);
         else if (canDoStreamingGhosts)  // Zones not Nodes
-            s = CommunicateGhostZonesWhileStreaming(ds, doms, spec, src);
+            madeGhosts = CommunicateGhostZonesWhileStreaming
+                (ds, doms, spec, src);
         else
         {
             avtGhostNodeGenerator gnf;
-            s = gnf.CreateGhosts(ds);
+            madeGhosts = gnf.CreateGhosts(ds);
         }
     }
     else if (ghostType == GHOST_ZONE_DATA)
     {
         if (hasDomainBoundaryInfo)
-            s = CommunicateGhostZonesFromDomainBoundariesFromFile(ds, doms,
-                                                                  spec, src);
+            madeGhosts = CommunicateGhostZonesFromDomainBoundariesFromFile
+                (ds, doms, spec, src);
         else if (canUseGlobalNodeIds)
-            s = CommunicateGhostZonesFromGlobalNodeIds(ds, doms, spec, src);
+            madeGhosts = CommunicateGhostZonesFromGlobalNodeIds
+                (ds, doms, spec, src);
         else if (canDoStreamingGhosts)
-            s = CommunicateGhostZonesWhileStreaming(ds, doms, spec, src);
+            madeGhosts = CommunicateGhostZonesWhileStreaming
+                (ds, doms, spec, src);
     }
     else
     {
@@ -7276,7 +7280,7 @@ avtGenericDatabase::CommunicateGhosts(avtGhostDataType ghostType,
     }
     visitTimer->StopTimer(portion2, "Time to actually communicate ghost data");
 
-    if (s)
+    if (madeGhosts)
     {
         //
         // This will tell everything downstream that we have created ghost

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7276,8 +7276,7 @@ avtGenericDatabase::CommunicateGhosts(avtGhostDataType ghostType,
     }
     visitTimer->StopTimer(portion2, "Time to actually communicate ghost data");
 
-    bool madeGhosts = s;
-    if (madeGhosts)
+    if (s)
     {
         //
         // This will tell everything downstream that we have created ghost

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -52,6 +52,7 @@
 #include <avtDomainBoundaries.h>
 #include <avtDomainNesting.h>
 #include <avtFileFormatInterface.h>
+#include <avtGhostNodeGenerator.h>
 #include <avtMemory.h>
 #include <avtMixedVariable.h>
 #include <avtParallel.h>
@@ -7252,6 +7253,11 @@ avtGenericDatabase::CommunicateGhosts(avtGhostDataType ghostType,
             s = CommunicateGhostNodesFromGlobalNodeIds(ds, doms, spec, src);
         else if (canDoStreamingGhosts)  // Zones not Nodes
             s = CommunicateGhostZonesWhileStreaming(ds, doms, spec, src);
+        else
+        {
+            avtGhostNodeGenerator gnf;
+            s = gnf.CreateGhosts(ds);
+        }
     }
     else if (ghostType == GHOST_ZONE_DATA)
     {

--- a/src/avt/Database/Ghost/avtGhostNodeGenerator.C
+++ b/src/avt/Database/Ghost/avtGhostNodeGenerator.C
@@ -90,10 +90,10 @@ avtGhostNodeGenerator::CreateGhosts(avtDatasetCollection &ds)
     MPI_Allgather(&nChunks, 1, MPI_INT, chunksPerProc, 1, MPI_INT, VISIT_MPI_COMM);
     int nChunksTotal = 0;
     for (int i = 0; i < nProcs; i++)
-        nChunksTotal += chunksPerProc[i];
-
-    for (int i = 0; i < nProcs; i++)
+    {
         debug2 << "ChunksPerProc[" << i << "]=" << chunksPerProc[i] << endl;
+        nChunksTotal += chunksPerProc[i];
+    }
     debug2 << "nChunksTotal=" << nChunksTotal << endl;
 #endif
     

--- a/src/avt/Database/Ghost/avtGhostNodeGenerator.C
+++ b/src/avt/Database/Ghost/avtGhostNodeGenerator.C
@@ -1,0 +1,739 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+// ************************************************************************* //
+//                           avtGhostNodeGenerator.C                         //
+// ************************************************************************* //
+
+#include <avtGhostNodeGenerator.h>
+
+#ifdef PARALLEL
+#include <mpi.h>
+#endif 
+
+#include <vtkDataSet.h>
+#include <vtkPointData.h>
+#include <vtkStructuredGrid.h>
+#include <vtkUnsignedCharArray.h>
+
+#include <DebugStream.h>
+#include <TimingsManager.h>
+
+#include <avtDatasetCollection.h>
+#include <avtParallel.h>
+
+#include <vector>
+
+
+// ****************************************************************************
+//  Method: avtGhostNodeGenerator constructor
+//
+//  Programmer: Eric Brugger
+//  Creation:   May 28, 2020
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+avtGhostNodeGenerator::avtGhostNodeGenerator()
+{
+}
+
+
+// ****************************************************************************
+//  Method: avtGhostNodeGenerator destructor
+//
+//  Programmer: Eric Brugger
+//  Creation:   May 28, 2020
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+avtGhostNodeGenerator::~avtGhostNodeGenerator()
+{
+}
+
+
+// ****************************************************************************
+//  Method: avtGhostNodeGenerator::CreateGhosts
+//
+//  Purpose:
+//    Create the ghost nodes.
+//
+//  Programmer: Eric Brugger
+//  Creation:   May 28, 2020
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+bool
+avtGhostNodeGenerator::CreateGhosts(avtDatasetCollection &ds)
+{
+    int nChunks = ds.GetNDomains();
+
+    //
+    // Check that the datasets meet the criteria for creating ghost nodes.
+    //
+    if (!IsValid(ds))
+        return false;
+
+#ifdef PARALLEL
+    //
+    // Determine the number of chunks per rank.
+    //
+    int iProc  = PAR_Rank();
+    int nProcs = PAR_Size();
+    int *chunksPerProc = new int[nProcs];
+    MPI_Allgather(&nChunks, 1, MPI_INT, chunksPerProc, 1, MPI_INT, VISIT_MPI_COMM);
+    int nChunksTotal = 0;
+    for (int i = 0; i < nProcs; i++)
+        nChunksTotal += chunksPerProc[i];
+
+    for (int i = 0; i < nProcs; i++)
+        debug2 << "ChunksPerProc[" << i << "]=" << chunksPerProc[i] << endl;
+    debug2 << "nChunksTotal=" << nChunksTotal << endl;
+#endif
+    
+    //
+    // Create the list of extents of each block.
+    //
+    double *dsExtents = new double [nChunks*6];
+    for (int i = 0; i < nChunks; i++)
+    {
+        vtkDataSet *d = ds.GetDataset(i, 0);
+        vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
+        vtkPoints *points = sgrid->GetPoints();
+
+        int ndims[3];
+        sgrid->GetDimensions(ndims);
+
+        int zdims[3];
+        zdims[0] = ndims[0] - 1;
+        zdims[1] = ndims[1] - 1;
+        zdims[2] = ndims[2] - 1;
+
+        int nx = ndims[0];
+        int ny = ndims[1];
+        int nxy = nx * ny;
+
+        int nx2 = zdims[0];
+        int ny2 = zdims[1];
+        int nxy2 = nx2 * ny2;
+
+        int nxyz = ndims[0] * ndims[1] * ndims[2];
+        double coord[3];
+        points->GetPoint(0, coord);
+        double xmin = coord[0];
+        double xmax = coord[0];
+        double ymin = coord[1];
+        double ymax = coord[1];
+        double zmin = coord[2];
+        double zmax = coord[2];
+        for (int j = 1; j < nxyz; j++)
+        {
+            points->GetPoint(j, coord);
+            xmin = xmin < coord[0] ? xmin : coord[0];
+            xmax = xmax > coord[0] ? xmax : coord[0];
+            ymin = ymin < coord[1] ? ymin : coord[1];
+            ymax = ymax > coord[1] ? ymax : coord[1];
+            zmin = zmin < coord[2] ? zmin : coord[2];
+            zmax = zmax > coord[2] ? zmax : coord[2];
+        }
+        dsExtents[i*6+0] = xmin;
+        dsExtents[i*6+1] = xmax;
+        dsExtents[i*6+2] = ymin;
+        dsExtents[i*6+3] = ymax;
+        dsExtents[i*6+4] = zmin;
+        dsExtents[i*6+5] = zmax;
+    }
+
+#ifdef PARALLEL
+    //
+    // Send the block extents to all the processors.
+    //
+    double *dsExtentsTotal = new double[nChunksTotal*6];
+    int *offsets = new int[nProcs];
+    offsets[0] = 0;
+    for (int i = 1; i < nProcs; i++)
+        offsets[i] = offsets[i-1] + chunksPerProc[i-1] * 6;
+    int *recvcounts = new int[nProcs];
+    for (int i = 0; i < nProcs; i++)
+        recvcounts[i] = chunksPerProc[i] * 6;
+    MPI_Allgatherv(dsExtents, nChunks*6, MPI_DOUBLE, dsExtentsTotal,
+                   recvcounts, offsets, MPI_DOUBLE, VISIT_MPI_COMM);
+#endif
+
+    //
+    // Create the list of external faces for each dataset.
+    //
+    int *nFaces = new int[nChunks];
+    double **faceExtents = new double*[nChunks];
+    bool **faceExternal = new bool*[nChunks];
+    for (int i = 0; i < nChunks; i++)
+    {
+        vtkDataSet *d = ds.GetDataset(i, 0);
+        vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
+        vtkPoints *points = sgrid->GetPoints();
+
+        int ndims[3];
+        sgrid->GetDimensions(ndims);
+        int nx = ndims[0];
+        int ny = ndims[1];
+        int nz = ndims[2];
+
+        int nx2 = ndims[0] - 1;
+        int ny2 = ndims[1] - 1;
+        int nz2 = ndims[2] - 1;
+
+        nFaces[i] = nx2 * ny2 * 2 + nx2 * nz2 * 2 + ny2 * nz2 * 2;
+
+        faceExternal[i] = new bool[nFaces[i]];
+        bool *external = faceExternal[i];
+        for (int j = 0; j < nFaces[i]; j++)
+            external[j] = true;
+
+        faceExtents[i] = new double[nFaces[i]*6];
+        double *extents = faceExtents[i];
+        int iface = 0;
+
+        // Do the x faces.
+        for (int ix = 0; ix < nx; ix += nx-1)
+        {
+            for (int iy = 0; iy < ny2; iy++)
+            {
+                for (int iz = 0; iz < nz2; iz++)
+                {
+                    int ndx[4];
+                    ndx[0] = iz     * nx * ny + iy     * nx + ix;
+                    ndx[1] = (iz+1) * nx * ny + iy     * nx + ix;
+                    ndx[2] = (iz+1) * nx * ny + (iy+1) * nx + ix;
+                    ndx[3] = iz     * nx * ny + (iy+1) * nx + ix;
+                    double coord[3];
+                    points->GetPoint(ndx[0], coord);
+                    double xmin = coord[0];
+                    double xmax = coord[0];
+                    double ymin = coord[1];
+                    double ymax = coord[1];
+                    double zmin = coord[2];
+                    double zmax = coord[2];
+                    for (int in = 1; in < 4; in++)
+                    {
+                        points->GetPoint(ndx[in], coord);
+                        xmin = xmin < coord[0] ? xmin : coord[0];
+                        xmax = xmax > coord[0] ? xmax : coord[0];
+                        ymin = ymin < coord[1] ? ymin : coord[1];
+                        ymax = ymax > coord[1] ? ymax : coord[1];
+                        zmin = zmin < coord[2] ? zmin : coord[2];
+                        zmax = zmax > coord[2] ? zmax : coord[2];
+                    }
+                    extents[iface*6+0] = xmin;
+                    extents[iface*6+1] = xmax;
+                    extents[iface*6+2] = ymin;
+                    extents[iface*6+3] = ymax;
+                    extents[iface*6+4] = zmin;
+                    extents[iface*6+5] = zmax;
+                    iface++;
+                }
+            }
+        }
+
+        // Do the y faces.
+        for (int iy = 0; iy < ny; iy += ny-1)
+        {
+            for (int ix = 0; ix < nx2; ix++)
+            {
+                for (int iz = 0; iz < nz2; iz++)
+                {
+                    int ndx[4];
+                    ndx[0] = iz     * nx * ny + iy * nx + ix;
+                    ndx[1] = (iz+1) * nx * ny + iy * nx + ix;
+                    ndx[2] = (iz+1) * nx * ny + iy * nx + (ix+1);
+                    ndx[3] = iz     * nx * ny + iy * nx + (ix+1);
+              
+                    double coord[3];
+                    points->GetPoint(ndx[0], coord);
+                    double xmin = coord[0];
+                    double xmax = coord[0];
+                    double ymin = coord[1];
+                    double ymax = coord[1];
+                    double zmin = coord[2];
+                    double zmax = coord[2];
+                    for (int in = 1; in < 4; in++)
+                    {
+                        points->GetPoint(ndx[in], coord);
+                        xmin = xmin < coord[0] ? xmin : coord[0];
+                        xmax = xmax > coord[0] ? xmax : coord[0];
+                        ymin = ymin < coord[1] ? ymin : coord[1];
+                        ymax = ymax > coord[1] ? ymax : coord[1];
+                        zmin = zmin < coord[2] ? zmin : coord[2];
+                        zmax = zmax > coord[2] ? zmax : coord[2];
+                    }
+                    extents[iface*6+0] = xmin;
+                    extents[iface*6+1] = xmax;
+                    extents[iface*6+2] = ymin;
+                    extents[iface*6+3] = ymax;
+                    extents[iface*6+4] = zmin;
+                    extents[iface*6+5] = zmax;
+                    iface++;
+                }
+            }
+        }
+
+        // Do the z faces.
+        for (int iz = 0; iz < nz; iz += nz-1)
+        {
+            for (int ix = 0; ix < nx2; ix++)
+            {
+                for (int iy = 0; iy < ny2; iy++)
+                {
+                    int ndx[4];
+                    ndx[0] = iz * nx * ny + iy     * nx + ix;
+                    ndx[1] = iz * nx * ny + (iy+1) * nx + ix;
+                    ndx[2] = iz * nx * ny + (iy+1) * nx + (ix+1);
+                    ndx[3] = iz * nx * ny + iy     * nx + (ix+1);
+                    double coord[3];
+                    points->GetPoint(ndx[0], coord);
+                    double xmin = coord[0];
+                    double xmax = coord[0];
+                    double ymin = coord[1];
+                    double ymax = coord[1];
+                    double zmin = coord[2];
+                    double zmax = coord[2];
+                    for (int in = 1; in < 4; in++)
+                    {
+                        points->GetPoint(ndx[in], coord);
+                        xmin = xmin < coord[0] ? xmin : coord[0];
+                        xmax = xmax > coord[0] ? xmax : coord[0];
+                        ymin = ymin < coord[1] ? ymin : coord[1];
+                        ymax = ymax > coord[1] ? ymax : coord[1];
+                        zmin = zmin < coord[2] ? zmin : coord[2];
+                        zmax = zmax > coord[2] ? zmax : coord[2];
+                    }
+                    extents[iface*6+0] = xmin;
+                    extents[iface*6+1] = xmax;
+                    extents[iface*6+2] = ymin;
+                    extents[iface*6+3] = ymax;
+                    extents[iface*6+4] = zmin;
+                    extents[iface*6+5] = zmax;
+                    iface++;
+                }
+            }
+        }
+
+        assert(iface == nFaces[i]);
+    }
+
+#ifdef PARALLEL
+    //
+    // Determine the number of faces per block.
+    //
+    int *nFacesTotal = new int[nChunksTotal];
+    offsets[0] = 0;
+    for (int i = 1; i < nProcs; i++)
+        offsets[i] = offsets[i-1] + chunksPerProc[i-1];
+    MPI_Allgatherv(nFaces, nChunks, MPI_INT, nFacesTotal, chunksPerProc,
+                   offsets, MPI_INT, VISIT_MPI_COMM);
+#endif
+
+    //
+    // Match faces against the local blocks.
+    //
+    for (int i = 0; i < nChunks; i++)
+    {
+        for (int j = i + 1; j < nChunks; j++)
+        {
+            //
+            // Skip this block if there is no overlap in extents.
+            //
+            bool xoverlap = !(dsExtents[i*6+1] < dsExtents[j*6+0] ||
+                              dsExtents[i*6+0] > dsExtents[j*6+1]);
+            bool yoverlap = !(dsExtents[i*6+3] < dsExtents[j*6+2] ||
+                              dsExtents[i*6+2] > dsExtents[j*6+3]);
+            bool zoverlap = !(dsExtents[i*6+5] < dsExtents[j*6+4] ||
+                              dsExtents[i*6+4] > dsExtents[j*6+5]);
+            if (!xoverlap || !yoverlap || !zoverlap)
+            {
+                debug4 << "Skipping block " << i << " vs " << j << endl;
+                continue;
+            }
+            double *extents1 = faceExtents[i];
+            double *extents2 = faceExtents[j];
+            bool *external1 = faceExternal[i];
+            bool *external2 = faceExternal[j];
+            for (int iface1 = 0; iface1 < nFaces[i]; iface1++)
+            {
+                //
+                // Check if the face is within the bound of the block.
+                //
+                if (extents1[iface1*6+0] < dsExtents[j*6+0] || 
+                    extents1[iface1*6+1] > dsExtents[j*6+1] ||
+                    extents1[iface1*6+2] < dsExtents[j*6+2] ||
+                    extents1[iface1*6+3] > dsExtents[j*6+3] ||
+                    extents1[iface1*6+4] < dsExtents[j*6+4] ||
+                    extents1[iface1*6+5] > dsExtents[j*6+5])
+                {
+                    continue;
+                }
+                for (int iface2 = 0; iface2 < nFaces[j]; iface2++)
+                {
+                    if (external2[iface2] &&
+                        extents1[iface1*6+0] == extents2[iface2*6+0] &&
+                        extents1[iface1*6+1] == extents2[iface2*6+1] &&
+                        extents1[iface1*6+2] == extents2[iface2*6+2] &&
+                        extents1[iface1*6+3] == extents2[iface2*6+3] &&
+                        extents1[iface1*6+4] == extents2[iface2*6+4] &&
+                        extents1[iface1*6+5] == extents2[iface2*6+5])
+                    {
+                        external1[iface1] = false;
+                        external2[iface2] = false;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+#ifdef PARALLEL
+    //
+    // Broadcast all the faces to all the processors.
+    // 
+    int nGlobalFaces = 0;
+    for (int i = 0; i < nChunksTotal; i++)
+        nGlobalFaces += nFacesTotal[i];
+    double *faceExtentsTotal = new double[nGlobalFaces*6];
+    int nLocalFaces = 0;
+    for (int i = 0; i < nChunks; i++)
+        nLocalFaces += nFaces[i];
+    double *faceExtentsLocal = new double[nLocalFaces*6];
+    int iface = 0;
+    for (int i = 0; i < nChunks; i++)
+    {
+        double *extents = faceExtents[i];
+        for (int j = 0; j < nFaces[i]*6; j++)
+        {
+            faceExtentsLocal[iface] = extents[j];
+            iface++;
+        }
+    }
+
+    assert(iface == nLocalFaces * 6);
+
+    debug2 << "nGlobalFaces=" << nGlobalFaces << endl;
+    debug2 << "nLocalFaces=" << nLocalFaces << endl;
+
+    iface = 0;
+    for (int i = 0; i < nProcs; i++)
+    {
+        recvcounts[i] = 0;
+        for (int j = 0; j < chunksPerProc[i]; j++)
+        {
+            recvcounts[i] += nFacesTotal[iface] * 6;
+            iface++;
+        }
+    }
+    offsets[0] = 0;
+    for (int i = 1; i < nProcs; i++)
+    {
+        offsets[i] = offsets[i-1] + recvcounts[i-1];
+    }
+    MPI_Allgatherv(faceExtentsLocal, nLocalFaces*6, MPI_DOUBLE,
+                   faceExtentsTotal, recvcounts, offsets, MPI_DOUBLE,
+                   VISIT_MPI_COMM);
+
+    //
+    // Match faces against the other processor blocks.
+    //
+    int chunk_start = 0, chunk_end = 0;
+    for (int i = 0; i < iProc; i++)
+        chunk_start += chunksPerProc[i];
+    chunk_end = chunk_start + chunksPerProc[iProc]; 
+    for (int i = 0; i < nChunks; i++)
+    {
+        for (int iFaceExtentsTotal = 0, j = 0;
+             j < nChunksTotal; iFaceExtentsTotal += nFacesTotal[j]*6, j++)
+        {
+            //
+            // Skip this block if it belongs to this processor.
+            //
+            if (j >= chunk_start && j < chunk_end)
+            {
+                continue;
+            }
+
+            //
+            // Skip this block if there is no overlap in extents.
+            //
+            bool xoverlap = !(dsExtents[i*6+1] < dsExtentsTotal[j*6+0] ||
+                              dsExtents[i*6+0] > dsExtentsTotal[j*6+1]);
+            bool yoverlap = !(dsExtents[i*6+3] < dsExtentsTotal[j*6+2] ||
+                              dsExtents[i*6+2] > dsExtentsTotal[j*6+3]);
+            bool zoverlap = !(dsExtents[i*6+5] < dsExtentsTotal[j*6+4] ||
+                              dsExtents[i*6+4] > dsExtentsTotal[j*6+5]);
+            if (!xoverlap || !yoverlap || !zoverlap)
+            {
+                debug4 << "Skipping block " << i << " vs " << j << endl;
+                continue;
+            }
+            double *extents1 = faceExtents[i];
+            double *extents2 = &faceExtentsTotal[iFaceExtentsTotal];
+            bool *external1 = faceExternal[i];
+            for (int iface1 = 0; iface1 < nFaces[i]; iface1++)
+            {
+                //
+                // Check if the face is within the bound of the block.
+                //
+                if (extents1[iface1*6+0] < dsExtentsTotal[j*6+0] || 
+                    extents1[iface1*6+1] > dsExtentsTotal[j*6+1] ||
+                    extents1[iface1*6+2] < dsExtentsTotal[j*6+2] ||
+                    extents1[iface1*6+3] > dsExtentsTotal[j*6+3] ||
+                    extents1[iface1*6+4] < dsExtentsTotal[j*6+4] ||
+                    extents1[iface1*6+5] > dsExtentsTotal[j*6+5])
+                {
+                    continue;
+                }
+                for (int iface2 = 0; iface2 < nFacesTotal[j]; iface2++)
+                {
+                    if (extents1[iface1*6+0] == extents2[iface2*6+0] &&
+                        extents1[iface1*6+1] == extents2[iface2*6+1] &&
+                        extents1[iface1*6+2] == extents2[iface2*6+2] &&
+                        extents1[iface1*6+3] == extents2[iface2*6+3] &&
+                        extents1[iface1*6+4] == extents2[iface2*6+4] &&
+                        extents1[iface1*6+5] == extents2[iface2*6+5])
+                    {
+                        external1[iface1] = false;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    //
+    // Clean up parallel related memory.
+    //
+    delete [] chunksPerProc;
+    delete [] dsExtentsTotal;
+    delete [] offsets;
+    delete [] recvcounts;
+    delete [] nFacesTotal;
+    delete [] faceExtentsTotal;
+    delete [] faceExtentsLocal;
+#endif
+
+    //
+    // Add the ghost node information based on the external faces.
+    //
+    for (int i = 0; i < nChunks; i++)
+    {
+        vtkDataSet *d = ds.GetDataset(i, 0);
+        vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
+        vtkPoints *points = sgrid->GetPoints();
+
+        int ndims[3];
+        sgrid->GetDimensions(ndims);
+        int nx = ndims[0];
+        int ny = ndims[1];
+        int nz = ndims[2];
+        int nvals = nx * ny * nz;
+
+        int nx2 = ndims[0] - 1;
+        int ny2 = ndims[1] - 1;
+        int nz2 = ndims[2] - 1;
+
+        //
+        // Create the ghost nodes array, initializing it to no ghost
+        // nodes.
+        //
+        vtkUnsignedCharArray *ghostNodes = vtkUnsignedCharArray::New();
+        ghostNodes->SetName("avtGhostNodes");
+        ghostNodes->SetNumberOfTuples(nvals);
+        for (int j = 0; j < nvals; j++)
+        {
+            ghostNodes->SetValue(j, 0);
+        }
+
+        //
+        // Loop over all the faces, setting the ghost flag for all the
+        // nodes of any ghost faces. We must traverse the faces in the
+        // same order that we did above.
+        //
+        int iface = 0;
+        bool *external = faceExternal[i];
+
+        // Do the x faces.
+        for (int ix = 0; ix < nx; ix += nx-1)
+        {
+            for (int iy = 0; iy < ny2; iy++)
+            {
+                for (int iz = 0; iz < nz2; iz++)
+                {
+                    if (!external[iface])
+                    {
+                        int ndx[4];
+                        ndx[0] = iz     * nx * ny + iy     * nx + ix;
+                        ndx[1] = (iz+1) * nx * ny + iy     * nx + ix;
+                        ndx[2] = (iz+1) * nx * ny + (iy+1) * nx + ix;
+                        ndx[3] = iz     * nx * ny + (iy+1) * nx + ix;
+                        for (int in = 0; in < 4; in++)
+                        {
+                            ghostNodes->SetValue(ndx[in], 1);
+                        }
+                    }
+                    iface++;
+                }
+            }
+        }
+
+        // Do the y faces.
+        for (int iy = 0; iy < ny; iy += ny-1)
+        {
+            for (int ix = 0; ix < nx2; ix++)
+            {
+                for (int iz = 0; iz < nz2; iz++)
+                {
+                    if (!external[iface])
+                    {
+                        int ndx[4];
+                        ndx[0] = iz     * nx * ny + iy * nx + ix;
+                        ndx[1] = (iz+1) * nx * ny + iy * nx + ix;
+                        ndx[2] = (iz+1) * nx * ny + iy * nx + (ix+1);
+                        ndx[3] = iz     * nx * ny + iy * nx + (ix+1);
+                        for (int in = 0; in < 4; in++)
+                        {
+                            ghostNodes->SetValue(ndx[in], 1);
+                        }
+                    }
+                    iface++;
+                }
+            }
+        }
+
+        // Do the z faces.
+        for (int iz = 0; iz < nz; iz += nz-1)
+        {
+            for (int ix = 0; ix < nx2; ix++)
+            {
+                for (int iy = 0; iy < ny2; iy++)
+                {
+                    if (!external[iface])
+                    {
+                        int ndx[4];
+                        ndx[0] = iz * nx * ny + iy     * nx + ix;
+                        ndx[1] = iz * nx * ny + (iy+1) * nx + ix;
+                        ndx[2] = iz * nx * ny + (iy+1) * nx + (ix+1);
+                        ndx[3] = iz * nx * ny + iy     * nx + (ix+1);
+                        for (int in = 0; in < 4; in++)
+                        {
+                            ghostNodes->SetValue(ndx[in], 1);
+                        }
+                    }
+                    iface++;
+                }
+            }
+        }
+
+        assert(iface == nFaces[i]);
+
+        //
+        // Add the ghost data to the dataset.
+        //
+        vtkDataSet *d2 = d->NewInstance();
+        d2->ShallowCopy(d);
+        d2->GetPointData()->AddArray(ghostNodes);
+        ds.SetDataset(i, 0, d2);
+        d2->Delete();
+        ghostNodes->Delete();
+    }
+
+    //
+    // Free memory from calculating shared faces.
+    //
+    delete [] dsExtents;
+    delete [] nFaces;
+    for (int i = 0; i < nChunks; i++)
+        delete [] faceExtents[i];
+    delete [] faceExtents;
+    for (int i = 0; i < nChunks; i++)
+        delete [] faceExternal[i];
+    delete [] faceExternal;
+
+    return true;
+}
+
+
+// ****************************************************************************
+//  Method: avtGhostNodeGenerator::IsValid
+//
+//  Purpose:
+//    Check if the datasets meet the criteria to create ghost nodes with
+//    this class.
+//
+//  Programmer: Eric Brugger
+//  Creation:   May 28, 2020
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+bool
+avtGhostNodeGenerator::IsValid(avtDatasetCollection &ds)
+{
+    int nChunks = ds.GetNDomains();
+
+    //
+    // Check that we only have structured grids and that the total
+    // number of faces to consider is less than 20 million.
+    //
+    int valid = 1;
+    long long nFaces;
+    for (int i = 0; i < nChunks; i++)
+    {
+        vtkDataSet *d = ds.GetDataset(i, 0);
+        if (d->GetDataObjectType() != VTK_STRUCTURED_GRID)
+        {
+            valid = 0;
+            break;
+        }
+        vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
+
+        int ndims[3];
+        sgrid->GetDimensions(ndims);
+
+        int nx2 = ndims[0] - 1;
+        int ny2 = ndims[1] - 1;
+        int nz2 = ndims[2] - 1;
+
+        nFaces += nx2 * ny2 * 2 + nx2 * nz2 * 2 + ny2 * nz2 * 2;
+    }
+
+#ifdef PARALLEL
+    int valid2;
+    MPI_Allreduce(&valid, &valid2, 1, MPI_INT, MPI_MIN, VISIT_MPI_COMM);
+    valid = valid2;
+#endif
+
+    if (valid == 0)
+    {
+        debug1 << "Skipping ghost node creation since we don't have all "
+                  "structured grids." << endl;
+        return false;
+    }
+
+#ifdef PARALLEL
+    long long nFaces2;
+    MPI_Allreduce(&nFaces, &nFaces2, 1, MPI_LONG_LONG, MPI_SUM, VISIT_MPI_COMM);
+    nFaces = nFaces2;
+#endif
+
+    if (nFaces > 20000000)
+    {
+        debug1 << "Skipping ghost node creation since the total number of "
+                  "faces to consider is greater than 20 million." << endl;
+        return false;
+    }
+
+    return true;
+}

--- a/src/avt/Database/Ghost/avtGhostNodeGenerator.h
+++ b/src/avt/Database/Ghost/avtGhostNodeGenerator.h
@@ -49,8 +49,6 @@ class DATABASE_API avtGhostNodeGenerator
 
     bool                            CreateGhosts(avtDatasetCollection &ds);
 
-  protected:
-
   private:
     bool                            IsValid(avtDatasetCollection &ds);
 };

--- a/src/avt/Database/Ghost/avtGhostNodeGenerator.h
+++ b/src/avt/Database/Ghost/avtGhostNodeGenerator.h
@@ -1,0 +1,59 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+// ************************************************************************* //
+//                           avtGhostNodeGenerator.h                         //
+// ************************************************************************* //
+
+#ifndef AVT_GHOST_NODE_GENERATOR_H
+#define AVT_GHOST_NODE_GENERATOR_H
+
+#include <database_exports.h>
+
+#include <string>
+#include <vector>
+
+class avtDatasetCollection;
+
+// ****************************************************************************
+//  Class: avtGhostNodeGenerator
+//
+//  Purpose:
+//      It generates ghost nodes for a collection of structured grids.
+//
+//      It creates a list of the extents for all the faces for all the grids
+//      on a given processor and then does an all to all exchange so that
+//      each processor has the extents for all the faces for all the blocks.
+//      This in theory could use a lot of memory so if the total number
+//      of faces will exceed 20 million it doesn't execute.
+//
+//      There are some optimizations where it doesn't check faces between
+//      blocks that don't have any overlap or check ndividual faces against
+//      blocks that don't wholely contain the face.
+//
+//      The high level idea for the algorithm came from Matt Larsen.
+//
+//  Programmer: Eric Brugger
+//  Creation:   May 28, 2020
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+class DATABASE_API avtGhostNodeGenerator
+{
+  public:
+                                    avtGhostNodeGenerator();
+    virtual                        ~avtGhostNodeGenerator();
+
+    bool                            CreateGhosts(avtDatasetCollection &ds);
+
+  protected:
+
+  private:
+    bool                            IsValid(avtDatasetCollection &ds);
+};
+
+
+#endif

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -47,6 +47,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Revolve operator was enhanced to be capable of revolving points/particles.</li>
   <li>The Mili library was updated to version 19.2.</li>
   <li>The Lineout operator documentation was improved in the GUI manual to describe in detail how the sampling and interpolation is performed.</li>
+  <li>Added the ability to generate ghost nodes for datasets that consist of collections of structured grids by matching the coordinates of the nodes on the exterior of individual structured grids. The coordinates must match exactly for them to be matched. Ghost nodes allow internal faces to be eliminated from Mesh, Filled Boundary, Pseudocolor and Subset plots. This improves rendering performance by reducing the amount of geometery to render. It also improves image quality for images rendered with transparency since it eliminates geometry that you are most likely not interested in seeing.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -47,7 +47,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Revolve operator was enhanced to be capable of revolving points/particles.</li>
   <li>The Mili library was updated to version 19.2.</li>
   <li>The Lineout operator documentation was improved in the GUI manual to describe in detail how the sampling and interpolation is performed.</li>
-  <li>Added the ability to generate ghost nodes for datasets that consist of collections of structured grids by matching the coordinates of the nodes on the exterior of individual structured grids. The coordinates must match exactly for them to be matched. Ghost nodes allow internal faces to be eliminated from Mesh, Filled Boundary, Pseudocolor and Subset plots. This improves rendering performance by reducing the amount of geometery to render. It also improves image quality for images rendered with transparency since it eliminates geometry that you are most likely not interested in seeing.</li>
+  <li>Added the ability to generate ghost nodes for datasets that consist of collections of structured grids by matching the coordinates of the nodes on the exterior of individual structured grids. The coordinates must match exactly for them to be matched. Ghost nodes allow internal faces to be eliminated from Mesh, Filled Boundary, Pseudocolor and Subset plots. This improves rendering performance by reducing the amount of geometry to render. It also improves image quality for images rendered with transparency since it eliminates geometry that you are most likely not interested in seeing.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/hybrid/ghost_node.py
+++ b/src/test/tests/hybrid/ghost_node.py
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------------------------
+#  CLASSES: nightly
+#
+#  Test Case:  ghost_node.py 
+#
+#  Tests:      ghost node removal of multi_curv3d.silo
+#
+#  Programmer: Eric Brugger
+#  Date:       July 6, 2020 
+#
+#  Modifications:
+#
+# ----------------------------------------------------------------------------
+TurnOffAllAnnotations() # defines global object 'a'
+
+OpenDatabase(silo_data_path("multi_curv3d.silo"))
+
+AddPlot("Pseudocolor", "d")
+pc = PseudocolorAttributes()
+pc.opacityType = pc.Constant
+pc.opacityVariable = ""
+pc.opacity = 0.25
+SetPlotOptions(pc)
+DrawPlots()
+
+v = View3DAttributes()
+v.viewNormal = (-0.491824, 0.420414, 0.76247)
+v.focus = (0, 2.5, 15)
+v.viewUp = (0.214182, 0.907212, -0.362066)
+v.viewAngle = 30
+v.parallelScale = 16.0078
+v.nearPlane = -32.0156
+v.farPlane = 32.0156
+v.imagePan = (0, 0)
+v.imageZoom = 1
+SetView3D(v)
+
+Test("ghost_node_01")
+
+CloseDatabase(silo_data_path("multi_curv3d.silo"))
+
+Exit()

--- a/test/baseline/hybrid/ghost_node/ghost_node_01.png
+++ b/test/baseline/hybrid/ghost_node/ghost_node_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f3e7eeef1ce48e2bebfad2359a45ca667fe994d87e7328c76bfa2a69ebe1a04
+size 8565


### PR DESCRIPTION
### Description

Added the ability to generate ghost nodes for datasets that consist of collections of structured grids by matching the coordinates of the nodes on the exterior of individual structured grids. The coordinates must match exactly for them to be matched. Ghost nodes allow internal faces to be eliminated from Mesh, Filled Boundary, Pseudocolor and Subset plots. This improves rendering performance by reducing the amount of geometry to render. It also improves image quality for images rendered with transparency since it eliminates geometry that you are most likely not interested in seeing.

### Type of change

New feature.

### How Has This Been Tested?

I added a test using multi_curv3d.silo of a pseudocolor plot with transparency. The transparency allows one to verify that all the interior faces have been removed. I also tested it with a a CGNS dataset with 216 domains performing pseudocolor and subset plots of domains.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have added debugging support to my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added any new baselines to the repo
- [X] I have assigned reviewers