### PR TITLE
Fix test suite failures associated with ghost node creation addition.

### DIFF
--- a/src/avt/Database/Ghost/avtGhostNodeGenerator.C
+++ b/src/avt/Database/Ghost/avtGhostNodeGenerator.C
@@ -104,24 +104,21 @@ avtGhostNodeGenerator::CreateGhosts(avtDatasetCollection &ds)
     for (int i = 0; i < nChunks; i++)
     {
         vtkDataSet *d = ds.GetDataset(i, 0);
+        if (d == NULL)
+        {
+            dsExtents[i*6+0] = DBL_MAX;
+            dsExtents[i*6+1] = -DBL_MAX;
+            dsExtents[i*6+2] = DBL_MAX;
+            dsExtents[i*6+3] = -DBL_MAX;
+            dsExtents[i*6+4] = DBL_MAX;
+            dsExtents[i*6+5] = -DBL_MAX;
+            continue;
+        }
         vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
         vtkPoints *points = sgrid->GetPoints();
 
         int ndims[3];
         sgrid->GetDimensions(ndims);
-
-        int zdims[3];
-        zdims[0] = ndims[0] - 1;
-        zdims[1] = ndims[1] - 1;
-        zdims[2] = ndims[2] - 1;
-
-        int nx = ndims[0];
-        int ny = ndims[1];
-        int nxy = nx * ny;
-
-        int nx2 = zdims[0];
-        int ny2 = zdims[1];
-        int nxy2 = nx2 * ny2;
 
         int nxyz = ndims[0] * ndims[1] * ndims[2];
         double coord[3];
@@ -175,6 +172,13 @@ avtGhostNodeGenerator::CreateGhosts(avtDatasetCollection &ds)
     for (int i = 0; i < nChunks; i++)
     {
         vtkDataSet *d = ds.GetDataset(i, 0);
+        if (d == NULL)
+        {
+            nFaces[i] = 0;
+            faceExternal[i] = new bool[0];
+            faceExtents[i] = new double[0];
+            continue;
+        }
         vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
         vtkPoints *points = sgrid->GetPoints();
 
@@ -529,8 +533,11 @@ avtGhostNodeGenerator::CreateGhosts(avtDatasetCollection &ds)
     for (int i = 0; i < nChunks; i++)
     {
         vtkDataSet *d = ds.GetDataset(i, 0);
+        if (d == NULL)
+        {
+            continue;
+        }
         vtkStructuredGrid *sgrid = (vtkStructuredGrid *) d;
-        vtkPoints *points = sgrid->GetPoints();
 
         int ndims[3];
         sgrid->GetDimensions(ndims);
@@ -688,10 +695,14 @@ avtGhostNodeGenerator::IsValid(avtDatasetCollection &ds)
     // number of faces to consider is less than 20 million.
     //
     int valid = 1;
-    long long nFaces;
+    long long nFaces = 0;
     for (int i = 0; i < nChunks; i++)
     {
         vtkDataSet *d = ds.GetDataset(i, 0);
+        if (d == NULL)
+        {
+            continue;
+        }
         if (d->GetDataObjectType() != VTK_STRUCTURED_GRID)
         {
             valid = 0;
@@ -734,6 +745,8 @@ avtGhostNodeGenerator::IsValid(avtDatasetCollection &ds)
                   "faces to consider is greater than 20 million." << endl;
         return false;
     }
+
+    debug1 << "Performing ghost node creation." << endl;
 
     return true;
 }

--- a/test/baseline/databases/export_db/export_db_3_01.png
+++ b/test/baseline/databases/export_db/export_db_3_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94b794db573267ba7b519c71ab8c444b582e1cf72cec04924796e2fc14bb8da3
-size 15647
+oid sha256:f56f9229e1ea336b6c3d6790b9123eb8ebcde02a297db2a2e40640d2f0870bfa
+size 16790

--- a/test/baseline/databases/export_db/export_db_3_02.png
+++ b/test/baseline/databases/export_db/export_db_3_02.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a6292c099ce22ac13861fab17544486f6d2f93793397e6daa453126b9b952cb
-size 15309
+oid sha256:88759bafbb66744c7761dcc5038db4e0baf50cf6d04d3d434c4d3db7dc2fff63
+size 17162

--- a/test/baseline/databases/export_db/export_db_3_03.png
+++ b/test/baseline/databases/export_db/export_db_3_03.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4e5280b72a9610fc56884a7263b516ab12ca6fedaae4e6a92927870a929140f
-size 16088
+oid sha256:4c1752cc1d3c51df940717ae28469edc2a369d419f3d6d914c8f28a44cacaa2f
+size 17548

--- a/test/baseline/hybrid/mesh_quality/mesh_quality_05.png
+++ b/test/baseline/hybrid/mesh_quality/mesh_quality_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e632f0f84f0e2d94236c658be8af0768687308dfe2d0ed866ff32aec886db60a
-size 19375
+oid sha256:fcc3f841c87ab5fab67f2c347b7cd98e59ce785997426189317e20a83ccca458
+size 19373


### PR DESCRIPTION
### Description

This fixes the test suite failures associated with the changes I checked in yesterday to create ghost nodes for collections of structured grids. There were a few images that needed rebaselining. I also fixed some bugs associated with not all the processors having data. I also cleaned up some warnings with unused variables and uninitialized variables. I also fixed a bug in that could cause a deadlock that was probably very rare that was now being exposed by the test suite. There was some logic that decided to change the type of ghost information requested and it could be done differently on different processors. I added communication to sync them up so they would all request the same thing.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested the changes on all the test that failed.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I have added any new baselines to the repo