### PR TITLE
Modify internallauncher to unsetenv LD_PRELOAD.

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -2826,6 +2826,10 @@ class MainLauncher(object):
     #   Eric Brugger, Thu Jan  9 16:30:42 PST 2020
     #   Add lib/mesagl to the LD_LIBRARY_PATH for mcurvit.
     #
+    #   Eric Brugger, Tue Jul 14 12:51:01 PDT 2020
+    #   Add code to unsetenv LD_PRELOAD to protect against users setting
+    #   it for the GL library, which would break rendering.
+    #
     ############################################################################
 
     def SetupEnvironment(self):
@@ -2902,6 +2906,9 @@ class MainLauncher(object):
 
         # Unset QT_PLUGIN_PATH
         UNSETENV("QT_PLUGIN_PATH")
+
+        # Unset LD_PRELOAD
+        UNSETENV("LD_PRELOAD")
 
         # Turn off trapping of floating point exceptions.
         SETENV("TRAP_FPE", "")

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -50,6 +50,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added the ability to generate ghost nodes for datasets that consist of collections of structured grids by matching the coordinates of the nodes on the exterior of individual structured grids. The coordinates must match exactly for them to be matched. Ghost nodes allow internal faces to be eliminated from Mesh, Filled Boundary, Pseudocolor and Subset plots. This improves rendering performance by reducing the amount of geometry to render. It also improves image quality for images rendered with transparency since it eliminates geometry that you are most likely not interested in seeing.</li>
   <li>Updated the host profiles for the Sandia National Laboratories computer systems, adding host profiles for new systems and removing ones for obsolete systems.</li>
   <li>Added support for the FILETYPE keyword to the Tecplot reader. The FULL type is the only type supported. An error is generated if it isn't.</li>
+  <li>Modified the startup script to unsetenv LD_PRELOAD to protect against users setting it for the GL library, which would break rendering.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #4821 

I modified the internallauncher to unsetenv LD_PRELOAD to protect against users setting it to an incompatible libGL.so.1.

### Type of change

New feature.

### How Has This Been Tested?

I set LD_PRELOAD to /usr/lib/libGL.so.1 (the system one), which is incompatible with VisIt. I then ran VisIt and sure enough, rendering failed. I then made the change to internallauncher and ran VisIt again and everything worked fine.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers