### PR TITLE
Apply centos8 patch for Qt on RHEL8.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -57,6 +57,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.3</font></b></p>
 <ul>
   <li>The build_visit script was enhanced to allow VisIt to build on Ubuntu 20.</li>
+  <li>The build_visit script was enhanced to allow VisIt to build on Redhat Enterprise Linux 8.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -231,6 +231,14 @@ function apply_qt_patch
                     return 1
                 fi
             fi
+        elif [[ -f /etc/os-release ]] ; then
+            VER=`cat /etc/os-release | grep "REDHAT_SUPPORT_PRODUCT_VERSION" | cut -d'=' -f 2`
+            if [[ "${VER:1:1}" == "8" ]] ; then
+                apply_qt_5101_centos8_patch
+                if [[ $? != 0 ]] ; then
+                    return 1
+                fi
+            fi
         elif [[ -f /etc/issue ]] ; then
             VER=`cat /etc/issue | grep "Debian" | cut -d' ' -f 3`
             if [[ "${VER:0:2}" == "10" ]] ; then


### PR DESCRIPTION
### Description

Resolves #4881 

Modified build_visit to apply the centos8 patch for Qt on Redhat Enterprise Linux 8 systems (RHEL8).

### Type of change

New feature.

### How Has This Been Tested?

I don't have access to the RHEL8 system, so I tested the added logic on a Centos 8 system, that contains similar operating system identification information as RHEL8 systems.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers