### PR TITLE
Fixed a precision problem where fast gradient can result in double fo…

### DIFF
--- a/src/avt/Expressions/General/avtGradientExpression.C
+++ b/src/avt/Expressions/General/avtGradientExpression.C
@@ -1632,6 +1632,12 @@ avtGradientExpression::CalculateNodalToZonalHexGrad(vtkDataSet *ds,
 //    Add an argument for the output variable name, since this is now a static
 //    function.
 //
+//    Brad Whitlock, Fri Jul 17 11:33:38 PDT 2020
+//    Use NewInstance to allocate cell grad so we preserve the input array's
+//    precision. This prevents the value from being removed downstream in
+//    the avtCompactTreeFilter (variables with mixed types get hashed to
+//    different keys in VTK).
+//
 // ****************************************************************************
 
 vtkDataArray *
@@ -1651,7 +1657,7 @@ avtGradientExpression::FastGradient(vtkDataSet *in_ds,
     if (!allHexes)
         return NULL;
 
-    vtkDoubleArray *cellGrad = vtkDoubleArray::New();
+    vtkDataArray *cellGrad = arr->NewInstance();
     cellGrad->SetNumberOfComponents(3);
     cellGrad->SetNumberOfTuples(ncells);
     cellGrad->SetName("tmpGrad");

--- a/src/config-site/optimusprime.local.cmake
+++ b/src/config-site/optimusprime.local.cmake
@@ -74,7 +74,8 @@ VISIT_OPTION_DEFAULT(VISIT_VTK_DIR ${VISITHOME}/vtk/${VTK_VERSION}/${VISITARCH})
 ## MPICH
 ##
 # Give VisIt information so it can install MPI into the binary distribution.
-VISIT_OPTION_DEFAULT(VISIT_MPICH_DIR ${VISITHOME}/mpich/3.0.4/${VISITARCH})
+#VISIT_OPTION_DEFAULT(VISIT_MPICH_DIR ${VISITHOME}/mpich/3.0.4/${VISITARCH})
+VISIT_OPTION_DEFAULT(VISIT_MPICH_DIR /usr/local/mpich-3.3.2)
 VISIT_OPTION_DEFAULT(VISIT_MPICH_INSTALL ON TYPE BOOL)
 
 # Tell VisIt the parallel compiler so it can deduce parallel flags


### PR DESCRIPTION
…r some domains, float for non hex domains. This later causes scalars made from the gradient to be eliminated, resulting in a white Pseudocolor plot.

### Description

Resolves #4902 

I changed the fast gradient routine so it makes its output gradient using the same type as the input scalar.


### Type of change

Bug fix.

### How Has This Been Tested?

Locally, using a specific file.

### Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [ ] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
