### PR TITLE
Mili configure on mac

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -1028,8 +1028,15 @@ function build_mili
          extra_ac_flags="ac_cv_build=powerpc64le-unknown-linux-gnu"
     fi
 
+    # The 19.2 configure script does not play well with our fortran mac patch.
+    # We can use an older configure script that includes this patch already.
+    config_script=configure
+    if [[ "$OPSYS" == "Darwin" ]]; then
+        config_script=configure_15_1
+    fi
+
     info "Invoking command to configure Mili"
-    ./configure CXX="$CXX_COMPILER" CC="$C_COMPILER" \
+    ./${config_script} CXX="$CXX_COMPILER" CC="$C_COMPILER" \
                 CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
                 ac_cv_prog_FOUND_GMAKE=make $extra_ac_flags \
                 --prefix="$VISITDIR/mili/$MILI_VERSION/$VISITARCH"


### PR DESCRIPTION
### Description

The Mili 19.2 configure script is quite a bit different than the 15.1 version, and our fortran patch does not work with it. As a result, building on mac without a fortran compiler will fail. I've updated the bv_mili script to use the older 15.1 configure script when on Mac, and I've confirmed with Kevin Durrenberger that this should be okay. 

Resolves #4898 



### Type of change
Bug fix.

### How Has This Been Tested?

I've built third-party libs (including mili) on Mac and built VisIt against them.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
