### PR TITLE
Mili material repeats

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2706,6 +2706,10 @@ avtMiliFileFormat::AddMiliDerivedVariables(avtDatabaseMetaData *md,
 //      We don't need to add the OriginalZone/NodeLabels for the
 //      sand mesh.
 //
+//      Alister Maguire, Tue Jul 21 10:52:18 PDT 2020
+//      No need to add the materials for each mesh. Only add to the
+//      non-sand mesh.
+//
 // ****************************************************************************
 
 void
@@ -2796,13 +2800,6 @@ avtMiliFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md,
             sandMesh->hasSpatialExtents    = false;
 
             md->Add(sandMesh);
-
-            AddMaterialToMetaData(md,
-                                  matName,
-                                  sandMeshName,
-                                  numMats,
-                                  matNames,
-                                  matColors);
         }
 
         //

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -38,7 +38,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug preventing VisIt from correctly reading some types of files on Ubuntu when using non-English language settings.</li>
   <li>Adding and deleting expressions in the expressions window now only takes effect when actually clicking the apply button.</li>
   <li>Fixed a bug with the CGNS reader that caused VisIt to crash when doing a Subset plot of "zones" when reading data decomposed across multiple CGNS files.</li>
-  <li>Fixed a bug preventing database readers from being able to plot variables of the form "variable_name(subname)".</li>
+  <li>Fixed a bug preventing database plugins from being able to plot variables of the form "variable_name(subname)".</li>
+  <li>Fixed a bug which caused the Mili database plugin to add duplicate materials.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

The materials only needed to be added to one mesh in the database plugins. Mili was adding them to both the regular mesh and the sand mesh, which resulted in extra materials showing up in the explode operator menu.

Resolves #4910 

### Type of change

Bug fix.

### How Has This Been Tested?
I've investigated the changes using FilledBoundary and the explode operator.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
