### PR TITLE
Update the pixie test results.

### DIFF
--- a/test/baseline/databases/pixie/mode_specific.json
+++ b/test/baseline/databases/pixie/mode_specific.json
@@ -1,5 +1,0 @@
-{"modes":
-    {"scalable,parallel,icet":
-        {"pixie_06.png" : "scalable_parallel"}
-     }
-}

--- a/test/baseline/databases/pixie/parallel/pixie_06.png
+++ b/test/baseline/databases/pixie/parallel/pixie_06.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6bd608ecec2216e6d539968180906896da9d1dcc88af46502fa4beaeecc3f939
-size 3829
+oid sha256:2dcc1d5121246fce2bbf933bac86fa61f6c3c957dffc753eebeba50c08c5f878
+size 3787

--- a/test/baseline/databases/pixie/scalable_parallel/pixie_06.png
+++ b/test/baseline/databases/pixie/scalable_parallel/pixie_06.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bd608ecec2216e6d539968180906896da9d1dcc88af46502fa4beaeecc3f939
-size 3829


### PR DESCRIPTION
### Description

Updated the pixie test results. Removed the scalable,parallel,icet mode specific baselines since they were no longer necessary. I updated one of the parallel mode specific baselines. It still isn't 100% correct and doesn't match the serial result, but it is an improvement, so progress is being made.

### Type of change

Bug fix.

### How Has This Been Tested?

I ran the test suite on quartz for pixie and confirmed that the tests pass in all modes.

### Checklist:

- [X] I have added any new baselines to the repo