### PR TITLE
Merge from 3.1RC.

### DIFF
--- a/src/gui/QvisPlotManagerWidget.C
+++ b/src/gui/QvisPlotManagerWidget.C
@@ -25,6 +25,7 @@
 #include <QToolButton>
 #include <QButtonGroup>
 #include <QRadioButton>
+#include <QScrollBar>
 
 #include <GetMetaDataException.h>
 
@@ -199,6 +200,10 @@ using std::vector;
 //   Brad Whitlock, Fri Sep 13 12:24:36 PDT 2013
 //   Hook up plot animation.
 //
+//   Kevin Griffin, Wed Aug 12 11:40:27 PDT 2020
+//   Updated the vertical scroll bar mode to ScrollPerPixel and to use a
+//   single step.
+//
 // ****************************************************************************
 
 QvisPlotManagerWidget::QvisPlotManagerWidget(QMenuBar *menuBar,QWidget *parent)
@@ -280,6 +285,8 @@ QvisPlotManagerWidget::QvisPlotManagerWidget(QMenuBar *menuBar,QWidget *parent)
     plotListBox = new QvisPlotListBox(this);
     plotListBox->setSelectionMode(QAbstractItemView::ExtendedSelection);
     plotListBox->setMinimumHeight(fontMetrics().boundingRect("X").height() * 6);
+    plotListBox->verticalScrollBar()->setSingleStep(1);
+    plotListBox->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     topLayout->addWidget(plotListBox,10);
 
     connect(plotListBox, SIGNAL(itemSelectionChanged()),

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -40,6 +40,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the CGNS reader that caused VisIt to crash when doing a Subset plot of "zones" when reading data decomposed across multiple CGNS files.</li>
   <li>Fixed a bug preventing database plugins from being able to plot variables of the form "variable_name(subname)".</li>
   <li>Fixed a bug which caused the Mili database plugin to add duplicate materials.</li>
+  <li>Fixed a bug which caused external surfaces to be lost in the pseudocolor plot when using a gradient expression on a Curvilinear mesh (Structured Grid)</li>
+ <li>Changed the vertical scroll bar mode for the plot list to <b>ScrollPerPixel</b> and to use a single step so that the bottom of the plot list is not cutoff.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #3781. Changed vertical scroll mode for plot list to ScrollPerPixel and to use a single step so the plot list is not cut off.