### PR TITLE
out-of-source build manuals

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -444,9 +444,12 @@
 #      VISIT_DATA_MANUAL_EXAMPLES => VISIT_ENABLE_DATA_MANUAL_EXAMPLES
 #      VISIT_BUILD_DIAGNOSTICS    => VISIT_ENABLE_DIAGNOSTICS
 #      VISIT_BUILD_AVTEXAMPLES    => VISIT_ENABLE_EXAMPLES
-
+#
 #    Kathleen Biagas, Thu Feb 20 14:45:33 MST 2020
 #    Having trouble with sphinx-build exe (Win10), so use script instead.
+#
+#    Alister Maguire, Thu Aug 13 13:41:20 PDT 2020
+#    Updated the manuals target so that it builds in the binary directory.
 #
 #****************************************************************************
 
@@ -2301,7 +2304,7 @@ if(VISIT_PYTHON3_DIR AND VISIT_ENABLE_MANUALS)
         CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
   else()
     add_custom_target(manuals
-                  COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build -b html ${VISIT_SOURCE_DIR}/doc ${VISIT_SOURCE_DIR}/resources/help/en_US/manual -a)
+                  COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build -b html ${VISIT_SOURCE_DIR}/doc ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
   endif()
 endif()
 

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -43,6 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug preventing some multi-processor mili datasets from being properly read.</li>
   <li>Fixed a bug which caused external surfaces to be lost in the pseudocolor plot when using a gradient expression on a Curvilinear mesh (Structured Grid)</li>
  <li>Changed the vertical scroll bar mode for the plot list to <b>ScrollPerPixel</b> and to use a single step so that the bottom of the plot list is not cutoff.</li>
+  <li>Fixed a bug preventing VisIt from displaying the manuals when using an out-of-source build.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

This PR make a slight change to the manuals target so that it is built in the binary directory. This fixes an issue where VisIt couldn't find the manuals for out-of-source builds.

Resolves #4968 

### Type of change

Bug fix

### How Has This Been Tested?

I've confirmed that VisIt can now find the manuals for out-of-source builds.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
