### PR TITLE
Fix python atts richcompare method.

### DIFF
--- a/src/operators/AMRStitchCell/PyAMRStitchCellAttributes.C
+++ b/src/operators/AMRStitchCell/PyAMRStitchCellAttributes.C
@@ -229,8 +229,8 @@ static PyObject *
 AMRStitchCellAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AMRStitchCellAttributesType)
+    if ( Py_TYPE(self) != &AMRStitchCellAttributesType
+         || Py_TYPE(other) != &AMRStitchCellAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/AxisAlignedSlice4D/PyAxisAlignedSlice4DAttributes.C
+++ b/src/operators/AxisAlignedSlice4D/PyAxisAlignedSlice4DAttributes.C
@@ -504,8 +504,8 @@ static PyObject *
 AxisAlignedSlice4DAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AxisAlignedSlice4DAttributesType)
+    if ( Py_TYPE(self) != &AxisAlignedSlice4DAttributesType
+         || Py_TYPE(other) != &AxisAlignedSlice4DAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/BoundaryOp/PyBoundaryOpAttributes.C
+++ b/src/operators/BoundaryOp/PyBoundaryOpAttributes.C
@@ -196,8 +196,8 @@ static PyObject *
 BoundaryOpAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &BoundaryOpAttributesType)
+    if ( Py_TYPE(self) != &BoundaryOpAttributesType
+         || Py_TYPE(other) != &BoundaryOpAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Box/PyBoxAttributes.C
+++ b/src/operators/Box/PyBoxAttributes.C
@@ -450,8 +450,8 @@ static PyObject *
 BoxAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &BoxAttributesType)
+    if ( Py_TYPE(self) != &BoxAttributesType
+         || Py_TYPE(other) != &BoxAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/CartographicProjection/PyCartographicProjectionAttributes.C
+++ b/src/operators/CartographicProjection/PyCartographicProjectionAttributes.C
@@ -312,8 +312,8 @@ static PyObject *
 CartographicProjectionAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &CartographicProjectionAttributesType)
+    if ( Py_TYPE(self) != &CartographicProjectionAttributesType
+         || Py_TYPE(other) != &CartographicProjectionAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Clip/PyClipAttributes.C
+++ b/src/operators/Clip/PyClipAttributes.C
@@ -1094,8 +1094,8 @@ static PyObject *
 ClipAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ClipAttributesType)
+    if ( Py_TYPE(self) != &ClipAttributesType
+         || Py_TYPE(other) != &ClipAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Cone/PyConeAttributes.C
+++ b/src/operators/Cone/PyConeAttributes.C
@@ -556,8 +556,8 @@ static PyObject *
 ConeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ConeAttributesType)
+    if ( Py_TYPE(self) != &ConeAttributesType
+         || Py_TYPE(other) != &ConeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ConnCompReduce/PyConnCompReduceAttributes.C
+++ b/src/operators/ConnCompReduce/PyConnCompReduceAttributes.C
@@ -196,8 +196,8 @@ static PyObject *
 ConnCompReduceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ConnCompReduceAttributesType)
+    if ( Py_TYPE(self) != &ConnCompReduceAttributesType
+         || Py_TYPE(other) != &ConnCompReduceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ConnectedComponents/PyConnectedComponentsAttributes.C
+++ b/src/operators/ConnectedComponents/PyConnectedComponentsAttributes.C
@@ -199,8 +199,8 @@ static PyObject *
 ConnectedComponentsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ConnectedComponentsAttributesType)
+    if ( Py_TYPE(self) != &ConnectedComponentsAttributesType
+         || Py_TYPE(other) != &ConnectedComponentsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Context/PyContextAttributes.C
+++ b/src/operators/Context/PyContextAttributes.C
@@ -388,8 +388,8 @@ static PyObject *
 ContextAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ContextAttributesType)
+    if ( Py_TYPE(self) != &ContextAttributesType
+         || Py_TYPE(other) != &ContextAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/CoordSwap/PyCoordSwapAttributes.C
+++ b/src/operators/CoordSwap/PyCoordSwapAttributes.C
@@ -359,8 +359,8 @@ static PyObject *
 CoordSwapAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &CoordSwapAttributesType)
+    if ( Py_TYPE(self) != &CoordSwapAttributesType
+         || Py_TYPE(other) != &CoordSwapAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/CracksClipper/PyCracksClipperAttributes.C
+++ b/src/operators/CracksClipper/PyCracksClipperAttributes.C
@@ -429,8 +429,8 @@ static PyObject *
 CracksClipperAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &CracksClipperAttributesType)
+    if ( Py_TYPE(self) != &CracksClipperAttributesType
+         || Py_TYPE(other) != &CracksClipperAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/CreateBonds/PyCreateBondsAttributes.C
+++ b/src/operators/CreateBonds/PyCreateBondsAttributes.C
@@ -971,8 +971,8 @@ static PyObject *
 CreateBondsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &CreateBondsAttributesType)
+    if ( Py_TYPE(self) != &CreateBondsAttributesType
+         || Py_TYPE(other) != &CreateBondsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Cylinder/PyCylinderAttributes.C
+++ b/src/operators/Cylinder/PyCylinderAttributes.C
@@ -383,8 +383,8 @@ static PyObject *
 CylinderAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &CylinderAttributesType)
+    if ( Py_TYPE(self) != &CylinderAttributesType
+         || Py_TYPE(other) != &CylinderAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/DataBinning/PyDataBinningAttributes.C
+++ b/src/operators/DataBinning/PyDataBinningAttributes.C
@@ -1252,8 +1252,8 @@ static PyObject *
 DataBinningAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DataBinningAttributesType)
+    if ( Py_TYPE(self) != &DataBinningAttributesType
+         || Py_TYPE(other) != &DataBinningAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Decimate/PyDecimateAttributes.C
+++ b/src/operators/Decimate/PyDecimateAttributes.C
@@ -196,8 +196,8 @@ static PyObject *
 DecimateAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DecimateAttributesType)
+    if ( Py_TYPE(self) != &DecimateAttributesType
+         || Py_TYPE(other) != &DecimateAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/DeferExpression/PyDeferExpressionAttributes.C
+++ b/src/operators/DeferExpression/PyDeferExpressionAttributes.C
@@ -241,8 +241,8 @@ static PyObject *
 DeferExpressionAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DeferExpressionAttributesType)
+    if ( Py_TYPE(self) != &DeferExpressionAttributesType
+         || Py_TYPE(other) != &DeferExpressionAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Delaunay/PyDelaunayAttributes.C
+++ b/src/operators/Delaunay/PyDelaunayAttributes.C
@@ -229,8 +229,8 @@ static PyObject *
 DelaunayAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DelaunayAttributesType)
+    if ( Py_TYPE(self) != &DelaunayAttributesType
+         || Py_TYPE(other) != &DelaunayAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Displace/PyDisplaceAttributes.C
+++ b/src/operators/Displace/PyDisplaceAttributes.C
@@ -228,8 +228,8 @@ static PyObject *
 DisplaceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DisplaceAttributesType)
+    if ( Py_TYPE(self) != &DisplaceAttributesType
+         || Py_TYPE(other) != &DisplaceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/DualMesh/PyDualMeshAttributes.C
+++ b/src/operators/DualMesh/PyDualMeshAttributes.C
@@ -229,8 +229,8 @@ static PyObject *
 DualMeshAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DualMeshAttributesType)
+    if ( Py_TYPE(self) != &DualMeshAttributesType
+         || Py_TYPE(other) != &DualMeshAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Edge/PyEdgeAttributes.C
+++ b/src/operators/Edge/PyEdgeAttributes.C
@@ -199,8 +199,8 @@ static PyObject *
 EdgeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &EdgeAttributesType)
+    if ( Py_TYPE(self) != &EdgeAttributesType
+         || Py_TYPE(other) != &EdgeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Elevate/PyElevateAttributes.C
+++ b/src/operators/Elevate/PyElevateAttributes.C
@@ -586,8 +586,8 @@ static PyObject *
 ElevateAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ElevateAttributesType)
+    if ( Py_TYPE(self) != &ElevateAttributesType
+         || Py_TYPE(other) != &ElevateAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/EllipsoidSlice/PyEllipsoidSliceAttributes.C
+++ b/src/operators/EllipsoidSlice/PyEllipsoidSliceAttributes.C
@@ -392,8 +392,8 @@ static PyObject *
 EllipsoidSliceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &EllipsoidSliceAttributesType)
+    if ( Py_TYPE(self) != &EllipsoidSliceAttributesType
+         || Py_TYPE(other) != &EllipsoidSliceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Explode/PyExplodeAttributes.C
+++ b/src/operators/Explode/PyExplodeAttributes.C
@@ -1081,8 +1081,8 @@ static PyObject *
 ExplodeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExplodeAttributesType)
+    if ( Py_TYPE(self) != &ExplodeAttributesType
+         || Py_TYPE(other) != &ExplodeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ExternalSurface/PyExternalSurfaceAttributes.C
+++ b/src/operators/ExternalSurface/PyExternalSurfaceAttributes.C
@@ -234,8 +234,8 @@ static PyObject *
 ExternalSurfaceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExternalSurfaceAttributesType)
+    if ( Py_TYPE(self) != &ExternalSurfaceAttributesType
+         || Py_TYPE(other) != &ExternalSurfaceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ExtractPointFunction2D/PyExtractPointFunction2DAttributes.C
+++ b/src/operators/ExtractPointFunction2D/PyExtractPointFunction2DAttributes.C
@@ -334,8 +334,8 @@ static PyObject *
 ExtractPointFunction2DAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExtractPointFunction2DAttributesType)
+    if ( Py_TYPE(self) != &ExtractPointFunction2DAttributesType
+         || Py_TYPE(other) != &ExtractPointFunction2DAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Extrude/PyExtrudeAttributes.C
+++ b/src/operators/Extrude/PyExtrudeAttributes.C
@@ -406,8 +406,8 @@ static PyObject *
 ExtrudeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExtrudeAttributesType)
+    if ( Py_TYPE(self) != &ExtrudeAttributesType
+         || Py_TYPE(other) != &ExtrudeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/FFT/PyFFTAttributes.C
+++ b/src/operators/FFT/PyFFTAttributes.C
@@ -196,8 +196,8 @@ static PyObject *
 FFTAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &FFTAttributesType)
+    if ( Py_TYPE(self) != &FFTAttributesType
+         || Py_TYPE(other) != &FFTAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/FiveFoldTetSubdivision/PyFiveFoldTetSubdivisionAttributes.C
+++ b/src/operators/FiveFoldTetSubdivision/PyFiveFoldTetSubdivisionAttributes.C
@@ -532,8 +532,8 @@ static PyObject *
 FiveFoldTetSubdivisionAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &FiveFoldTetSubdivisionAttributesType)
+    if ( Py_TYPE(self) != &FiveFoldTetSubdivisionAttributesType
+         || Py_TYPE(other) != &FiveFoldTetSubdivisionAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Flux/PyFluxAttributes.C
+++ b/src/operators/Flux/PyFluxAttributes.C
@@ -263,8 +263,8 @@ static PyObject *
 FluxAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &FluxAttributesType)
+    if ( Py_TYPE(self) != &FluxAttributesType
+         || Py_TYPE(other) != &FluxAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/IndexSelect/PyIndexSelectAttributes.C
+++ b/src/operators/IndexSelect/PyIndexSelectAttributes.C
@@ -882,8 +882,8 @@ static PyObject *
 IndexSelectAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &IndexSelectAttributesType)
+    if ( Py_TYPE(self) != &IndexSelectAttributesType
+         || Py_TYPE(other) != &IndexSelectAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/IntegralCurve/PyIntegralCurveAttributes.C
+++ b/src/operators/IntegralCurve/PyIntegralCurveAttributes.C
@@ -3533,8 +3533,8 @@ static PyObject *
 IntegralCurveAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &IntegralCurveAttributesType)
+    if ( Py_TYPE(self) != &IntegralCurveAttributesType
+         || Py_TYPE(other) != &IntegralCurveAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/InverseGhostZone/PyInverseGhostZoneAttributes.C
+++ b/src/operators/InverseGhostZone/PyInverseGhostZoneAttributes.C
@@ -409,8 +409,8 @@ static PyObject *
 InverseGhostZoneAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &InverseGhostZoneAttributesType)
+    if ( Py_TYPE(self) != &InverseGhostZoneAttributesType
+         || Py_TYPE(other) != &InverseGhostZoneAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Isosurface/PyIsosurfaceAttributes.C
+++ b/src/operators/Isosurface/PyIsosurfaceAttributes.C
@@ -656,8 +656,8 @@ static PyObject *
 IsosurfaceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &IsosurfaceAttributesType)
+    if ( Py_TYPE(self) != &IsosurfaceAttributesType
+         || Py_TYPE(other) != &IsosurfaceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Isovolume/PyIsovolumeAttributes.C
+++ b/src/operators/Isovolume/PyIsovolumeAttributes.C
@@ -260,8 +260,8 @@ static PyObject *
 IsovolumeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &IsovolumeAttributesType)
+    if ( Py_TYPE(self) != &IsovolumeAttributesType
+         || Py_TYPE(other) != &IsovolumeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/LCS/PyLCSAttributes.C
+++ b/src/operators/LCS/PyLCSAttributes.C
@@ -2654,8 +2654,8 @@ static PyObject *
 LCSAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LCSAttributesType)
+    if ( Py_TYPE(self) != &LCSAttributesType
+         || Py_TYPE(other) != &LCSAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Lagrangian/PyLagrangianAttributes.C
+++ b/src/operators/Lagrangian/PyLagrangianAttributes.C
@@ -474,8 +474,8 @@ static PyObject *
 LagrangianAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LagrangianAttributesType)
+    if ( Py_TYPE(self) != &LagrangianAttributesType
+         || Py_TYPE(other) != &LagrangianAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/LimitCycle/PyLimitCycleAttributes.C
+++ b/src/operators/LimitCycle/PyLimitCycleAttributes.C
@@ -2755,8 +2755,8 @@ static PyObject *
 LimitCycleAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LimitCycleAttributesType)
+    if ( Py_TYPE(self) != &LimitCycleAttributesType
+         || Py_TYPE(other) != &LimitCycleAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/LineSampler/PyLineSamplerAttributes.C
+++ b/src/operators/LineSampler/PyLineSamplerAttributes.C
@@ -2437,8 +2437,8 @@ static PyObject *
 LineSamplerAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LineSamplerAttributesType)
+    if ( Py_TYPE(self) != &LineSamplerAttributesType
+         || Py_TYPE(other) != &LineSamplerAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Lineout/PyLineoutAttributes.C
+++ b/src/operators/Lineout/PyLineoutAttributes.C
@@ -488,8 +488,8 @@ static PyObject *
 LineoutAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LineoutAttributesType)
+    if ( Py_TYPE(self) != &LineoutAttributesType
+         || Py_TYPE(other) != &LineoutAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Merge/PyMergeOperatorAttributes.C
+++ b/src/operators/Merge/PyMergeOperatorAttributes.C
@@ -231,8 +231,8 @@ static PyObject *
 MergeOperatorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MergeOperatorAttributesType)
+    if ( Py_TYPE(self) != &MergeOperatorAttributesType
+         || Py_TYPE(other) != &MergeOperatorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/MetricThreshold/PyMetricThresholdAttributes.C
+++ b/src/operators/MetricThreshold/PyMetricThresholdAttributes.C
@@ -942,8 +942,8 @@ static PyObject *
 MetricThresholdAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MetricThresholdAttributesType)
+    if ( Py_TYPE(self) != &MetricThresholdAttributesType
+         || Py_TYPE(other) != &MetricThresholdAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ModelFit/PyModelFitAtts.C
+++ b/src/operators/ModelFit/PyModelFitAtts.C
@@ -1097,8 +1097,8 @@ static PyObject *
 ModelFitAtts_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ModelFitAttsType)
+    if ( Py_TYPE(self) != &ModelFitAttsType
+         || Py_TYPE(other) != &ModelFitAttsType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/MultiresControl/PyMultiresControlAttributes.C
+++ b/src/operators/MultiresControl/PyMultiresControlAttributes.C
@@ -259,8 +259,8 @@ static PyObject *
 MultiresControlAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MultiresControlAttributesType)
+    if ( Py_TYPE(self) != &MultiresControlAttributesType
+         || Py_TYPE(other) != &MultiresControlAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/OnionPeel/PyOnionPeelAttributes.C
+++ b/src/operators/OnionPeel/PyOnionPeelAttributes.C
@@ -568,8 +568,8 @@ static PyObject *
 OnionPeelAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &OnionPeelAttributesType)
+    if ( Py_TYPE(self) != &OnionPeelAttributesType
+         || Py_TYPE(other) != &OnionPeelAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/PDF/PyPDFAttributes.C
+++ b/src/operators/PDF/PyPDFAttributes.C
@@ -1202,8 +1202,8 @@ static PyObject *
 PDFAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PDFAttributesType)
+    if ( Py_TYPE(self) != &PDFAttributesType
+         || Py_TYPE(other) != &PDFAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/PersistentParticles/PyPersistentParticlesAttributes.C
+++ b/src/operators/PersistentParticles/PyPersistentParticlesAttributes.C
@@ -576,8 +576,8 @@ static PyObject *
 PersistentParticlesAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PersistentParticlesAttributesType)
+    if ( Py_TYPE(self) != &PersistentParticlesAttributesType
+         || Py_TYPE(other) != &PersistentParticlesAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Poincare/PyPoincareAttributes.C
+++ b/src/operators/Poincare/PyPoincareAttributes.C
@@ -3551,8 +3551,8 @@ static PyObject *
 PoincareAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PoincareAttributesType)
+    if ( Py_TYPE(self) != &PoincareAttributesType
+         || Py_TYPE(other) != &PoincareAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Project/PyProjectAttributes.C
+++ b/src/operators/Project/PyProjectAttributes.C
@@ -322,8 +322,8 @@ static PyObject *
 ProjectAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ProjectAttributesType)
+    if ( Py_TYPE(self) != &ProjectAttributesType
+         || Py_TYPE(other) != &ProjectAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/RadialResample/PyRadialResampleAttributes.C
+++ b/src/operators/RadialResample/PyRadialResampleAttributes.C
@@ -565,8 +565,8 @@ static PyObject *
 RadialResampleAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &RadialResampleAttributesType)
+    if ( Py_TYPE(self) != &RadialResampleAttributesType
+         || Py_TYPE(other) != &RadialResampleAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Reflect/PyReflectAttributes.C
+++ b/src/operators/Reflect/PyReflectAttributes.C
@@ -749,8 +749,8 @@ static PyObject *
 ReflectAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ReflectAttributesType)
+    if ( Py_TYPE(self) != &ReflectAttributesType
+         || Py_TYPE(other) != &ReflectAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Remap/PyRemapAttributes.C
+++ b/src/operators/Remap/PyRemapAttributes.C
@@ -581,8 +581,8 @@ static PyObject *
 RemapAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &RemapAttributesType)
+    if ( Py_TYPE(self) != &RemapAttributesType
+         || Py_TYPE(other) != &RemapAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/RemoveCells/PyRemoveCellsAttributes.C
+++ b/src/operators/RemoveCells/PyRemoveCellsAttributes.C
@@ -334,8 +334,8 @@ static PyObject *
 RemoveCellsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &RemoveCellsAttributesType)
+    if ( Py_TYPE(self) != &RemoveCellsAttributesType
+         || Py_TYPE(other) != &RemoveCellsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Replicate/PyReplicateAttributes.C
+++ b/src/operators/Replicate/PyReplicateAttributes.C
@@ -704,8 +704,8 @@ static PyObject *
 ReplicateAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ReplicateAttributesType)
+    if ( Py_TYPE(self) != &ReplicateAttributesType
+         || Py_TYPE(other) != &ReplicateAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Resample/PyResampleAttributes.C
+++ b/src/operators/Resample/PyResampleAttributes.C
@@ -721,8 +721,8 @@ static PyObject *
 ResampleAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ResampleAttributesType)
+    if ( Py_TYPE(self) != &ResampleAttributesType
+         || Py_TYPE(other) != &ResampleAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Revolve/PyRevolveAttributes.C
+++ b/src/operators/Revolve/PyRevolveAttributes.C
@@ -442,8 +442,8 @@ static PyObject *
 RevolveAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &RevolveAttributesType)
+    if ( Py_TYPE(self) != &RevolveAttributesType
+         || Py_TYPE(other) != &RevolveAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/SPHResample/PySPHResampleAttributes.C
+++ b/src/operators/SPHResample/PySPHResampleAttributes.C
@@ -550,8 +550,8 @@ static PyObject *
 SPHResampleAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SPHResampleAttributesType)
+    if ( Py_TYPE(self) != &SPHResampleAttributesType
+         || Py_TYPE(other) != &SPHResampleAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Slice/PySliceAttributes.C
+++ b/src/operators/Slice/PySliceAttributes.C
@@ -941,8 +941,8 @@ static PyObject *
 SliceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SliceAttributesType)
+    if ( Py_TYPE(self) != &SliceAttributesType
+         || Py_TYPE(other) != &SliceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Smooth/PySmoothOperatorAttributes.C
+++ b/src/operators/Smooth/PySmoothOperatorAttributes.C
@@ -394,8 +394,8 @@ static PyObject *
 SmoothOperatorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SmoothOperatorAttributesType)
+    if ( Py_TYPE(self) != &SmoothOperatorAttributesType
+         || Py_TYPE(other) != &SmoothOperatorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/SphereSlice/PySphereSliceAttributes.C
+++ b/src/operators/SphereSlice/PySphereSliceAttributes.C
@@ -272,8 +272,8 @@ static PyObject *
 SphereSliceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SphereSliceAttributesType)
+    if ( Py_TYPE(self) != &SphereSliceAttributesType
+         || Py_TYPE(other) != &SphereSliceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Stagger/PyStaggerAttributes.C
+++ b/src/operators/Stagger/PyStaggerAttributes.C
@@ -260,8 +260,8 @@ static PyObject *
 StaggerAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &StaggerAttributesType)
+    if ( Py_TYPE(self) != &StaggerAttributesType
+         || Py_TYPE(other) != &StaggerAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/StatisticalTrends/PyStatisticalTrendsAttributes.C
+++ b/src/operators/StatisticalTrends/PyStatisticalTrendsAttributes.C
@@ -587,8 +587,8 @@ static PyObject *
 StatisticalTrendsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &StatisticalTrendsAttributesType)
+    if ( Py_TYPE(self) != &StatisticalTrendsAttributesType
+         || Py_TYPE(other) != &StatisticalTrendsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/SubdivideQuads/PySubdivideQuadsAttributes.C
+++ b/src/operators/SubdivideQuads/PySubdivideQuadsAttributes.C
@@ -330,8 +330,8 @@ static PyObject *
 SubdivideQuadsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SubdivideQuadsAttributesType)
+    if ( Py_TYPE(self) != &SubdivideQuadsAttributesType
+         || Py_TYPE(other) != &SubdivideQuadsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/SurfCompPrep/PySurfCompPrepAttributes.C
+++ b/src/operators/SurfCompPrep/PySurfCompPrepAttributes.C
@@ -870,8 +870,8 @@ static PyObject *
 SurfCompPrepAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SurfCompPrepAttributesType)
+    if ( Py_TYPE(self) != &SurfCompPrepAttributesType
+         || Py_TYPE(other) != &SurfCompPrepAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/SurfaceNormal/PySurfaceNormalAttributes.C
+++ b/src/operators/SurfaceNormal/PySurfaceNormalAttributes.C
@@ -223,8 +223,8 @@ static PyObject *
 SurfaceNormalAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SurfaceNormalAttributesType)
+    if ( Py_TYPE(self) != &SurfaceNormalAttributesType
+         || Py_TYPE(other) != &SurfaceNormalAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Tessellate/PyTessellateAttributes.C
+++ b/src/operators/Tessellate/PyTessellateAttributes.C
@@ -231,8 +231,8 @@ static PyObject *
 TessellateAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TessellateAttributesType)
+    if ( Py_TYPE(self) != &TessellateAttributesType
+         || Py_TYPE(other) != &TessellateAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ThreeSlice/PyThreeSliceAttributes.C
+++ b/src/operators/ThreeSlice/PyThreeSliceAttributes.C
@@ -295,8 +295,8 @@ static PyObject *
 ThreeSliceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ThreeSliceAttributesType)
+    if ( Py_TYPE(self) != &ThreeSliceAttributesType
+         || Py_TYPE(other) != &ThreeSliceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Threshold/PyThresholdAttributes.C
+++ b/src/operators/Threshold/PyThresholdAttributes.C
@@ -198,8 +198,8 @@ static PyObject *
 ThresholdAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ThresholdAttributesType)
+    if ( Py_TYPE(self) != &ThresholdAttributesType
+         || Py_TYPE(other) != &ThresholdAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ToroidalPoloidalProjection/PyToroidalPoloidalProjection.C
+++ b/src/operators/ToroidalPoloidalProjection/PyToroidalPoloidalProjection.C
@@ -398,8 +398,8 @@ static PyObject *
 ToroidalPoloidalProjection_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ToroidalPoloidalProjectionType)
+    if ( Py_TYPE(self) != &ToroidalPoloidalProjectionType
+         || Py_TYPE(other) != &ToroidalPoloidalProjectionType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Transform/PyTransformAttributes.C
+++ b/src/operators/Transform/PyTransformAttributes.C
@@ -1665,8 +1665,8 @@ static PyObject *
 TransformAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TransformAttributesType)
+    if ( Py_TYPE(self) != &TransformAttributesType
+         || Py_TYPE(other) != &TransformAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/TriangulateRegularPoints/PyTriangulateRegularPointsAttributes.C
+++ b/src/operators/TriangulateRegularPoints/PyTriangulateRegularPointsAttributes.C
@@ -298,8 +298,8 @@ static PyObject *
 TriangulateRegularPointsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TriangulateRegularPointsAttributesType)
+    if ( Py_TYPE(self) != &TriangulateRegularPointsAttributesType
+         || Py_TYPE(other) != &TriangulateRegularPointsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/Tube/PyTubeAttributes.C
+++ b/src/operators/Tube/PyTubeAttributes.C
@@ -421,8 +421,8 @@ static PyObject *
 TubeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TubeAttributesType)
+    if ( Py_TYPE(self) != &TubeAttributesType
+         || Py_TYPE(other) != &TubeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/operators/ZoneDump/PyZoneDumpAttributes.C
+++ b/src/operators/ZoneDump/PyZoneDumpAttributes.C
@@ -327,8 +327,8 @@ static PyObject *
 ZoneDumpAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ZoneDumpAttributesType)
+    if ( Py_TYPE(self) != &ZoneDumpAttributesType
+         || Py_TYPE(other) != &ZoneDumpAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Boundary/PyBoundaryAttributes.C
+++ b/src/plots/Boundary/PyBoundaryAttributes.C
@@ -1029,8 +1029,8 @@ static PyObject *
 BoundaryAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &BoundaryAttributesType)
+    if ( Py_TYPE(self) != &BoundaryAttributesType
+         || Py_TYPE(other) != &BoundaryAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Contour/PyContourAttributes.C
+++ b/src/plots/Contour/PyContourAttributes.C
@@ -1361,8 +1361,8 @@ static PyObject *
 ContourAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ContourAttributesType)
+    if ( Py_TYPE(self) != &ContourAttributesType
+         || Py_TYPE(other) != &ContourAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Curve/PyCurveAttributes.C
+++ b/src/plots/Curve/PyCurveAttributes.C
@@ -1634,8 +1634,8 @@ static PyObject *
 CurveAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &CurveAttributesType)
+    if ( Py_TYPE(self) != &CurveAttributesType
+         || Py_TYPE(other) != &CurveAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/FilledBoundary/PyFilledBoundaryAttributes.C
+++ b/src/plots/FilledBoundary/PyFilledBoundaryAttributes.C
@@ -1328,8 +1328,8 @@ static PyObject *
 FilledBoundaryAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &FilledBoundaryAttributesType)
+    if ( Py_TYPE(self) != &FilledBoundaryAttributesType
+         || Py_TYPE(other) != &FilledBoundaryAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Histogram/PyHistogramAttributes.C
+++ b/src/plots/Histogram/PyHistogramAttributes.C
@@ -1062,8 +1062,8 @@ static PyObject *
 HistogramAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &HistogramAttributesType)
+    if ( Py_TYPE(self) != &HistogramAttributesType
+         || Py_TYPE(other) != &HistogramAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Label/PyLabelAttributes.C
+++ b/src/plots/Label/PyLabelAttributes.C
@@ -922,8 +922,8 @@ static PyObject *
 LabelAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LabelAttributesType)
+    if ( Py_TYPE(self) != &LabelAttributesType
+         || Py_TYPE(other) != &LabelAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Mesh/PyMeshAttributes.C
+++ b/src/plots/Mesh/PyMeshAttributes.C
@@ -1049,8 +1049,8 @@ static PyObject *
 MeshAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MeshAttributesType)
+    if ( Py_TYPE(self) != &MeshAttributesType
+         || Py_TYPE(other) != &MeshAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Molecule/PyMoleculeAttributes.C
+++ b/src/plots/Molecule/PyMoleculeAttributes.C
@@ -1150,8 +1150,8 @@ static PyObject *
 MoleculeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MoleculeAttributesType)
+    if ( Py_TYPE(self) != &MoleculeAttributesType
+         || Py_TYPE(other) != &MoleculeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/MultiCurve/PyMultiCurveAttributes.C
+++ b/src/plots/MultiCurve/PyMultiCurveAttributes.C
@@ -1090,8 +1090,8 @@ static PyObject *
 MultiCurveAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MultiCurveAttributesType)
+    if ( Py_TYPE(self) != &MultiCurveAttributesType
+         || Py_TYPE(other) != &MultiCurveAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/ParallelCoordinates/PyParallelCoordinatesAttributes.C
+++ b/src/plots/ParallelCoordinates/PyParallelCoordinatesAttributes.C
@@ -995,8 +995,8 @@ static PyObject *
 ParallelCoordinatesAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ParallelCoordinatesAttributesType)
+    if ( Py_TYPE(self) != &ParallelCoordinatesAttributesType
+         || Py_TYPE(other) != &ParallelCoordinatesAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Pseudocolor/PyPseudocolorAttributes.C
+++ b/src/plots/Pseudocolor/PyPseudocolorAttributes.C
@@ -2542,8 +2542,8 @@ static PyObject *
 PseudocolorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PseudocolorAttributesType)
+    if ( Py_TYPE(self) != &PseudocolorAttributesType
+         || Py_TYPE(other) != &PseudocolorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Scatter/PyScatterAttributes.C
+++ b/src/plots/Scatter/PyScatterAttributes.C
@@ -2065,8 +2065,8 @@ static PyObject *
 ScatterAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ScatterAttributesType)
+    if ( Py_TYPE(self) != &ScatterAttributesType
+         || Py_TYPE(other) != &ScatterAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Spreadsheet/PySpreadsheetAttributes.C
+++ b/src/plots/Spreadsheet/PySpreadsheetAttributes.C
@@ -757,8 +757,8 @@ static PyObject *
 SpreadsheetAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SpreadsheetAttributesType)
+    if ( Py_TYPE(self) != &SpreadsheetAttributesType
+         || Py_TYPE(other) != &SpreadsheetAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Subset/PySubsetAttributes.C
+++ b/src/plots/Subset/PySubsetAttributes.C
@@ -1190,8 +1190,8 @@ static PyObject *
 SubsetAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SubsetAttributesType)
+    if ( Py_TYPE(self) != &SubsetAttributesType
+         || Py_TYPE(other) != &SubsetAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Surface/PySurfaceAttributes.C
+++ b/src/plots/Surface/PySurfaceAttributes.C
@@ -942,8 +942,8 @@ static PyObject *
 SurfaceAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SurfaceAttributesType)
+    if ( Py_TYPE(self) != &SurfaceAttributesType
+         || Py_TYPE(other) != &SurfaceAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Tensor/PyTensorAttributes.C
+++ b/src/plots/Tensor/PyTensorAttributes.C
@@ -908,8 +908,8 @@ static PyObject *
 TensorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TensorAttributesType)
+    if ( Py_TYPE(self) != &TensorAttributesType
+         || Py_TYPE(other) != &TensorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Topology/PyTopologyAttributes.C
+++ b/src/plots/Topology/PyTopologyAttributes.C
@@ -657,8 +657,8 @@ static PyObject *
 TopologyAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TopologyAttributesType)
+    if ( Py_TYPE(self) != &TopologyAttributesType
+         || Py_TYPE(other) != &TopologyAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Truecolor/PyTruecolorAttributes.C
+++ b/src/plots/Truecolor/PyTruecolorAttributes.C
@@ -231,8 +231,8 @@ static PyObject *
 TruecolorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &TruecolorAttributesType)
+    if ( Py_TYPE(self) != &TruecolorAttributesType
+         || Py_TYPE(other) != &TruecolorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Vector/PyVectorAttributes.C
+++ b/src/plots/Vector/PyVectorAttributes.C
@@ -1366,8 +1366,8 @@ static PyObject *
 VectorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &VectorAttributesType)
+    if ( Py_TYPE(self) != &VectorAttributesType
+         || Py_TYPE(other) != &VectorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/Volume/PyVolumeAttributes.C
+++ b/src/plots/Volume/PyVolumeAttributes.C
@@ -1967,8 +1967,8 @@ static PyObject *
 VolumeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &VolumeAttributesType)
+    if ( Py_TYPE(self) != &VolumeAttributesType
+         || Py_TYPE(other) != &VolumeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/plots/WellBore/PyWellBoreAttributes.C
+++ b/src/plots/WellBore/PyWellBoreAttributes.C
@@ -1360,8 +1360,8 @@ static PyObject *
 WellBoreAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &WellBoreAttributesType)
+    if ( Py_TYPE(self) != &WellBoreAttributesType
+         || Py_TYPE(other) != &WellBoreAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/tools/dev/xml/GeneratePython.h
+++ b/src/tools/dev/xml/GeneratePython.h
@@ -3480,8 +3480,8 @@ class PythonGeneratorAttribute : public GeneratorBase
         c << name << "_richcompare(PyObject *self, PyObject *other, int op)" << Endl;
         c << "{" << Endl;
         c << "    // only compare against the same type " << Endl;
-        c << "    if ( Py_TYPE(self) == Py_TYPE(other) " << Endl;
-        c << "         && Py_TYPE(self) == &" <<name<< "Type)" << Endl;
+        c << "    if ( Py_TYPE(self) != &" <<name<< "Type" << Endl;
+        c << "         || Py_TYPE(other) != &" <<name<< "Type)" << Endl;
         c << "    {" << Endl;
         c << "        Py_INCREF(Py_NotImplemented);" << Endl;
         c << "        return Py_NotImplemented;" << Endl;

--- a/src/visitpy/visitpy/PyAnimationAttributes.C
+++ b/src/visitpy/visitpy/PyAnimationAttributes.C
@@ -393,8 +393,8 @@ static PyObject *
 AnimationAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AnimationAttributesType)
+    if ( Py_TYPE(self) != &AnimationAttributesType
+         || Py_TYPE(other) != &AnimationAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAnnotationAttributes.C
+++ b/src/visitpy/visitpy/PyAnnotationAttributes.C
@@ -1279,8 +1279,8 @@ static PyObject *
 AnnotationAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AnnotationAttributesType)
+    if ( Py_TYPE(self) != &AnnotationAttributesType
+         || Py_TYPE(other) != &AnnotationAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxes2D.C
+++ b/src/visitpy/visitpy/PyAxes2D.C
@@ -540,8 +540,8 @@ static PyObject *
 Axes2D_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &Axes2DType)
+    if ( Py_TYPE(self) != &Axes2DType
+         || Py_TYPE(other) != &Axes2DType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxes3D.C
+++ b/src/visitpy/visitpy/PyAxes3D.C
@@ -1014,8 +1014,8 @@ static PyObject *
 Axes3D_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &Axes3DType)
+    if ( Py_TYPE(self) != &Axes3DType
+         || Py_TYPE(other) != &Axes3DType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxesArray.C
+++ b/src/visitpy/visitpy/PyAxesArray.C
@@ -384,8 +384,8 @@ static PyObject *
 AxesArray_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AxesArrayType)
+    if ( Py_TYPE(self) != &AxesArrayType
+         || Py_TYPE(other) != &AxesArrayType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxisAttributes.C
+++ b/src/visitpy/visitpy/PyAxisAttributes.C
@@ -343,8 +343,8 @@ static PyObject *
 AxisAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AxisAttributesType)
+    if ( Py_TYPE(self) != &AxisAttributesType
+         || Py_TYPE(other) != &AxisAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxisLabels.C
+++ b/src/visitpy/visitpy/PyAxisLabels.C
@@ -279,8 +279,8 @@ static PyObject *
 AxisLabels_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AxisLabelsType)
+    if ( Py_TYPE(self) != &AxisLabelsType
+         || Py_TYPE(other) != &AxisLabelsType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxisTickMarks.C
+++ b/src/visitpy/visitpy/PyAxisTickMarks.C
@@ -327,8 +327,8 @@ static PyObject *
 AxisTickMarks_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AxisTickMarksType)
+    if ( Py_TYPE(self) != &AxisTickMarksType
+         || Py_TYPE(other) != &AxisTickMarksType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyAxisTitles.C
+++ b/src/visitpy/visitpy/PyAxisTitles.C
@@ -381,8 +381,8 @@ static PyObject *
 AxisTitles_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &AxisTitlesType)
+    if ( Py_TYPE(self) != &AxisTitlesType
+         || Py_TYPE(other) != &AxisTitlesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyColorAttribute.C
+++ b/src/visitpy/visitpy/PyColorAttribute.C
@@ -245,8 +245,8 @@ static PyObject *
 ColorAttribute_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ColorAttributeType)
+    if ( Py_TYPE(self) != &ColorAttributeType
+         || Py_TYPE(other) != &ColorAttributeType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyColorAttributeList.C
+++ b/src/visitpy/visitpy/PyColorAttributeList.C
@@ -302,8 +302,8 @@ static PyObject *
 ColorAttributeList_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ColorAttributeListType)
+    if ( Py_TYPE(self) != &ColorAttributeListType
+         || Py_TYPE(other) != &ColorAttributeListType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyColorControlPoint.C
+++ b/src/visitpy/visitpy/PyColorControlPoint.C
@@ -277,8 +277,8 @@ static PyObject *
 ColorControlPoint_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ColorControlPointType)
+    if ( Py_TYPE(self) != &ColorControlPointType
+         || Py_TYPE(other) != &ColorControlPointType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyColorControlPointList.C
+++ b/src/visitpy/visitpy/PyColorControlPointList.C
@@ -471,8 +471,8 @@ static PyObject *
 ColorControlPointList_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ColorControlPointListType)
+    if ( Py_TYPE(self) != &ColorControlPointListType
+         || Py_TYPE(other) != &ColorControlPointListType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyColorTableAttributes.C
+++ b/src/visitpy/visitpy/PyColorTableAttributes.C
@@ -478,8 +478,8 @@ static PyObject *
 ColorTableAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ColorTableAttributesType)
+    if ( Py_TYPE(self) != &ColorTableAttributesType
+         || Py_TYPE(other) != &ColorTableAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyConstructDataBinningAttributes.C
+++ b/src/visitpy/visitpy/PyConstructDataBinningAttributes.C
@@ -981,8 +981,8 @@ static PyObject *
 ConstructDataBinningAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ConstructDataBinningAttributesType)
+    if ( Py_TYPE(self) != &ConstructDataBinningAttributesType
+         || Py_TYPE(other) != &ConstructDataBinningAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyDBOptionsAttributes.C
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes.C
@@ -281,8 +281,8 @@ static PyObject *
 DBOptionsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &DBOptionsAttributesType)
+    if ( Py_TYPE(self) != &DBOptionsAttributesType
+         || Py_TYPE(other) != &DBOptionsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyEngineProperties.C
+++ b/src/visitpy/visitpy/PyEngineProperties.C
@@ -327,8 +327,8 @@ static PyObject *
 EngineProperties_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &EnginePropertiesType)
+    if ( Py_TYPE(self) != &EnginePropertiesType
+         || Py_TYPE(other) != &EnginePropertiesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyExportDBAttributes.C
+++ b/src/visitpy/visitpy/PyExportDBAttributes.C
@@ -571,8 +571,8 @@ static PyObject *
 ExportDBAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExportDBAttributesType)
+    if ( Py_TYPE(self) != &ExportDBAttributesType
+         || Py_TYPE(other) != &ExportDBAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyExpression.C
+++ b/src/visitpy/visitpy/PyExpression.C
@@ -575,8 +575,8 @@ static PyObject *
 Expression_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExpressionType)
+    if ( Py_TYPE(self) != &ExpressionType
+         || Py_TYPE(other) != &ExpressionType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyExpressionList.C
+++ b/src/visitpy/visitpy/PyExpressionList.C
@@ -302,8 +302,8 @@ static PyObject *
 ExpressionList_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ExpressionListType)
+    if ( Py_TYPE(self) != &ExpressionListType
+         || Py_TYPE(other) != &ExpressionListType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyFileOpenOptions.C
+++ b/src/visitpy/visitpy/PyFileOpenOptions.C
@@ -618,8 +618,8 @@ static PyObject *
 FileOpenOptions_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &FileOpenOptionsType)
+    if ( Py_TYPE(self) != &FileOpenOptionsType
+         || Py_TYPE(other) != &FileOpenOptionsType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyFontAttributes.C
+++ b/src/visitpy/visitpy/PyFontAttributes.C
@@ -453,8 +453,8 @@ static PyObject *
 FontAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &FontAttributesType)
+    if ( Py_TYPE(self) != &FontAttributesType
+         || Py_TYPE(other) != &FontAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyGaussianControlPoint.C
+++ b/src/visitpy/visitpy/PyGaussianControlPoint.C
@@ -324,8 +324,8 @@ static PyObject *
 GaussianControlPoint_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &GaussianControlPointType)
+    if ( Py_TYPE(self) != &GaussianControlPointType
+         || Py_TYPE(other) != &GaussianControlPointType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyGaussianControlPointList.C
+++ b/src/visitpy/visitpy/PyGaussianControlPointList.C
@@ -302,8 +302,8 @@ static PyObject *
 GaussianControlPointList_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &GaussianControlPointListType)
+    if ( Py_TYPE(self) != &GaussianControlPointListType
+         || Py_TYPE(other) != &GaussianControlPointListType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyGlobalAttributes.C
+++ b/src/visitpy/visitpy/PyGlobalAttributes.C
@@ -1284,8 +1284,8 @@ static PyObject *
 GlobalAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &GlobalAttributesType)
+    if ( Py_TYPE(self) != &GlobalAttributesType
+         || Py_TYPE(other) != &GlobalAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyGlobalLineoutAttributes.C
+++ b/src/visitpy/visitpy/PyGlobalLineoutAttributes.C
@@ -521,8 +521,8 @@ static PyObject *
 GlobalLineoutAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &GlobalLineoutAttributesType)
+    if ( Py_TYPE(self) != &GlobalLineoutAttributesType
+         || Py_TYPE(other) != &GlobalLineoutAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyInteractorAttributes.C
+++ b/src/visitpy/visitpy/PyInteractorAttributes.C
@@ -434,8 +434,8 @@ static PyObject *
 InteractorAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &InteractorAttributesType)
+    if ( Py_TYPE(self) != &InteractorAttributesType
+         || Py_TYPE(other) != &InteractorAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyKeyframeAttributes.C
+++ b/src/visitpy/visitpy/PyKeyframeAttributes.C
@@ -266,8 +266,8 @@ static PyObject *
 KeyframeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &KeyframeAttributesType)
+    if ( Py_TYPE(self) != &KeyframeAttributesType
+         || Py_TYPE(other) != &KeyframeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyLaunchProfile.C
+++ b/src/visitpy/visitpy/PyLaunchProfile.C
@@ -1585,8 +1585,8 @@ static PyObject *
 LaunchProfile_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LaunchProfileType)
+    if ( Py_TYPE(self) != &LaunchProfileType
+         || Py_TYPE(other) != &LaunchProfileType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyLightAttributes.C
+++ b/src/visitpy/visitpy/PyLightAttributes.C
@@ -459,8 +459,8 @@ static PyObject *
 LightAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &LightAttributesType)
+    if ( Py_TYPE(self) != &LightAttributesType
+         || Py_TYPE(other) != &LightAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyMachineProfile.C
+++ b/src/visitpy/visitpy/PyMachineProfile.C
@@ -1073,8 +1073,8 @@ static PyObject *
 MachineProfile_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MachineProfileType)
+    if ( Py_TYPE(self) != &MachineProfileType
+         || Py_TYPE(other) != &MachineProfileType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyMaterialAttributes.C
+++ b/src/visitpy/visitpy/PyMaterialAttributes.C
@@ -612,8 +612,8 @@ static PyObject *
 MaterialAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MaterialAttributesType)
+    if ( Py_TYPE(self) != &MaterialAttributesType
+         || Py_TYPE(other) != &MaterialAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyMeshManagementAttributes.C
+++ b/src/visitpy/visitpy/PyMeshManagementAttributes.C
@@ -639,8 +639,8 @@ static PyObject *
 MeshManagementAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &MeshManagementAttributesType)
+    if ( Py_TYPE(self) != &MeshManagementAttributesType
+         || Py_TYPE(other) != &MeshManagementAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyNameschemeAttributes.C
+++ b/src/visitpy/visitpy/PyNameschemeAttributes.C
@@ -682,8 +682,8 @@ static PyObject *
 NameschemeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &NameschemeAttributesType)
+    if ( Py_TYPE(self) != &NameschemeAttributesType
+         || Py_TYPE(other) != &NameschemeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyPickAttributes.C
+++ b/src/visitpy/visitpy/PyPickAttributes.C
@@ -1439,8 +1439,8 @@ static PyObject *
 PickAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PickAttributesType)
+    if ( Py_TYPE(self) != &PickAttributesType
+         || Py_TYPE(other) != &PickAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyPickVarInfo.C
+++ b/src/visitpy/visitpy/PyPickVarInfo.C
@@ -965,8 +965,8 @@ static PyObject *
 PickVarInfo_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PickVarInfoType)
+    if ( Py_TYPE(self) != &PickVarInfoType
+         || Py_TYPE(other) != &PickVarInfoType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyPlot.C
+++ b/src/visitpy/visitpy/PyPlot.C
@@ -1129,8 +1129,8 @@ static PyObject *
 Plot_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PlotType)
+    if ( Py_TYPE(self) != &PlotType
+         || Py_TYPE(other) != &PlotType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyPlotList.C
+++ b/src/visitpy/visitpy/PyPlotList.C
@@ -302,8 +302,8 @@ static PyObject *
 PlotList_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PlotListType)
+    if ( Py_TYPE(self) != &PlotListType
+         || Py_TYPE(other) != &PlotListType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyPrinterAttributes.C
+++ b/src/visitpy/visitpy/PyPrinterAttributes.C
@@ -493,8 +493,8 @@ static PyObject *
 PrinterAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &PrinterAttributesType)
+    if ( Py_TYPE(self) != &PrinterAttributesType
+         || Py_TYPE(other) != &PrinterAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyProcessAttributes.C
+++ b/src/visitpy/visitpy/PyProcessAttributes.C
@@ -616,8 +616,8 @@ static PyObject *
 ProcessAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ProcessAttributesType)
+    if ( Py_TYPE(self) != &ProcessAttributesType
+         || Py_TYPE(other) != &ProcessAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyQueryAttributes.C
+++ b/src/visitpy/visitpy/PyQueryAttributes.C
@@ -470,8 +470,8 @@ static PyObject *
 QueryAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &QueryAttributesType)
+    if ( Py_TYPE(self) != &QueryAttributesType
+         || Py_TYPE(other) != &QueryAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyQueryOverTimeAttributes.C
+++ b/src/visitpy/visitpy/PyQueryOverTimeAttributes.C
@@ -619,8 +619,8 @@ static PyObject *
 QueryOverTimeAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &QueryOverTimeAttributesType)
+    if ( Py_TYPE(self) != &QueryOverTimeAttributesType
+         || Py_TYPE(other) != &QueryOverTimeAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyRenderingAttributes.C
+++ b/src/visitpy/visitpy/PyRenderingAttributes.C
@@ -1637,8 +1637,8 @@ static PyObject *
 RenderingAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &RenderingAttributesType)
+    if ( Py_TYPE(self) != &RenderingAttributesType
+         || Py_TYPE(other) != &RenderingAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySaveSubWindowAttributes.C
+++ b/src/visitpy/visitpy/PySaveSubWindowAttributes.C
@@ -415,8 +415,8 @@ static PyObject *
 SaveSubWindowAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SaveSubWindowAttributesType)
+    if ( Py_TYPE(self) != &SaveSubWindowAttributesType
+         || Py_TYPE(other) != &SaveSubWindowAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySaveSubWindowsAttributes.C
+++ b/src/visitpy/visitpy/PySaveSubWindowsAttributes.C
@@ -933,8 +933,8 @@ static PyObject *
 SaveSubWindowsAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SaveSubWindowsAttributesType)
+    if ( Py_TYPE(self) != &SaveSubWindowsAttributesType
+         || Py_TYPE(other) != &SaveSubWindowsAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySaveWindowAttributes.C
+++ b/src/visitpy/visitpy/PySaveWindowAttributes.C
@@ -1055,8 +1055,8 @@ static PyObject *
 SaveWindowAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SaveWindowAttributesType)
+    if ( Py_TYPE(self) != &SaveWindowAttributesType
+         || Py_TYPE(other) != &SaveWindowAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySelectionList.C
+++ b/src/visitpy/visitpy/PySelectionList.C
@@ -475,8 +475,8 @@ static PyObject *
 SelectionList_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SelectionListType)
+    if ( Py_TYPE(self) != &SelectionListType
+         || Py_TYPE(other) != &SelectionListType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySelectionProperties.C
+++ b/src/visitpy/visitpy/PySelectionProperties.C
@@ -1058,8 +1058,8 @@ static PyObject *
 SelectionProperties_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SelectionPropertiesType)
+    if ( Py_TYPE(self) != &SelectionPropertiesType
+         || Py_TYPE(other) != &SelectionPropertiesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySelectionSummary.C
+++ b/src/visitpy/visitpy/PySelectionSummary.C
@@ -547,8 +547,8 @@ static PyObject *
 SelectionSummary_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SelectionSummaryType)
+    if ( Py_TYPE(self) != &SelectionSummaryType
+         || Py_TYPE(other) != &SelectionSummaryType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PySelectionVariableSummary.C
+++ b/src/visitpy/visitpy/PySelectionVariableSummary.C
@@ -336,8 +336,8 @@ static PyObject *
 SelectionVariableSummary_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &SelectionVariableSummaryType)
+    if ( Py_TYPE(self) != &SelectionVariableSummaryType
+         || Py_TYPE(other) != &SelectionVariableSummaryType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyThresholdOpAttributes.C
+++ b/src/visitpy/visitpy/PyThresholdOpAttributes.C
@@ -704,8 +704,8 @@ static PyObject *
 ThresholdOpAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ThresholdOpAttributesType)
+    if ( Py_TYPE(self) != &ThresholdOpAttributesType
+         || Py_TYPE(other) != &ThresholdOpAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewAttributes.C
+++ b/src/visitpy/visitpy/PyViewAttributes.C
@@ -882,8 +882,8 @@ static PyObject *
 ViewAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewAttributesType)
+    if ( Py_TYPE(self) != &ViewAttributesType
+         || Py_TYPE(other) != &ViewAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewAxisArrayAttributes.C
+++ b/src/visitpy/visitpy/PyViewAxisArrayAttributes.C
@@ -392,8 +392,8 @@ static PyObject *
 ViewAxisArrayAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewAxisArrayAttributesType)
+    if ( Py_TYPE(self) != &ViewAxisArrayAttributesType
+         || Py_TYPE(other) != &ViewAxisArrayAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewCurveAttributes.C
+++ b/src/visitpy/visitpy/PyViewCurveAttributes.C
@@ -486,8 +486,8 @@ static PyObject *
 ViewCurveAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewCurveAttributesType)
+    if ( Py_TYPE(self) != &ViewCurveAttributesType
+         || Py_TYPE(other) != &ViewCurveAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewerClientAttributes.C
+++ b/src/visitpy/visitpy/PyViewerClientAttributes.C
@@ -596,8 +596,8 @@ static PyObject *
 ViewerClientAttributes_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewerClientAttributesType)
+    if ( Py_TYPE(self) != &ViewerClientAttributesType
+         || Py_TYPE(other) != &ViewerClientAttributesType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewerClientInformation.C
+++ b/src/visitpy/visitpy/PyViewerClientInformation.C
@@ -379,8 +379,8 @@ static PyObject *
 ViewerClientInformation_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewerClientInformationType)
+    if ( Py_TYPE(self) != &ViewerClientInformationType
+         || Py_TYPE(other) != &ViewerClientInformationType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewerClientInformationElement.C
+++ b/src/visitpy/visitpy/PyViewerClientInformationElement.C
@@ -394,8 +394,8 @@ static PyObject *
 ViewerClientInformationElement_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewerClientInformationElementType)
+    if ( Py_TYPE(self) != &ViewerClientInformationElementType
+         || Py_TYPE(other) != &ViewerClientInformationElementType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyViewerRPC.C
+++ b/src/visitpy/visitpy/PyViewerRPC.C
@@ -2859,8 +2859,8 @@ static PyObject *
 ViewerRPC_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &ViewerRPCType)
+    if ( Py_TYPE(self) != &ViewerRPCType
+         || Py_TYPE(other) != &ViewerRPCType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyWindowInformation.C
+++ b/src/visitpy/visitpy/PyWindowInformation.C
@@ -1367,8 +1367,8 @@ static PyObject *
 WindowInformation_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &WindowInformationType)
+    if ( Py_TYPE(self) != &WindowInformationType
+         || Py_TYPE(other) != &WindowInformationType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtArrayMetaData.C
+++ b/src/visitpy/visitpy/PyavtArrayMetaData.C
@@ -308,8 +308,8 @@ static PyObject *
 avtArrayMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtArrayMetaDataType)
+    if ( Py_TYPE(self) != &avtArrayMetaDataType
+         || Py_TYPE(other) != &avtArrayMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtBaseVarMetaData.C
+++ b/src/visitpy/visitpy/PyavtBaseVarMetaData.C
@@ -330,8 +330,8 @@ static PyObject *
 avtBaseVarMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtBaseVarMetaDataType)
+    if ( Py_TYPE(self) != &avtBaseVarMetaDataType
+         || Py_TYPE(other) != &avtBaseVarMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtCurveMetaData.C
+++ b/src/visitpy/visitpy/PyavtCurveMetaData.C
@@ -458,8 +458,8 @@ static PyObject *
 avtCurveMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtCurveMetaDataType)
+    if ( Py_TYPE(self) != &avtCurveMetaDataType
+         || Py_TYPE(other) != &avtCurveMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtDatabaseMetaData.C
+++ b/src/visitpy/visitpy/PyavtDatabaseMetaData.C
@@ -2946,8 +2946,8 @@ static PyObject *
 avtDatabaseMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtDatabaseMetaDataType)
+    if ( Py_TYPE(self) != &avtDatabaseMetaDataType
+         || Py_TYPE(other) != &avtDatabaseMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtDefaultPlotMetaData.C
+++ b/src/visitpy/visitpy/PyavtDefaultPlotMetaData.C
@@ -305,8 +305,8 @@ static PyObject *
 avtDefaultPlotMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtDefaultPlotMetaDataType)
+    if ( Py_TYPE(self) != &avtDefaultPlotMetaDataType
+         || Py_TYPE(other) != &avtDefaultPlotMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtLabelMetaData.C
+++ b/src/visitpy/visitpy/PyavtLabelMetaData.C
@@ -198,8 +198,8 @@ static PyObject *
 avtLabelMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtLabelMetaDataType)
+    if ( Py_TYPE(self) != &avtLabelMetaDataType
+         || Py_TYPE(other) != &avtLabelMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtMatSpeciesMetaData.C
+++ b/src/visitpy/visitpy/PyavtMatSpeciesMetaData.C
@@ -308,8 +308,8 @@ static PyObject *
 avtMatSpeciesMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtMatSpeciesMetaDataType)
+    if ( Py_TYPE(self) != &avtMatSpeciesMetaDataType
+         || Py_TYPE(other) != &avtMatSpeciesMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtMaterialMetaData.C
+++ b/src/visitpy/visitpy/PyavtMaterialMetaData.C
@@ -385,8 +385,8 @@ static PyObject *
 avtMaterialMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtMaterialMetaDataType)
+    if ( Py_TYPE(self) != &avtMaterialMetaDataType
+         || Py_TYPE(other) != &avtMaterialMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtMeshMetaData.C
+++ b/src/visitpy/visitpy/PyavtMeshMetaData.C
@@ -2504,8 +2504,8 @@ static PyObject *
 avtMeshMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtMeshMetaDataType)
+    if ( Py_TYPE(self) != &avtMeshMetaDataType
+         || Py_TYPE(other) != &avtMeshMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtScalarMetaData.C
+++ b/src/visitpy/visitpy/PyavtScalarMetaData.C
@@ -1158,8 +1158,8 @@ static PyObject *
 avtScalarMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtScalarMetaDataType)
+    if ( Py_TYPE(self) != &avtScalarMetaDataType
+         || Py_TYPE(other) != &avtScalarMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtSimulationCommandSpecification.C
+++ b/src/visitpy/visitpy/PyavtSimulationCommandSpecification.C
@@ -529,8 +529,8 @@ static PyObject *
 avtSimulationCommandSpecification_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtSimulationCommandSpecificationType)
+    if ( Py_TYPE(self) != &avtSimulationCommandSpecificationType
+         || Py_TYPE(other) != &avtSimulationCommandSpecificationType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtSimulationInformation.C
+++ b/src/visitpy/visitpy/PyavtSimulationInformation.C
@@ -787,8 +787,8 @@ static PyObject *
 avtSimulationInformation_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtSimulationInformationType)
+    if ( Py_TYPE(self) != &avtSimulationInformationType
+         || Py_TYPE(other) != &avtSimulationInformationType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtSpeciesMetaData.C
+++ b/src/visitpy/visitpy/PyavtSpeciesMetaData.C
@@ -497,8 +497,8 @@ static PyObject *
 avtSpeciesMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtSpeciesMetaDataType)
+    if ( Py_TYPE(self) != &avtSpeciesMetaDataType
+         || Py_TYPE(other) != &avtSpeciesMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtSubsetsMetaData.C
+++ b/src/visitpy/visitpy/PyavtSubsetsMetaData.C
@@ -797,8 +797,8 @@ static PyObject *
 avtSubsetsMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtSubsetsMetaDataType)
+    if ( Py_TYPE(self) != &avtSubsetsMetaDataType
+         || Py_TYPE(other) != &avtSubsetsMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtSymmetricTensorMetaData.C
+++ b/src/visitpy/visitpy/PyavtSymmetricTensorMetaData.C
@@ -231,8 +231,8 @@ static PyObject *
 avtSymmetricTensorMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtSymmetricTensorMetaDataType)
+    if ( Py_TYPE(self) != &avtSymmetricTensorMetaDataType
+         || Py_TYPE(other) != &avtSymmetricTensorMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtTensorMetaData.C
+++ b/src/visitpy/visitpy/PyavtTensorMetaData.C
@@ -231,8 +231,8 @@ static PyObject *
 avtTensorMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtTensorMetaDataType)
+    if ( Py_TYPE(self) != &avtTensorMetaDataType
+         || Py_TYPE(other) != &avtTensorMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtVarMetaData.C
+++ b/src/visitpy/visitpy/PyavtVarMetaData.C
@@ -511,8 +511,8 @@ static PyObject *
 avtVarMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtVarMetaDataType)
+    if ( Py_TYPE(self) != &avtVarMetaDataType
+         || Py_TYPE(other) != &avtVarMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;

--- a/src/visitpy/visitpy/PyavtVectorMetaData.C
+++ b/src/visitpy/visitpy/PyavtVectorMetaData.C
@@ -231,8 +231,8 @@ static PyObject *
 avtVectorMetaData_richcompare(PyObject *self, PyObject *other, int op)
 {
     // only compare against the same type 
-    if ( Py_TYPE(self) == Py_TYPE(other) 
-         && Py_TYPE(self) == &avtVectorMetaDataType)
+    if ( Py_TYPE(self) != &avtVectorMetaDataType
+         || Py_TYPE(other) != &avtVectorMetaDataType)
     {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;


### PR DESCRIPTION
Updated GeneratePython.h with the fix described in the bug ticket, then used gen_python_all target to regenerate.
Resolves #4985.

I ran bov.py test which crashed previously, and passes now.

