### PR TITLE
Roll back the version of openssl to 1.0.2j.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_openssl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openssl.sh
@@ -21,12 +21,12 @@ function bv_openssl_depends_on
 
 function bv_openssl_info
 {
-    export OPENSSL_VERSION=${OPENSSL_VERSION:-"1.1.1g"}
+    export OPENSSL_VERSION=${OPENSSL_VERSION:-"1.0.2j"}
     export OPENSSL_FILE=${OPENSSL_FILE:-"openssl-${OPENSSL_VERSION}.tar.gz"}
     export OPENSSL_URL=${OPENSSL_URL:-"https://www.openssl.org/source/"}
     export OPENSSL_BUILD_DIR=${OPENSSL_BUILD_DIR:-"openssl-${OPENSSL_VERSION}"}
-    export OPENSSL_MD5_CHECKSUM="76766e98997660138cdaf13a187bd234"
-    export OPENSSL_SHA256_CHECKSUM="ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46"
+    export OPENSSL_MD5_CHECKSUM="96322138f0b69e61b7212bc53d5e912b"
+    export OPENSSL_SHA256_CHECKSUM="e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431"
 }
 
 function bv_openssl_print


### PR DESCRIPTION
### Description

Roll back the version of openssl in build_visit to 1.0.2j. This was already done on develop, just making the same change on the 3.1RC.

### Type of change

Bug fix..

### How Has This Been Tested?

I haven't tested this. Presumably this has been tested on develop.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code