### PR TITLE
Fix plot-add-menu disablement

### DIFF
--- a/src/gui/FileServerList.C
+++ b/src/gui/FileServerList.C
@@ -288,7 +288,7 @@ FileServerList::SelectAll()
     Select(ID_showDotFilesFlag,          (void *)&showDotFilesFlag);
 }
 
-// *************************************************************************************
+// ****************************************************************************
 // Method: FileServerList::Initialize
 //
 // Purpose: 
@@ -322,7 +322,7 @@ FileServerList::SelectAll()
 //   Brad Whitlock, Thu Jul 29 13:42:24 PST 2004
 //   I added smartFileGroupingFlag.
 //
-// *************************************************************************************
+// ****************************************************************************
 
 void
 FileServerList::Initialize()
@@ -1437,6 +1437,10 @@ FileServerList::CloseFile()
 //   Brad Whitlock, Mon Dec 13 10:35:24 PST 2010
 //   Call the "Ex" versions of GetMetaData and GetSIL.
 //
+//   Kathleen Biagas, Mon Aug 31 16:43:27 MST 2020
+//   Add openFile to the appliedFileList if not already there, as may be
+//   the case when a database is opened from the CLI.
+//
 // ****************************************************************************
 
 void
@@ -1511,6 +1515,16 @@ FileServerList::OpenAndGetMetaData(const QualifiedFilename &filename,
                 openFileTimeState = timeState;
                 fileAction = action;
                 Select(ID_fileAction, (void *)&fileAction);
+                // add to appliedFilesList if not already there
+                bool found = false;
+                for (size_t i = 0; i < appliedFileList.size() && !found; ++i)
+                    found = appliedFileList[i] == openFile;
+                if (!found)
+                {
+                    appliedFileList.push_back(openFile);
+                    Select(ID_appliedFileListFlag,(void *)&appliedFileListFlag);
+                }
+
             }
             CATCH2(GetMetaDataException, gmde)
             {

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -44,6 +44,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug which caused external surfaces to be lost in the pseudocolor plot when using a gradient expression on a Curvilinear mesh (Structured Grid).</li>
   <li>Changed the vertical scroll bar mode for the plot list to <b>ScrollPerPixel</b> and to use a single step so that the bottom of the plot list is not cutoff.</li>
   <li>Fixed a bug preventing VisIt from displaying the manuals when using an out-of-source build.</li>
+  <li>Fixed a bug where the Plots Add menu would become disabled after drawing plots via the CLI, then calling OpenGUI() and deleting a plot.
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Gui was closing the file after plot was deleted because the file opened from the cli wasn't added to its appliedFileList.
With no open file, the plot-add menu was disabled.
Updated FileServer to add the openFile to its appliedFileList (if not already present).

Resolves #2604.

### How Has This Been Tested?

I performed the steps described in the ticket, and behavior has been fixed.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
