### PR TITLE
Fix plot-add-menu becoming disabled.

### DIFF
--- a/src/gui/FileServerList.C
+++ b/src/gui/FileServerList.C
@@ -288,7 +288,7 @@ FileServerList::SelectAll()
     Select(ID_showDotFilesFlag,          (void *)&showDotFilesFlag);
 }
 
-// *************************************************************************************
+// ****************************************************************************
 // Method: FileServerList::Initialize
 //
 // Purpose: 
@@ -322,7 +322,7 @@ FileServerList::SelectAll()
 //   Brad Whitlock, Thu Jul 29 13:42:24 PST 2004
 //   I added smartFileGroupingFlag.
 //
-// *************************************************************************************
+// ****************************************************************************
 
 void
 FileServerList::Initialize()
@@ -1437,6 +1437,10 @@ FileServerList::CloseFile()
 //   Brad Whitlock, Mon Dec 13 10:35:24 PST 2010
 //   Call the "Ex" versions of GetMetaData and GetSIL.
 //
+//   Kathleen Biagas, Mon Aug 31 16:43:27 MST 2020
+//   Add openFile to the appliedFileList if not already there, as may be
+//   the case when a database is opened from the CLI.
+//
 // ****************************************************************************
 
 void
@@ -1511,6 +1515,16 @@ FileServerList::OpenAndGetMetaData(const QualifiedFilename &filename,
                 openFileTimeState = timeState;
                 fileAction = action;
                 Select(ID_fileAction, (void *)&fileAction);
+                // add to appliedFilesList if not already there
+                bool found = false;
+                for (size_t i = 0; i < appliedFileList.size() && !found; ++i)
+                    found = appliedFileList[i] == openFile;
+                if (!found)
+                {
+                    appliedFileList.push_back(openFile);
+                    Select(ID_appliedFileListFlag,(void *)&appliedFileListFlag);
+                }
+
             }
             CATCH2(GetMetaDataException, gmde)
             {

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -26,32 +26,33 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug preventing SaveWindow from saving OSPRay rendered images.</li>
   <li>Fixed a bug with the Pixie reader when it read 3D curvilinear meshes in parallel.</li>
-  <li>Fixed parallel engine crash when creating ghosts from global ids.</li>
-  <li>Fixed the issue with the progress dialog staying visible when a client connection fails.</li>
-  <li>Added a menu indicator icon to Color Table buttons so it is more obvious the button can be pushed to see available options.<li>
-  <li>Fixed a bug preventing the ability to Pick Through Time using mesh quality metrics.</li>
+  <li>Fixed a bug where the parallel engine crashed when creating ghost zones from global ids.</li>
+  <li>Fixed a bug with the progress dialog staying visible when a client connection fails.</li>
+  <li>Added a menu indicator icon to the Color Table buttons so that it is more obvious that the button can be pushed to see available options.<li>
+  <li>Fixed a bug preventing the user from being able to performa a Pick Through Time using mesh quality metrics.</li>
   <li>Fixed a couple of bugs with the MutilCurve plot. Fixed a bug where portions of the axes were missing or incomplete after switching the orientation. Fixed a bug where there were no tickmarks when displaying 16 curves.</li>
-  <li>Fixed a bug in ColorTable window that limited number of color control points to 200.</li>
+  <li>Fixed a bug in the ColorTable window that limited the number of color control points to 200.</li>
   <li>Added Philip Blakely's code to fix the memory leak in the Lines Database.</li>
-  <li>Fixed a bug in ColorTable window that prevented colors on 'equal' control points from being changed.</li>
-  <li>Duplicate expressions in the gui are now handled gracefully with an automatic name change.</li>
+  <li>Fixed a bug in the ColorTable window that prevented colors on 'equal' control points from being changed.</li>
+  <li>Modified the GUI so that duplicate expressions are now handled gracefully with an automatic name change.</li>
   <li>Fixed a bug preventing VisIt from correctly reading some types of files on Ubuntu when using non-English language settings.</li>
   <li>Adding and deleting expressions in the expressions window now only takes effect when actually clicking the apply button.</li>
   <li>Fixed a bug with the CGNS reader that caused VisIt to crash when doing a Subset plot of "zones" when reading data decomposed across multiple CGNS files.</li>
-  <li>Fixed a bug preventing database plugins from being able to plot variables of the form "variable_name(subname)".</li>
-  <li>Fixed a bug which caused the Mili database plugin to add duplicate materials.</li>
   <li>Fixed a bug preventing some multi-processor mili datasets from being properly read.</li>
-  <li>Fixed a bug which caused external surfaces to be lost in the pseudocolor plot when using a gradient expression on a Curvilinear mesh (Structured Grid)</li>
- <li>Changed the vertical scroll bar mode for the plot list to <b>ScrollPerPixel</b> and to use a single step so that the bottom of the plot list is not cutoff.</li>
+  <li>Fixed a bug preventing database readers from being able to plot variables of the form "variable_name(subname)".</li>
+  <li>Fixed a bug that caused the Mili database reader to add duplicate materials.</li>
+  <li>Fixed a bug which caused external surfaces to be lost in the pseudocolor plot when using a gradient expression on a Curvilinear mesh (Structured Grid).</li>
+  <li>Changed the vertical scroll bar mode for the plot list to <b>ScrollPerPixel</b> and to use a single step so that the bottom of the plot list is not cutoff.</li>
   <li>Fixed a bug preventing VisIt from displaying the manuals when using an out-of-source build.</li>
+  <li>Fixed a bug where the Plots Add menu would become disabled after drawing plots via the CLI, then calling OpenGUI() and deleting a plot.
 </ul>
 
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.1.3</font></b></p>
 <ul>
-  <li>The Mili library was updated to version 19.2.</li>
   <li>Increased the number of curves allowed by the MultiCurve plot from 16 to 20.</li>
   <li>The Revolve operator was enhanced to be capable of revolving points/particles.</li>
+  <li>The Mili library was updated to version 19.2.</li>
   <li>The Lineout operator documentation was improved in the GUI manual to describe in detail how the sampling and interpolation is performed.</li>
   <li>Added the ability to generate ghost nodes for datasets that consist of collections of structured grids by matching the coordinates of the nodes on the exterior of individual structured grids. The coordinates must match exactly for them to be matched. Ghost nodes allow internal faces to be eliminated from Mesh, Filled Boundary, Pseudocolor and Subset plots. This improves rendering performance by reducing the amount of geometry to render. It also improves image quality for images rendered with transparency since it eliminates geometry that you are most likely not interested in seeing.</li>
   <li>Updated the host profiles for the Sandia National Laboratories computer systems, adding host profiles for new systems and removing ones for obsolete systems.</li>


### PR DESCRIPTION
Resolves #2604.
Merge from 3.1RC.
Gui was closing the file after plot was deleted because the file opened from the cli wasn't added to its appliedFileList.
