### PR TITLE
Modify rect2d.silo to include a variable with mixed material values.

### DIFF
--- a/data/silo_hdf5_test_data.7z
+++ b/data/silo_hdf5_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2435f8d6fe58ee7d0aa1e83d9dbfff4821909e556a4c2f1b48dda6513f172857
-size 8644389
+oid sha256:d66351b87a268a3c5591225b8abd7e7b18f954304ef810e443ffaa4d77ab0ae4
+size 14464601

--- a/data/silo_pdb_test_data.7z
+++ b/data/silo_pdb_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd307d8145330118dbba6859ef6c3c05aa59db8bf11285f2af718d276ac239e8
-size 14822087
+oid sha256:85eb8e5f1bbb078792d4634d15ec49829fd384bb92b49566089e635d18b1f7c1
+size 14820394

--- a/src/tools/data/datagen/testall.C
+++ b/src/tools/data/datagen/testall.C
@@ -1324,7 +1324,6 @@ build_ucd2d_lines(DBfile * dbfile, int size)
     double          dtime;
     int             tdim;
     float          *coords[2];
-    int             dims[1];
     float           x[13], y[13];
     float           d[13],u[13],v[13];
     float           p[16];
@@ -1472,8 +1471,6 @@ build_ucd2d_lines(DBfile * dbfile, int size)
 
     DBPutUcdmesh(dbfile, "ucd_linesmesh2d", 2, NULL, coords, nnodes, nzones,
                  "ucd2d_zonelist", NULL, DB_FLOAT, optlist);
-
-    dims[0] = nzones;
 
     DBPutUcdvar1(dbfile, "d", "ucd_linesmesh2d", d, nnodes, NULL, 0, DB_FLOAT,
                  DB_NODECENT, NULL);
@@ -2661,7 +2658,6 @@ build_ucd3d_lines(DBfile * dbfile, int size)
     double          dtime;
     int             tdim;
     float          *coords[3];
-    int             dims[1];
     float           x[13], y[13], z[13];
     float           d[13];
     float           p[16];
@@ -3478,7 +3474,6 @@ main(int argc, char *argv[])
 {
     int            i;
     int            size;
-    int            ntests = 0;
     int            driver = DB_PDB;
 
     //
@@ -3498,7 +3493,7 @@ main(int argc, char *argv[])
         else if (strcmp(argv[i], "DB_PDB") == 0)
             driver = DB_PDB;
         else
-           fprintf(stderr,"Uncrecognized driver name \"%s\"\n", argv[i]);
+           fprintf(stderr,"WARNING: Unrecognized command line option %s.\n", argv[i]);
     }
 
     //
@@ -3507,10 +3502,6 @@ main(int argc, char *argv[])
     DBShowErrors(DB_ABORT, NULL);
 
     MakeFiles(size, driver);
-    ntests++;
-
-    if (!ntests)
-        printf("No tests performed.\n");
 
     return(0);
 }

--- a/src/tools/data/datagen/testall.C
+++ b/src/tools/data/datagen/testall.C
@@ -349,6 +349,12 @@ build_rect2d(DBfile * dbfile, int size)
     ascii = ALLOC_N (float, nx * ny);
     asciiw = ALLOC_N (char, nx * ny * 9);
     matlist = ALLOC_N (int, nx * ny);
+    //
+    // The 40 was choosen to hopefully over allocate the array. There
+    // is a check later on that checks if we exceeded the allocation
+    // and exits with an error message on the assumption that we will
+    // have clobbered memory and things may be in a bad state.
+    //
     mix_next = ALLOC_N (int, 40 * ny);
     mix_mat  = ALLOC_N (int, 40 * ny);
     mix_zone = ALLOC_N (int, 40 * ny);
@@ -544,6 +550,17 @@ build_rect2d(DBfile * dbfile, int size)
                      mix_vf, &mixlen, 18, 0.1);
 
     //
+    // Check if we have exceeded the allocation for the mixed variable
+    // arrays. If we have print an error message and exit.
+    //
+    if (mixlen > 40 * ny)
+    {
+        fprintf (stderr, "ERROR: Hard-coded mixlen exceeded at line %d.\n",
+                 __LINE__);
+        exit (1);
+    }
+
+    //
     // Calculate dmix.
     //
     for (i = 0; i < nx * ny; i++)
@@ -560,12 +577,6 @@ build_rect2d(DBfile * dbfile, int size)
             mix_dmix[m2] = mix_mat[m2] * 0.2;
             d[i] = mix_dmix[m1] * mix_vf[m1] + mix_dmix[m2] * mix_vf[m2];
         }
-    }
-
-    if (mixlen > 40 * ny)
-    {
-        printf ("mixlen = %d\n", mixlen);
-        exit (1);
     }
 
     //


### PR DESCRIPTION
### Description

I modified testall.C to add a variable that includes per material values for mixed material zones to the file rect2d.silo. The new variable is dmix. I used it to generate both PDB and HDF5 versions of Silo files and replaced them in the appropriate tar files in the data directory.

I did this so that I had a readily available file to test functionality that utilized variables with per material values for mixed material zones.

### Type of change

New feature.

### How Has This Been Tested?

I ran the program and then opened up the resulting Silo files with VisIt 3.1.2 and verified that the new data was as expected. I did a pseudocolor plot of dmix, with and without "Force interface reconstruction"

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have assigned reviewers