### PR TITLE
Correct rect2d.silo generation.

### DIFF
--- a/data/silo_hdf5_test_data.7z
+++ b/data/silo_hdf5_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d66351b87a268a3c5591225b8abd7e7b18f954304ef810e443ffaa4d77ab0ae4
-size 14464601
+oid sha256:ff5b7587e21669876d2fcefb07ff7318e1dc58195c03f39da4621430ddc3fab4
+size 14467409

--- a/data/silo_pdb_test_data.7z
+++ b/data/silo_pdb_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85eb8e5f1bbb078792d4634d15ec49829fd384bb92b49566089e635d18b1f7c1
-size 14820394
+oid sha256:97c1b8363670ec83a80fe4bbc8320c0549d89b6f39ac1c977c59d9d247e16cad
+size 14821193

--- a/src/tools/data/datagen/testall.C
+++ b/src/tools/data/datagen/testall.C
@@ -567,7 +567,7 @@ build_rect2d(DBfile * dbfile, int size)
     {
         if (matlist[i] > 0)
         {
-            d[i] = matlist[i] * 0.2;
+            dmix[i] = matlist[i] * 0.2;
         }
         else
         {
@@ -575,7 +575,7 @@ build_rect2d(DBfile * dbfile, int size)
             int m2 = mix_next[m1] - 1;
             mix_dmix[m1] = mix_mat[m1] * 0.2;
             mix_dmix[m2] = mix_mat[m2] * 0.2;
-            d[i] = mix_dmix[m1] * mix_vf[m1] + mix_dmix[m2] * mix_vf[m2];
+            dmix[i] = mix_dmix[m1] * mix_vf[m1] + mix_dmix[m2] * mix_vf[m2];
         }
     }
 
@@ -635,8 +635,8 @@ build_rect2d(DBfile * dbfile, int size)
     DBFreeOptlist(varOptList);
 
     varOptList = rect2d_var_optlist("g/cm^2", &cycle, &time, &dtime);
-    DBPutQuadvar1(dbfile, "dmix", meshname, d, zdims, ndims, mix_dmix, mixlen,
-                  DB_FLOAT, DB_ZONECENT, varOptList);
+    DBPutQuadvar1(dbfile, "dmix", meshname, dmix, zdims, ndims, mix_dmix,
+                  mixlen, DB_FLOAT, DB_ZONECENT, varOptList);
     DBFreeOptlist(varOptList);
 
     DBPutMaterial(dbfile, matname, meshname, nmats, matnos, matlist, dims2,


### PR DESCRIPTION
### Description

I accidentally modified the value of the variable "d" in my change of the generation of rect2d.silo by testall.C. This caused a bunch of test suite failures. I will check these changes in and then rebaseline the changed images in a separate checkin later today.

### Type of change

Bug fix.

### How Has This Been Tested?

I checked the "d" was now the same as it was before my change yesterday.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code