### PR TITLE
Revert browser manuals update RC

### DIFF
--- a/src/gui/QvisHelpWindow.C
+++ b/src/gui/QvisHelpWindow.C
@@ -1405,10 +1405,6 @@ QvisHelpWindow::displayHome()
 //   Kathleen Bonnell, Thu Apr  8 17:20:52 PST 2010
 //   Convert file to url so it will work on windows.
 //
-//   Alister Maguire, Thu Aug 13 16:50:36 PDT 2020
-//   Updated so that the VisIt manuals are rendered in the user's default
-//   web browser.
-//
 // ****************************************************************************
 
 bool
@@ -1421,24 +1417,7 @@ QvisHelpWindow::displayPage(const QString &page, bool reload)
         QString file(CompleteFileName(page));
         if(QFile(file).exists())
         {
-            //
-            // We open the VisIt manuals using the user's default browser. All
-            // other pages are rendered inside of the widget using Qt.
-            //
-            if (page == manualPath)
-            {
-                helpBrowser->clear();
-                if (!QDesktopServices::openUrl(QUrl::fromLocalFile(file)))
-                {
-                    Error(tr("The VisIt Manuals were unable to be "
-                        "opened."));
-                }
-            }
-            else
-            {
-                helpBrowser->setSource(QUrl::fromLocalFile(file));
-            }
-
+            helpBrowser->setSource(QUrl::fromLocalFile(file));
             helpFile = page;
             retval = true;
         }

--- a/src/resources/help/en_US/relnotes3.1.3.html
+++ b/src/resources/help/en_US/relnotes3.1.3.html
@@ -64,7 +64,6 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added the Tessellate operator, which tessellates high order elements into linear elements. The following high order cell types are supported: QUADRATIC_EDGE, CUBIC_LINE, LAGRANGE_TRIANGLE, QUADRATIC_TRIANGLE, BIQUADRATIC_TRIANGLE, LAGRANGE_QUADRILATERAL, BIQUADRATIC_QUAD, QUADRATIC_QUAD, LAGRANGE_TETRAHEDRON, QUATRADIC_TETRA, LAGRANGE_HEXAHEDRON and QUADRATIC_HEXAHEDRON. All unsupported types will be removed from the mesh.</li>
   <li>Added parallel support for Remap operator.</li>
   <li>Added host profiles for the Lawrence Livermore National Laboratory's Tron system. Removed the host profiles for the Lawrence Livermore National Laboratory's Cmax system.</li>
-  <li>Enhanced the VisIt Help menu such that the VisIt Manuals are opened in the user's default web browser instead of being rendered in the GUI window.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

This reverts commit 88be2a270864b3a622d5e5bf78ec5629a62b7a23.

We're encountering some issues with opening the docs on certain systems.
We need to figure out a better way of handling this. Reverting for the time being.

### How Has This Been Tested?

I've opened the manuals in VisIt's help menu to make sure that the changes have been reverted.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
