### PR TITLE
Enable paradis readers on Windows

### DIFF
--- a/src/databases/CMakeLists.txt
+++ b/src/databases/CMakeLists.txt
@@ -367,6 +367,11 @@ CHECK_THIRDPARTY_SATISFIED(MFEM    MFEM)
 
 CHECK_THIRDPARTY_SATISFIED(OpenEXR OPENEXR)
 
+if(VISIT_PARADIS)
+    CHECK_THIRDPARTY_SATISFIED(paraDIS BOOST)
+    CHECK_THIRDPARTY_SATISFIED(paraDIS_tecplot BOOST)
+endif()
+
 # special cases for windows
 IF(WIN32)
     CHECK_THIRDPARTY_SATISFIED(H5Part H5PART)
@@ -376,10 +381,6 @@ ELSE()
     ELSE()
         CHECK_THIRDPARTY_SATISFIED(H5Part H5PART)
     ENDIF()
-    if(VISIT_PARADIS)
-        CHECK_THIRDPARTY_SATISFIED(paraDIS BOOST)
-        CHECK_THIRDPARTY_SATISFIED(paraDIS_tecplot BOOST)
-    endif()
 ENDIF()
 
 # Save the list of all library dirs and libs so the engine can use it

--- a/src/databases/paraDIS/CMakeLists.txt
+++ b/src/databases/paraDIS/CMakeLists.txt
@@ -23,13 +23,7 @@ parallelParaDIS.C
 Dumpfile.C
 paraDIS_lib/paradis.C
 paraDIS_lib/paradis_c_interface.C
-RC_cpp_lib/RC_c_lib/args.c
 RC_cpp_lib/RC_c_lib/debugutil.c
-RC_cpp_lib/RC_c_lib/fileutils.c
-RC_cpp_lib/RC_c_lib/inventor.c
-RC_cpp_lib/RangeList.C
-RC_cpp_lib/timer.C
-RC_cpp_lib/pathutil.C
 )
 
 SET(LIBE_SOURCES
@@ -41,13 +35,7 @@ parallelParaDIS.C
 Dumpfile.C
 paraDIS_lib/paradis.C
 paraDIS_lib/paradis_c_interface.C
-RC_cpp_lib/RC_c_lib/args.c
 RC_cpp_lib/RC_c_lib/debugutil.c
-RC_cpp_lib/RC_c_lib/fileutils.c
-RC_cpp_lib/RC_c_lib/inventor.c
-RC_cpp_lib/RangeList.C
-RC_cpp_lib/timer.C
-RC_cpp_lib/pathutil.C
 )
 
 INCLUDE_DIRECTORIES(

--- a/src/databases/paraDIS/RC_cpp_lib/RC_c_lib/debugutil.c
+++ b/src/databases/paraDIS/RC_cpp_lib/RC_c_lib/debugutil.c
@@ -32,13 +32,17 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <math.h>
 #include <stdarg.h>
 #include "debugutil.h"
 #include <time.h>
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif
 
 static  int iVerbose = 0;
 static  int iCheck = 0;

--- a/src/databases/paraDIS/RC_cpp_lib/pathutil.h
+++ b/src/databases/paraDIS/RC_cpp_lib/pathutil.h
@@ -1,8 +1,12 @@
 #ifndef RDC_PATHUTIL_H
 #define RDC_PATHUTIL_H
+#ifdef RC_CPP_VISIT_BUILD
+#include <FileFunctions.h>
+#else
 #include "stringutil.h"
 
 #include <limits.h>
+#endif
 #ifdef _WIN32
 #include <direct.h>
 #define getcwd _getcwd
@@ -31,7 +35,14 @@
   Dirname("/") == "/"
 
 */ 
-inline string Dirname(string filename) {
+inline string Dirname(string filename)
+{
+#ifdef RC_CPP_VISIT_BUILD
+  // KSB 9-25-2020
+  // Rather than rework the unix-specific code below, utilize VisIt's
+  // Dirname function which works on all our platforms.
+  return FileFunctions::Dirname(filename);
+#else
   string dirname = StripBack(filename, "/"); 
 
   if (!dirname.length()) return string("/");
@@ -53,13 +64,21 @@ inline string Dirname(string filename) {
     throw string("Error in Dirname(): Logic error: there are no '/' chars in supposedly absolute path: ") + dirname; 
   }
   return  StripBack(dirname.substr(0,loc),"/"); 
+#endif
 }
 
 //===============================================================
 /*!
   Returns the last link of the filename, ala the "basename" shell command.  
 */ 
-inline string Basename(string filename) {
+inline string Basename(string filename)
+{
+#ifdef RC_CPP_VISIT_BUILD
+  // KSB 9-25-2020
+  // Rather than rework the unix-specific code below, utilize VisIt's
+  // Basename function which works on all our platforms.
+  return FileFunctions::Basename(filename);
+#else
   filename = StripBack(filename, "/"); 
   string::size_type loc = filename.rfind("/");
   if (loc == string::npos) {
@@ -68,5 +87,6 @@ inline string Basename(string filename) {
   string filename2 = filename.substr(loc+1); 
   
   return filename2; 
+#endif
 }
 #endif

--- a/src/databases/paraDIS/avtparaDISFileFormat.C
+++ b/src/databases/paraDIS/avtparaDISFileFormat.C
@@ -10,9 +10,6 @@
 #include <avtparaDISOptions.h>
 #include <DBOptionsAttributes.h>
 #include <DebugStream.h>
-#include "stringutil.h"
-#include "debugutil.h"
-#include "pathutil.h"
 #include "version.h"
 #include "paradis.h"
 #include <string>

--- a/src/databases/paraDIS/paraDIS.xml
+++ b/src/databases/paraDIS/paraDIS.xml
@@ -1,34 +1,13 @@
 <?xml version="1.0"?>
   <Plugin name="paraDIS" type="database" label="paraDIS simulation dump metafile" version="2.3.4" enabled="true" mdspecificcode="false" onlyengine="false" noengine="false" dbtype="STSD" haswriter="false" hasoptions="true">
-    <Files components="M">
-      avtparaDISFileFormat.C      
-      avtparaDISOptions.C     
+    <Files components="E,M">
+      avtparaDISFileFormat.C
+      avtparaDISOptions.C
       parallelParaDIS.C
       Dumpfile.C
-      paraDIS_lib/paradis.C 
-      paraDIS_lib/paradis_c_interface.C   
-      RC_cpp_lib/RC_c_lib/args.c 
-      RC_cpp_lib/RC_c_lib/debugutil.c 
-      RC_cpp_lib/RC_c_lib/fileutils.c 
-      RC_cpp_lib/RC_c_lib/inventor.c
-      RC_cpp_lib/RangeList.C 
-      RC_cpp_lib/timer.C 
-      RC_cpp_lib/pathutil.C
-    </Files>
-    <Files components="E">
-      avtparaDISFileFormat.C      
-      avtparaDISOptions.C      
-      parallelParaDIS.C
-      Dumpfile.C
-      paraDIS_lib/paradis.C 
-      paraDIS_lib/paradis_c_interface.C   
-      RC_cpp_lib/RC_c_lib/args.c 
-      RC_cpp_lib/RC_c_lib/debugutil.c 
-      RC_cpp_lib/RC_c_lib/fileutils.c 
-      RC_cpp_lib/RC_c_lib/inventor.c
-      RC_cpp_lib/RangeList.C 
-      RC_cpp_lib/timer.C 
-      RC_cpp_lib/pathutil.C
+      paraDIS_lib/paradis.C
+      paraDIS_lib/paradis_c_interface.C
+      RC_cpp_lib/RC_c_lib/debugutil.c
     </Files>
     <CXXFLAGS>
       -IparaDIS_lib

--- a/src/databases/paraDIS_tecplot/CMakeLists.txt
+++ b/src/databases/paraDIS_tecplot/CMakeLists.txt
@@ -18,33 +18,16 @@ SET(LIBM_SOURCES
 paraDIS_tecplotMDServerPluginInfo.C
 ${COMMON_SOURCES}
 avtparaDIS_tecplotFileFormat.C
-RC_c_lib/args.c
-RC_c_lib/debugutil.c
-RC_c_lib/signals.c
-RC_c_lib/fileutils.c
-RC_c_lib/inventor.c
-RC_cpp_lib/RangeList.C
-RC_cpp_lib/timer.C
-RC_cpp_lib/pathutil.C
 )
 
 SET(LIBE_SOURCES
 paraDIS_tecplotEnginePluginInfo.C
 ${COMMON_SOURCES}
 avtparaDIS_tecplotFileFormat.C
-RC_c_lib/args.c
-RC_c_lib/debugutil.c
-RC_c_lib/signals.c
-RC_c_lib/fileutils.c
-RC_c_lib/inventor.c
-RC_cpp_lib/RangeList.C
-RC_cpp_lib/timer.C
-RC_cpp_lib/pathutil.C
 )
 
 INCLUDE_DIRECTORIES(
 ${CMAKE_CURRENT_SOURCE_DIR}
-RC_c_lib
 RC_cpp_lib
 ${VISIT_COMMON_INCLUDES}
 ${VISIT_INCLUDE_DIR}/avt/DBAtts/MetaData

--- a/src/databases/paraDIS_tecplot/paraDIS_tecplot.xml
+++ b/src/databases/paraDIS_tecplot/paraDIS_tecplot.xml
@@ -1,40 +1,20 @@
 <?xml version="1.0"?>
   <Plugin name="paraDIS_tecplot" type="database" label="paraDIS simulation dump metafile" version="1.0a1" enabled="true" mdspecificcode="false" engspecificcode="false" onlyengine="false" noengine="false" dbtype="STSD" haswriter="false" hasoptions="false" filePatternsStrict="false">
-    <Files components="M">
-avtparaDIS_tecplotFileFormat.C    
-RC_c_lib/args.c 
-RC_c_lib/debugutil.c 
-RC_c_lib/signals.c 
-RC_c_lib/fileutils.c 
-RC_c_lib/inventor.c
-RC_cpp_lib/RangeList.C 
-RC_cpp_lib/timer.C 
-RC_cpp_lib/pathutil.C
-     </Files>
-    <Files components="E">
-avtparaDIS_tecplotFileFormat.C    
-RC_c_lib/args.c 
-RC_c_lib/debugutil.c 
-RC_c_lib/signals.c 
-RC_c_lib/fileutils.c 
-RC_c_lib/inventor.c
-RC_cpp_lib/RangeList.C 
-RC_cpp_lib/timer.C 
-RC_cpp_lib/pathutil.C
-     </Files>
-   <CXXFLAGS>
-      -IRC_c_lib
-      -IRC_cpp_lib
+    <Files components="M,E">
+        avtparaDIS_tecplotFileFormat.C
+    </Files>
+    <CXXFLAGS>
+        -IRC_cpp_lib
     </CXXFLAGS>
     <DEFINES>
-      -DNO_BOOST
+        -DNO_BOOST
     </DEFINES>
     <FilePatterns>
-      *.fld
-      *.field
-      *.cyl
-      *.cylinder
-      *.dat      
+        *.fld
+        *.field
+        *.cyl
+        *.cylinder
+        *.dat
     </FilePatterns>
     <Attribute name="" purpose="" persistent="true" keyframe="true" exportAPI="" exportInclude="">
     </Attribute>

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -30,7 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.1.4</font></b></p>
 <ul>
-  <li>Enhancement 1</li>
+  <li>Enabled the paraDIS and paraDIS_tecplot readers on Windows.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
Port paradis plugins to Windows. Resolves #5078

While attempting to fix compile errors I discovered that not all of the paraDIS code base stored in the VisIt plugin needs to be compiled with the reader, so I removed unnecessary sources from the xml file (and thereby CMakeLists.txt).

Merge from 3.1RC