### PR TITLE
Remove check for unrecognized modes

### DIFF
--- a/src/test/tests/faulttolerance/assertmode.py
+++ b/src/test/tests/faulttolerance/assertmode.py
@@ -24,18 +24,11 @@ def GetModeKeysFromClArgs():
     return ('serial',)
 
 #
-# Ensure all mode keys are known
-#
-def AllModeKeysRecognized():
-    for m in activeModeKeys:
-        if m not in knownModeKeys:
-            return False
-    return True
-
-#
 # Ensure all mode keys are compatible
 #
 def AllModeKeysCompatible():
+    if 'serial' in activeModeKeys and 'parallel' in activeModeKeys:
+        return False
     if 'pdb' in activeModeKeys and 'hdf5' in activeModeKeys:
         return False
     if 'icet' in activeModeKeys and 'parallel' not in activeModeKeys:
@@ -102,9 +95,7 @@ def AllowdynamicClargMatchesMode():
 # need to interrogate their contents in the above functions.
 #
 activeModeKeys = GetModeKeysFromClArgs()
-knownModeKeys = json.loads(TestEnv.params["mode_keys"])
 
-AssertTrue("All mode strings recognized", AllModeKeysRecognized())
 AssertTrue("All mode strings compatible", AllModeKeysCompatible())
 AssertTrue("Engine matches mode", EngineMatchesMode())
 AssertTrue("Silo data path matches mode", SiloDataPathMatchesMode())

--- a/src/test/visit_test_suite.py
+++ b/src/test/visit_test_suite.py
@@ -254,7 +254,6 @@ def launch_visit_test(args):
     tparams["sessionfiles"]   = opts["sessionfiles"]
     tparams["cmake_cmd"]      = opts["cmake_cmd"]
     tparams["clargs"]         = json.dumps(sys.argv)
-    tparams["mode_keys"]      = json.dumps(known_mode_keys())
 
     exe_dir, exe_file = os.path.split(tparams["visit_bin"])
     if sys.platform.startswith("win"):
@@ -604,10 +603,10 @@ def parse_args():
     parser.add_option("-m",
                       "--modes",
                       default=defs["modes"],
-                      help="specify mode in which to run tests "
-                           "choose from %s "
-                           "and comma-separated combinations such as "
-                           "scalable,parallel [default serial]"%known_mode_keys())
+                      help="specify mode keys used to run tests "
+                           "choose from %s and comma-separated combinations such as "
+                           "scalable,parallel. Any unrecognized mode keys are passed "
+                           "through uninterpreted. [default serial]"%known_mode_keys())
     parser.add_option("-c",
                       "--classes",
                       default=defs["classes"],


### PR DESCRIPTION
`regressiontest_pascal` overloads the `-m` (mode) command-line argument to the test harness with keys like `pascal` (for the host) and `trunk` (for the branch -- actually why are we calling it `trunk`, it should be `develop` if it is intended to truly be a git branchname). It expects these unrecognized keys to be passed through uninterpreted but I had added logic in the `assertmode.py` test to flag any mode key that was unrecognized.

Since these extra *mode* keys can change somewhat routinely, I opted not to create a maint. issue and removed the check for UNrecognized keys from the test.