### PR TITLE
Fix help display on windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -454,6 +454,9 @@
 #    Alister Maguire, Thu Aug 13 13:41:20 PDT 2020
 #    Updated the manuals target so that it builds in the binary directory.
 #
+#    Kathleen Biagas, Thu Oct 1, 2020
+#    Add retrieval of git revision hash.
+#
 #****************************************************************************
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.8 FATAL_ERROR)
@@ -1733,28 +1736,26 @@ ENDFUNCTION(MAC_NIB_INSTALL)
 #-----------------------------------------------------------------------------
 #dummy revision, in case commands fail
 SET(VISIT_GIT_VERSION "Unknown")
-# Get the subversion revision number
-IF(EXISTS ${VISIT_SOURCE_DIR}/GIT_VERSION)
-    FILE(STRINGS ${VISIT_SOURCE_DIR}/GIT_VERSION VISIT_GIT_VERSION)
-ELSE(EXISTS ${VISIT_SOURCE_DIR}/GIT_VERSION)
     IF (EXISTS ${VISIT_SOURCE_DIR}/../.git)
         # Only try and determine the version number if it looks like
         # we're in a working copy (a .git directory should be present)
-#        FIND_PACKAGE(Subversion)
-#        IF(Subversion_FOUND)
-#            Subversion_WC_INFO(${PROJECT_SOURCE_DIR} VISIT)
-#            SET(VISIT_SVN_REVISION "${VISIT_WC_REVISION}")
-#        ELSE(Subversion_FOUND)
-#            IF(WIN32)
-#                INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindTortoiseSVN.cmake)
-#                IF(TortoiseSVN_FOUND)
-#                    TortoiseSVN_WC_INFO(${PROJECT_SOURCE_DIR} VISIT)
-#                    SET(VISIT_SVN_REVISION "${VISIT_WC_REVISION}")
-#                ENDIF(TortoiseSVN_FOUND)
-#            ENDIF(WIN32)
-#        ENDIF(Subversion_FOUND)
-    ENDIF (EXISTS ${VISIT_SOURCE_DIR}/../.git)
-ENDIF(EXISTS ${VISIT_SOURCE_DIR}/GIT_VERSION)
+    find_package(Git QUIET)
+    if(Git_FOUND)
+        # if we would prefer the full hash, remove --short in the command
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
+            WORKING_DIRECTORY "${VISIT_SOURCE_DIR}"
+            RESULT_VARIABLE found_it
+            OUTPUT_VARIABLE git_rev
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(${found_it} EQUAL 0)
+            SET(VISIT_GIT_VERSION ${git_rev})
+        endif()
+        unset(found_it)
+        unset(git_rev)
+    endif()
+endif()
 
 #-----------------------------------------------------------------------------
 # Set up resource files for Windows applications.

--- a/src/bin/visit.c
+++ b/src/bin/visit.c
@@ -2,6 +2,7 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
+#include <conio.h>
 #include <direct.h>
 #include <stdio.h>
 #include <string.h>
@@ -15,9 +16,11 @@
 #include <shlobj.h>
 #include <shlwapi.h>
 
-#include <vector>
-#include <string>
+#include <fstream>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 using std::vector;
 using std::string;
@@ -55,7 +58,10 @@ typedef vector<string> stringVector;
 /*
  * Constants
  */
-static const char usage[] = 
+
+// Old Style usage text to be used for Released versions (no console),
+// if a NewConsole cannot be created.
+static const char usage[] =
 "USAGE:  visit [arguments]\n"
 "\n"
 "    Program arguments:\n"
@@ -97,6 +103,40 @@ static const char usage[] =
 "        -env                 Print environment strings set up by the launcher\n"
 "\n";
 
+// Extra usage flags for Windows (not part of visitusage.txt)
+// The Tools section will always be needed due to how they are launched on
+// Windows.
+// Some of the others are part of visitusageplus.txt so can be removed if
+// it is decided that -fullhelp should be supported on Windows.
+static const char windows_usage[] =
+"\n"
+" Windows-OS specific options.\n"
+"\n"
+"    Tools options:\n"
+"--------------------------------------------------------------------------\n"
+"        -xmledit             Run the xmledit tool.\n"
+"        -xml2atts            Run the xml2atts tool.\n"
+"        -xml2cmake           Run the xml2cmake tool.\n"
+"        -xml2java            Run the xml2java tool.\n"
+"        -xml2python          Run the xml2python tool.\n"
+"        -public              xml2cmake: force install plugins publicly\n"
+"        -private             xml2cmake: force install plugins privately\n"
+"        -clobber             Permit xml2... tools to overwrite old files\n"
+"        -noprint             Silence debugging output from xml2... tools\n"
+"        -silex               Run the silex tool.\n"
+"\n"
+"    Debugging options:\n"
+"--------------------------------------------------------------------------\n"
+"        -newconsole          Run the component in a new console window\n"
+"        -env                 Print environment strings set up by the launcher\n"
+"\n"
+"    Movie options:\n"
+"--------------------------------------------------------------------------\n"
+"        -mpeg2encode         Run mpeg2encode program for movie-making\n"
+"        -composite           Run composite program for movie-making\n"
+"        -transition          Run transition program for movie-making\n"
+"\n";
+
 /*
  * Prototypes
  */
@@ -107,6 +147,12 @@ string AddPath(char *, const char *, const char*);
 bool   ReadKey(const char *key, char **keyval);
 void   PrintEnvironment(void);
 string WinGetEnv(const char * name);
+string GetUsageTextDir(void);
+
+bool RedirectConsoleIO();
+bool ReleaseConsole();
+void AdjustConsoleBuffer(int16_t minLength);
+bool CreateNewConsole(int16_t minLength);
 
 static bool EndsWith(const char *s, const char *suffix)
 {
@@ -131,8 +177,8 @@ static bool EndsWith(const char *s, const char *suffix)
  *
  * Modifications:
  *   Brad Whitlock, Mon Jul 15 10:57:32 PDT 2002
- *   I changed the code so it uses the entire path to the executable. This 
- *   prevents an error where the viewer cannot be found because of another 
+ *   I changed the code so it uses the entire path to the executable. This
+ *   prevents an error where the viewer cannot be found because of another
  *   Windows program called "viewer".
  *
  *   Brad Whitlock, Thu Jul 18 11:32:52 PDT 2002
@@ -172,33 +218,33 @@ static bool EndsWith(const char *s, const char *suffix)
  *
  *   Brad Whitlock, Tue Sep 19 17:09:57 PST 2006
  *   Added support for mpeg2enc.exe so we can create MPEG movies on Windows.
- * 
+ *
  *   Brad Whitlock, Thu Dec 21 14:52:11 PST 2006
  *   Added support for transition and composite programs.
  *
  *   Kathleen Bonnell, Thu Mar 22 09:29:45 PDT 2007
- *   Enclose argv[i] in quotes before calling PUSHARG, if there are spaces. 
+ *   Enclose argv[i] in quotes before calling PUSHARG, if there are spaces.
  *
- *   Kathleen Bonnell, Mon Jul  2 10:43:29 PDT 2007 
- *   Remove last fix. 
+ *   Kathleen Bonnell, Mon Jul  2 10:43:29 PDT 2007
+ *   Remove last fix.
  *
- *   Kathleen Bonnell, Tue Jul 24 15:19:23 PDT 2007 
+ *   Kathleen Bonnell, Tue Jul 24 15:19:23 PDT 2007
  *   Added tests for spaces in args, so they can be surrounded in quotes, and
  *   for args beginning with quotes so that the entire arg can be concatenated
- *   into 1 argument surrounded by quotes. 
+ *   into 1 argument surrounded by quotes.
  *
- *   Kathleen Bonnell, Tue Jan  8 18:09:38 PST 2008 
+ *   Kathleen Bonnell, Tue Jan  8 18:09:38 PST 2008
  *   When parsing args, moved around the order of testing for spaces and
- *   surrounding quotes, to fix problem with path-with-spaces used with -o. 
- * 
- *   Kathleen Bonnell, Fri Feb 29 16:43:46 PST 2008 
- *   Added call to free printCommand. 
+ *   surrounding quotes, to fix problem with path-with-spaces used with -o.
  *
- *   Kathleen Bonnell, Thu Jul 17 4:16:22 PDT 2008 
+ *   Kathleen Bonnell, Fri Feb 29 16:43:46 PST 2008
+ *   Added call to free printCommand.
+ *
+ *   Kathleen Bonnell, Thu Jul 17 4:16:22 PDT 2008
  *   Added call to free visitargs if not found, because ReadKey does the
  *   allocation regardless.
  *
- *   Kathleen Bonnell, Wed Sep 10 16:19:53 PDT 2008 
+ *   Kathleen Bonnell, Wed Sep 10 16:19:53 PDT 2008
  *   Added loopback support: it replaces the remote host name with 127.0.0.1
  *   unless the "-noloopback" flag is given by visit or by the user.
  *
@@ -206,7 +252,7 @@ static bool EndsWith(const char *s, const char *suffix)
  *   I fixed a bug with host renaming that caused invalid security keys on
  *   machines with short hostnames.
  *
- *   Kathleen Bonnell, Tue Mar 17 16:55:32 MST 2009 
+ *   Kathleen Bonnell, Tue Mar 17 16:55:32 MST 2009
  *   Added 'TestForConfigFiles' and attendant methods.
  *
  *   Kathleen Bonnell, Frid Sep 11 10:43:57 MST 2009
@@ -219,17 +265,17 @@ static bool EndsWith(const char *s, const char *suffix)
  *   Add support for xml2cmake.
  *
  *   Kathleen Bonnell, Tue May 3 14:31:50 MST 2011
- *   Add support for -env. 
+ *   Add support for -env.
  *
  *   Kathleen Bonnell, Mon Sep 26 07:13:08 MST 2011
  *   Add support for parallel engine.  Use string for arg storage.
  *
  *   Kathleen Bonnell, Thu Sep 29 16:41:28 MST 2011
  *   Pass over 'visit' and '-visit' args.
- * 
+ *
  *   Brad Whitlock, Thu Dec 8 14:51:PST 2011
- *   Skip over arguments that end with 'visit', 'visit.exe', 'visit"', 
- *   'visit.exe"' since we're starting the argv iteration at 0, which means 
+ *   Skip over arguments that end with 'visit', 'visit.exe', 'visit"',
+ *   'visit.exe"' since we're starting the argv iteration at 0, which means
  *   we'll pick up the visit.exe program.
  *
  *   Brad Whitlock, Tue Dec 13 10:49:34 PDT 2011
@@ -246,7 +292,7 @@ static bool EndsWith(const char *s, const char *suffix)
  *   Prevent arguments ending in '.visit' from being skipped.
  *
  *   Kathleen Biagas, Wed Nov 7 09:46:15 PDT 2012
- *   Removed 'TestForConfigFIles' and attendent methods. Remove version # 
+ *   Removed 'TestForConfigFIles' and attendent methods. Remove version #
  *   from VISITUSERHOME path.
  *
  *   Kathleen Biagas, Wed Dec 19 17:35:21 MST 2012
@@ -295,9 +341,9 @@ static bool EndsWith(const char *s, const char *suffix)
 int
 VisItLauncherMain(int argc, char *argv[])
 {
-    bool addMovieArguments = false; 
-    bool addCinemaArguments = false; 
-    bool addVISITARGS = true; 
+    bool addMovieArguments = false;
+    bool addCinemaArguments = false;
+    bool addVISITARGS = true;
     bool addPluginVars = false;
     bool newConsole = false;
     bool noloopback = false;
@@ -313,16 +359,16 @@ VisItLauncherMain(int argc, char *argv[])
     string component("gui");
     string tmpArg;
     string apitrace_component("");
-    
+
 
     //
     // Parse the command line arguments.
-    // 
+    //
     for(int i = 0; i < argc; ++i)
     {
         if(ARG("-visit"))
         {
-           continue; 
+           continue;
         }
         else if (!ENDSWITH(".visit") && !ENDSWITH(".visit\"") &&
                 (ENDSWITH("visit")   || ENDSWITH("visit.exe") ||
@@ -332,12 +378,56 @@ VisItLauncherMain(int argc, char *argv[])
         }
         else if(ARG("-help"))
         {
-            printf("%s", usage);
+            string usageFile(GetUsageTextDir());
+            usageFile += "visitusage.txt";
+            std::ifstream inFile;
+            inFile.open(usageFile);
+            std::stringstream strStream;
+            strStream << inFile.rdbuf();
+            string usageText = strStream.str();
+            inFile.close();
+            // add the windows-specific text
+            usageText += string(windows_usage);
+
+#ifdef VISIT_WINDOWS_APPLICATION
+            // Create a console and redirect i/o to it.
+            // A MessageBox is good only for small amounts of text.
+            if (CreateNewConsole(1024))
+            {
+                cerr << usageText.c_str() << endl;
+                //cerr << "NOTE: For a more complete list of options, use '-fullhelp'." << endl;
+                cerr << "Press any key to continue ... " << endl;
+                _getch();
+                ReleaseConsole();
+            }
+            else
+            {
+                // Use the truncated help text here with a pointer to the
+                // user doc's for more information:
+                string msg(usage);
+                msg += "Please see the user manual for a more complete list.\n";
+                msg += "https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/gui_manual/StartupOptions/index.html";
+                MessageBox(NULL,
+                           (LPCSTR)msg.c_str(),
+                           (LPCSTR)"Usage",
+                           MB_ICONINFORMATION | MB_OK);
+            }
+#else
+            cerr << usageText.c_str() << endl;
+            //    cerr << "NOTE: For a more complete list of options, use '-fullhelp'." << endl;
+#endif
             return 0;
         }
         else if(ARG("-version"))
         {
-            printf("%s\n", VISIT_VERSION);
+#ifdef VISIT_WINDOWS_APPLICATION
+            MessageBox(NULL,
+                       (LPCSTR)VISIT_VERSION,
+                       (LPCSTR)"VisIt Version",
+                       MB_ICONINFORMATION | MB_OK);
+#else
+            cerr << VISIT_VERSION << endl;
+#endif
             return 0;
         }
         else if(ARG("-gui"))
@@ -397,9 +487,16 @@ VisItLauncherMain(int argc, char *argv[])
         }
         else if(ARG("-mpeg_encode"))
         {
-            fprintf(stderr, "The mpeg_encode component is not supported "
-                            "on Windows! You can only generate sequences "
-                            "of still images.\n");
+            string msg("The mpeg_encode component is not supported "
+                            "on Windows! Try -mpeg2encode.\n");
+#ifdef VISIT_WINDOWS_APPLICATION
+            MessageBox(NULL,
+                       (LPCSTR)msg.c_str(),
+                       (LPCSTR)"",
+                       MB_ICONEXCLAMATION | MB_OK);
+#else
+            cerr << msg << endl;
+#endif
             return -1;
         }
         else if(ARG("-xmledit"))
@@ -438,7 +535,7 @@ VisItLauncherMain(int argc, char *argv[])
             }
         }
         else if(ARG("-np"))
-        {       
+        {
             if (component == "engine")
             {
                 parallel = true;
@@ -542,7 +639,7 @@ VisItLauncherMain(int argc, char *argv[])
                 componentArgs.push_back(tmpArg);
                 i += (nArgsSkip -1);
             }
-            else 
+            else
             {
                 componentArgs.push_back(argv[i]);
             }
@@ -690,7 +787,7 @@ VisItLauncherMain(int argc, char *argv[])
         // found, we've switched to a serial engine.
         // mpi exec
         command.push_back(mpipath);
-        // mpi exec args, 
+        // mpi exec args,
         command.push_back("-n");
         command.push_back(nps);
         // engine_par, Surrounded by quotes
@@ -721,10 +818,10 @@ VisItLauncherMain(int argc, char *argv[])
         if((componentArgs[i] == "-host") && !noloopback)
         {
             // Replace the host arg with the loopback
-            componentArgs[i+1] = "127.0.0.1"; 
+            componentArgs[i+1] = "127.0.0.1";
         }
 
-        if (!BEGINSWITHQUOTE(componentArgs[i].c_str()) && 
+        if (!BEGINSWITHQUOTE(componentArgs[i].c_str()) &&
             HASSPECIAL(componentArgs[i].c_str()))
         {
             DQUOTEARG(componentArgs[i].c_str());
@@ -732,7 +829,7 @@ VisItLauncherMain(int argc, char *argv[])
         }
         else
             command.push_back(componentArgs[i]);
-        
+
     }
 
     if (!engineArgs.empty())
@@ -764,9 +861,9 @@ VisItLauncherMain(int argc, char *argv[])
         visitargs = 0;
     }
 
-    // 
+    //
     // Print the run information.
-    // 
+    //
     // cmdLine is used with console-app version as argument to system command.
     // so the first 'arg' must be quoted.
     string cmdLine(quote + command[0] + quote);
@@ -781,7 +878,7 @@ VisItLauncherMain(int argc, char *argv[])
 
     // We can't use system() since that opens a cmd shell.
     // the exeName is the second arg to _spawnv, and doesn't need quotes,
-    // but when used as the first arg in the exeArgs list, it does. 
+    // but when used as the first arg in the exeArgs list, it does.
     const char *exeName = command[0].c_str();
     const char **exeArgs = new const char *[command.size()+1];
     string quotedCommand(quote + command[0] + quote);
@@ -812,11 +909,11 @@ VisItLauncherMain(int argc, char *argv[])
             case ENOMEM:
                 snprintf(errmsg, 30,  "_spawn error: %d: ENOMEM\n", err);
                 break;
-            default: 
+            default:
                 snprintf(errmsg, 30, "_spawn error: %d: UNKNOWN\n", err);
                 break;
         }
-        MessageBox(NULL, errmsg, component.c_str(), MB_OK);
+        MessageBox(NULL, errmsg, component.c_str(), MB_ICONEXCLAMATION | MB_OK);
     }
     delete [] exeArgs;
 #else
@@ -848,8 +945,8 @@ VisItLauncherMain(int argc, char *argv[])
  *            should be freed by the caller.
  *
  * Modifications:
- *   Kathleen Bonnell, Fri Feb 29 16:43:46 PST 2008 
- *   Only malloc keyval if it is null. 
+ *   Kathleen Bonnell, Fri Feb 29 16:43:46 PST 2008
+ *   Only malloc keyval if it is null.
  *
  *   Kathleen Bonnell, Thu Jun 17 20:23:51 MST 2010
  *   Location of VisIt's registry keys has changed to Software\Classes.
@@ -863,18 +960,18 @@ ReadKeyFromRoot(HKEY which_root, const char *key, char **keyval)
     char regkey[100];
     HKEY hkey;
 
-    /* 
-     * Try and read the key from the system registry. 
+    /*
+     * Try and read the key from the system registry.
      */
     sprintf(regkey, "Software\\Classes\\VISIT%s", VISIT_VERSION);
     if (*keyval == 0)
         *keyval = (char *)malloc(500);
-    
-    if(RegOpenKeyEx(which_root, regkey, 0, KEY_QUERY_VALUE, &hkey) == 
+
+    if(RegOpenKeyEx(which_root, regkey, 0, KEY_QUERY_VALUE, &hkey) ==
        ERROR_SUCCESS)
     {
         DWORD keyType, strSize = 500;
-        if(RegQueryValueEx(hkey, key, NULL, &keyType, (LPBYTE)*keyval, 
+        if(RegQueryValueEx(hkey, key, NULL, &keyType, (LPBYTE)*keyval,
                            &strSize) == ERROR_SUCCESS)
         {
             readSuccess = true;
@@ -920,8 +1017,8 @@ ReadKey(const char *key, char **keyval)
 
     if((retval = ReadKeyFromRoot(HKEY_LOCAL_MACHINE, key, keyval)) == 0)
         retval = ReadKeyFromRoot(HKEY_CURRENT_USER, key, keyval);
-    
-    return retval;     
+
+    return retval;
 }
 
 
@@ -948,7 +1045,7 @@ ReadKey(const char *key, char **keyval)
  *   Brad Whitlock, Fri Feb 28 12:24:11 PDT 2003
  *   I improved how the path is added and I fixed a potential memory problem.
  *
- *   Brad Whitlock, Wed Apr 23 09:28:44 PDT 2003 
+ *   Brad Whitlock, Wed Apr 23 09:28:44 PDT 2003
  *   I added VISITSYSTEMCONFIG to the environment.
  *
  *   Brad Whitlock, Tue Aug 12 10:47:16 PDT 2003
@@ -966,14 +1063,14 @@ ReadKey(const char *key, char **keyval)
  *
  *   Kathleen Bonnell, Thu Jul 19 07:56:22 PDT 2007
  *   Added VISITUSERHOME, which defaults to VISITHOME if the reg key could
- *   not be found.  Create the directory if it does not exist, and add 
+ *   not be found.  Create the directory if it does not exist, and add
  *   "My images" subdir for saving windows.
  *
- *   Kathleen Bonnell, Tue Jan  8 18:09:38 PST 2008 
+ *   Kathleen Bonnell, Tue Jan  8 18:09:38 PST 2008
  *   Account for the fact that VisIt may be built with MSVC8, so location of
- *   config dir and binaries differs -- use new _VISIT_MSVC define. 
- *   
- *   Kathleen Bonnell, Fri Feb 29 16:43:46 PST 2008 
+ *   config dir and binaries differs -- use new _VISIT_MSVC define.
+ *
+ *   Kathleen Bonnell, Fri Feb 29 16:43:46 PST 2008
  *   Added call to free visituserpath and visitdevdir.
  *
  *   Kathleen Bonnell, Thu Apr 17 10:20:25 PDT 2008
@@ -982,25 +1079,25 @@ ReadKey(const char *key, char **keyval)
  *   Use "Application Data" path for private plugins, as users have write-
  *   privileges there (and it better supports roaming profiles).
  *
- *   Kathleen Bonnell, Wed May 21 08:12:16 PDT 2008 
- *   Use ';' to separate different paths for VISITPLUGINDIR. 
+ *   Kathleen Bonnell, Wed May 21 08:12:16 PDT 2008
+ *   Use ';' to separate different paths for VISITPLUGINDIR.
  *
  *   Kathleen Bonnell, Mon Jun 2 18:08:32 PDT 2008
  *   Change how VisItDevDir is retrieved and stored.
  *
- *   Kathleen Bonnell, Thu July 17 16:20:22 PDT 2008 
+ *   Kathleen Bonnell, Thu July 17 16:20:22 PDT 2008
  *   Free visitpath if we didn't find VISITHOME, because ReadKey mallocs
  *   regardless.  Same for tempvisitdev.  If VISITDEVDIR not defined, then
  *   find the full path to this executable and use it for visitpath and
  *   visitdevdir instead.
  *
- *   Kathleen Bonnell, Thu July 31 16:55:43 PDT 2008 
+ *   Kathleen Bonnell, Thu July 31 16:55:43 PDT 2008
  *   Initialize visitdevdir.
  *
- *   Kathleen Bonnell, Wed Oct 8 08:49:11 PDT 2008 
+ *   Kathleen Bonnell, Wed Oct 8 08:49:11 PDT 2008
  *   Re-organized code.  Modified settingup of VISITSSH and VISITSSHARGS so
- *   that if these are already set by user in environment they won't be 
- *   overwritten. 
+ *   that if these are already set by user in environment they won't be
+ *   overwritten.
  *
  *   Kathleen Bonnell, Wed Apr 22 17:47:34 PDT 2009
  *   Added VISITULTRAHOME env var.
@@ -1014,17 +1111,17 @@ ReadKey(const char *key, char **keyval)
  *   Kathleen Bonnell, Tue Mar 30 16:46:19 MST 2010
  *   Test for dev dir and set vars accordingly.
  *
- *   Kathleen Bonnell, Wed Dec 1 08:43:44 MST 2010 
+ *   Kathleen Bonnell, Wed Dec 1 08:43:44 MST 2010
  *   Add variables necessary for plugin development if necessary.
  *
- *   Kathleen Bonnell, Tue May 3 14:33:17 MST 2011 
+ *   Kathleen Bonnell, Tue May 3 14:33:17 MST 2011
  *   Add root lib directory to PYTHONPATH.
  *
  *   Brad Whitlock, Tue Dec 13 10:10:23 PDT 2011
  *   I made the routine return all of the environment strings in a stringVector
  *   instead of calling _putenv on all of them.
  *
- *   Kathleen Biagas, Fri May 4 14:05:27 PDT 2012 
+ *   Kathleen Biagas, Fri May 4 14:05:27 PDT 2012
  *   Return usingdev as an arg.
  *
  *   Kathleen Biagas, Thu Nov  1 11:03:09 PDT 2012
@@ -1042,7 +1139,7 @@ ReadKey(const char *key, char **keyval)
  *
  *****************************************************************************/
 
-std::string 
+string
 GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
     bool &needsMesaOverride)
 {
@@ -1122,7 +1219,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
                 config = vp.substr(pos+1);
         }
     }
- 
+
     /*
      * Determine visit user path (Path to My Documents).
      */
@@ -1144,7 +1241,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
                             " before running VisIt again.\n",
                             personalUserHome.c_str());
 #ifdef VISIT_WINDOWS_APPLICATION
-                MessageBox(NULL, tmp, "", MB_OK);
+                MessageBox(NULL, tmp, "", MB_ICONEXCLAMATION | MB_OK);
 #else
                 fprintf(stderr, tmp);
 #endif
@@ -1160,7 +1257,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
                             "VISITUSERHOME before running VisIt again.\n",
                             personalUserHome.c_str());
 #ifdef VISIT_WINDOWS_APPLICATION
-                MessageBox(NULL, tmp, "", MB_OK);
+                MessageBox(NULL, tmp, "", MB_ICONEXCLAMATION | MB_OK);
 #else
                 fprintf(stderr, tmp);
 #endif
@@ -1179,8 +1276,8 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
             bool haveVISITUSERHOME=0;
             TCHAR szPath[MAX_PATH];
             struct _stat fs;
-            if(SUCCEEDED(SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, 
-                                     SHGFP_TYPE_CURRENT, szPath))) 
+            if(SUCCEEDED(SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL,
+                                     SHGFP_TYPE_CURRENT, szPath)))
             {
                 snprintf(visituserpath, 512, "%s\\VisIt", szPath);
                 haveVISITUSERHOME = true;
@@ -1228,7 +1325,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
     /*
      * Set the plugin dir.
      */
-    { 
+    {
         sprintf(tmp, "VISITPLUGINDIR=%s;%s", userHome.c_str(), visitpath);
         env.push_back(tmp);
         if (addPluginVars)
@@ -1270,7 +1367,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
         sprintf(tmp, "PYTHONHOME=%s\\lib\\python",visitpath);
         env.push_back(tmp);
     }
-    else 
+    else
     {
         string vp(visitpath);
         size_t pos = vp.find_last_of("\\");
@@ -1290,7 +1387,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
     /*
      * Set the SSH program.
      */
-    { 
+    {
         char *ssh = NULL, *sshargs = NULL;
         bool needVISITSSH = false;
         bool haveSSH = false, haveSSHARGS = false, freeSSH = false, freeSSHARGS = false;
@@ -1320,7 +1417,7 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
                 {
                     sprintf(tmp, "VISITSSH=%s", ssh);
                     env.push_back(tmp);
-                    errmsg.clear(); 
+                    errmsg.clear();
                 }
                 else
                 {
@@ -1340,9 +1437,9 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
             {
                 errmsg += "Using VisIt's qtssh.";
 #ifdef VISIT_WINDOWS_APPLICATION
-                MessageBox(NULL, 
-                           (LPCSTR)errmsg.c_str(), 
-                           "", 
+                MessageBox(NULL,
+                           (LPCSTR)errmsg.c_str(),
+                           "",
                            MB_ICONEXCLAMATION | MB_OK);
 #else
                 cerr << errmsg << endl;
@@ -1378,17 +1475,17 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
 
 /******************************************************************************
  *
- * Purpose: Sets the VisIt environment variables from a vector of VAR=VALUE 
+ * Purpose: Sets the VisIt environment variables from a vector of VAR=VALUE
  *          strings.
  *
  * Programmer: Brad Whitlock
- * Date:       
+ * Date:
  *
  * Input Arguments:
  *   env       : The vector of environment strings.
  *
  * Modifications:
- * 
+ *
  *****************************************************************************/
 
 void
@@ -1413,14 +1510,14 @@ SetVisItEnvironment(const stringVector &env)
  * Modifications:
  *   Kathleen Bonnell, Mon Jun 2 18:11:01 PDT 2008
  *   Add 'visitdev' argument. Add it to the path if not null.
- * 
+ *
  *   Kathleen Bonnell, Sun Feb 28 16:23:45 MST 2010
  *   Add visitpath and visitdev to beginning of PATH, not end.  Ensure they
  *   don't get duplicated in the PATH string.
- * 
+ *
  *****************************************************************************/
 
-std::string
+string
 AddPath(char *tmp, const char *visitpath, const char *visitdev)
 {
     char *env = 0, *path;
@@ -1443,7 +1540,7 @@ AddPath(char *tmp, const char *visitpath, const char *visitdev)
        token = strtok( env2, ";" );
        while(token != NULL)
        {
-           /* 
+           /*
             * If the token does not contain "VisIt " then add it to the path.
             */
            skiptoken = false;
@@ -1461,7 +1558,7 @@ AddPath(char *tmp, const char *visitpath, const char *visitdev)
                path += (len + 1);
            }
 
-           /* 
+           /*
             * Get next token:
             */
            token = strtok( NULL, ";" );
@@ -1470,26 +1567,56 @@ AddPath(char *tmp, const char *visitpath, const char *visitdev)
        free(env2);
     }
 
-    return std::string(tmp);
+    return string(tmp);
 }
 
+/******************************************************************************
+ *
+ * Purpose: Prints the VisIt environment variables.
+ *
+ * Modifications:
+ *   Kathleen Biagas, Wednesday Sept 30, 2020
+ *   Modified to fill a string and to print to mesage box if WinApp.
+ *****************************************************************************/
 void
 PrintEnvironment()
 {
     char *tmp;
-
+    string envStr;
     if((tmp = getenv("VISITHOME")) != NULL)
     {
-        fprintf(stdout, "LIBPATH=%s\\lib\n", tmp);
-        fprintf(stdout, "VISITHOME=%s\n", tmp);
+        envStr = envStr + string("LIBPATH=") + string(tmp) + string("\\lib\n");
+        envStr = envStr + "VISITHOME=" + string(tmp) + "\n";
     }
     if((tmp = getenv("VISITARCHHOME")) != NULL)
-        fprintf(stdout, "VISITARCHHOME=%s\n", tmp);
+    {
+        envStr = envStr + "VISITARCHHOME=" + string(tmp) + "\n";
+    }
     if((tmp = getenv("VISITULTRAHOME")) != NULL)
-        fprintf(stdout, "VISITULTRAHOME=%s\n", tmp);
+    {
+        envStr = envStr + "VISITULTRAHOME=" + string(tmp) + "\n";
+    }
     if((tmp = getenv("VISITPLUGINDIR")) != NULL)
-        fprintf(stdout, "VISITPLUGINDIR=%s\n", tmp);
+    {
+        envStr = envStr + "VISITPLUGINDIR=" + string(tmp) + "\n";
+    }
+    if((tmp = getenv("VISITSSH")) != NULL)
+    {
+        envStr = envStr + "VISITSSH=" + string(tmp) + "\n";
+    }
+    if((tmp = getenv("VISITSSHARGS")) != NULL)
+    {
+        envStr = envStr + "VISITSSHARGS=" + string(tmp) + "\n";
+    }
 
+#ifdef VISIT_WINDOWS_APPLICATION
+    MessageBox(NULL,
+               LPCSTR(envStr.c_str()),
+               LPCSTR("VisIt environment variables:"),
+               MB_ICONINFORMATION | MB_OK);
+#else
+    cerr << envStr << endl;
+#endif
 }
 
 
@@ -1506,23 +1633,38 @@ WinGetEnv(const char * name)
     return retval;
 }
 
+string
+GetUsageTextDir()
+{
+    char modFName[MAX_PATH];
+    string usageDir;
+    if (GetModuleFileName(NULL, modFName, MAX_PATH) != 0)
+    {
+        string tpath(modFName);
+        size_t pos = tpath.find_last_of('\\');
+        usageDir = tpath.substr(0, pos) +  "\\resources\\usage\\";
+    }
+    return usageDir;
+}
+
+
 // ****************************************************************************
 // Method: main/WinMain
 //
-// Purpose: 
+// Purpose:
 //   The program entry point function.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Nov 23 13:15:31 PST 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 #if defined(VISIT_WINDOWS_APPLICATION)
 int WINAPI
 WinMain(HINSTANCE hInstance,     // handle to the current instance
-        HINSTANCE hPrevInstance, // handle to the previous instance    
+        HINSTANCE hPrevInstance, // handle to the previous instance
         LPSTR lpCmdLine,         // pointer to the command line
         int nCmdShow             // show state of window
 )
@@ -1536,4 +1678,106 @@ main(int argc, char **argv)
     return VisItLauncherMain(argc, argv);
 }
 #endif
+
+
+// methods for creating console and redirecting io
+
+bool RedirectConsoleIO()
+{
+    bool result = true;
+    FILE* fp;
+
+    // Redirect STDIN if the console has an input handle
+    if (GetStdHandle(STD_INPUT_HANDLE) != INVALID_HANDLE_VALUE)
+        if (freopen_s(&fp, "CONIN$", "r", stdin) != 0)
+            result = false;
+        else
+            setvbuf(stdin, NULL, _IONBF, 0);
+
+    // Redirect STDOUT if the console has an output handle
+    if (GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
+        if (freopen_s(&fp, "CONOUT$", "w", stdout) != 0)
+            result = false;
+        else
+            setvbuf(stdout, NULL, _IONBF, 0);
+
+    // Redirect STDERR if the console has an error handle
+    if (GetStdHandle(STD_ERROR_HANDLE) != INVALID_HANDLE_VALUE)
+        if (freopen_s(&fp, "CONOUT$", "w", stderr) != 0)
+            result = false;
+        else
+            setvbuf(stderr, NULL, _IONBF, 0);
+
+    // Make C++ standard streams point to console as well.
+    std::ios::sync_with_stdio(true);
+
+    // Clear the error state for each of the C++ standard streams.
+    std::wcout.clear();
+    std::cout.clear();
+    std::wcerr.clear();
+    std::cerr.clear();
+    std::wcin.clear();
+    std::cin.clear();
+
+    return result;
+}
+
+bool ReleaseConsole()
+{
+    bool result = true;
+    FILE* fp;
+
+    // Just to be safe, redirect standard IO to NUL before releasing.
+
+    // Redirect STDIN to NUL
+    if (freopen_s(&fp, "NUL:", "r", stdin) != 0)
+        result = false;
+    else
+        setvbuf(stdin, NULL, _IONBF, 0);
+
+    // Redirect STDOUT to NUL
+    if (freopen_s(&fp, "NUL:", "w", stdout) != 0)
+        result = false;
+    else
+        setvbuf(stdout, NULL, _IONBF, 0);
+
+    // Redirect STDERR to NUL
+    if (freopen_s(&fp, "NUL:", "w", stderr) != 0)
+        result = false;
+    else
+        setvbuf(stderr, NULL, _IONBF, 0);
+
+    // Detach from console
+    if (!FreeConsole())
+        result = false;
+
+    return result;
+}
+
+void AdjustConsoleBuffer(int16_t minLength)
+{
+    // Set the screen buffer to be big enough to scroll some text
+    CONSOLE_SCREEN_BUFFER_INFO conInfo;
+    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &conInfo);
+    if (conInfo.dwSize.Y < minLength)
+        conInfo.dwSize.Y = minLength;
+    SetConsoleScreenBufferSize(GetStdHandle(STD_OUTPUT_HANDLE), conInfo.dwSize);
+}
+
+bool CreateNewConsole(int16_t minLength)
+{
+    bool result = false;
+
+    // Release any current console and redirect IO to NUL
+    ReleaseConsole();
+
+    // Attempt to create new console
+    if (AllocConsole())
+    {
+        AdjustConsoleBuffer(minLength);
+        result = RedirectConsoleIO();
+    }
+
+    return result;
+}
 

--- a/src/common/misc/VisItInit.C
+++ b/src/common/misc/VisItInit.C
@@ -13,6 +13,7 @@
 #if defined(_WIN32)
 #include <process.h>
 #include <winsock2.h>
+#include <winuser.h>
 #else
 #include <ctype.h>
 #include <unistd.h>
@@ -341,10 +342,16 @@ VisItInit::Initialize(int &argc, char *argv[], int r, int n, bool strip, bool si
         }
         else if (strcmp("-git_revision",  argv[i]) == 0)
         {
+            std::string msg;
             if(visitcommon::GITVersion() == "")
-                cerr << "GIT version is unknown!" << endl;
+                msg = "GIT version is unknown!";
             else
-                cerr << "Built from version " << visitcommon::GITVersion() << endl;
+                msg = "Built from version "  +  visitcommon::GITVersion();
+#if defined(WIN32) && defined(VISIT_WINDOWS_APPLICATION)
+            MessageBox(NULL, LPCSTR(msg.c_str()), LPCSTR(""), MB_ICONINFORMATION | MB_OK);
+#else
+            cerr << msg << endl;
+#endif
             exit(0); // HOOKS_IGNORE
         }
     }

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.1.4</font></b></p>
 <ul>
   <li>Fixed a bug that resulted in domain boundaries being visible when using the OSPRay volume renderer.</li>
+  <li>Fixed display of -help text on Windows.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/usage/visitusage.txt
+++ b/src/resources/usage/visitusage.txt
@@ -45,7 +45,9 @@
 
         -window_anchor <x,y> The x,y position on the screen where VisIt's GUI
                              will show its windows (Main window excluded).
-        -style <style>       One of: windows,cde,motif,sgi.
+        -style <style>       One of: Windows,Fusion. If more options are
+                             available, they will be listed in the gui
+                             under Options->Appearance.
         -locale <locale>     The locale that you want VisIt to use when displaying
                              translated menus and controls. VisIt will use the
                              default locale if the -locale option is not
@@ -64,8 +66,8 @@
     Version options
     ---------------------------------------------------------------------------
         -version             Do NOT run VisIt. Just print the current version.
-        -git_version         Do NOT run VisIt. Just print the Git version it
-                             was built from.
+        -git_revision        Do NOT run VisIt. Just print the Git revision
+                             number it was built from.
         -beta                Run the current beta version.
         -v <version>         Run a specified version. Specifying 2 digits,
                              such as X.Y, will run the latest patch release


### PR DESCRIPTION
Resolves #5088

Also updated to use visitusage.txt, which is same help text as other platforms.
Updated visitusage.txt relating to -style and -git_revision.
Added logic to retrieve git revision hash.
I ran visit -help from a release build (where visit is build as a windows app) and from a development build where I specified that it should be built as a console app. In both cases, help text was displayed effectively.

This is merge from 3.1RC.
