### PR TITLE
Enhance the Holhraum Flux query to ignore bad ray traces.

### DIFF
--- a/src/avt/Queries/Queries/avtHohlraumFluxQuery.C
+++ b/src/avt/Queries/Queries/avtHohlraumFluxQuery.C
@@ -618,7 +618,7 @@ avtHohlraumFluxQuery::IntegrateLine(int oneSide, int otherSide,
     }
     else
     {
-        debug5 << "Throwing away line." << endl;
+        debug5 << "avtHohlraumFluxQuery::IntegrateLine: Ignoring degenerate line." << endl;
     }
 }
 

--- a/src/avt/Queries/Queries/avtHohlraumFluxQuery.C
+++ b/src/avt/Queries/Queries/avtHohlraumFluxQuery.C
@@ -11,6 +11,7 @@
 #include <avtLineScanFilter.h>
 #include <avtOriginatingSource.h>
 #include <avtParallel.h>
+#include <DebugStream.h>
 #include <QueryArgumentException.h>
 
 #include <vectortypes.h>
@@ -522,6 +523,10 @@ avtHohlraumFluxQuery::ExecuteLineScan(vtkPolyData *pd)
 //    I added a flag which has the query optionally use the emissivity divided
 //    by the absorbtivity in place of the emissivity.
 //
+//    Eric Brugger, Fri Oct  2 09:15:29 PDT 2020
+//    Add logic to ignore the line if the line doesn't go from one side to
+//    the other.
+//
 // ****************************************************************************
 
 void
@@ -568,7 +573,7 @@ avtHohlraumFluxQuery::IntegrateLine(int oneSide, int otherSide,
     }
     output->GetPoint(currPt, pt0);
 
-    while (currPt != endPt)
+    while (currPt != endPt && currSeg != -1)
     {
         int newPt = -1, newSeg = -1;
         WalkChain1(output, currPt, currSeg,
@@ -604,9 +609,16 @@ avtHohlraumFluxQuery::IntegrateLine(int oneSide, int otherSide,
         pt0[1]  = pt1[1];
         pt0[2]  = pt1[2];
     }
-    for (ii = 0 ; ii < numBins ; ii++)
+    if (currPt == endPt)
     {
-        radBins[ii] += tmpBins[ii];
+        for (ii = 0 ; ii < numBins ; ii++)
+        {
+            radBins[ii] += tmpBins[ii];
+        }
+    }
+    else
+    {
+        debug5 << "Throwing away line." << endl;
     }
 }
 

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.1.4</font></b></p>
 <ul>
   <li>Fixed display of -help text on Windows.</li>
+  <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now deteected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -26,7 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.1.4</font></b></p>
 <ul>
   <li>Fixed display of -help text on Windows.</li>
-  <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now deteected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
+  <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now detected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

I enhanced the Hohlraum Flux query to detect some ray traces that were bad and ignore them. Since these are extremely rare, it doesn't effect the result significantly.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested it on the data provided by the user that demonstrated the bug.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers.