### PR TITLE
Enhance the Holhraum Flux query to ignore bad ray traces. (#5112)

### DIFF
--- a/src/avt/Queries/Queries/avtHohlraumFluxQuery.C
+++ b/src/avt/Queries/Queries/avtHohlraumFluxQuery.C
@@ -11,6 +11,7 @@
 #include <avtLineScanFilter.h>
 #include <avtOriginatingSource.h>
 #include <avtParallel.h>
+#include <DebugStream.h>
 #include <QueryArgumentException.h>
 
 #include <vectortypes.h>
@@ -522,6 +523,10 @@ avtHohlraumFluxQuery::ExecuteLineScan(vtkPolyData *pd)
 //    I added a flag which has the query optionally use the emissivity divided
 //    by the absorbtivity in place of the emissivity.
 //
+//    Eric Brugger, Fri Oct  2 09:15:29 PDT 2020
+//    Add logic to ignore the line if the line doesn't go from one side to
+//    the other.
+//
 // ****************************************************************************
 
 void
@@ -568,7 +573,7 @@ avtHohlraumFluxQuery::IntegrateLine(int oneSide, int otherSide,
     }
     output->GetPoint(currPt, pt0);
 
-    while (currPt != endPt)
+    while (currPt != endPt && currSeg != -1)
     {
         int newPt = -1, newSeg = -1;
         WalkChain1(output, currPt, currSeg,
@@ -604,9 +609,16 @@ avtHohlraumFluxQuery::IntegrateLine(int oneSide, int otherSide,
         pt0[1]  = pt1[1];
         pt0[2]  = pt1[2];
     }
-    for (ii = 0 ; ii < numBins ; ii++)
+    if (currPt == endPt)
     {
-        radBins[ii] += tmpBins[ii];
+        for (ii = 0 ; ii < numBins ; ii++)
+        {
+            radBins[ii] += tmpBins[ii];
+        }
+    }
+    else
+    {
+        debug5 << "avtHohlraumFluxQuery::IntegrateLine: Ignoring degenerate line." << endl;
     }
 }
 

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug that resulted in domain boundaries being visible when using the OSPRay volume renderer.</li>
   <li>Fixed display of -help text on Windows.</li>
   <li>Fixed a bug that caused incorrect opacity attenuation when ray casting datasets within very large or very small ranges.</li>
+  <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now detected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Merge from the 3.1RC to develop.