### PR TITLE
Expressions that request the mesh can't yet use DDQOT

### DIFF
--- a/src/avt/Expressions/Abstract/avtUnaryMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtUnaryMathExpression.C
@@ -35,11 +35,15 @@
 //    Alister Maguire, Mon Feb 24 14:25:20 MST 2020
 //    Removed canApplyToDirectDatabaseQOT. It now defaults to true.
 //
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false. There are cases where the
+//    variable is derived from the mesh, which DDQOT can't handle yet.
+//
 // ****************************************************************************
 
 avtUnaryMathExpression::avtUnaryMathExpression()
 {
-    ;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/CMFE/avtCMFEExpression.C
+++ b/src/avt/Expressions/CMFE/avtCMFEExpression.C
@@ -54,6 +54,9 @@
 //    Hank Childs, Sun Mar 22 14:13:16 CDT 2009
 //    Initialized onDemandProcessing.
 //
+//    Alister Maguire, Fri Oct  9 11:04:05 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtCMFEExpression::avtCMFEExpression()
@@ -63,6 +66,7 @@ avtCMFEExpression::avtCMFEExpression()
     onDemandProcessing = false;
     calculateMeshExtents = false;
     initialSILHasData = false;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtConnComponentsExpression.C
+++ b/src/avt/Expressions/General/avtConnComponentsExpression.C
@@ -65,12 +65,16 @@
 //    Ryan Bleile, Wed Jun 11 09:47:30 CDT 2014
 //    Modifies default for enableGhostNeighbors to fit new scheme
 //
+//    Alister Maguire, Fri Oct  9 11:04:05 PDT 2020
+//    Setting canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtConnComponentsExpression::avtConnComponentsExpression()
 {
     nFinalComps = 0;
     enableGhostNeighbors = 0;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtConstantFunctionExpression.C
+++ b/src/avt/Expressions/General/avtConstantFunctionExpression.C
@@ -30,12 +30,16 @@
 //    Jeremy Meredith, Wed Feb 20 10:00:31 EST 2008
 //    Support either nodal or zonal values.
 //
+//    Alister Maguire, Fri Oct  9 11:04:05 PDT 2020
+//    Setting canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtConstantFunctionExpression::avtConstantFunctionExpression(bool n)
 {
     nodal = n;
     value = 0;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtCoordinateExtremaExpression.C
+++ b/src/avt/Expressions/General/avtCoordinateExtremaExpression.C
@@ -36,12 +36,16 @@
 //    Hank Childs, Thu Jul  8 06:48:38 PDT 2010
 //    Add support for polar coordinates.
 //
+//    Alister Maguire, Fri Oct  9 11:04:05 PDT 2020
+//    Setting canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtCoordinateExtremaExpression::avtCoordinateExtremaExpression()
 {
     getMinimum = true;
     coordinateType = CT_X;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtEdgeNormalExpression.C
+++ b/src/avt/Expressions/General/avtEdgeNormalExpression.C
@@ -29,11 +29,17 @@
 //  Programmer: Jeremy Meredith
 //  Creation:   March 10, 2014
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtEdgeNormalExpression::avtEdgeNormalExpression()
 {
     isPoint = true;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtGradientExpression.C
+++ b/src/avt/Expressions/General/avtGradientExpression.C
@@ -56,11 +56,15 @@
 //    Cyrus Harrison, Wed Aug  8 11:19:10 PDT 2007
 //    Add support for multiple gradient algorithms.
 //
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtGradientExpression::avtGradientExpression()
 {
      gradientAlgo = SAMPLE;
+     canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtRandomExpression.C
+++ b/src/avt/Expressions/General/avtRandomExpression.C
@@ -28,11 +28,16 @@
 //  Programmer: Hank Childs
 //  Creation:   February 5, 2004
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtRandomExpression::avtRandomExpression()
 {
-    ;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/General/avtSurfaceNormalExpression.C
+++ b/src/avt/Expressions/General/avtSurfaceNormalExpression.C
@@ -27,12 +27,18 @@
 //  Programmer: Hank Childs
 //  Creation:   September 22, 2005
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtSurfaceNormalExpression::avtSurfaceNormalExpression()
 {
     isPoint            = true;
     zonesHaveBeenSplit = false;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/Management/avtConstantCreatorExpression.C
+++ b/src/avt/Expressions/Management/avtConstantCreatorExpression.C
@@ -22,12 +22,18 @@
 //  Programmer: Hank Childs
 //  Creation:   February 5, 2004
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:04:05 PDT 2020
+//    Setting canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtConstantCreatorExpression::avtConstantCreatorExpression()
 {
     value = 0;
     isSingleton = true;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/Math/avtCylindricalCoordinatesExpression.C
+++ b/src/avt/Expressions/Math/avtCylindricalCoordinatesExpression.C
@@ -24,11 +24,16 @@
 //  Programmer: Hank Childs
 //  Creation:   June 30, 2005
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtCylindricalCoordinatesExpression::avtCylindricalCoordinatesExpression()
 {
-    ;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/Math/avtCylindricalRadiusExpression.C
+++ b/src/avt/Expressions/Math/avtCylindricalRadiusExpression.C
@@ -35,11 +35,16 @@
 //  Programmer: Cyrus Harrison
 //  Creation:   April 2, 2008
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtCylindricalRadiusExpression::avtCylindricalRadiusExpression()
 {
-    ;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/avt/Expressions/Math/avtPolarCoordinatesExpression.C
+++ b/src/avt/Expressions/Math/avtPolarCoordinatesExpression.C
@@ -24,11 +24,16 @@
 //  Programmer: Hank Childs
 //  Creation:   February 5, 2004
 //
+//  Modifications:
+//
+//    Alister Maguire, Fri Oct  9 11:46:22 PDT 2020
+//    Set canApplyToDirectDatabaseQOT to false.
+//
 // ****************************************************************************
 
 avtPolarCoordinatesExpression::avtPolarCoordinatesExpression()
 {
-    ;
+    canApplyToDirectDatabaseQOT = false;
 }
 
 

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed display of -help text on Windows.</li>
   <li>Fixed a bug that caused incorrect opacity attenuation when ray casting datasets within very large or very small ranges.</li>
   <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now detected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
+  <li>Fixed a bug that prevented the Pick Through Time from working with expressions that relied on mesh information.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5117 

These changes flag more mesh requesting expressions as being incompatible with DDQOT.


### Type of change

Bugfix.

### How Has This Been Tested?
I've performed pick through time on the variables that have been flagged. The query would fail before being flagged, and they now correctly display the curves.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
