### PR TITLE
Modify internallauncher to pass bank when launching with srun.

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -401,6 +401,8 @@ class JobSubmitter_prun(JobSubmitter):
 # Date:       Thu May 17 14:22:04 PDT 2012
 #
 # Modifications:
+#   Eric Brugger, Fri Oct  9 13:58:21 PDT 2020
+#   Add logic to pass the bank to srun.
 #
 ###############################################################################
 
@@ -423,6 +425,8 @@ class JobSubmitter_srun(JobSubmitter):
             parcmd = parcmd + ["-J", self.parallel.name]
         if self.parallel.partition != None:
             parcmd = parcmd + ["-p", self.parallel.partition]
+        if self.parallel.bank != None:
+            parcmd = parcmd + ["-A", self.parallel.bank]
         if self.parallel.time != None:
             parcmd = parcmd + ["-t", self.parallel.time]
         parcmd = debugger.CreateCommand(parcmd + self.VisItExecutable() + args)

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -29,7 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed display of -help text on Windows.</li>
   <li>Fixed a bug that caused incorrect opacity attenuation when ray casting datasets within very large or very small ranges.</li>
   <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now detected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
-  <li>Fix a bug with the launcher script where the bank was not passed when launching with srun.</li>
+  <li>Fixed a bug with the launcher script where the bank was not passed when launching with srun.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -29,6 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed display of -help text on Windows.</li>
   <li>Fixed a bug that caused incorrect opacity attenuation when ray casting datasets within very large or very small ranges.</li>
   <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now detected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
+  <li>Fix a bug with the launcher script where the bank was not passed when launching with srun.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5072

Modified the internallauncher to pass the bank information when launching with srun. 

### Type of change

Bug fix.

### How Has This Been Tested?

I applied my fix to the publicly installed VisIt 3.1.3 and launched VisIt with:

visit -l srun -np 4 -b wbronze

and it passed the bank information to srun.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers