### PR TITLE
Modify internallauncher to use our mpirun/mpiexec if it exists.

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -112,6 +112,10 @@ class JobSubmitter(object):
 #   Call the new PPNArgument function to get the correct MPI argument for 
 #   the "process per node" flag.
 #
+#   Eric Brugger, Fri Oct  9 15:41:37 PDT 2020
+#   Modify the routine to use our mpirun if we are running an installed
+#   version and it exists.
+#
 ###############################################################################
 
 class JobSubmitter_mpirun(JobSubmitter):
@@ -119,6 +123,12 @@ class JobSubmitter_mpirun(JobSubmitter):
         super(JobSubmitter_mpirun,self).__init__(launcher)
 
     def Executable(self):
+        # Use our mpirun if we are running an installed version and it
+        # exists.
+        if self.launcher.generalArgs.dv == 0:
+            mpirun = os.path.join(GETENV("VISITARCHHOME"),"bin","mpirun")
+            if os.path.exists(mpirun):
+                return [mpirun]
         return ["mpirun"]
 
     def CreateCommand(self, args, debugger):
@@ -154,7 +164,7 @@ class JobSubmitter_mpirun(JobSubmitter):
 #   mpiexec from the VisIt architecture/bin directory, if it exists.
 #
 #   Cyrus Harrison, Fri Feb  1 17:02:02 PST 2013
-#   Use mpiexe on OSX 10.6 and beyond.
+#   Use mpiexec on OSX 10.6 and beyond.
 #
 #   David Camp, Tue Mar 11 10:17:48 PDT 2014
 #   Added the -ppn (process per node) option to the mpiexec.
@@ -172,6 +182,10 @@ class JobSubmitter_mpirun(JobSubmitter):
 #   Call the new PPNArgument function to get the correct MPI argument for 
 #   the "process per node" flag.
 #
+#   Eric Brugger, Fri Oct  9 15:41:37 PDT 2020
+#   Modify the routine to use our mpiexec if we are running an installed
+#   version and it exists.
+#
 ################################################################################
 
 class JobSubmitter_mpiexec(JobSubmitter):
@@ -179,11 +193,9 @@ class JobSubmitter_mpiexec(JobSubmitter):
         super(JobSubmitter_mpiexec,self).__init__(launcher)
 
     def Executable(self):
-        # If we're running on MacOS X 10.7 or later, use our own mpich
-        # that we bundle with VisIt when we're running an installed version
-        # of the code.
-        if self.launcher.os == "darwin" and self.launcher.osver >= 10 and \
-           self.launcher.generalArgs.dv == 0:
+        # Use our mpiexec if we are running an installed version and it
+        # exists.
+        if self.launcher.generalArgs.dv == 0:
             mpiexec = os.path.join(GETENV("VISITARCHHOME"),"bin","mpiexec")
             if os.path.exists(mpiexec):
                 return [mpiexec]

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -36,6 +36,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.1.4</font></b></p>
 <ul>
   <li>Enabled the paraDIS and paraDIS_tecplot readers on Windows.</li>
+  <li>It is now possible to easily run VisIt in parallel with all the Linux distributions. To run in parallel, simply pass the number of processors to use with the "-np" command line option. For example, "visit -np 4" to run on 4 processors.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #5122 

I modified the internallauncher to use our installed mpirun/mpiexec if it exists. I added the logic for mpirun and there was some logic that was constrained to OSX for mpiexec, but I made that logic match the mpirun case, since I didn't see any reason for them to be different. In fact on Linux you can use either mpirun or mpiexec and I suspect the same is true on OSX.

### Type of change

New feature.

### How Has This Been Tested?

I made the changes on a CentOS 8 system and it successfully launched a parallel engine using the default mpirun (visit -np 4) and mpiexec (visit -np 4 -l mpiexec).

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers