### PR TITLE
Modify internallauncher to use our mpirun/mpiexec if it exists. (#5124)

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -113,6 +113,10 @@ class JobSubmitter(object):
 #   Call the new PPNArgument function to get the correct MPI argument for 
 #   the "process per node" flag.
 #
+#   Eric Brugger, Fri Oct  9 15:41:37 PDT 2020
+#   Modify the routine to use our mpirun if we are running an installed
+#   version and it exists.
+#
 ###############################################################################
 
 class JobSubmitter_mpirun(JobSubmitter):
@@ -120,6 +124,12 @@ class JobSubmitter_mpirun(JobSubmitter):
         super(JobSubmitter_mpirun,self).__init__(launcher)
 
     def Executable(self):
+        # Use our mpirun if we are running an installed version and it
+        # exists.
+        if self.launcher.generalArgs.dv == 0:
+            mpirun = os.path.join(GETENV("VISITARCHHOME"),"bin","mpirun")
+            if os.path.exists(mpirun):
+                return [mpirun]
         return ["mpirun"]
 
     def CreateCommand(self, args, debugger):
@@ -155,7 +165,7 @@ class JobSubmitter_mpirun(JobSubmitter):
 #   mpiexec from the VisIt architecture/bin directory, if it exists.
 #
 #   Cyrus Harrison, Fri Feb  1 17:02:02 PST 2013
-#   Use mpiexe on OSX 10.6 and beyond.
+#   Use mpiexec on OSX 10.6 and beyond.
 #
 #   David Camp, Tue Mar 11 10:17:48 PDT 2014
 #   Added the -ppn (process per node) option to the mpiexec.
@@ -173,6 +183,10 @@ class JobSubmitter_mpirun(JobSubmitter):
 #   Call the new PPNArgument function to get the correct MPI argument for 
 #   the "process per node" flag.
 #
+#   Eric Brugger, Fri Oct  9 15:41:37 PDT 2020
+#   Modify the routine to use our mpiexec if we are running an installed
+#   version and it exists.
+#
 ################################################################################
 
 class JobSubmitter_mpiexec(JobSubmitter):
@@ -180,11 +194,9 @@ class JobSubmitter_mpiexec(JobSubmitter):
         super(JobSubmitter_mpiexec,self).__init__(launcher)
 
     def Executable(self):
-        # If we're running on MacOS X 10.7 or later, use our own mpich
-        # that we bundle with VisIt when we're running an installed version
-        # of the code.
-        if self.launcher.os == "darwin" and self.launcher.osver >= 10 and \
-           self.launcher.generalArgs.dv == 0:
+        # Use our mpiexec if we are running an installed version and it
+        # exists.
+        if self.launcher.generalArgs.dv == 0:
             mpiexec = os.path.join(GETENV("VISITARCHHOME"),"bin","mpiexec")
             if os.path.exists(mpiexec):
                 return [mpiexec]

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -36,6 +36,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.1.4</font></b></p>
 <ul>
   <li>Enabled the paraDIS and paraDIS_tecplot readers on Windows.</li>
+  <li>It is now possible to easily run VisIt in parallel with all the Linux distributions. To run in parallel, simply pass the number of processors to use with the "-np" command line option. For example, "visit -np 4" to run on 4 processors.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
Resolves #5122
Merge from the 3.1RC to develop.