### PR TITLE
Removed unsetenv LD_PRELOAD from the internal launcher. (#5133)

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -2850,6 +2850,11 @@ class MainLauncher(object):
     #   Add code to unsetenv LD_PRELOAD to protect against users setting
     #   it for the GL library, which would break rendering.
     #
+    #   Eric Brugger, Mon Oct 12 13:49:41 PDT 2020
+    #   Removed the code to unsetenv LD_PRELOAD in favor of doing it in the
+    #   custom launcher since doing it here interfered with other sites that
+    #   were setting LD_PRELOAD to get VisIt to work.
+    #
     ############################################################################
 
     def SetupEnvironment(self):
@@ -2926,9 +2931,6 @@ class MainLauncher(object):
 
         # Unset QT_PLUGIN_PATH
         UNSETENV("QT_PLUGIN_PATH")
-
-        # Unset LD_PRELOAD
-        UNSETENV("LD_PRELOAD")
 
         # Turn off trapping of floating point exceptions.
         SETENV("TRAP_FPE", "")

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Hohlraum Flux query, where a ray would not be traced properly resulting in a compute engine crash. Those cases are now detected and the ray is ignored. Since this happens in extremely rare situations, this does not have a significant effect on the result.</li>
   <li>Fixed a bug that prevented the Pick Through Time from working with expressions that relied on mesh information.</li>
   <li>Fixed a bug with the launcher script where the bank was not passed when launching with srun.</li>
+  <li>Modified the startup script to remove the code that unsetenv LD_PRELOAD since it was causing VisIt to fail at sites that were using LD_PRELOAD for VisIt to work properly. If you need to unsetenv LD_PRELOAD, it should be done in the custom launcher script, an example of which can be found in the <a href="https://github.com/visit-dav/visit/blob/develop/src/resources/hosts/llnl/customlauncher">LLNL customlauncher</a>.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -202,6 +202,10 @@ class JobSubmitter_bsub_LLNL(JobSubmitter):
 #   I removed the logic for setting the visitarch to "linux-x86_64-toss3"
 #   on toss3 systems. I removed the logic for hoth.
 #
+#   Eric Brugger, Mon Oct 12 13:49:41 PDT 2020
+#   Add code to unsetenv LD_PRELOAD to protect against users setting
+#   it for the GL library, which would break rendering.
+#
 ###############################################################################
 
 class LLNLLauncher(MainLauncher):
@@ -261,6 +265,9 @@ class LLNLLauncher(MainLauncher):
         if self.visitarch == "linux-x86_64":
             mpi_ld_library_paths = ["/usr/tce/packages/mvapich2/mvapich2-2.2-intel-16.0.3/lib", "/usr/tce/packages/intel/intel-16.0.3/lib/intel64"]
             SETENV("LD_LIBRARY_PATH", self.joinpaths(mpi_ld_library_paths))
+
+        # Unset LD_PRELOAD
+        UNSETENV("LD_PRELOAD")
 
     #
     # Override the JobSubmitterFactory method so the custom job submitter can


### PR DESCRIPTION
Resolves #5102 
Merge from the 3.1RC to develop.