### PR TITLE
Expression checkbox label updated

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -581,7 +581,7 @@ QvisExpressionsWindow::CreateWindowContents()
     delButton = new QPushButton(tr("Delete"), f1);
     listLayout->addWidget(delButton, 2,1);
 
-    displayAllVars = new QCheckBox(tr("Display expressions from database"), f1);
+    displayAllVars = new QCheckBox(tr("Display expressions from database\nand auto-generated expressions"), f1);
     listLayout->addWidget(displayAllVars, 3,0, 1,2);
 
     mainSplitter->addWidget(f1);

--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -90,7 +90,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Other bugs fixed in version 3.2</font></b></p>
 <ul>
-  <li>Bug Fix 1</li>
+  <li>Expression checkbox indicates display database AND auto-generated expressions.</li>
   <li>Bug Fix 2</li>
 </ul>
 

--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -90,7 +90,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Other bugs fixed in version 3.2</font></b></p>
 <ul>
-  <li>Expression checkbox indicates display database AND auto-generated expressions.</li>
+  <li>The checkbox in the Expression window that turns on the display of expressions from the database now indicates that it displays expressions from the database and auto generated ones.</li>
   <li>Bug Fix 2</li>
 </ul>
 


### PR DESCRIPTION
### Description

Resolves #2950

Changed expression checkbox label to be more informative

### How Has This Been Tested?

Before:
![Screen Shot 2020-10-14 at 11 13 55 AM](https://user-images.githubusercontent.com/18565891/96028694-7b8b7480-0e0e-11eb-8019-5c95e1b50e27.png)

After:
![Screen Shot 2020-10-14 at 11 12 22 AM](https://user-images.githubusercontent.com/18565891/96028712-8219ec00-0e0e-11eb-8b0f-d68f313fcda3.png)


### Checklist:

- [X] I have updated the release notes
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
