### PR TITLE
Fixed Qt build errors for macOS 10.15

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -45,7 +45,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.4</font></b></p>
 <ul>
-  <li>Developer Changes 1</li>
+  <li>Updated build_visit scripts for macOS 10.15</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/masonry/opts/mb-3.1.3-darwin-10.14-x86_64-release.json
+++ b/src/tools/dev/masonry/opts/mb-3.1.3-darwin-10.14-x86_64-release.json
@@ -4,7 +4,7 @@
  "branch": "v3.1.3",
  "arch":   "darwin-x86_64",
  "cert":   "Developer ID Application: Kevin Griffin (K2QL7A77SW)",
- "codesign_param": "--deep -f --timestamp none",
+ "codesign_param": "--deep -f",
  "make_nthreads": 8, 
  "skip_checkout": "no",
  "boost_dir": "/Users/griffin28/VisIt/boost/1_60_0/i386-apple-darwin15_clang",

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -259,7 +259,9 @@ function apply_qt_patch
         fi
 
         if [[ "$OPSYS" == "Darwin" ]]; then
-            if [[ `sw_vers -productVersion` == 10.14.[0-9]* ]]; then
+            productVersion=`sw_vers -productVersion`
+            if [[ $productVersion == 10.14.[0-9]* || \
+                  $productVersion == 10.15.[0-9]* ]] ; then
                 apply_qt_5101_macos_mojave_patch
                 if [[ $? != 0 ]] ; then
                     return 1
@@ -405,7 +407,7 @@ diff -c qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm.ori
   QFontEngine *QCoreTextFontEngine::cloneWithSize(qreal pixelSize) const
 EOF
     if [[ $? != 0 ]] ; then
-        warn "qt 5.10.1 macOS 10.14 patch failed."
+        warn "qt 5.10.1 macOS patch failed."
         return 1
     fi
     


### PR DESCRIPTION
### Description

Resolves #5147. Fixed Qt build errors for macOS 10.15

### How Has This Been Tested?

Successfully built Qt on macOS 10.15

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [x] New and existing unit tests pass locally with my changes
