### PR TITLE
Merge from 3.1RC

### DIFF
--- a/src/gui/main/CMakeLists.txt
+++ b/src/gui/main/CMakeLists.txt
@@ -17,6 +17,9 @@
 #   Kathleen Biagas, Tue May 24 16:17:22 MST 2016
 #   Add qwt lib.
 #
+#   Kevin Griffin, Mon Oct 19 09:43:37 PDT 2020
+#   Updated GUI bundle name, identifier and copyright
+#
 #****************************************************************************
 
 INCLUDE_DIRECTORIES(
@@ -58,14 +61,14 @@ ELSE(NOT APPLE)
     ADD_EXECUTABLE(gui_exe MACOSX_BUNDLE main.C ${GUI_STATIC_SOURCES} ${VISIT_SOURCE_DIR}/common/icons/${GUI_ICON_FILE})
 
     SET_TARGET_PROPERTIES( gui_exe PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${VISIT_SOURCE_DIR}/include/GUIInfo.plist.in)
-    SET(MACOSX_BUNDLE_BUNDLE_NAME          "VisIt ${VISIT_VERSION}")
+    SET(MACOSX_BUNDLE_BUNDLE_NAME          "VisIt GUI ${VISIT_VERSION}")
     SET(MACOSX_BUNDLE_INFO_STRING          "Graphical client for VisIt")
     SET(MACOSX_BUNDLE_ICON_FILE            ${GUI_ICON_FILE})
-    SET(MACOSX_BUNDLE_GUI_IDENTIFIER       VISI)
+    SET(MACOSX_BUNDLE_GUI_IDENTIFIER       "gov.llnl.visit.gui")
     SET(MACOSX_BUNDLE_LONG_VERSION_STRING  "VisIt version ${VISIT_VERSION}")
     SET(MACOSX_BUNDLE_SHORT_VERSION_STRING "VisIt ${VISIT_VERSION}")
     SET(MACOSX_BUNDLE_BUNDLE_VERSION       ${VISIT_VERSION})
-    SET(MACOSX_BUNDLE_COPYRIGHT            "Copyright (c) 2000 - 2019, Lawrence Livermore National Security, LLC")
+    SET(MACOSX_BUNDLE_COPYRIGHT            "Copyright (c) 2000 - 2020, Lawrence Livermore National Security, LLC")
 
 ENDIF(NOT APPLE)
 

--- a/src/include/ViewerInfo.plist.in
+++ b/src/include/ViewerInfo.plist.in
@@ -9,25 +9,25 @@
     <key>CFBundleExecutable</key>
     <string>viewer</string>
     <key>CFBundleGetInfoString</key>
-    <string>Graphical viewer for VisIt</string>
+    <string>${MACOSX_BUNDLE_INFO_STRING}</string>
     <key>CFBundleIconFile</key>
-    <string>VisItIcon.icns</string>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
     <key>CFBundleIdentifier</key>
-    <string>VISV</string>
+    <string>${MACOSX_BUNDLE_VIEWER_IDENTIFIER}</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleLongVersionString</key>
-    <string>VisIt version @VISIT_VERSION@</string>
+    <string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
     <key>CFBundleName</key>
-    <string>VisIt Viewer @VISIT_VERSION@</string>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>VisIt @VISIT_VERSION@</string>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>@VISIT_VERSION@</string>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
     <key>CSResourcesFileMapped</key>
     <true/>
     <key>LSRequiresCarbon</key>
@@ -35,7 +35,7 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>Copyright (c) 2000 - 2019, Lawrence Livermore National Security, LLC</string>
+    <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
     <key>NSRequiresAquaSystemAppearance</key>

--- a/src/tools/dev/scripts/Info.plist.in
+++ b/src/tools/dev/scripts/Info.plist.in
@@ -11,7 +11,7 @@
         <key>CFBundleIconFile</key>
         <string>VisIt.icns</string>
         <key>CFBundleIdentifier</key>
-        <string>VISI</string>
+        <string>gov.llnl.visit</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleLongVersionString</key>
@@ -38,6 +38,6 @@
         <key>LSRequiresCarbon</key>
         <true/>
         <key>NSHumanReadableCopyright</key>
-        <string>Copyright (c) 2000 - 2019, Lawrence Livermore National Security, LLC</string>
+        <string>Copyright (c) 2000 - 2020, Lawrence Livermore National Security, LLC</string>
 </dict>
 </plist>

--- a/src/viewer/main/CMakeLists.txt
+++ b/src/viewer/main/CMakeLists.txt
@@ -17,6 +17,9 @@
 #  Only add ViewerSubmitParallEngineToWindowsHPC if we actually have the
 #  HPC scheduler.
 #
+#  Kevin Griffin, Mon Oct 19 09:43:37 PDT 2020
+#  Updated the bundle name, icon file name, identifier and copyright
+#
 #****************************************************************************
 
 IF(VISIT_PARALLEL AND WIN32 AND HAVE_HPC_SCHEDULER)
@@ -243,14 +246,14 @@ ELSE(NOT APPLE)
     ADD_EXECUTABLE(viewer_exe MACOSX_BUNDLE viewer.C ${VIEWER_STATIC_SOURCES} ${VISIT_SOURCE_DIR}/common/icons/${VIEWER_ICON_FILE})
     
     SET_TARGET_PROPERTIES( viewer_exe PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${VISIT_SOURCE_DIR}/include/ViewerInfo.plist.in)
-    SET(MACOSX_BUNDLE_BUNDLE_NAME          "VisIt ${VISIT_VERSION}")
+    SET(MACOSX_BUNDLE_BUNDLE_NAME          "VisIt Viewer ${VISIT_VERSION}")
     SET(MACOSX_BUNDLE_INFO_STRING          "Graphical viewer for VisIt")
-    SET(MACOSX_BUNDLE_ICON_FILE            ${GUI_ICON_FILE})
-    SET(MACOSX_BUNDLE_GUI_IDENTIFIER       VISI)
+    SET(MACOSX_BUNDLE_ICON_FILE            ${VIEWER_ICON_FILE})
+    SET(MACOSX_BUNDLE_GUI_IDENTIFIER       "gov.llnl.visit.viewer")
     SET(MACOSX_BUNDLE_LONG_VERSION_STRING  "VisIt version ${VISIT_VERSION}")
     SET(MACOSX_BUNDLE_SHORT_VERSION_STRING "VisIt ${VISIT_VERSION}")
     SET(MACOSX_BUNDLE_BUNDLE_VERSION       ${VISIT_VERSION})
-    SET(MACOSX_BUNDLE_COPYRIGHT            "Copyright (c) 2000 - 2019, Lawrence Livermore National Security, LLC")
+    SET(MACOSX_BUNDLE_COPYRIGHT            "Copyright (c) 2000 - 2020, Lawrence Livermore National Security, LLC")
     
     IF(VISIT_STATIC)
         MAC_NIB_INSTALL(viewer)


### PR DESCRIPTION
Resolves #5170. Updated Info.plist and supporting CMakeLists.txt files to have standard bundle identifiers and fixed the copyright date. Also cleaned up the setting and using of CMake variables.

