### PR TITLE
Fix sr mode viewCurve regression failure.

### DIFF
--- a/src/test/tests/rendering/viewChange.py
+++ b/src/test/tests/rendering/viewChange.py
@@ -355,6 +355,25 @@ def TestLargeValueLineoutWithLogScaling():
     SetPlotOptions(curveAtts)
     Test("largeValueLineout")
 
+    # save the curve as VTK so Mesh plot and 2D view can be tested.
+    swa = SaveWindowAttributes() 
+    swa.fileName="lineoutRes"
+    swa.family=0
+    swa.format=swa.VTK
+    SetSaveWindowAttributes(swa)
+    if TestEnv.params["scalable"] == 0:
+        SaveWindow()
+    else:
+        # Turn of SR mode for the saveWindow, then turn it back on
+        ra = GetRenderingAttributes()
+        srm = ra.scalableActivationMode
+        ra.scalableActivationMode = ra.Never
+        SetRenderingAttributes(ra)
+        SaveWindow()
+        ra = GetRenderingAttributes()
+        ra.scalableActivationMode = srm
+        SetRenderingAttributes(ra)
+
     v = GetViewCurve()
     v.rangeScale  = v.LOG 
     SetViewCurve(v)
@@ -363,14 +382,6 @@ def TestLargeValueLineoutWithLogScaling():
     v = GetViewCurve()
     v.rangeScale  = v.LINEAR 
     SetViewCurve(v)
-
-    # now save the curve as VTK so Mesh plot and 2D view can be tested.
-    swa = SaveWindowAttributes() 
-    swa.fileName="lineoutRes"
-    swa.family=0
-    swa.format=swa.VTK
-    SetSaveWindowAttributes(swa)
-    SaveWindow()
 
     DeleteAllPlots()
     OpenDatabase("lineoutRes.vtk")

--- a/test/baseline/rendering/viewChange/largeValueMeshCurve_logScaling.png
+++ b/test/baseline/rendering/viewChange/largeValueMeshCurve_logScaling.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:613438325cefdf6bb9feef3f49361ac6f1f28b6d04f21091c4010435b953a4b3
-size 4849
+oid sha256:5eb1ca4de4de354a5ce03bbdb03b4c2feb1f3a35e9876be52ddc1f1d6d4b21f9
+size 4851


### PR DESCRIPTION
Take window out of SR mode before saving vtk file, then turn it back on.
Update baseline due to very slight change in coordinate values of saved
vtk file.

