### PR TITLE
Remove VISIT_SPHINX and old way of building manuals.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -464,6 +464,10 @@
 #    For Apple, copied manuals directory to the install directory so it can
 #    be found by the packaging target.
 #
+#    Kathleen Biagas, Wed Oct 21, 2020
+#    Removed VISIT_SPHINX, moved Python-3 doc generation logic into doc
+#    subdir's CMakeLists.txt
+#
 #****************************************************************************
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.8 FATAL_ERROR)
@@ -766,7 +770,6 @@ OPTION(VISIT_NOLINK_MPI_WITH_LIBRARIES "Do not link MPI with VisIt's parallel sh
 OPTION(VISIT_CREATE_SOCKET_RELAY_EXECUTABLE "Create a separate executable that forwards VisIt's socket connection between engine and component launcher" ON)
 OPTION(VISIT_RPATH_RELATIVE_TO_EXECUTABLE_PATH "Install rpath relative to executable location using \$ORIGIN tag" OFF)
 OPTION(VISIT_FORTRAN "Enable compilation of Fortran example progams" OFF)
-OPTION(VISIT_SPHINX "Enable ability to build sphinx documentation" OFF)
 
 OPTION(IGNORE_THIRD_PARTY_LIB_PROBLEMS "Ignore problems finding requested third party libraries")
 OPTION(VISIT_FORCE_SSH_TUNNELING "Force ssh tunnelling for sockets" OFF)
@@ -2183,9 +2186,7 @@ if(NOT VISIT_ENGINE_ONLY AND NOT VISIT_SERVER_COMPONENTS_ONLY AND NOT BUILD_CTES
       add_subdirectory(test)
 endif()
 
-IF(VISIT_SPHINX)
-    ADD_SUBDIRECTORY(doc)
-ENDIF()
+add_subdirectory(doc)
 
 #-----------------------------------------------------------------------------
 # CPack -- This leverages our install targets to provide a "make package" that

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -9,60 +9,57 @@
 #
 #   Mark C. Miller, Mon Jun  8 16:45:05 PDT 2020
 #   Added linkcheck builder
+#
+#   Kathleen Biagas, Wed Oct 21, 2020
+#   Replaced old logic with python-3 creation of manuals, which was moved
+#   from root CMakeLists.txt.
+#
 #****************************************************************************
 
-INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindSphinx.cmake)
+if(VISIT_PYTHON3_DIR AND VISIT_ENABLE_MANUALS)
+  if(WIN32)
+    # Need a different path for windows because sphinx-build
+    # is in a different location.
 
-if(NOT DEFINED SPHINX_THEME)
-    set(SPHINX_THEME sphinx_rtd_theme)
+    # don't pollute the src repo, build the docs in the binary dir.
+    # This doesn't allow the manuals to be found if running a dev build,
+    # so location may need to be rethought, but other than building them
+    # in exe/Release and in exe/Debug, thought this location was best.
+    add_custom_target(manuals
+        COMMAND ${VISIT_PYTHON3_DIR}/python.exe
+                ${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py
+        -b html ${VISIT_SOURCE_DIR}/doc 
+        ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
+    # Add command to ensure the manuals are installed to the correct location
+    install(DIRECTORY ${VISIT_BINARY_DIR}/resources/help/en_US/manual
+        DESTINATION ${VISIT_INSTALLED_VERSION_RESOURCES}/help/en_US/
+        FILE_PERMISSIONS OWNER_READ OWNER_WRITE
+                         GROUP_READ GROUP_WRITE
+                         WORLD_READ
+        DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                              GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                              WORLD_READ             WORLD_EXECUTE
+        CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
+  elseif(APPLE)
+    add_custom_target(manuals
+                  COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build
+                  -b html ${VISIT_SOURCE_DIR}/doc
+                  ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
+    # Add command to ensure the manuals are installed to the correct location
+    install(DIRECTORY ${VISIT_BINARY_DIR}/resources/help/en_US/manual
+        DESTINATION ${VISIT_INSTALLED_VERSION_RESOURCES}/help/en_US/
+        FILE_PERMISSIONS OWNER_READ OWNER_WRITE
+                         GROUP_READ GROUP_WRITE
+                         WORLD_READ
+        DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                              GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                              WORLD_READ             WORLD_EXECUTE
+        CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
+  else()
+    add_custom_target(manuals
+                  COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build
+                  -b html ${VISIT_SOURCE_DIR}/doc
+                  ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
+  endif()
 endif()
- 
-if(NOT DEFINED SPHINX_THEME_DIR)
-    set(SPHINX_THEME_DIR _themes)
-endif()
- 
-# configured documentation tools and intermediate build results
-#set(BINARY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_build")
- 
-# Sphinx cache with pickled ReST documents
-#set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_doctrees")
- 
-# HTML output directory
-set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/html")
 
-# linkcheck output directory
-set(SPHINX_LINKCHECK_DIR "${CMAKE_CURRENT_BINARY_DIR}/_linkcheck")
-
-if(WIN32)
-    set(sphinx_launcher ${PYTHON_EXECUTABLE})
-endif()
-
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/conf.py"
-    "${CMAKE_CURRENT_BINARY_DIR}/conf.py"
-    @ONLY)
- 
-add_custom_target(user_manuals ALL
-    ${sphinx_launcher}
-    ${SPHINX_EXECUTABLE}
-        -a -q -b html
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${SPHINX_HTML_DIR}"
-    COMMENT "Building Sphinx-HTML documentation for GUI and CLI")
-
-add_custom_target(linkcheck ALL
-    ${sphinx_launcher}
-    ${SPHINX_EXECUTABLE}
-        -a -q -b linkcheck
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${SPHINX_LINKCHECK_DIR}"
-    COMMENT "Running linkcheck builder on Sphinx documentation")
-
-add_custom_command(TARGET linkcheck
-    COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/check_links.cmake"
-    POST_BUILD
-    )
-
-if(WIN32)
-    unset(sphinx_launcher)
-endif()


### PR DESCRIPTION
Removed VISIT_SPHINX cmake var.
Moved python3-manuals building logic into doc/CMakeLists.txt, replacing
ol-style sphinx generation logic.
This is a merge from 3.1RC.

Resolves #4413