### PR TITLE
fix use of -cli with -o "somefile* database",FORMAT

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -36,6 +36,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where applying Log scaling to the view of a Curve plot (or lineout curve) yielded wrong results.</li>
   <li>Fixed a bug with the variable menu not being sorted properly when the variable list had mixed-case names and variable grouping was used.</li>
   <li>Fixed a bug with the conn_cmfe expression where mapping a variable from a polyhedral mesh to a point mesh failed when the mesh was material selected.</li>
+  <li>Fixed a bug with specifying -cli and -o "somefile* database",FORMAT from the command line.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/visitpy/cli/cli.C
+++ b/src/visitpy/cli/cli.C
@@ -645,7 +645,7 @@ main(int argc, char *argv[])
             
             if(split.size() == 2)
             {
-                command << "OpenDatabase(\"" << split[0] << ", 0, \"" << split[1] << "\")";
+                command << "OpenDatabase(\"" << split[0] << "\", 0, \"" << split[1] << "\")";
             }  
             else
             {


### PR DESCRIPTION
Resolves #2730.
Ensure the filename portion of the created OpenDatabase call has the final quote.
Updated release notes.

I tested this:
```
% cp globe.silo foo1.exo
% cp globe.silo foo2.exo
% cp globe.silo foo3.exo
% ./bin/visit -o "foo*.exo database",Silo_1.0 -cli
```
And it works.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have updated the release notes
- [X] I have assigned reviewers
