### PR TITLE
Update Tron, Zin, Zindev host profiles to use ssh tunneling.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -50,6 +50,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>It is now possible to easily run VisIt in parallel with all the Linux distributions. To run in parallel, simply pass the number of processors to use with the "-np" command line option. For example, "visit -np 4" to run on 4 processors.</li>
   <li>Removed the host profiles for the Lawrence Livermore National Laboratory's Max, Sequoia and Shark systems.</li>
   <li>Added documentation for the "XRay Image" query to the Query section of the Quantitative Analysis chapter in the GUI Manual.</li>
+  <li>Updated the host profiles for the Lawrence Livermore National Laboratory's Tron, Zin and Zindev systems to use SSH tunneling.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_tron.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_tron.xml
@@ -4,6 +4,7 @@
     <Field name="directory" type="string">/usr/gapps/visit</Field>
     <Field name="hostAliases" type="string">"tron#.llnl.gov tron##.llnl.gov tron###.llnl.gov tron# tron## tron###"</Field>
     <Field name="hostNickname" type="string">"LLNL Closed Tron"</Field>
+    <Field name="tunnelSSH" type="bool">true</Field>
     <Object name="LaunchProfile">
         <Field name="profileName" type="string">serial</Field>
         <Field name="timeout" type="int">480</Field>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_zin.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_zin.xml
@@ -5,6 +5,7 @@
     <Field name="hostNickname" type="string">LLNL Closed Zin</Field>
     <Field name="directory" type="string">/usr/gapps/visit</Field>
     <Field name="clientHostDetermination" type="string">ParsedFromSSHCLIENT</Field>
+    <Field name="tunnelSSH" type="bool">true</Field>
     <Object name="LaunchProfile">
         <Field name="profileName" type="string">serial</Field>
         <Field name="timeout" type="int">480</Field>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_zindev.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_zindev.xml
@@ -5,6 +5,7 @@
     <Field name="hostNickname" type="string">LLNL Closed Zindev</Field>
     <Field name="directory" type="string">/usr/gapps/visit</Field>
     <Field name="clientHostDetermination" type="string">ParsedFromSSHCLIENT</Field>
+    <Field name="tunnelSSH" type="bool">true</Field>
     <Object name="LaunchProfile">
         <Field name="profileName" type="string">serial</Field>
         <Field name="timeout" type="int">480</Field>

--- a/src/resources/hosts/llnl_rz/host_llnl_rzansel.xml
+++ b/src/resources/hosts/llnl_rz/host_llnl_rzansel.xml
@@ -5,7 +5,6 @@
     <Field name="userName" type="string">notset</Field>
     <Field name="hostAliases" type="string">"rzansel#.llnl.gov rzansel##.llnl.gov rzansel# rzansel##"</Field>
     <Field name="directory" type="string">/usr/gapps/visit</Field>
-    <Field name="tunnelSSH" type="bool">true</Field>
     <Field name="shareOneBatchJob" type="bool">false</Field>
     <Field name="sshPortSpecified" type="bool">false</Field>
     <Field name="sshPort" type="int">22</Field>


### PR DESCRIPTION
### Description

I turned on ssh tunneling in several host profiles. This wasn't the case in the past, but it is now necessary for client/server to work to those systems. I also found a host profile with ssh tunneling set twice, so I removed one of them.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested the one for zin when I encountered the issue with a user. The rest haven't been tested, but the change is trivial and should be fine.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes