### PR TITLE
Correct the version comparison function in build_visit.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -59,6 +59,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated build_visit scripts for macOS 10.15</li>
   <li>Removed FastBit and FastQuery from VisIt.</li>
   <li>Added notarization capability to the masonry macOS build scripts.</li>
+  <li>Updated a version comparison function in build_visit so that it worked on Manjaro Linux (Arch Linux derivative).</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -59,7 +59,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated build_visit scripts for macOS 10.15</li>
   <li>Removed FastBit and FastQuery from VisIt.</li>
   <li>Added notarization capability to the masonry macOS build scripts.</li>
-  <li>Updated a version comparison function in build_visit so that it worked on Manjaro Linux (Arch Linux derivative).</li>
+  <li>Updated a version comparison function in build_visit so that it worked on Manjaro Linux, an Arch Linux derivative.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -21,11 +21,11 @@ function vercomp ()
             # fill empty fields in ver2 with zeros
             ver2[i]=0
         fi
-        if [[ 10#${ver1[i]} > 10#${ver2[i]} ]]
+        if [[ 10#${ver1[i]} -gt 10#${ver2[i]} ]]
         then
             return 1
         fi
-        if [[ 10#${ver1[i]} < 10#${ver2[i]} ]]
+        if [[ 10#${ver1[i]} -lt 10#${ver2[i]} ]]
         then
             return 2
         fi


### PR DESCRIPTION
### Description

Resolves #4806 

I applied the patch suggested in #4806, to replace ">" with "-gt" and "<" with "-lt". This was necessary to get build_visit to work on Manjaro Linux. This has actually been put on develop, but I'm now putting it on the 3.1RC. I also updated the release notes.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested that the new test constructs work properly. This change has also been on develop since June 2020, so that should also imply that it is fine.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes