### PR TITLE
Remove refs to MSVC 6

### DIFF
--- a/src/avt/Database/Database/avtTransformManager.C
+++ b/src/avt/Database/Database/avtTransformManager.C
@@ -61,9 +61,6 @@
 using std::vector;
 using std::map;
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x)) > 0.5 ? ceil(x) : floor(x);}
-#endif
 
 // ****************************************************************************
 //  Function: GetArrayTypeName 

--- a/src/avt/Database/Ghost/avtUnstructuredPointBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredPointBoundaries.C
@@ -220,18 +220,8 @@ avtUnstructuredPointBoundaries::Generate(vector<int> domainNum,
             }
 
             vector<int> givenCells, givenPoints;
-#if defined(_MSC_VER) && (_MSC_VER <= 1200) // MSVC 6
-            for(std::set<vtkIdType>::const_iterator cell_it = cells.begin();
-                cell_it != cells.end(); ++cell_it)
-                givenCells.push_back(*cell_it);
-
-            for(std::set<vtkIdType>::const_iterator point_it = points.begin();
-                point_it != points.end(); ++point_it)
-                givenPoints.push_back(*point_it);
-#else
             givenCells.assign(cells.begin(), cells.end());
             givenPoints.assign(points.begin(), points.end());
-#endif
             // sendDom gives to recvDom with point filter on.
             SetGivenCellsAndPoints(sendDom, recvDom, givenCells, 
                                                      givenPoints, true);

--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -49,10 +49,6 @@
 
 #include <visit-config.h>
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x)) > 0.5 ? ceil(x) : floor(x);}
-#endif
-
 
 // This array contains strings that correspond to the file types that are 
 // enumerated in the DatasetFileFormat enum.

--- a/src/avt/Filters/avtImgCommunicator.C
+++ b/src/avt/Filters/avtImgCommunicator.C
@@ -22,9 +22,6 @@
 #include <limits>
 #include <set>
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x)) > 0.5 ? ceil(x) : floor(x);}
-#endif
 
 enum blendDirection {FRONT_TO_BACK = 0, BACK_TO_FRONT = 1};
 

--- a/src/avt/Filters/avtOSPRayImageCompositor.C
+++ b/src/avt/Filters/avtOSPRayImageCompositor.C
@@ -25,9 +25,6 @@
 #include <algorithm>
 #include <set>
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x))>0.5?ceil(x):floor(x);}
-#endif
 
 enum blendDirection {FRONT_TO_BACK = 0, BACK_TO_FRONT = 1};
 

--- a/src/avt/Filters/avtOSPRayVoxelExtractor.C
+++ b/src/avt/Filters/avtOSPRayVoxelExtractor.C
@@ -38,9 +38,6 @@
 #include <limits>
 #include <math.h>
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x)) > 0.5 ? ceil(x) : floor(x);}
-#endif
 
 // ****************************************************************************
 //  Method: avtOSPRayVoxelExtractor constructor

--- a/src/avt/Filters/avtSLIVRImageCompositor.C
+++ b/src/avt/Filters/avtSLIVRImageCompositor.C
@@ -22,9 +22,6 @@
 #include <limits>
 #include <set>
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x)) > 0.5 ? ceil(x) : floor(x);}
-#endif
 
 enum blendDirection {FRONT_TO_BACK = 0, BACK_TO_FRONT = 1};
 

--- a/src/avt/Filters/avtSLIVRVoxelExtractor.C
+++ b/src/avt/Filters/avtSLIVRVoxelExtractor.C
@@ -37,9 +37,6 @@
 #include <limits>
 #include <math.h>
 
-#if defined (_MSC_VER) && (_MSC_VER < 1800) && !defined(round)
-inline double round(double x) {return (x-floor(x)) > 0.5 ? ceil(x) : floor(x);}
-#endif
 
 // ****************************************************************************
 //  Method: avtSLIVRVoxelExtractor constructor

--- a/src/avt/Pipeline/Data/pipeline_exports.h
+++ b/src/avt/Pipeline/Data/pipeline_exports.h
@@ -26,16 +26,6 @@
 #pragma warning(disable:4786)
 // Turn off warning about forcing value to bool 'true' or 'false'
 #pragma warning(disable:4800)
-
-// Define VISIT_LONG_LONG so the Windows compiler can handle it.
-#ifndef VISIT_LONG_LONG
-#if defined(_MSC_VER) && (_MSC_VER <= 1200)
-#define VISIT_LONG_LONG __int64
-#else
-#define VISIT_LONG_LONG long long
-#endif
-#endif
-
 #endif
 #else
 # if __GNUC__ >= 4 && (defined(AVTPIPELINE_EXPORTS) || defined(avtpipeline_ser_EXPORTS) || defined(avtpipeline_par_EXPORTS))
@@ -43,9 +33,10 @@
 # else
 #   define PIPELINE_API /* hidden by default */
 # endif
-#ifndef VISIT_LONG_LONG
-#define VISIT_LONG_LONG long long
 #endif
+
+#ifndef VISIT_LONG_LONG
+# define VISIT_LONG_LONG long long
 #endif
 
 #endif

--- a/src/common/expr/ParsingExprList.C
+++ b/src/common/expr/ParsingExprList.C
@@ -297,14 +297,8 @@ GetRealVariableHelper(const string &var, set<string> expandedVars)
     }
 
     // For each leaf, look for a real variable
-#if defined(_MSC_VER) && (_MSC_VER <= 1200)
-    // Don't use const iterator on win32 MSVC 6.
-    for (std::vector<std::string>::iterator it = varLeaves.begin();
-         it != varLeaves.end(); ++it)
-#else
     for (std::vector<std::string>::const_iterator it = varLeaves.begin();
          it != varLeaves.end(); ++it)
-#endif
     {
         string realvar = GetRealVariableHelper(*it, expandedVars);
 

--- a/src/common/utility/array_ref_ptr.h
+++ b/src/common/utility/array_ref_ptr.h
@@ -182,12 +182,8 @@ array_ref_ptr<T>::RemoveReference(void)
     }
 }
 
-#if defined(_MSC_VER) && (_MSC_VER <= 1200) // MSVC 6
-template <class T, class S>
-#else
 template <class T>
 template <class S>
-#endif
 void
 array_ref_ptr<T>::CopyTo(array_ref_ptr<S> &rhs)
 {

--- a/src/common/utility/visitstream.h
+++ b/src/common/utility/visitstream.h
@@ -5,15 +5,6 @@
 #ifndef VISIT_STREAM_H
 #define VISIT_STREAM_H
 
-#if defined(_MSC_VER) && (_MSC_VER <= 1200)
-// We're on Windows using the Microsoft VC++ 6.0 compiler. We need to 
-// include the .h versions of iostream and fstream.
-
-#include <iostream.h>
-#include <fstream.h>
-#include <strstrea.h>
-
-#else
 // Include iostream and some using statements.
 #include <iostream>
 
@@ -33,7 +24,5 @@ using std::ofstream;
 using std::streampos;
 
 #include <sstream>
-
-#endif
 
 #endif

--- a/src/doc/dev_manual/StyleGuide.rst
+++ b/src/doc/dev_manual/StyleGuide.rst
@@ -491,59 +491,6 @@ another library that you change the class so it uses the appropriate
 API macro for the new host library. This goes especially for VTK
 classes that have become part of one of VisIt_'s libraries.
 
-Include visitstream.h instead of iostream.h
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-VisIt_ relies on many stream classes and older versions of MSVC provide
-two different stream class hierarchies. One stream class hierarchy is
-compatible with STL, the other one is not. Furthermore, MSVC6 has issues
-with strings and both versions of the stream class hierarchy. To avoid
-these problems on Windows and on other platforms, VisIt_ coding style
-prohibits the inclusion of any of the stream header files. When you
-need to use streams, include <visitstream.h>. The <visitstream.h> header
-file includes the stream header files that are compatible with the
-VisIt_ source code and the MSVC compiler.
-
-You still need std:: for iterators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-It is fair practice to use the using statement within a .C file so that
-namespace qualification is not required. For example, if you wanted to
-use the std::map class but did not want to call it std::map everywhere,
-you could add: using std::map to your source code and then use the map
-class. ::
-
-    #include <map>
-    using std::map;
-    map<int, int> M;
-
-It is typical to instantiate a variable of an STL container class such
-as std::map and then iterate through it using iterators. Normally, you
-would just declare an iterator without the std:: if you've used the using
-statement for the class over which you want to iterate. Old versions of
-MSVC prevent this due to an apparent flaw in its namespace resolution. ::
-
-    #include <map>
-    using std::map;
-    map<int, int> M;
-
-    // This does not work using MSVC6
-    for(map<int,int>::const_iterator it = M.begin(); it != M.end(); ++it)
-    { /*code*/ }
-
-    // But this does work
-    for(std::map<int,int>::const_iterator it = M.begin(); it != M.end(); ++it)
-    { /* code */ }
-
-Note that you can avoid this bug in MSVC6 if you use typedefs. ::
-
-    #include <map>
-    using std::map;
-    // Define a type based on map.
-    typedef map<int,int> IntIntMap;
-    IntIntMap M;
-    for(IntIntMap::const_iterator it = M.begin(); it != M.end(); ++it)
-    { /* code */}
 
 No constructor or destructor definitions in header file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -614,23 +561,6 @@ compiler being used. ::
     #include <snprintf.h>
     SNPRINTF(buf, 20, "Message: %s", s);
 
-Do not use long long type
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Some code in VisIt_ needs to use very large integers that exceed the
-precision of 32 bits. In these cases, the logical thing to do is use the
-long long type if you are on a 32 bit computer. Unfortunately, the
-long long type is not supported by MSVC 6. Instead of long long, you can
-use VISIT_LONG_LONG so that you have access to a 64 bit integer type.
-The VISIT_LONG_LONG macro actually evaluates to __int64 on Windows so
-you retain the ability to use 64 bits of integer precision without the
-use of long long. ::
-
-    // Don't do this
-    long long nZones = 100000000000000;
-
-    // Do this instead
-    VISIT_LONG_LONG nZones = 100000000000000;
 
 Do not use variables called near or far
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/sim/V2/lib/VisItControlInterface_V2.c
+++ b/src/sim/V2/lib/VisItControlInterface_V2.c
@@ -12,9 +12,6 @@
 #include "VisIt_NameList.h"
 
 #ifdef _WIN32
-#if _MSC_VER < 1600
-#define _WIN32_WINNT 0x0502
-#endif
 #include <winsock2.h>
 #include <direct.h>
 #include <sys/stat.h>


### PR DESCRIPTION
In developer manual style guide.
Removed preprocessor tests for older MSVC compilers no longer supported by VisIt.
This is a merge from 3.1RC.

