### PR TITLE
Rebase due to change in color index for auto-colors

### DIFF
--- a/test/baseline/plots/mesh/mesh_random_color_02.png
+++ b/test/baseline/plots/mesh/mesh_random_color_02.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b29d51bff9838eaa507ba5a4a0543455b03b72a55128b640ba6a6f67e64899be
-size 1512
+oid sha256:e875780a303c544cbb3f27d06fa790703e65b83a6091fab4a4de60f5c85067ba
+size 1479

--- a/test/baseline/plots/mesh/mesh_random_color_03.png
+++ b/test/baseline/plots/mesh/mesh_random_color_03.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31229a5e53aca17f01d34134d64ad94a37551657b26bd7c9f30531535bdc25fb
-size 2689
+oid sha256:c52e6af0b6a1f51eeba554de056d9e7f3a89a64668893e7db82aef0ba430ac25
+size 2444

--- a/test/baseline/rendering/viewChange/largeValueLineout.png
+++ b/test/baseline/rendering/viewChange/largeValueLineout.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89eba91cc226245a43c7e575b713b236e019320460aa80272a5d0103f4bbc4d4
-size 6688
+oid sha256:8d0c7ed28a162c2580ca26ebe40b61ada06c6ab3a42e697954bf82bbe384e803
+size 6427

--- a/test/baseline/rendering/viewChange/largeValueLineout_logScaling.png
+++ b/test/baseline/rendering/viewChange/largeValueLineout_logScaling.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:986b6ca4197ffd48258a6bef6baa17b75768fe510baa29b539462cbb095d23c0
-size 6633
+oid sha256:bfa232e71819462f692b34f92b2993e3742343345bb903f71f00735cd0238baf
+size 6247


### PR DESCRIPTION
These failures are due to a difference in how color indexing into color table is handled for auto-color selection.