### PR TITLE
remove interrupt engine logic

### DIFF
--- a/src/gui/QvisEngineWindow.C
+++ b/src/gui/QvisEngineWindow.C
@@ -113,6 +113,9 @@ QvisEngineWindow::~QvisEngineWindow()
 //    Brad Whitlock, Mon Oct 10 12:55:52 PDT 2011
 //    I added some information.
 //
+//    Alister Maguire, Thu Nov 12 09:58:35 PST 2020
+//    Removed the interrupt engine logic as it is no longer used.
+//
 // ****************************************************************************
 
 void
@@ -194,11 +197,6 @@ QvisEngineWindow::CreateWindowContents()
     QHBoxLayout *buttonLayout1 = new QHBoxLayout();
     topLayout->addLayout(buttonLayout1);
     
-    interruptEngineButton = new QPushButton(tr("Interrupt"), central);
-    connect(interruptEngineButton, SIGNAL(clicked()), this, SLOT(interruptEngine()));
-    interruptEngineButton->setEnabled(false);
-    buttonLayout1->addWidget(interruptEngineButton);
-
     clearCacheButton = new QPushButton(tr("Clear cache"), central);
     connect(clearCacheButton, SIGNAL(clicked()), this, SLOT(clearCache()));
     clearCacheButton->setEnabled(false);
@@ -298,6 +296,9 @@ QvisEngineWindow::SubjectRemoved(Subject *TheRemovedSubject)
 //    Cyrus Harrison, Tue Jun 24 11:15:28 PDT 2008
 //    Initial Qt4 Port.
 //
+//   Alister Maguire, Thu Nov 12 09:58:35 PST 2020
+//   Remove interrupt engine logic.
+//
 // ****************************************************************************
 
 void
@@ -366,9 +367,6 @@ QvisEngineWindow::UpdateWindow(bool doAll)
         // Update the engine information.
         UpdateInformation(current);
 
-        // Set the enabled state of the various widgets.
-        // KSB: When INTERRUPT ENGINE has been fixed, uncomment the next line.
-        //interruptEngineButton->setEnabled(host.size() > 0);
         closeEngineButton->setEnabled(host.size() > 0);
         clearCacheButton->setEnabled(host.size() > 0);
         engineCombo->setEnabled(host.size() > 0);
@@ -725,37 +723,6 @@ QvisEngineWindow::closeEngine()
         // The user actually chose to close the engine.
         GetViewerMethods()->CloseComputeEngine(host, sim);
     }
-}
-
-// ****************************************************************************
-// Method: QvisEngineWindow::interruptEngine
-//
-// Purpose: 
-//   This is a Qt slot function that is called to interrupt the engine that's
-//   displayed in the window.
-//
-// Programmer: Brad Whitlock
-// Creation:   Wed May 2 16:38:41 PST 2001
-//
-// Modifications:
-//    Jeremy Meredith, Tue Mar 30 09:34:33 PST 2004
-//    I added support for simulations.
-//   
-//    Cyrus Harrison, Tue Jun 24 11:15:28 PDT 2008
-//    Initial Qt4 Port.
-//
-// ****************************************************************************
-
-void
-QvisEngineWindow::interruptEngine()
-{
-    int index = engineCombo->currentIndex();
-    if (index < 0)
-        return;
-    string host = engines->GetEngineName()[index];
-    string sim  = engines->GetSimulationName()[index];
-
-    GetViewerProxy()->InterruptComputeEngine(host, sim);
 }
 
 // ****************************************************************************

--- a/src/gui/QvisEngineWindow.h
+++ b/src/gui/QvisEngineWindow.h
@@ -52,6 +52,10 @@ class StatusAttributes;
 //    Brad Whitlock, Mon Oct 10 12:40:06 PDT 2011
 //    I added more information.
 //
+//    Alister Maguire, Thu Nov 12 09:58:35 PST 2020
+//    Removed interruptEngine and interruptEngineButton. We decided this
+//    is very unlikely to ever be implemented.
+//
 // ****************************************************************************
 
 class GUI_API QvisEngineWindow : public QvisPostableWindowObserver
@@ -78,7 +82,6 @@ private:
     void UpdateStatusEntry(const QString &key);
 private slots:
     void closeEngine();
-    void interruptEngine();
     void selectEngine(int index);
     void clearCache();
 private:
@@ -100,7 +103,6 @@ private:
     QProgressBar     *totalProgressBar;
     QLabel           *stageStatusLabel;
     QProgressBar     *stageProgressBar;
-    QPushButton      *interruptEngineButton;
     QPushButton      *closeEngineButton;
     QPushButton      *clearCacheButton;
 };

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -41,6 +41,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug that prevented Pick over time from working correctly when running VisIt in parallel.</li>
   <li>Fixed a bug with specifying -cli and -o "somefile* database",FORMAT from the command line.</li>
   <li>Fixed a bug with the calculating of the data extents after calculating an expression that could result in the minimum being incorrectly set to zero when the minumum was greater than zero and the data was material selected.</li>
+  <li>Removed misleading "Interrupt" button from the Compute Engine window.</li>
 </ul>
 
 <a name="Enhancements"></a>
@@ -53,7 +54,6 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added documentation for the "XRay Image" query to the Query section of the Quantitative Analysis chapter in the GUI Manual.</li>
   <li>Updated the host profiles for the Lawrence Livermore National Laboratory's Tron, Zin and Zindev systems to use SSH tunneling.</li>
   <li>Enhanced the Pick Through Time so that it uses a much faster route when picking verdict metric variables.</li>
-  <li>Removed misleading "Interrupt" button from the Compute Engine window.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -53,6 +53,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added documentation for the "XRay Image" query to the Query section of the Quantitative Analysis chapter in the GUI Manual.</li>
   <li>Updated the host profiles for the Lawrence Livermore National Laboratory's Tron, Zin and Zindev systems to use SSH tunneling.</li>
   <li>Enhanced the Pick Through Time so that it uses a much faster route when picking verdict metric variables.</li>
+  <li>Removed misleading "Interrupt" button from the Compute Engine window.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #5164 

This PR removes the "interrupt" option from the compute engine window.


### Type of change

Task. The feature is no longer used.

### How Has This Been Tested?

I've opened up the compute engine window and confirmed the option has been removed.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
