### PR TITLE
Bugfix/maguire7/default orientation reset dev

### DIFF
--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -2580,6 +2580,10 @@ QvisGUIApplication::ExtractSystemDefaultAppearance()
 //    Brad Whitlock, Wed Nov 26 11:17:56 PDT 2008
 //    I moved the bulk of the code into winutil's SetAppearance function.
 //
+//    Alister Maguire, Thu Nov 12 13:19:56 PST 2020
+//    Updated the orientation set so that it handles moving in and
+//    out of default settings.
+//
 // ****************************************************************************
 
 void
@@ -2595,12 +2599,18 @@ QvisGUIApplication::CustomizeAppearance(bool notify)
     if(notify)
     {
         //
-        // Set the window orientation if is was selected and the main window
-        // has been created.
+        // Set the window orientation. We can't rely on whether or not
+        // orientation has been actively changed, because we might be
+        // transitioning from default to custom or vice versa.
         //
-        bool orientationSelected = aa->IsSelected(AppearanceAttributes::ID_orientation);
-        if(orientationSelected)
+        if (aa->GetUseSystemDefault())
+        {
+            SetOrientation(aa->GetDefaultOrientation());
+        }
+        else
+        {
             SetOrientation(aa->GetOrientation());
+        }
 
         // Tell the viewer about the new appearance.
         aa->Notify();

--- a/src/resources/help/en_US/relnotes3.1.4.html
+++ b/src/resources/help/en_US/relnotes3.1.4.html
@@ -42,6 +42,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with specifying -cli and -o "somefile* database",FORMAT from the command line.</li>
   <li>Fixed a bug with the calculating of the data extents after calculating an expression that could result in the minimum being incorrectly set to zero when the minumum was greater than zero and the data was material selected.</li>
   <li>Removed misleading "Interrupt" button from the Compute Engine window.</li>
+  <li>Fixed a bug that prevented the GUI orientation from resetting back to vertical when changing from a custom appearance to the default appearance.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #4574 

This PR resolves a bug that prevented the GUI orientation from resetting back to its default after changing to a custom appearance. 


### Type of change

Bug fix.

### How Has This Been Tested?

I've opened up the GUI and tested the behavior before and after the fix.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
