### PR TITLE
Fix Windows compile error.

### DIFF
--- a/src/avt/Database/Formats/avtFileFormatInterface.C
+++ b/src/avt/Database/Formats/avtFileFormatInterface.C
@@ -760,18 +760,18 @@ avtFileFormatInterface::GetQOTCoordMesh(const QueryOverTimeAttributes *QOTAtts,
                 {
                     vtkCell *cell      = fullMesh->GetCell(element);
                     vtkPoints *cellPts = cell->GetPoints();
-                    int numCellPoints  = cell->GetNumberOfPoints();
-                    vtkIdType pointIds[numCellPoints];
+                    vtkIdType numCellPoints  = cell->GetNumberOfPoints();
+                    vtkNew<vtkIdList> pointIds;
+                    pointIds->SetNumberOfIds(numCellPoints);
 
-                    for (int p = 0; p < numCellPoints; ++p)
+                    for (vtkIdType p = 0; p < numCellPoints; ++p)
                     {
                         coordPoints->InsertNextPoint(cellPts->GetPoint(p));
-                        pointIds[p] = pointId;
+                        pointIds->SetId(p, pointId);
                         pointId += 1;
                     }
 
-                    coordMesh->InsertNextCell(cell->GetCellType(),
-                        numCellPoints, pointIds);
+                    coordMesh->InsertNextCell(cell->GetCellType(), pointIds);
 
                     break;
                 }
@@ -852,18 +852,18 @@ avtFileFormatInterface::GetQOTCoordMesh(const QueryOverTimeAttributes *QOTAtts,
                 {
                     vtkCell *cell      = fullMesh->GetCell(element);
                     vtkPoints *cellPts = cell->GetPoints();
-                    int numCellPoints  = cell->GetNumberOfPoints();
-                    vtkIdType pointIds[numCellPoints];
+                    vtkIdType numCellPoints  = cell->GetNumberOfPoints();
+                    vtkNew<vtkIdList> pointIds;
+                    pointIds->SetNumberOfIds(numCellPoints);
 
-                    for (int p = 0; p < numCellPoints; ++p)
+                    for (vtkIdType p = 0; p < numCellPoints; ++p)
                     {
                         coordPoints->InsertNextPoint(cellPts->GetPoint(p));
-                        pointIds[p] = pointId;
+                        pointIds->SetId(p, pointId);
                         pointId += 1;
                     }
 
-                    coordMesh->InsertNextCell(cell->GetCellType(),
-                        numCellPoints, pointIds);
+                    coordMesh->InsertNextCell(cell->GetCellType(), pointIds);
 
                     break;
                 }

--- a/src/doc/dev_manual/StyleGuide.rst
+++ b/src/doc/dev_manual/StyleGuide.rst
@@ -639,3 +639,21 @@ Example: ::
        return;
     }
     myvector[val] =  ... // SEGV!
+
+Allocate dynamic arrays on the heap, not the stack
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the size of an array cannot be determined at compile-time, then it cannot be allocated on the stack, but must be allocated on the heap.
+
+Example: ::
+
+    const int nPoints = dataset->GetNumberOfPoints();
+
+    // Since value of nPoints can only be determined at run-time,
+
+    // this will not compile with Visual Studio
+    int myarray[nPoints];
+
+    // this will compile
+    int *myarray2 = new int[nPoints];
+


### PR DESCRIPTION
Merge from 3.1RC.

Dynamic array was being allocated on stack, Visual Studio won't compile that.
Since logic involved VTK, used vtk constructs instead.
Updated style guide to reflect this difference on Windows compiler.

