### PR TITLE
Fix regression errors

### DIFF
--- a/src/config-site/quartz386.cmake
+++ b/src/config-site/quartz386.cmake
@@ -8,7 +8,7 @@
 ##
 ## Setup VISITHOME & VISITARCH variables.
 ##
-SET(VISITHOME /usr/workspace/wsa/visit/visit/thirdparty_shared/3.2.0/toss3)
+SET(VISITHOME /usr/WS1/visit/visit/thirdparty_shared/3.2.0/toss3)
 SET(VISITARCH linux-x86_64_gcc-6.1)
 VISIT_OPTION_DEFAULT(VISIT_SLIVR TRUE TYPE BOOL)
 

--- a/src/test/tests/plugins/pluginVsInstallHelpers
+++ b/src/test/tests/plugins/pluginVsInstallHelpers
@@ -21,12 +21,17 @@ import pprint
 #
 #   Helper which saves a file to the test suite's logs directory.
 #
+#   Modifications:
+#     Kathleen Biagas, Wed Nov 18, 2020
+#     Changed location to result_dir.
+#
 # -----------------------------------------------------------------------------
 def saveLogFile(f):
-    logdir = test_root_path("logs")
+    res_dir = TestEnv.params["result_dir"]
+    logdir = pjoin(res_dir, "logs")
     if not os.path.isdir(logdir):
         os.mkdir(logdir)
-    logdir = abs_path(logdir, "plugins") 
+    logdir = pjoin(logdir, "plugins") 
     if not os.path.isdir(logdir):
         os.mkdir(logdir)
     shutil.copy2(f, logdir)
@@ -46,86 +51,6 @@ def getVersion():
     version = vf.readline()
     vf.close()
     return version[:-1].strip()
-
-# -----------------------------------------------------------------------------
-#   Method: createPackage
-#
-#   Programmer: Kathleen Biagas
-#   Date:       Thu Nov 8, 2018
-#
-#   Helper which calls 'make package' in the build dir.
-#
-# -----------------------------------------------------------------------------
-def createPackage():
-    print "createPackage, chdir to: ", visit_bin_path("..")
-    os.chdir(visit_bin_path(".."))
-    version = getVersion().replace(".", "_")
-    # this is for linux, won't work on windows, what about Mac?
-    # is there a better way to check if the package has already been created?
-    pkgFiles = glob.glob(visit_bin_path("..", 'visit%s.*.tar.gz'%version))
-    print "pkg exists? ", pkgFiles
-    if len(pkgFiles) > 0:
-        return 1
-
-    status = 1
-    fname = abs_path(TestEnv.params["run_dir"], "createPackage_results.txt")
-    f = open(fname, "w")
-    try:
-        subprocess.check_call(["gmake", "-j", "8", "package"],stdout=f,stderr=f)
-        status = 1
-    except subprocess.CalledProcessError as err:
-        status = 0
-    except OSError as e:
-        status = 0
-    f.close()
-    if not status:
-        saveLogFile(fname)
-    os.chdir(test_root_path())
-    return status
-
-# -----------------------------------------------------------------------------
-#   Method: installPackage
-#
-#   Programmer: Kathleen Biagas
-#   Date:       Thu Nov 8, 2018
-#
-#   Helper which installs the package in the build dir.
-#
-#   Modifications:
-#     Eric Brugger, Thu Oct  3 10:16:05 PDT 2019
-#     Remove logic to rename hardware path on toss3 systems.
-#
-# -----------------------------------------------------------------------------
-def installPackage():
-    fname = abs_path(TestEnv.params["run_dir"], "installPackage_results.txt")
-    f = open(fname, "w")
-    f.write("installPackage, chdir to: %s\n"%visit_bin_path(".."))
-    os.chdir(visit_bin_path(".."))
-    installCmd = visit_src_path( "svn_bin", "visit-install")
-    f.write("installPackage, installCmd: %s\n"% installCmd)
-    installDir = visit_bin_path("..", "_install")
-    f.write("installPackage, installDir: %s\n"% installDir)
-    version = getVersion()
-    if (os.path.isdir(abs_path(installDir, version))):
-        f.write("install path already exists\n")
-        f.close()
-        return 1
-    
-    status = 1
-    try:
-        f.write("calling install cmd\n")
-        subprocess.check_call([installCmd, "-c", "llnl_open", version, "linux-x86_64", installDir ], stdout=f,stderr=f)
-        f.write("calling install cmd ... done\n")
-        status = 1
-    except subprocess.CalledProcessError as err:
-        status = 0
-    except OSError as e:
-        status = 0
-    f.close()
-    if not status:
-        saveLogFile(fname)
-    os.chdir(test_root_path())
-    return status
 
 # -----------------------------------------------------------------------------
 #   Method: regencmake
@@ -286,21 +211,6 @@ def buildPlugin(pluginType, pluginList):
 # -----------------------------------------------------------------------------
 
 def do_plugin_type(pluginType, pluginList):
-    # createPackage and installPackage cause the test to overrun the limit
-    # so, instead of creating (which has been added to the build),
-    # just check that the install exists
-
-    #success = createPackage()
-    #if not success:
-    #    TestText("%sVsInstall"%pluginType, "Create package failed")
-    #    Exit(-1)
-
-    #success = installPackage()
-
-    #if not success:
-    #    TestText("%sVsInstall"%pluginType, "Install package failed")
-    #    Exit(-1)
-
     installDir = visit_bin_path("..", "_install")
     version = getVersion()
     if not os.path.isdir(abs_path(installDir, version)):

--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -301,6 +301,12 @@ export PATH=/usr/tce/packages/cuda/cuda-8.0/bin:\$PATH
 export CUDA_HOME=/usr/tce/packages/cuda/cuda-8.0
 export LD_LIBRARY_PATH=/usr/tce/packages/cuda/cuda-8.0/lib64:\$LD_LIBRARY_PATH
 
+# since gcc-6 isn't the default, make sure to set CC and CXX, otherwise
+# pluginVsInstall tests won't use the right compiler
+
+export CC=/usr/tce/packages/gcc/gcc-6.1.0/bin/gcc
+export CXX=/usr/tce/packages/gcc/gcc-6.1.0/bin/g++
+
 if test "$serial" = "true" ; then
     sed -i "s/VISIT_PARALLEL ON/VISIT_PARALLEL OFF/" config-site/pascal83.cmake
 fi

--- a/test/baseline/operators/radial_resample/ops_radialresampleop_rect3d.png
+++ b/test/baseline/operators/radial_resample/ops_radialresampleop_rect3d.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:840794460b00e7ae85fbe9bd0f3d7fd15190629ed2ee72d3cf249cf7e4f31300
-size 24588
+oid sha256:0f201f4108f0fc5b5cb8639106d12247047bd91f0cf3ce7c926fb822e38b9762
+size 24598

--- a/test/baseline/plots/scatter/scatter_19.png
+++ b/test/baseline/plots/scatter/scatter_19.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb69e468275e498ebe2adf59b5fe3839cfd96cc31e2486226acabad5bff8625c
-size 44790
+oid sha256:5369303f607806679fb6b28ff6c64afad55aed4a5681d6a7e4ef856f7008d2f3
+size 47359


### PR DESCRIPTION
 Add compiler to regresstiontest_pascal.

Since gcc-6 isn't default need to notify test suite of correct
compiler to use (for pluginVsInstall tests).

Modify quartz config-site to use fully resolved path to thirdparty
instead of link. This fixes dependency filtering for pluginVsInstall tests.

Rebaseline a couple of images due to qt-update.

I compiled and ran the failing tests in all three testing modes on pascal.
