### PR TITLE
Remove 'set -x' to reduce verbosity in build_visit log file.

### DIFF
--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -330,8 +330,6 @@ function verify_sha_checksum
         return 0
     fi
 
-    set -x
-
     if [[ $checksum_algo == 512 ]]; then
         tmp=`shasum -a $checksum_algo $dfile | tr ' ' '\n' | grep '^[0-9a-f]\{128\}'`
     else


### PR DESCRIPTION
This was already done on develop. (PR #5017)

