### PR TITLE
Modify Stimulate Image reader to handle negative pixel delta.

### DIFF
--- a/src/databases/Image/avtImageFileFormat.C
+++ b/src/databases/Image/avtImageFileFormat.C
@@ -614,6 +614,11 @@ avtImageFileFormat::ProcessDataSelections(int *xmin, int *xmax,
 //    Remove call to SetSource(NULL), as it now removes information necessary
 //    for the dataset. 
 //
+//    Eric Brugger, Mon Nov 23 12:53:21 PST 2020
+//    Correct the reading of Stimulate files to handle the case of a negative
+//    step. Previously, a negative step would have resulted in monotonically
+//    decreasing coordindates, which is invalid for a rectilinear grid.
+//
 // *****************************************************************************
 
 void avtImageFileFormat::ReadInImage(void)
@@ -723,6 +728,20 @@ void avtImageFileFormat::ReadInImage(void)
         reader->GetOrigin(xStart, yStart);
         reader->GetStep(xStep, yStep);
         reader->Delete();
+        if (xStep < 0.)
+        {
+            int dims[3];
+            image->GetDimensions(dims);
+            xStart = xStart + dims[0] * xStep;
+            xStep = - xStep;
+        }
+        if (yStep < 0.)
+        {
+            int dims[3];
+            image->GetDimensions(dims);
+            yStart = yStart + dims[1] * yStep;
+            yStep = - yStep;
+        }
     }
     else
         EXCEPTION1(InvalidFilesException, fname.c_str());

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -1,0 +1,46 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="GENERATOR" content="Microsoft FrontPage 5.0">
+  <meta name="ProgId" content="FrontPage.Editor.Document">
+  <title>VisIt 3.1.5 Release Notes</title>
+</head>
+<body>
+
+
+<center><b><font size="6">VisIt 3.1.5 Release Notes</font></b></center>
+
+<p>Welcome to VisIt's release notes page. This page describes the important
+enhancements and bug-fixes that were added to this release.</p>
+
+<p><b>Sections</b></p>
+<ul>
+  <li><a href="#Bugs_fixed">Bug Fixes</a></li>
+  <li><a href="#Enhancements">Enhancements</a></li>
+  <li><a href="#Dev_changes">Changes for VisIt developers</a></li>
+</ul>
+
+<a name="Bugs_fixed"></a>
+<p><b><font size="4">Bugs fixed in version 3.1.5</font></b></p>
+<ul>
+  <li>Fixed a bug in the Stimulate Image reader (file extensions spr, sdt), where a negative pixel delta in the metadata resulted in incorrect pick results, incorrect sampled lineouts and potentially other erroneous behavior.</li>
+</ul>
+
+<a name="Enhancements"></a>
+<p><b><font size="4">Enhancements in version 3.1.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Dev_changes"></a>
+<p><b><font size="4">Changes for VisIt developers in version 3.1.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<p>Click the following link to view the release notes for the previous version
+of VisIt: <a href=relnotes3.1.4.html>3.1.4</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
### Description

Corrects a bug in the Stimulate Image reader where a negative pixel delta resulted in a vtk rectilinear grid with monotonically decreasing coordinates. vtk rectlinear grids only support monotonically increasing coordinates. This didn't cause problems for many portions of VisIt, for example pseudocolor and mesh plots were fine. Zone picks and lineouts with sampling were incorrect though.

Now the reader flips the order of the coordinates if this situation is encountered.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested it on user data.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [X] I have assigned reviewers