### PR TITLE
Add a pdebug profile to the magma host profiles.

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -31,7 +31,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.1.5</font></b></p>
 <ul>
-  <li></li>
+  <li>Added a host profile for the pdebug queue for the Lawrence Livermore National Laboratory's Magma system.</li>
+  <li>Added a 60 minute time limit to the host profile for the pdebug queue for the Lawrence Livermore Laboratory's Zin system.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_magma.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_magma.xml
@@ -26,6 +26,26 @@
         <Field name="parallel" type="bool">false</Field>
     </Object>
     <Object name="LaunchProfile">
+        <Field name="profileName" type="string">parallel interactive pdebug</Field>
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">96</Field>
+        <Field name="numNodesSet" type="bool">false</Field>
+        <Field name="numNodes" type="int">0</Field>
+        <Field name="partitionSet" type="bool">true</Field>
+        <Field name="partition" type="string">pdebug</Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">true</Field>
+        <Field name="timeLimit" type="string">1:00:00</Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+        <Field name="launchMethod" type="string">srun</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"></Field>
+        <Field name="parallel" type="bool">true</Field>
+    </Object>
+    <Object name="LaunchProfile">
         <Field name="profileName" type="string">parallel batch pbatch</Field>
         <Field name="timeout" type="int">480</Field>
         <Field name="numProcessors" type="int">96</Field>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_zin.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_zin.xml
@@ -35,8 +35,8 @@
         <Field name="partition" type="string">pdebug</Field>
         <Field name="bankSet" type="bool">false</Field>
         <Field name="bank" type="string"></Field>
-        <Field name="timeLimitSet" type="bool">false</Field>
-        <Field name="timeLimit" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">true</Field>
+        <Field name="timeLimit" type="string">1:00:00</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
         <Field name="launchMethod" type="string">srun</Field>
         <Field name="forceStatic" type="bool">true</Field>


### PR DESCRIPTION
### Description

Resolves #5274 

Added a pdebug profile to the magma host profiles. I also noticed that the zin pdebug profile didn't have a time limit set, so I added a 60 minute time limit to it.

### Type of change

Bug fix.

### How Has This Been Tested?

I installed the new host profiles and tested them on magma and zin.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [X] I have assigned reviewers