### PR TITLE
Fix stray VTK_FLOAT

### DIFF
--- a/src/databases/PlainText/avtPlainTextFileFormat.C
+++ b/src/databases/PlainText/avtPlainTextFileFormat.C
@@ -289,7 +289,7 @@ avtPlainTextFileFormat::GetMesh(const char *meshname)
             vals->SetName(meshname);
 
             vtkRectilinearGrid *rg =
-                vtkVisItUtility::Create1DRGrid(nrows,VTK_FLOAT);
+                vtkVisItUtility::Create1DRGrid(nrows,VTK_DOUBLE);
             rg->GetPointData()->SetScalars(vals);
 
             vtkDataArray *xc = rg->GetXCoordinates();


### PR DESCRIPTION
### Description

Resolves #5266 

In my work on #5284, I missed a stray `VTK_FLOAT` that was causing bad behavior. Once corrected, the Spreadsheet plot displayed data correctly.