### PR TITLE
bv_mfem, only hand c++ flags to c++ compiler

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -128,7 +128,7 @@ function build_mfem
     CXXFLAGS="-std=c++11 ${CXXFLAGS}"
 
     vopts="-DCMAKE_C_COMPILER:STRING=${C_COMPILER}"
-    vopts="${vopts} -DCMAKE_C_FLAGS:STRING=\"${C_OPT_FLAGS}\""
+    vopts="${vopts} -DCMAKE_C_FLAGS:STRING=\"${C_OPT_FLAGS} $CFLAGS\""
     vopts="${vopts} -DCMAKE_CXX_COMPILER:STRING=${CXX_COMPILER}"
     vopts="${vopts} -DCMAKE_CXX_FLAGS:STRING=\"${CXX_OPT_FLAGS} $CXXFLAGS\""
     vopts="${vopts} -DCMAKE_INSTALL_PREFIX:PATH=${VISITDIR}/mfem/${MFEM_VERSION}/${VISITARCH}"

--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -128,9 +128,9 @@ function build_mfem
     CXXFLAGS="-std=c++11 ${CXXFLAGS}"
 
     vopts="-DCMAKE_C_COMPILER:STRING=${C_COMPILER}"
-    vopts="${vopts} -DCMAKE_C_FLAGS:STRING=\"${C_OPT_FLAGS} $CXXFLAGS\""
+    vopts="${vopts} -DCMAKE_C_FLAGS:STRING=\"${C_OPT_FLAGS}\""
     vopts="${vopts} -DCMAKE_CXX_COMPILER:STRING=${CXX_COMPILER}"
-    vopts="${vopts} -DCMAKE_CXX_FLAGS:STRING=\"${CXX_OPT_FLAGS}\""
+    vopts="${vopts} -DCMAKE_CXX_FLAGS:STRING=\"${CXX_OPT_FLAGS} $CXXFLAGS\""
     vopts="${vopts} -DCMAKE_INSTALL_PREFIX:PATH=${VISITDIR}/mfem/${MFEM_VERSION}/${VISITARCH}"
     if test "x${DO_STATIC_BUILD}" = "xyes" ; then
         vopts="${vopts} -DBUILD_SHARED_LIBS:BOOL=OFF"


### PR DESCRIPTION
### Description

Fix for build_visit mfem support related to c++11 flags.

`-std=c++11` was being passed to the C compiler, which some C compilers (such as clang on macOS) aren't happy about:

```
[harrison37@elder build (develop)]$ ./bv_run_cmake.sh 
-- (optional) USER_CONFIG = /Users/harrison37/Work/github/visit-dav/visit/build-mb-develop-darwin-10.14-x86_64-py2/thirdparty_shared/mfem-Add_FMS_support/config/user.cmake
-- USE_XSDK_DEFAULTS = 'OFF'
-- The C compiler identification is AppleClang 11.0.0.11000033
-- Check for working C compiler: /usr/bin/clang
-- Check for working C compiler: /usr/bin/clang -- broken
CMake Error at /Users/harrison37/Work/github/visit-dav/visit/build-mb-develop-darwin-10.14-x86_64-py2/thirdparty_shared/third_party/cmake/3.9.3/darwin-x86_64/share/cmake-3.9/Modules/CMakeTestCCompiler.cmake:51 (message):
  The C compiler "/usr/bin/clang" is not able to compile a simple test
  program.

  It fails with the following output:

   Change Dir: /Users/harrison37/Work/github/visit-dav/visit/build-mb-develop-darwin-10.14-x86_64-py2/thirdparty_shared/mfem-Add_FMS_support/build/CMakeFiles/CMakeTmp

  

  Run Build Command:"/usr/bin/make" "cmTC_68972/fast"

  /Applications/Xcode.app/Contents/Developer/usr/bin/make -f
  CMakeFiles/cmTC_68972.dir/build.make CMakeFiles/cmTC_68972.dir/build

  Building C object CMakeFiles/cmTC_68972.dir/testCCompiler.c.o

  /usr/bin/clang -O2 -std=c++11 -fno-common -fexceptions -isysroot
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
  -mmacosx-version-min=10.13 -o CMakeFiles/cmTC_68972.dir/testCCompiler.c.o
  -c
  /Users/harrison37/Work/github/visit-dav/visit/build-mb-develop-darwin-10.14-x86_64-py2/thirdparty_shared/mfem-Add_FMS_support/build/CMakeFiles/CMakeTmp/testCCompiler.c


  error: invalid argument '-std=c++11' not allowed with 'C'

  make[1]: *** [CMakeFiles/cmTC_68972.dir/testCCompiler.c.o] Error 1

  make: *** [cmTC_68972/fast] Error 2

```
  
This fix moves those flags to the C++ flags.



### Type of change

bug fix
### How Has This Been Tested?

This was tested by running build_visit on my macOS machine.
