### PR TITLE
py2to3 port for custom launchers

### DIFF
--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -206,6 +206,9 @@ class JobSubmitter_bsub_LLNL(JobSubmitter):
 #   Add code to unsetenv LD_PRELOAD to protect against users setting
 #   it for the GL library, which would break rendering.
 #
+#   Cyrus Harrison, Fri Dec 11 09:34:38 PST 2020
+#   Python 3 port (avoid using old string methods)
+#
 ###############################################################################
 
 class LLNLLauncher(MainLauncher):
@@ -216,10 +219,10 @@ class LLNLLauncher(MainLauncher):
     def GetIPAddress(self):
         p = subprocess.Popen(["/sbin/ifconfig"], stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         output = p.communicate()
-        iplines = [x for x in string.split(output[0], "\n") if string.find(x, "inet addr") != -1]
-        start = string.find(iplines[0], "inet addr")
-        end = string.find(iplines[0], "Bcast:")
-        IP = string.replace(iplines[0][start + 10:end], " ", "")
+        iplines = [x for x in output[0].split("\n") if x.find("inet addr") != -1]
+        start = iplines[0].find("inet addr")
+        end = iplines[0].find("Bcast:")
+        IP = iplines[0][start + 10:end].replace(" ", "")
         return IP
 
     def Customize(self):
@@ -228,8 +231,8 @@ class LLNLLauncher(MainLauncher):
         # with an IP address.
         #
         if self.parallelArgs.parallel and \
-           (string.find(self.generalArgs.exe_name, "_par") != -1 or \
-            string.find(self.generalArgs.exe_name, "_ser") != -1):
+           (self.generalArgs.exe_name.find("_par") != -1 or \
+            self.generalArgs.exe_name.find("_ser") != -1):
             if self.sectorname() == "vulcanlac" or \
                self.sectorname() == "rzuseqlac" or \
                self.sectorname() == "seqlac":

--- a/src/resources/hosts/nersc/customlauncher
+++ b/src/resources/hosts/nersc/customlauncher
@@ -93,6 +93,9 @@ class JobSubmitter_salloc_NERSC(JobSubmitter_sbatch_NERSC):
 #   Eric Brugger, Mon Aug 12 16:06:46 PDT 2019
 #   Changed GetIPAddress to handle the new location and output from ifconfig.
 #
+#   Cyrus Harrison, Fri Dec 11 09:34:38 PST 2020
+#   Python 3 port (avoid using old string methods)
+#
 ###############################################################################
 
 class NERSCLauncher(MainLauncher):
@@ -106,10 +109,10 @@ class NERSCLauncher(MainLauncher):
     def GetIPAddress(self):
         p = subprocess.Popen(["/usr/bin/ifconfig"], stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         output = p.communicate()
-        iplines = [x for x in string.split(output[0], "\n") if string.find(x, "inet ") != -1]
-        start = string.find(iplines[0], "inet ")
-        end = string.find(iplines[0], "netmask")
-        IP = string.replace(iplines[0][start + 4:end], " ", "")
+        iplines = [x for x in output[0].split("\n") if x.find("inet ") != -1]
+        start = iplines[0].find("inet ")
+        end = iplines[0].find("netmask")
+        IP = iplines[0][start + 4:end].replace(" ", "")
         return IP
 
     def Customize(self):
@@ -127,8 +130,8 @@ class NERSCLauncher(MainLauncher):
             # with an IP address.
             #
             if self.parallelArgs.parallel and \
-               (string.find(self.generalArgs.exe_name, "_par") != -1 or \
-                string.find(self.generalArgs.exe_name, "_ser") != -1):
+               (self.generalArgs.exe_name.find("_par") != -1 or \
+                self.generalArgs.exe_name.find("_ser") != -1):
                 self.generalArgs.host = self.GetIPAddress()
                 self.generalArgs.guesshost = 0
                 self.generalArgs.sshtunneling = 0

--- a/src/resources/hosts/nics/customlauncher
+++ b/src/resources/hosts/nics/customlauncher
@@ -73,6 +73,9 @@ class JobSubmitter_qsub_NICS(JobSubmitter_qsub):
 #
 # Modifications:
 #
+#   Cyrus Harrison, Fri Dec 11 09:34:38 PST 2020
+#   Python 3 port (avoid using old string methods)
+#
 ###############################################################################
 
 class NICSLauncher(MainLauncher):
@@ -114,7 +117,7 @@ class NICSLauncher(MainLauncher):
         if self.IsRunningOnKraken():
             self.generalArgs.host = self.hostname()
             if "krakenpf" in self.generalArgs.host:
-                self.generalArgs.host = string.replace(self.generalArgs.host, "krakenpf", "login")
+                self.generalArgs.host = self.generalArgs.host.replace("krakenpf", "login")
 
             # The /sw filesystem is not accessible from the compute nodes.
             # NICS requires that only required support files be present on /lustre.

--- a/src/resources/hosts/ornl/customlauncher
+++ b/src/resources/hosts/ornl/customlauncher
@@ -304,9 +304,9 @@ class ORNLLauncher(MainLauncher):
             # Replace the hostname to which the engine will connect back.
             self.generalArgs.host = self.hostname()
             if "jaguarpf" in self.generalArgs.host:
-                self.generalArgs.host = string.replace(self.generalArgs.host, "jaguarpf-", "")
+                self.generalArgs.host = self.generalArgs.host.replace("jaguarpf-", "")
             else:
-                self.generalArgs.host = string.replace(self.generalArgs.host, "jaguar", "login")
+                self.generalArgs.host = self.generalArgs.host.replace("jaguar", "login")
 
             addedpaths = ["/opt/torque/default/bin", "/usr/bin"]
             if GETENV("PATH") == "":


### PR DESCRIPTION
### Description

Earlier pass missed python 2 to 3 on custom launchers (they don't end in .py)

For this work, I ran a 2to3 pass, no changes were found which is good.

2to3 doesn't pick up some older patterns that don't work in python3 , including using  `string.find(val,a)` vs   `val.find(a)`, etc

I fixed where we were using this old style of calling string methods.



### Type of change

Bug Fix.



