### PR TITLE
fix for python 3 module init issue

### DIFF
--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -265,12 +265,12 @@ static int InitializeViewerProxy(ViewerProxy* viewerproxy = NULL);
 // methods!
 //
 // As of 2020-12-14, the current number of methods is ~350.
-// 500 is used as a conservative estimate of future growth.
+// 1024 is used as a conservative estimate of future growth.
 //
 // When this number is too small, we show a runtime error
 // at cli startup.
 //
-int VISIT_METHODS_MAX_SIZE = 512;
+int VISIT_METHODS_MAX_SIZE = 1024;
 
 //
 // Type definitions

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -261,14 +261,14 @@ static int InitializeViewerProxy(ViewerProxy* viewerproxy = NULL);
 //
 // This vector is used to hold structs that are handed to python 
 // as pointers. These structs can't be realloced, or else Python
-// will dance around in memory when trying call our module
+// will dance around in memory when trying to call our module
 // methods!
 //
 // As of 2020-12-14, the current number of methods is ~350.
 // 500 is used as a conservative estimate of future growth.
 //
 // When this number is too small, we show a runtime error
-// with at cli startup .
+// at cli startup.
 //
 int VISIT_METHODS_MAX_SIZE = 512;
 


### PR DESCRIPTION
### Description

Resolves #4954

Fixes mystery crash in python 3. 

The source of the issue was the vector that holds our method structs was implicitly
reallocated as methods were added during the multi-step init process.

Pointers to these structs are handed to python ...

This broke several interface methods (those added early in the init process!)

The realloc explains why we saw messages like: `METH_OLDARGS is no longer supported!`.
We were lucky if things worked, if not -- random outcomes were provided.

My solution is to use reserve to pre-allocate the memory used for these structs on first use 
along with runtime checks if we exceeded the allocation in the future.  

### Type of change

Bug Fix.

### How Has This Been Tested?

Test on my macOS system, including dialing down the `VISIT_METHODS_MAX_SIZE` to very small (5) to make sure we provide a sensible error message when we exceed the max size.


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the release notes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added debugging support to my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).

Meta Q: What is our new process for marking the N/A parts of the check list?