### PR TITLE
rc2dev: fix cell count multiplier logic in mesh plot

### DIFF
--- a/src/plots/Mesh/avtMeshPlot.C
+++ b/src/plots/Mesh/avtMeshPlot.C
@@ -232,6 +232,11 @@ avtMeshPlot::Create()
 //    Mark C. Miller, Mon Aug 23 20:24:31 PDT 2004
 //    Changed to the Set... method (Get is now done in avtPlot.C)
 //
+//    Mark C. Miller, Tue Dec 15 19:50:23 PST 2020
+//    Fix logic to set non-zero multipler only when...
+//       a) topo dim is zero...meaning its a point mesh and a glyphed plot
+//       b) spatial dim is 3...meaning glyphs set of 3D faces
+//    Also, set multipler to count of faces of each 3D glyph type.
 // ****************************************************************************
 
 void
@@ -239,11 +244,32 @@ avtMeshPlot::SetCellCountMultiplierForSRThreshold(const avtDataObject_p dob)
 {
     if (*dob)
     {
-        int dim = dob->GetInfo().GetAttributes().GetSpatialDimension();
-        if (dim == 0)
-            cellCountMultiplierForSRThreshold = 6.0;
-        else
+        int tdim = dob->GetInfo().GetAttributes().GetTopologicalDimension();
+
+        if (tdim > 0)
+        {
             cellCountMultiplierForSRThreshold = 1.0;
+            return;
+        }
+
+        int sdim = dob->GetInfo().GetAttributes().GetSpatialDimension();
+        if (sdim < 3)
+        {
+            cellCountMultiplierForSRThreshold = 1.0;
+            return;
+        }
+
+        switch (atts.GetPointType())
+        {
+            case Box:            cellCountMultiplierForSRThreshold = 6.0; break;
+            case Axis:           cellCountMultiplierForSRThreshold = 1.0; break;
+            case Icosahedron:    cellCountMultiplierForSRThreshold = 20.0; break;
+            case Octahedron:     cellCountMultiplierForSRThreshold = 8.0; break;
+            case Tetrahedron:    cellCountMultiplierForSRThreshold = 4.0; break;
+            case SphereGeometry: cellCountMultiplierForSRThreshold = 1.0; break;
+            case Point:          cellCountMultiplierForSRThreshold = 1.0; break;
+            case Sphere:         cellCountMultiplierForSRThreshold = 1.0; break;
+        }
     }
 }
 

--- a/src/plots/Mesh/avtMeshPlot.C
+++ b/src/plots/Mesh/avtMeshPlot.C
@@ -253,22 +253,42 @@ avtMeshPlot::SetCellCountMultiplierForSRThreshold(const avtDataObject_p dob)
         }
 
         int sdim = dob->GetInfo().GetAttributes().GetSpatialDimension();
-        if (sdim < 3)
+        if (sdim < 2)
         {
             cellCountMultiplierForSRThreshold = 1.0;
             return;
         }
 
-        switch (atts.GetPointType())
+        // 2D glyphs are polydata often comprised of multiple tris or quads
+        // but can include lines and points.
+        if (sdim == 2)
         {
-            case Box:            cellCountMultiplierForSRThreshold = 6.0; break;
-            case Axis:           cellCountMultiplierForSRThreshold = 1.0; break;
-            case Icosahedron:    cellCountMultiplierForSRThreshold = 20.0; break;
-            case Octahedron:     cellCountMultiplierForSRThreshold = 8.0; break;
-            case Tetrahedron:    cellCountMultiplierForSRThreshold = 4.0; break;
-            case SphereGeometry: cellCountMultiplierForSRThreshold = 1.0; break;
-            case Point:          cellCountMultiplierForSRThreshold = 1.0; break;
-            case Sphere:         cellCountMultiplierForSRThreshold = 1.0; break;
+            switch (atts.GetPointType())
+            {
+                case Box:            cellCountMultiplierForSRThreshold = 1.0; break;
+                case Axis:           cellCountMultiplierForSRThreshold = 1.5; break;
+                case Icosahedron:    cellCountMultiplierForSRThreshold = 10.0; break;
+                case Octahedron:     cellCountMultiplierForSRThreshold = 5.0; break;
+                case Tetrahedron:    cellCountMultiplierForSRThreshold = 1.0; break;
+                case SphereGeometry: cellCountMultiplierForSRThreshold = 1.0; break;
+                case Point:          cellCountMultiplierForSRThreshold = 1.0; break;
+                case Sphere:         cellCountMultiplierForSRThreshold = 1.0; break;
+            }
+        }
+
+        if (sdim == 3)
+        {
+            switch (atts.GetPointType())
+            {
+                case Box:            cellCountMultiplierForSRThreshold = 6.0; break;
+                case Axis:           cellCountMultiplierForSRThreshold = 3.0; break;
+                case Icosahedron:    cellCountMultiplierForSRThreshold = 20.0; break;
+                case Octahedron:     cellCountMultiplierForSRThreshold = 8.0; break;
+                case Tetrahedron:    cellCountMultiplierForSRThreshold = 4.0; break;
+                case SphereGeometry: cellCountMultiplierForSRThreshold = 1.0; break;
+                case Point:          cellCountMultiplierForSRThreshold = 1.0; break;
+                case Sphere:         cellCountMultiplierForSRThreshold = 1.0; break;
+            }
         }
     }
 }

--- a/src/plots/Mesh/avtMeshPlot.C
+++ b/src/plots/Mesh/avtMeshPlot.C
@@ -233,10 +233,10 @@ avtMeshPlot::Create()
 //    Changed to the Set... method (Get is now done in avtPlot.C)
 //
 //    Mark C. Miller, Tue Dec 15 19:50:23 PST 2020
-//    Fix logic to set non-zero multipler only when...
+//    Fix logic to set non-unit multipler only when...
 //       a) topo dim is zero...meaning its a point mesh and a glyphed plot
-//       b) spatial dim is 3...meaning glyphs set of 3D faces
-//    Also, set multipler to count of faces of each 3D glyph type.
+//       b) spatial dim is 2 or 3...meaning glyphs are sets of 3D faces
+//    Set multipler to count of faces of each 2 or 3D glyph type.
 // ****************************************************************************
 
 void
@@ -274,6 +274,7 @@ avtMeshPlot::SetCellCountMultiplierForSRThreshold(const avtDataObject_p dob)
                 case Point:          cellCountMultiplierForSRThreshold = 1.0; break;
                 case Sphere:         cellCountMultiplierForSRThreshold = 1.0; break;
             }
+            return;
         }
 
         if (sdim == 3)


### PR DESCRIPTION
### Description

Resolves #5208

The cell count multiplier logic in the mesh plot was triggering off spatial dimension and not topological dimension. In addition, it was not using the glyph type to set the multiplier nor variations in that for 2D and 3D glyphs. This update fixes that. The impact will be that VisIt will be more likely to go into SR mode when doing glyphed mesh plots.

As an aside, this work was accidentally commited (in 3 commits) directly to 3.1RC and @brugger1 reviewed via email.

### Type of change

Bug fix

### How Has This Been Tested?

Run locally on my system

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- :x: I have updated the release notes
- :x: I have made corresponding changes to the documentation
- :x: I have added debugging support to my changes
- :x: I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- :x: I have added any new baselines to the repo
- :x: I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
