### PR TITLE
Keyboard tracking in Integral curve operator set to true for changes in spinboxes

### DIFF
--- a/src/doc/tutorials/PotentialFlow.rst
+++ b/src/doc/tutorials/PotentialFlow.rst
@@ -204,7 +204,6 @@ Plotting streamlines of velocity
 7. Set *Samples along line* to "10".
 8. Click *Apply* and *Dismiss*.
 9. Click *Draw* on the Main GUI
-10. In IntegralCurve operator attributes, click *Apply* again (for good measure) and then *Dismiss*.
 
 .. figure:: images/PotentialFlow-Streamline-Atts.png
 

--- a/src/operators/IntegralCurve/QvisIntegralCurveWindow.C
+++ b/src/operators/IntegralCurve/QvisIntegralCurveWindow.C
@@ -465,7 +465,7 @@ QvisIntegralCurveWindow::CreateIntegrationTab(QWidget *pageIntegration)
     numberOfRandomSamplesLabel = new QLabel(tr("Number of random samples"), samplingGroup);
     samplingLayout->addWidget(numberOfRandomSamplesLabel, sRow, 0, 1, 2);
     numberOfRandomSamples = new QSpinBox(samplingGroup);
-    numberOfRandomSamples->setKeyboardTracking(false);
+    numberOfRandomSamples->setKeyboardTracking(true);
     numberOfRandomSamples->setMinimum(1);
     numberOfRandomSamples->setMaximum(100000000);
     connect(numberOfRandomSamples, SIGNAL(valueChanged(int)), this, SLOT(numberOfRandomSamplesChanged(int)));
@@ -474,7 +474,7 @@ QvisIntegralCurveWindow::CreateIntegrationTab(QWidget *pageIntegration)
     randomSeedLabel = new QLabel(tr("Random number seed"), samplingGroup);
     samplingLayout->addWidget(randomSeedLabel, sRow, 3, 1, 2);
     randomSeed = new QSpinBox(samplingGroup);
-    randomSeed->setKeyboardTracking(false);
+    randomSeed->setKeyboardTracking(true);
     randomSeed->setMinimum(0);
     randomSeed->setMaximum(100000000);
     connect(randomSeed, SIGNAL(valueChanged(int)), this, SLOT(randomSeedChanged(int)));
@@ -489,15 +489,15 @@ QvisIntegralCurveWindow::CreateIntegrationTab(QWidget *pageIntegration)
     sampleDensity[0] = new QSpinBox(samplingGroup);
     sampleDensity[1] = new QSpinBox(samplingGroup);
     sampleDensity[2] = new QSpinBox(samplingGroup);
-    sampleDensity[0]->setKeyboardTracking(false);
+    sampleDensity[0]->setKeyboardTracking(true);
     sampleDensity[0]->setMinimum(1);
     sampleDensity[0]->setMaximum(10000000);
     sampleDensity[0]->setValue(atts->GetSampleDensity0());
-    sampleDensity[1]->setKeyboardTracking(false);
+    sampleDensity[1]->setKeyboardTracking(true);
     sampleDensity[1]->setMinimum(1);
     sampleDensity[1]->setMaximum(10000000);
     sampleDensity[1]->setValue(atts->GetSampleDensity1());
-    sampleDensity[2]->setKeyboardTracking(false);
+    sampleDensity[2]->setKeyboardTracking(true);
     sampleDensity[2]->setMinimum(1);
     sampleDensity[2]->setMaximum(10000000);
     sampleDensity[2]->setValue(atts->GetSampleDensity2());
@@ -970,7 +970,7 @@ QvisIntegralCurveWindow::CreateAdvancedTab(QWidget *pageAdvanced)
 
     maxSLCountLabel = new QLabel(tr("Communication threshold"), algoGrp);
     maxSLCount = new QSpinBox(algoGrp);
-    maxSLCount->setKeyboardTracking(false);
+    maxSLCount->setKeyboardTracking(true);
     maxSLCount->setMinimum(1);
     maxSLCount->setMaximum(100000);
     connect(maxSLCount, SIGNAL(valueChanged(int)),
@@ -980,7 +980,7 @@ QvisIntegralCurveWindow::CreateAdvancedTab(QWidget *pageAdvanced)
 
     maxDomainCacheLabel = new QLabel(tr("Domain cache size"), algoGrp);
     maxDomainCache = new QSpinBox(algoGrp);
-    maxDomainCache->setKeyboardTracking(false);
+    maxDomainCache->setKeyboardTracking(true);
     maxDomainCache->setMinimum(1);
     maxDomainCache->setMaximum(100000);
     connect(maxDomainCache, SIGNAL(valueChanged(int)),
@@ -990,7 +990,7 @@ QvisIntegralCurveWindow::CreateAdvancedTab(QWidget *pageAdvanced)
 
     workGroupSizeLabel = new QLabel(tr("Work group size"), algoGrp);
     workGroupSize = new QSpinBox(algoGrp);
-    workGroupSize->setKeyboardTracking(false);
+    workGroupSize->setKeyboardTracking(true);
     workGroupSize->setMinimum(2);
     workGroupSize->setMaximum(1000000);
     connect(workGroupSize, SIGNAL(valueChanged(int)),

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug in the Stimulate Image reader (file extensions spr, sdt), where a negative pixel delta in the metadata resulted in incorrect pick results, incorrect sampled lineouts and potentially other erroneous behavior.</li>
   <li>Fixed a bug in the Histogram Options GUI where the plot was not updating with changes when the Apply button was clicked.</li>
+  <li>Fixed a bug in the Integral Curve Operator GUI where the plot was not updating with typed changes in the spinboxes when the Apply button was clicked.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #3744

Keyboard tracking turned on for all spin boxes in ICO. Don't have to click apply twice anymore.

@biagas this is set to false in all places it shows up (except for Histogram, which I changed a few weeks ago). [GenerateWindow](https://github.com/visit-dav/visit/blob/develop/src/tools/dev/xml/GenerateWindow.h#L122) has a note indicating that you set it this way on purpose ~4 years ago. Do you remember why?


### Type of change

Bugfix

### How Has This Been Tested?

Tested it on my local mac.
@cyrush please test and see if you can still duplicate the issue.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the release notes
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have added debugging support to my changes~~
~~- [ ] New and existing unit tests pass locally with my changes~~
~~- [ ] I have added any new baselines to the repo~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
