### PR TITLE
Fix various compiler warnings on macOS

### DIFF
--- a/src/avt/Expressions/Abstract/avtExpressionFilter.C
+++ b/src/avt/Expressions/Abstract/avtExpressionFilter.C
@@ -365,7 +365,7 @@ avtExpressionFilter::UpdateExtents(avtDataTree_p tree)
         // not referenced by the zone list.
         //
         unsigned char *referenced = NULL;
-        if (isPoint & ds->GetNumberOfCells() > 0)
+        if (isPoint && ds->GetNumberOfCells() > 0)
         {
             referenced = new unsigned char[data->GetNumberOfTuples()];
             memset(referenced, 0, data->GetNumberOfTuples());

--- a/src/common/expr/ExprNode.C
+++ b/src/common/expr/ExprNode.C
@@ -323,7 +323,7 @@ ListExpr::PrintNode(ostream &o)
     for (size_t i=0; i<elems->size(); i++)
     {
         char tmp[256];
-        snprintf(tmp, sizeof(tmp), "Element % 2zd: ", i);
+        snprintf(tmp, sizeof(tmp), "Element %2zu: ", i);
         (*elems)[i]->Print(o,tmp);
     }
 }
@@ -397,7 +397,7 @@ ArgsExpr::PrintNode(ostream &o)
     for (size_t i=0; i<args->size(); i++)
     {
         char tmp[256];
-        snprintf(tmp, sizeof(tmp), "Arg % 2zd: ", i);
+        snprintf(tmp, sizeof(tmp), "Arg %2zu: ", i);
         (*args)[i]->Print(o, tmp);
     }
 }

--- a/src/common/expr/ExprNode.C
+++ b/src/common/expr/ExprNode.C
@@ -323,7 +323,7 @@ ListExpr::PrintNode(ostream &o)
     for (size_t i=0; i<elems->size(); i++)
     {
         char tmp[256];
-        snprintf(tmp, 256, "Element % 2zu: ", i);
+        snprintf(tmp, sizeof(tmp), "Element % 2zd: ", i);
         (*elems)[i]->Print(o,tmp);
     }
 }
@@ -397,7 +397,7 @@ ArgsExpr::PrintNode(ostream &o)
     for (size_t i=0; i<args->size(); i++)
     {
         char tmp[256];
-        snprintf(tmp, 256, "Arg % 2zu: ", i);
+        snprintf(tmp, sizeof(tmp), "Arg % 2zd: ", i);
         (*args)[i]->Print(o, tmp);
     }
 }

--- a/src/common/misc/DebugStream.h
+++ b/src/common/misc/DebugStream.h
@@ -35,11 +35,11 @@ namespace DebugStream
     extern MISC_API int GetLevel();
 }
 
-#define debug1 if (!DebugStream::Level1()) ; else (DebugStream::Stream1((char const *)__FILE__,(int)__LINE__))
-#define debug2 if (!DebugStream::Level2()) ; else (DebugStream::Stream2())
-#define debug3 if (!DebugStream::Level3()) ; else (DebugStream::Stream3())
-#define debug4 if (!DebugStream::Level4()) ; else (DebugStream::Stream4())
-#define debug5 if (!DebugStream::Level5()) ; else (DebugStream::Stream5())
+#define debug1 DebugStream::Level1() && DebugStream::Stream1((char const *)__FILE__,(int)__LINE__)
+#define debug2 DebugStream::Level2() && DebugStream::Stream2()
+#define debug3 DebugStream::Level3() && DebugStream::Stream3()
+#define debug4 DebugStream::Level4() && DebugStream::Stream4()
+#define debug5 DebugStream::Level5() && DebugStream::Stream5()
 
 #define vcerr(c) if (VisItInit::IsComponent(#c)) std::cerr << #c ": "
 

--- a/src/databases/IDX/pidx_idx_io.C
+++ b/src/databases/IDX/pidx_idx_io.C
@@ -87,6 +87,7 @@ VisitIDXIO::DTypes convertType(PIDX_data_type intype)
         return VisitIDXIO::IDX_FLOAT64;
 
     fprintf(stderr, "Type not found for PIDX\n");
+    return VisitIDXIO::UNKNOWN;
 }
 
 

--- a/src/databases/IDX/visit_idx_utils.h
+++ b/src/databases/IDX/visit_idx_utils.h
@@ -27,16 +27,20 @@ static inline float      cfloat (std::string s) {float  value;std::istringstream
 static inline double     cdouble(std::string s) {double value;std::istringstream iss(s);iss>>value;return value;}
 static inline int        cround (double x) { x = x + 0.5 - (x<0); return (int)x; }
 
-// trim from start
+// trim from start (in place)
 static inline std::string &ltrim(std::string &s) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-  return s;
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+    return s;
 }
 
-// trim from end
+// trim from end (in place)
 static inline std::string &rtrim(std::string &s) {
-  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-  return s;
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+    return s;
 }
 
 // trim from both ends

--- a/src/databases/MFIXCDF/avtMFIXCDFFileFormat.C
+++ b/src/databases/MFIXCDF/avtMFIXCDFFileFormat.C
@@ -1448,8 +1448,12 @@ avtMFIXCDFFileFormat::GetVectorVar(int domain, const char *varname)
         nzvals= (widths[2]+3);
     }
 
-    vector<float> xvec(totZones), yvec(totZones), zvec(totZones);
-    float *xdata = &xvec[0], *ydata = &yvec[0], *zdata = &zvec[0];
+    vector<float> xvec(totZones);
+    vector<float> yvec(totZones);
+    vector<float> zvec(totZones);
+    float *xdata = &xvec[0];
+    float *ydata = &yvec[0];
+    float *zdata = &zvec[0];
 
     if (!strncmp(varname,"Vel_",4))
     {

--- a/src/databases/MFIXCDF/avtMFIXCDFFileFormat.C
+++ b/src/databases/MFIXCDF/avtMFIXCDFFileFormat.C
@@ -51,7 +51,6 @@
 #define cbrt(x) (pow(x, 1.0/3.0))
 #endif
 
-using std::auto_ptr;
 using std::vector;
 using std::ostringstream;
 
@@ -1449,14 +1448,8 @@ avtMFIXCDFFileFormat::GetVectorVar(int domain, const char *varname)
         nzvals= (widths[2]+3);
     }
 
-    // This trick with auto_ptr makes xvec, yvec and zvec get deleted
-    // when they go out of scope.
-    auto_ptr< vector<float> > xvec(new vector<float>(totZones));
-    float* xdata= &(*xvec)[0];
-    auto_ptr< vector<float> > yvec(new vector<float>(totZones));
-    float* ydata= &(*yvec)[0];
-    auto_ptr< vector<float> > zvec(new vector<float>(totZones));
-    float* zdata= &(*zvec)[0];
+    vector<float> xvec(totZones), yvec(totZones), zvec(totZones);
+    float *xdata = &xvec[0], *ydata = &yvec[0], *zdata = &zvec[0];
 
     if (!strncmp(varname,"Vel_",4))
     {

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDField.C
@@ -321,7 +321,7 @@ PMDField::SetGridSpacing(char * name,
             this->gridSpacing[2] = 0;
         }
         
-        delete tmpArray;
+        delete [] tmpArray;
     }
 }
 
@@ -374,7 +374,7 @@ PMDField::SetGridGlobalOffset(char * name,
             this->gridGlobalOffset[2] = 0;
         }
 
-        delete tmpArray;
+        delete [] tmpArray;
     }
 }
 
@@ -425,7 +425,7 @@ PMDField::SetGridPosition(char * name,
             gridPosition[2] = 0;
         }
 
-        delete tmpArray;
+        delete [] tmpArray;
     }
 }
 
@@ -546,7 +546,7 @@ PMDField::SetGeometry(char * name,
             debug5 << " tmpchar is not a valid geometry" << endl;
         }
 
-        delete buffer;
+        delete [] buffer;
     }
 }
 
@@ -610,7 +610,7 @@ PMDField::SetAxisLabels(char * name,
             }
         }
 
-        delete buffer;
+        delete [] buffer;
     }
 }
 
@@ -720,7 +720,7 @@ void PMDField::SetUnitDimension(char * name,
         }
         //cerr << this->unitsLabel << endl;
 
-        delete powers;
+        delete [] powers;
     }
 }
 
@@ -783,7 +783,7 @@ PMDField::SetFieldBoundary(char * name,
             //cerr << this->fieldBoundary[iLabel] << endl;
         }
 
-        delete buffer;
+        delete [] buffer;
     }
 }
 
@@ -844,7 +844,7 @@ PMDField::SetFieldBoundaryParameters(char * name,
             }
         }
 
-        delete buffer;
+        delete [] buffer;
     }
 }
 
@@ -888,7 +888,7 @@ PMDField::SetDataOrder(char * name,
 
         this->dataOrder = buffer;
 
-        delete buffer;
+        delete [] buffer;
     }
 }
 
@@ -947,7 +947,7 @@ PMDField::SetGeometryParameters(char * name,
         return -1;
       }
 
-      delete buffer;
+      delete [] buffer;
   }
   else
   {

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -222,7 +222,7 @@ void PMDFile::ScanFileAttributes()
             H5Aread (attrId, atype, buffer);
             buffer[size] = '\0';
 
-            strncpy(this->meshesPath,buffer,sizeof(buffer));
+            strncpy(this->meshesPath,buffer,size+1);
             delete [] buffer;
 
         }
@@ -234,7 +234,7 @@ void PMDFile::ScanFileAttributes()
             H5Aread (attrId, atype, buffer);
             buffer[size] = '\0';
 
-            strncpy(this->particlesPath,buffer,sizeof(buffer));
+            strncpy(this->particlesPath,buffer,size+1);
 
             delete [] buffer;
         }

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
@@ -1096,7 +1096,7 @@ PMDParticle::SetUnitDimension(char * name,
             }
         }
 
-        delete powers;
+        delete [] powers;
     }
     //cerr << unitLabel << endl;
     return unitLabel;


### PR DESCRIPTION
### Description
Although each could be its own PR...the overhead in branch and PR management is too great.

* The individiual commit comments (below) give some more details on each of the changes.
* **Note**: To replace deprecated `ptr_fun<>` in `visit_idx_utils.h`, I introduced use of a C++11 lambda. Is that OK? For Windows?
* The warning from `avtExpressionFilter.C` was an outright bug also.

### Type of change

Fixing compilation warnings.

### How Has This Been Tested?

I've compiled  and run on my local macOS system.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- :x: I have commented my code, particularly in hard-to-understand areas
- :x: I have updated the release notes
- :x: I have made corresponding changes to the documentation
- :x: I have added debugging support to my changes
- :x: I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- :x: I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
