### PR TITLE
Ensure build_visit script is executable

### DIFF
--- a/scripts/ci/docker/Dockerfile
+++ b/scripts/ci/docker/Dockerfile
@@ -62,6 +62,9 @@ COPY visit.build_visit.docker.src.tar /masonry
 COPY masonry_docker_ci_cleanup.py /
 RUN cd /masonry/build-mb-develop-ci-smoke/visit/src/tools/dev/scripts/ && tar -xzf /masonry/visit.build_visit.docker.src.tar
 
+# ensure build_visit script is executable
+RUN cd /masonry/build-mb-develop-ci-smoke/visit/src/tools/dev/scripts/ && chmod u+x build_visit
+
 # call masonry to build tpls
 RUN cd masonry && python bootstrap_visit.py opts/mb-develop-ci-smoke.json
 


### PR DESCRIPTION
Which it isn't if the build_docker_visit_ci.py script is run on Windows.

### Description

Added logic to make the build_visit script executable.

### How Has This Been Tested?

I ran build_docker_visit_ci.py script on Windows with success.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- :x: I have updated the release notes
- :x: I have made corresponding changes to the documentation
- :x: I have added debugging support to my changes
- :x: I have added tests that prove my fix is effective or that my feature works
- :x: New and existing unit tests pass locally with my changes
- :x: I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
