### PR TITLE
Build numpy before pillow

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -1912,15 +1912,6 @@ function bv_python_build
                 export PYTHON_COMMAND="${PYHOME}/bin/python3"
             fi
 
-            check_if_py_module_installed "PIL"
-            # use Pillow for when python 3
-            info "Building the Python Pillow Imaging Library"
-            build_pillow
-            if [[ $? != 0 ]] ; then
-                error "Pillow build failed. Bailing out."
-            fi
-            info "Done building the Python Pillow Imaging Library"
-
             check_if_py_module_installed "numpy"
             if [[ $? != 0 ]] ; then
                 info "Building the numpy module"
@@ -1930,6 +1921,15 @@ function bv_python_build
                 fi
                 info "Done building the numpy module."
             fi
+
+            check_if_py_module_installed "PIL"
+            # use Pillow for when python 3
+            info "Building the Python Pillow Imaging Library"
+            build_pillow
+            if [[ $? != 0 ]] ; then
+                error "Pillow build failed. Bailing out."
+            fi
+            info "Done building the Python Pillow Imaging Library"
 
             if [[ "$BUILD_MPI4PY" == "yes" ]]; then
 


### PR DESCRIPTION
So that setup tools are available.

Ran into a problem with build_visit with '--python --use-python2 --no-sphinx'.
Pillow wouldn't install because  setuptools weren't available.
They get installed with numpy, so I moved numpy build before pillow.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
~~I have commented my code, particularly in hard-to-understand areas~~
~~I have updated the release notes~~
~~I have made corresponding changes to the documentation~~
~~I have added debugging support to my changes~~
~~I have added tests that prove my fix is effective or that my feature works~~
~~New and existing unit tests pass locally with my changes~~
~~I have added any new baselines to the repo~~
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
