### PR TITLE
Update regressiontest_pascal to use CMake 3.14.7.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -92,6 +92,9 @@
 #
 #   Kathleen Biagas, Mon Feb 24 2020
 #   VISIT_BUILD_AVTEXAMPLES renamed to VISIT_ENABLE_AVTEXAMPLES
+#
+#   Eric Brugger, Mon Dec 21 09:11:31 PST 2020
+#   Update cmakeCmd to use CMake 3.14.7, required by new VTKm.
 
 #
 # Determine the users name and e-mail address.
@@ -204,7 +207,7 @@ done
 
 if test "$branch" = "trunk" ; then
     workingDir="test_trunk"
-    cmakeCmd="/usr/workspace/wsa/visit/visit/thirdparty_shared/3.2.0/toss3/cmake/3.9.3/linux-x86_64_gcc-6.1/bin/cmake"
+    cmakeCmd="/usr/workspace/wsa/visit/visit/thirdparty_shared/3.2.0/toss3/cmake/3.14.7/linux-x86_64_gcc-6.1/bin/cmake"
 else
     workingDir="test_branch"
     cmakeCmd="/usr/gapps/visit/thirdparty_shared/2.12.0/cmake/3.0.2/linux-x86_64_gcc-4.4/bin/cmake"


### PR DESCRIPTION
### Description

Update regressiontest_pascal to use CMake 3.14.7, which is required by the newer VTKm now being used by VisIt. This prevented the test suite from running for almost a week now, since the CMake command failed.

### Type of change

Bug fix.

### How Has This Been Tested?

I manually tested the new CMake and it got past the CMake step, whereas using the previous CMake version did not.

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
:x: I have commented my code, particularly in hard-to-understand areas
:x: I have updated the release notes
:x: I have made corresponding changes to the documentation
:x: I have added debugging support to my changes
:x: I have added tests that prove my fix is effective or that my feature works
:x: New and existing unit tests pass locally with my changes
:x: I have added any new baselines to the repo
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).