### PR TITLE
Wrapped notarization code into a masonry action

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -41,7 +41,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.5</font></b></p>
 <ul>
-  <li></li>
+  <li>Created a NotarizeAction in the masonry scripts so that notarization can be executed in the correct order with the rest of the actions.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/masonry/masonry.py
+++ b/src/tools/dev/masonry/masonry.py
@@ -12,6 +12,11 @@ import datetime
 import json
 import errno
 import webbrowser
+import time
+
+import glob
+import re
+import plistlib  # Generate and parse macOS .plist files
 
 from os.path import join as pjoin
 
@@ -22,6 +27,7 @@ __all__ = ["Context",
            "cmake",
            "make",
            "inorder",
+           "notarize",
            "view_log"]
 # ----------------------------------------------------------------------------
 #  Method: mkdir_p
@@ -90,6 +96,63 @@ def _decode_dict(data):
            value = _decode_dict(value)
         rv[key] = value
     return rv
+
+# ----------------------------------------------------------------------------
+#  Method: filter_files 
+#
+#  Programmer: Kevin Griffin
+#  Date:       Fri Dec 18 2020
+#
+#  Generates a list of binary files, frameworks, and bundles on macOS for code signing. 
+#  Items in the list are placed in the correct order for proper inside/out code signing. 
+#
+# ----------------------------------------------------------------------------
+def filter_files(sub_dir):
+    filtered_files = []
+    app_bundles = []
+    app_frameworks = []
+
+    files = glob.glob(pjoin(sub_dir, "*"))
+
+    # RE Patterns
+    headers_pattern = re.compile(r'/Headers/')
+    framework_pattern = re.compile(r'\.framework', flags=re.IGNORECASE)
+    bundle_pattern = re.compile(r'\.app', flags=re.IGNORECASE)
+    binary_pattern = re.compile(r'\.dylib|\.so|\.a', flags=re.IGNORECASE)
+
+    # Search for binaries
+    for f in files:
+        if headers_pattern.search(f) is not None:
+            continue
+
+        basename = os.path.basename(f)
+        endpos = len(basename)
+        pos = endpos - len(".app")
+
+        # Add app bundles last to ensure proper inside/out signing
+        if pos > 0 and bundle_pattern.search(basename, pos, endpos) is not None:
+            app_bundles.append(f)
+        else:
+            pos = endpos - len(".framework")
+            if pos > 0 and framework_pattern.search(basename, pos, endpos) is not None:
+                app_frameworks.append(f)
+
+        if os.path.isdir(f):
+            filtered_files += filter_files(f)
+        else:
+            if basename.find('.') == -1:
+                filtered_files.append(f)
+            else:
+                pos = endpos - len(".dylib") # length of the longest binary extension
+                if pos < 0:
+                    pos = 0
+
+                if binary_pattern.search(basename, pos, endpos) is not None:
+                    filtered_files.append(f)
+
+    filtered_files += app_frameworks
+    filtered_files += app_bundles
+    return filtered_files
 
 def json_loads(jsons):
     if os.path.isfile(jsons):
@@ -232,6 +295,184 @@ class Action(object):
             jsons = open(jsons).read()
         params = json_loads(jsons)
         return cls.load_dict(params)
+
+class NotarizeAction(Action):
+    def __init__(self,
+                 build_dir,
+                 build_type,
+                 build_version,
+                 build_arch,
+                 entitlements,
+                 cert,
+                 bundle_id,
+                 username,
+                 password,
+                 asc_provider,
+                 type="notarize",
+                 description=None,
+                 halt_on_error=True,
+                 env=None):
+        super(NotarizeAction,self).__init__()
+        self.params["build_dir"] = build_dir
+        self.params["build_type"] = build_type
+        self.params["build_version"] = build_version
+        self.params["build_arch"] = build_arch
+        self.params["entitlements"] = entitlements
+        self.params["cert"] = cert
+        self.params["bundle_id"] = bundle_id
+        self.params["username"] = username
+        self.params["password"] = password
+        self.params["asc_provider"] = asc_provider
+        self.params["type"] = type
+        self.params["description"] = description
+        self.params["halt_on_error"] = halt_on_error
+        self.params["env"] = env
+
+    def execute(self,base,key,tag,parent_res):
+        t_start = timenow();
+        res = {"action":
+               {"key": key,
+                "type":self.params["type"],
+                "name":tag,
+                "description": self.params["description"],
+                "build_dir": self.params["build_dir"],
+                "build_type": self.params["build_type"],
+                "build_version": self.params["build_version"],
+                "build_arch": self.params["build_arch"],
+                "entitlements": self.params["entitlements"],
+                "cert": self.params["cert"],
+                "bundle_id": self.params["bundle_id"],
+                "username": self.params["username"],
+                "password": self.params["password"],
+                "asc_provider": self.params["asc_provider"],
+                "env": self.params["env"],
+                "start_time":  timestamp(t_start),
+                "halt_on_error": self.params["halt_on_error"],
+                "finish_time":  None,
+                "elapsed_time": None,
+                "output": None}
+                }
+        parent_res["trigger"]["active_actions"] = [res]
+        base.log(key=key,result=parent_res)
+        cwd = os.path.abspath(os.getcwd())
+        env = os.environ.copy()
+
+        if not self.params["env"] is None:
+            env.update(self.params["env"])
+
+        try:
+            build_dir = pjoin(self.params["build_dir"], "build.%s" % self.params["build_type"])
+            bundle_dir = pjoin(build_dir, "_CPack_Packages/Darwin/Bundle")
+
+            ######################################
+            # Inside/Out Code Signing
+            ######################################
+            sub_dirs_base = pjoin(bundle_dir, "VisIt-%s/VisIt.app/Contents/Resources/%s/%s" % (self.params["build_version"], 
+                                                                                               self.params["build_version"], 
+                                                                                               self.params["build_arch"]))
+            sub_dirs = [pjoin(sub_dirs_base, "bin")]
+            sub_dirs.append(pjoin(sub_dirs_base, "lib"))
+            sub_dirs.append(pjoin(sub_dirs_base, "plugins"))
+            sub_dirs.append(pjoin(sub_dirs_base, "libsim"))
+
+            # Get the list of binaries in each directory and sign them
+            for sub_dir in sub_dirs:
+                binaries = filter_files(sub_dir)
+                for binary in binaries:
+                    cmd = 'codesign --force --options runtime --timestamp'
+                    cmd += ' --entitlements %s' % self.params["entitlements"]
+                    cmd += ' -s "%s" %s' % (self.params["cert"], binary)
+                    rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+                    print "[res: %s]" % rout
+
+            # codesign VisIt.app
+            visit_app = pjoin(bundle_dir, "VisIt-%s/VisIt.app" % self.params["build_version"])
+            cmd = 'codesign --force --options runtime --timestamp'
+            cmd += ' --entitlements %s' % self.params["entitlements"]
+            cmd += ' -s "%s" %s' % (self.params["cert"], visit_app) 
+            rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+            print "[res: %s]" % rout
+
+            # Create DMG to upload to Apple
+            notarize_dir = pjoin(self.params["build_dir"], "notarize.%s" % self.params["build_type"])
+            if not os.path.isdir(notarize_dir):
+                os.makedirs(notarize_dir)
+            os.chdir(notarize_dir)
+
+            src_folder = pjoin(bundle_dir, "VisIt-%s" % self.params["build_version"])
+            temp_dmg = pjoin(notarize_dir, "VisIt.dmg")
+
+            cmd = "hdiutil create -srcFolder %s -o %s" % (src_folder, temp_dmg)
+            rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+            print "[res: %s]" % rout
+            
+            ######################################
+            # Upload to Apple Notary Service 
+            ######################################
+
+            cmd = "xcrun altool --notarize-app"
+            cmd += " --primary-bundle-id %s" % self.params["bundle_id"]
+            cmd += " --username %s" % self.params["username"]
+            cmd += " --password %s" % self.params["password"]
+            cmd += " --asc-provider %s" % self.params["asc_provider"]
+            cmd += " --file %s" % temp_dmg 
+            cmd += " --output-format xml"
+            rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+
+            pl = plistlib.readPlistFromString(rout)
+            uuid = pl["notarization-upload"]["RequestUUID"]
+            print "[uuid: %s]" % uuid
+
+            # Check status of notarization request
+            cmd = "xcrun altool --notarization-info %s" % uuid
+            cmd += " --username %s" % self.params["username"]
+            cmd += " --password %s" % self.params["password"]
+            cmd += " --output-format xml"
+
+            status = "in progress"
+            while status == "in progress":
+                time.sleep(30)
+                rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+                pl = plistlib.readPlistFromString(rout)
+                status = pl["notarization-info"]["Status"]
+                status = status.strip()
+                print "[status: %s]" % status
+             
+            ###################################
+            # Staple notarization ticket to app bundle
+            ###################################
+
+            if status == "success":
+                cmd = "xcrun stapler staple %s" % visit_app
+                rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+                print "[stapler: %s]" % rout
+
+                # Create new DMG with stapled containing notarized app
+                dmg_stapled = pjoin(notarize_dir, "VisIt.stpl.dmg")
+                cmd = "hdiutil create -srcFolder %s -o %s" % (src_folder, dmg_stapled)
+                rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+                print "[hdiutil: %s]" % rout
+
+                dmg_release = pjoin(notarize_dir, "VisIt-%s.dmg" % self.params["build_version"])
+                cmd = "hdiutil convert %s -format UDZO -o %s" % (dmg_stapled, dmg_release)
+                rcode, rout = sexe(cmd, ret_output=True, echo=True, env=env)
+                print "[hdiutil:convert: %s]" % rout
+            else:
+                raise RuntimeError("Notarization Failed!")
+        except KeyboardInterrupt as e:
+            res["action"]["error"] = "notarize command interrupted by user (ctrl-c)"
+        except Exception as e:
+            traceback.print_exc(file=sys.stdout)
+            print e
+            res["action"]["error"] = str(e)
+
+        t_end = timenow()
+        res["action"]["finish_time"]  = timestamp(t_end)
+        res["action"]["elapsed_time"] = timedelta(t_start,t_end) 
+        os.chdir(cwd)
+        parent_res["trigger"]["active_actions"] = []
+        base.log(key=key,result=parent_res)
+        return res
 
 class ShellAction(Action):
     def __init__(self,
@@ -437,6 +678,7 @@ git     = GitAction
 cmake   = CMakeAction
 make    = MakeAction
 inorder = InorderTrigger
+notarize = NotarizeAction
 
 
 def view_log(fname):


### PR DESCRIPTION
Resolves #5283. Wrapped notarization code into a masonry action (NotarizeAction) so notarization can happen in the correct order with the rest of the actions.

### How Has This Been Tested?

Successfully created a notarized dmg with these changes.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- [x] New and existing unit tests pass locally with my changes
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
