### PR TITLE
Switch boxlib plugin from float to double

### DIFF
--- a/data/boxlib_test_data.7z
+++ b/data/boxlib_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:170c7e48e117985b985f103260c964c6a53e46fcedbadbcae7bf62bb6f3cc018
-size 22906592
+oid sha256:3827e98ccdfecf960c9a1a6e135b4b112993689efd068b312cd913048cff6fe0
+size 22988430

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Stimulate Image reader (file extensions spr, sdt), where a negative pixel delta in the metadata resulted in incorrect pick results, incorrect sampled lineouts and potentially other erroneous behavior.</li>
   <li>Fixed a bug in the Histogram Options GUI where the plot was not updating with changes when the Apply button was clicked.</li>
   <li>Fixed a bug in the Histogram Plot where <i>Use Current Plot</i> will now use the actual data extents.</li>
+  <li>Fixed a problem reading double precision data from boxlib files.</li>
 </ul>
 
 <a name="Enhancements"></a>
@@ -37,6 +38,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added a 60 minute time limit to the host profile for the pdebug queue for the Lawrence Livermore Laboratory's Zin system.</li>
   <li>Switched PlainText plugin from using single precision to double precision.</li>
   <li>Updated the documentation for the Smooth Operator.</li>
+  <li>Enhanced boxlib readers to always serve up to VisIt double precision data.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/databases/boxlib.py
+++ b/src/test/tests/databases/boxlib.py
@@ -94,6 +94,20 @@ silr.TurnOffSet(silr.SetsInCategory('materials')[1])
 SetPlotSILRestriction(silr)
 Test("boxlib_06")
 
+#
+# Test double precision is working by reading a known double precision
+# database and ensuring we get expected min/max values within 15 digits
+# of accuracy.
+#
+DeleteAllPlots()
+CloseDatabase(data_path("boxlib_test_data/3D/plt00000.cartgrid.body.small/Header"))
+OpenDatabase(data_path("boxlib_test_data/2D/plt0000000/Header"))
+AddPlot("Pseudocolor", "temperature1")
+DrawPlots()
+SetQueryOutputToValue()
+AssertTrue("temperature1 min", round(Query("Min"),15)==295.409999999999968)
+AssertTrue("temperature1 max", round(Query("Max"),15)==295.410000000000082)
+DeleteAllPlots()
+CloseDatabase(data_path("boxlib_test_data/2D/plt0000000/Header"))
+
 Exit()
-
-


### PR DESCRIPTION
### Description

Resolves #5226 

Switched boxlib plugins (2D and 3D) to replace uses of `vtkFloatArray` with `vtkDoubleArray` as well as associated local variables used to process data read from BoxLib library's `VisMF` object. See [this comment](https://github.com/visit-dav/visit/issues/5226#issuecomment-754161337) in #5226 for rationale. The `avtMaterial` object supports only `float` for mixed volume fractions and so that was not switched to `double`.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested manually on user's data and added a couple of assertion tests to `boxlib.py` test

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- :x: I have made corresponding changes to the documentation
- :x: I have added debugging support to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- :x: I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
