### PR TITLE
Disabling ghosts for t intersections dev

### DIFF
--- a/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
@@ -47,7 +47,7 @@ using   std::sort;
 //                            static data members
 // ----------------------------------------------------------------------------
 
-bool avtStructuredDomainBoundaries::createGhostsForTIntersections = true;
+bool avtStructuredDomainBoundaries::createGhostsForTIntersections = false;
 
 // ----------------------------------------------------------------------------
 //                            private helper methods

--- a/src/engine/main/Engine.C
+++ b/src/engine/main/Engine.C
@@ -2027,6 +2027,12 @@ Engine::ProcessInput()
 //    "-disable-ghosts-for-t-intersections" since new ghost generation
 //    method is now default.
 //
+//    Alister Maguire, Tue Jan  5 08:05:06 PST 2021
+//    Changed option from "-disable-ghosts-for-t-intersections" back to
+//    "-enable-ghosts-for-t-intersections". It turns out that this is a
+//    significant bottleneck. More info leading to this decision can
+//    be found here: https://github.com/visit-dav/visit/issues/5074
+//
 // ****************************************************************************
 
 void
@@ -2259,9 +2265,9 @@ Engine::ProcessCommandLine(int argc, char **argv)
         {
             LoadBalancer::SetScheme(LOAD_BALANCE_ABSOLUTE);
         }
-        else if (strcmp(argv[i], "-disable-ghosts-for-t-intersections") == 0)
+        else if (strcmp(argv[i], "-enable-ghosts-for-t-intersections") == 0)
         {
-            avtStructuredDomainBoundaries::SetCreateGhostsForTIntersections(false);
+            avtStructuredDomainBoundaries::SetCreateGhostsForTIntersections(true);
         }
         else if (strcmp(argv[i], "-plugindir") == 0  && (i+1) < argc )
         {

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -39,6 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Switched PlainText plugin from using single precision to double precision.</li>
   <li>UNV plugin was updated to read gmsh legacy files (thanks Olivier Cessenat).</li>
   <li>Updated the documentation for the Smooth Operator.</li>
+  <li>The -disable-ghost-zone-t-intersections flag has been reverted back to -enable-ghost-zone-t-intersections, and the creation of ghost zones for t-intersections will now be off by default. This will improve performance for the default situation where ghost zone t-intersections are not needed or desired.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -39,7 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Switched PlainText plugin from using single precision to double precision.</li>
   <li>UNV plugin was updated to read gmsh legacy files (thanks Olivier Cessenat).</li>
   <li>Updated the documentation for the Smooth Operator.</li>
-  <li>The -disable-ghost-zone-t-intersections flag has been reverted back to -enable-ghost-zone-t-intersections, and the creation of ghost zones for t-intersections will now be off by default. This will improve performance for the default situation where ghost zone t-intersections are not needed or desired.</li>
+  <li>The -disable-ghosts-for-t-intersections flag has been reverted back to -enable-ghosts-for-t-intersections, and the creation of ghosts for t-intersections will now be off by default. This will improve performance for the default situation where ghost t-intersections are not needed or desired.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #5074 

This reverts the -disable-ghost-zones-for-t-intersections flag back to -enable-ghost-zones-for-t-intersections and disables the creation of ghost zones for t-intersections by default. The purpose is to avoid a bottleneck performance issue that occurs with datasets that contain few AMR levels.


### Type of change

Enhancement.

### How Has This Been Tested?

I've visualized an AMR dataset with and without the -enable-ghost-zones-for-t-intersections flag and confirmed the appropriate behavior was occurring with the help of a print statement. Just to be safe, I also ran the Chombo and mfem tests (all pass).

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- :x: I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- :x:  I have made corresponding changes to the documentation
- :x:  I have added debugging support to my changes
- :x:  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- :x: I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
