### PR TITLE
Make sure manuals are installed on linux.

### DIFF
--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -7,59 +7,52 @@
 #   Kathleen Biagas, Thu March 7, 2019
 #   Added sphinx_launcher (python executable) for Windows.
 #
-#   Mark C. Miller, Mon Jun  8 16:45:05 PDT 2020
-#   Added linkcheck builder
-#
 #   Kathleen Biagas, Wed Oct 21, 2020
 #   Replaced old logic with python-3 creation of manuals, which was moved
 #   from root CMakeLists.txt.
 #
+#   Kathleen Biagas, Thu Jan 7, 2021
+#   Merge logic for creating the build and install commands, they are the
+#   same for all platforms, except the sphinx build command which is
+#   different on Windows.  Added logic to ensure sphinx build command exists.
+#
 #****************************************************************************
 
 if(VISIT_PYTHON3_DIR AND VISIT_ENABLE_MANUALS)
-  if(WIN32)
-    # Need a different path for windows because sphinx-build
-    # is in a different location.
+    message(STATUS "Configure manuals targets")
+    set(errmsgtail "Either install sphinx or set VISIT_ENABLE_MANUALS to false.")
+    if(WIN32)
+        # Need a different sphinx build command for windows
+        if(NOT EXISTS ${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py)
+            message(FATAL_ERROR "Manuals are enabled but"
+                   " ${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py"
+                   " does not exist. ${errmsgtail}")
+        endif()
+        set(sphinx_build_cmd "${VISIT_PYTHON3_DIR}/python.exe \ "
+              "${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py")
+    else()
+        if(NOT EXISTS ${VISIT_PYTHON3_DIR}/bin/sphinx-build)
+            message(FATAL_ERROR "Manuals are enabled but"
+                    " ${VISIT_PYTHON3_DIR}/bin/sphinx-build"
+                    " does not exist. ${errmsgtail}")
+        endif()
+        set(sphinx_build_cmd ${VISIT_PYTHON3_DIR}/bin/sphinx-build)
+    endif()
 
-    # don't pollute the src repo, build the docs in the binary dir.
-    # This doesn't allow the manuals to be found if running a dev build,
-    # so location may need to be rethought, but other than building them
-    # in exe/Release and in exe/Debug, thought this location was best.
-    add_custom_target(manuals
-        COMMAND ${VISIT_PYTHON3_DIR}/python.exe
-                ${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py
-        -b html ${VISIT_SOURCE_DIR}/doc 
+    # Add custom target to build the manuals
+    add_custom_target(manuals COMMAND ${sphinx_build_cmd}
+        -b html ${VISIT_SOURCE_DIR}/doc
         ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
+
     # Add command to ensure the manuals are installed to the correct location
     install(DIRECTORY ${VISIT_BINARY_DIR}/resources/help/en_US/manual
-        DESTINATION ${VISIT_INSTALLED_VERSION_RESOURCES}/help/en_US/
-        FILE_PERMISSIONS OWNER_READ OWNER_WRITE
-                         GROUP_READ GROUP_WRITE
-                         WORLD_READ
-        DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                              GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                              WORLD_READ             WORLD_EXECUTE
-        CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
-  elseif(APPLE)
-    add_custom_target(manuals
-                  COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build
-                  -b html ${VISIT_SOURCE_DIR}/doc
-                  ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
-    # Add command to ensure the manuals are installed to the correct location
-    install(DIRECTORY ${VISIT_BINARY_DIR}/resources/help/en_US/manual
-        DESTINATION ${VISIT_INSTALLED_VERSION_RESOURCES}/help/en_US/
-        FILE_PERMISSIONS OWNER_READ OWNER_WRITE
-                         GROUP_READ GROUP_WRITE
-                         WORLD_READ
-        DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                              GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                              WORLD_READ             WORLD_EXECUTE
-        CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
-  else()
-    add_custom_target(manuals
-                  COMMAND ${VISIT_PYTHON3_DIR}/bin/sphinx-build
-                  -b html ${VISIT_SOURCE_DIR}/doc
-                  ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
-  endif()
+            DESTINATION ${VISIT_INSTALLED_VERSION_RESOURCES}/help/en_US/
+            FILE_PERMISSIONS OWNER_READ OWNER_WRITE
+                             GROUP_READ GROUP_WRITE
+                             WORLD_READ
+            DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                                  GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                                  WORLD_READ             WORLD_EXECUTE
+            CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
 endif()
 

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -11,6 +11,9 @@
 #   Replaced old logic with python-3 creation of manuals, which was moved
 #   from root CMakeLists.txt.
 #
+#   Mark C. Miller, Mon Jun  8 16:45:05 PDT 2020
+#   Added linkcheck builder
+#
 #   Kathleen Biagas, Thu Jan 7, 2021
 #   Merge logic for creating the build and install commands, they are the
 #   same for all platforms, except the sphinx build command which is

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -7,12 +7,12 @@
 #   Kathleen Biagas, Thu March 7, 2019
 #   Added sphinx_launcher (python executable) for Windows.
 #
+#   Mark C. Miller, Mon Jun  8 16:45:05 PDT 2020
+#   Added linkcheck builder
+#
 #   Kathleen Biagas, Wed Oct 21, 2020
 #   Replaced old logic with python-3 creation of manuals, which was moved
 #   from root CMakeLists.txt.
-#
-#   Mark C. Miller, Mon Jun  8 16:45:05 PDT 2020
-#   Added linkcheck builder
 #
 #   Kathleen Biagas, Thu Jan 7, 2021
 #   Merge logic for creating the build and install commands, they are the


### PR DESCRIPTION
Ensure sphinx build command exists.
Resolves #4412.

I consolidated logic for the add_custom_command and install commands.
They are essentially the same for all platforms, with the exception of the sphinx build command which is different on Windows, so encapsulated that in a CMake var.

Added logic for ensuring sphinx build command exists.
Will create a fatal error with the following message:
```
Manuals are enabled but /path/to/sphinx-build does not exist. Either install sphinx or set VISIT_ENABLE_MANUALS to false.
```
I thought the fatal error was better, because VISIT_ENABLE_MANUALS is true by default, and
a warning may get lost in the overabundance of cmake output.


### How Has This Been Tested?

I tried the logic out on Windows and linux, both for python3 with sphinx installed and without.


### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have updated the release notes~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [] I have added debugging support to my changes~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing unit tests pass locally with my changes~~
~~- [ ] I have added any new baselines to the repo~~
- [X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
