### PR TITLE
py3 support for testing the visit_utils module

### DIFF
--- a/src/visitpy/visit_utils/CMakeLists.txt
+++ b/src/visitpy/visit_utils/CMakeLists.txt
@@ -53,3 +53,4 @@ configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_tests.sh.in"
 
 configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_visit_tests.sh.in"
                 "${CMAKE_CURRENT_BINARY_DIR}/run_visit_tests.sh" @ONLY)
+

--- a/src/visitpy/visit_utils/CMakeLists.txt
+++ b/src/visitpy/visit_utils/CMakeLists.txt
@@ -40,3 +40,16 @@ PYTHON_ADD_DISTUTILS_SETUP(visit_utils_py_setup
                            src/qplot/scene.py
                        )
 
+# gen scripts that help us test the visit_utils module
+set(_VISIT_UTILS_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+set(_VISIT_UTILS_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR} )
+
+set(_VISIT_EXECUTABLE ${PROJECT_BINARY_DIR}/bin/visit)
+
+# NOTE: These still run in source  ... 
+
+configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_tests.sh.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/run_python_tests.sh" @ONLY)
+
+configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_visit_tests.sh.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/run_visit_tests.sh" @ONLY)

--- a/src/visitpy/visit_utils/run_python_tests.sh.in
+++ b/src/visitpy/visit_utils/run_python_tests.sh.in
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+# Project developers.  See the top-level LICENSE file for dates and other
+# details.  No copyright assignment is required to contribute to VisIt.
+
+cd @_VISIT_UTILS_SRC_DIR@
+#
+@PYTHON_EXECUTABLE@ -B setup.py test $@
+#
+cd @_VISIT_UTILS_BIN_DIR@

--- a/src/visitpy/visit_utils/run_visit_tests.sh.in
+++ b/src/visitpy/visit_utils/run_visit_tests.sh.in
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+# Project developers.  See the top-level LICENSE file for dates and other
+# details.  No copyright assignment is required to contribute to VisIt.
+
+cd @_VISIT_UTILS_SRC_DIR@
+#
+@_VISIT_EXECUTABLE@ -nowin -cli -s setup.py test $@
+#
+cd @_VISIT_UTILS_BIN_DIR@

--- a/src/visitpy/visit_utils/setup_tests.py
+++ b/src/visitpy/visit_utils/setup_tests.py
@@ -81,6 +81,8 @@ class ExecuteTests(Command):
         """
         Helper called by 'run' to find python scripts in the 'tests' subdir.
         """
+        if not self.tests_dir in sys.path:
+            sys.path.append(self.tests_dir)
         for f in glob.glob(os.path.join(self.tests_dir,"*.py")):
             if not f.endswith('__init__.py'):
                 test = os.path.splitext(os.path.basename(f))[0]

--- a/src/visitpy/visit_utils/src/builtin/writescript.py
+++ b/src/visitpy/visit_utils/src/builtin/writescript.py
@@ -19,7 +19,11 @@
 ###############################################################################
 
 import string, sys
-visit = sys.modules['visit']
+
+try:
+    import visit
+except:
+    pass
 
 def WriteScript(f):
     """Write Python code to replicate the current VisIt state to the specified file object.

--- a/src/visitpy/visit_utils/src/common.py
+++ b/src/visitpy/visit_utils/src/common.py
@@ -38,14 +38,14 @@ except:
 #
 # Some functions wrap calls to the visit module, however not all require
 # it to exist.  Use @require_visit decorator to provide a friendly
-# exception if the visit module needed by not avalaible.
+# exception if the visit module needed but not available.
 #
 
 def require_visit(fn):
     """ Decorator for functions that require the visit module. """
     def run_fn(*args,**kwargs):
         # note: this check happens in the 'common' module but that should
-        # be sufficent - if we can't load it here we wont be able to in other
+        # be sufficient - if we can't load it here we wont be able to in other
         # namespaces.
         if not __visit_imported:
             raise VisItException("Could not import visit module")
@@ -56,7 +56,7 @@ def require_visit(fn):
 #
 # Some functions use PySide modules, however not all require
 # it to exist.  Use @require_pyside decorator to provide a friendly
-# exception if the PySide modules are not avalaible.
+# exception if the PySide modules are not available.
 #
 def require_pyside(fn):
     """ Decorator for functions that require PySide. """
@@ -116,6 +116,7 @@ def sexe(cmd,ret_output=False,echo = False):
     if ret_output:
         p = subprocess.Popen(cmd,
                              shell=True,
+                             universal_newlines=True,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
         res =p.communicate()[0]

--- a/src/visitpy/visit_utils/src/engine.py
+++ b/src/visitpy/visit_utils/src/engine.py
@@ -41,7 +41,7 @@ def open(**kwargs):
 
       engine.open(nprocs=36)
 
-    Launch engine with 36 MPI tasks using on a specific partition:
+    Launch engine with 36 MPI tasks using a specific partition:
 
       engine.open(nprocs=36, part="pbatch")
 

--- a/src/visitpy/visit_utils/src/engine.py
+++ b/src/visitpy/visit_utils/src/engine.py
@@ -12,14 +12,12 @@
 
 """
 
-
 import sys
 import os
 import math
+
 from .host_profile import *
-
 from .common import VisItException, hostname, require_visit
-
 
 try:
     import visit
@@ -35,7 +33,37 @@ def supported_hosts():
     return res
 
 def open(**kwargs):
-    """ Launch VisIt compute engine on the current host. """
+    """ Launch VisIt compute engine on the current host.
+
+    Example usage:
+    
+    Launch engine with 36 MPI tasks using default options for this host:
+
+      engine.open(nprocs=36)
+
+    Launch engine with 36 MPI tasks using on a specific partition:
+
+      engine.open(nprocs=36, part="pbatch")
+
+    Launch engine with 36 MPI tasks, ask for 60 minute time limit:
+
+      engine.open(nprocs=36, rtime=60)
+
+    If you already have a slurm batch allocation, you can use:
+
+      engine.open(method="slurm")
+
+    This reads the SLURM_JOB_NUM_NODES and SLURM_CPUS_ON_NODE 
+    env vars and uses these values to launch with srun.
+
+    If you already have a lsf batch allocation, you can use:
+
+      engine.open(method="lsf")
+
+    This reads the LSB_DJOB_NUMPROC env var and uses it
+    the to launch with mpirun.
+
+    """
     args = {"ppn":1,"part":None,"bank":None,"rtime":None,"vdir":None}
     if "method" not in kwargs:
         hname = hostname(False)
@@ -65,6 +93,15 @@ def open(**kwargs):
         args["nprocs"]   = nprocs
         args["ppn"]      = ppn
         kwargs["method"] = "srun"
+    elif kwargs["method"] == "lsf":
+        args["host"] = hostname(False)
+        if "LSB_DJOB_NUMPROC" in os.environ:
+            nprocs = int(os.environ["LSB_DJOB_NUMPROC"])
+        else:
+            raise VisItException("engine.open(method='lsf') requires "
+                                 "LSB_DJOB_NUMPROC env vars")
+        args["nprocs"]   = nprocs
+        kwargs["method"] = "mpirun"
     else:
         args["host"] = hostname(False)
     args.update(kwargs)

--- a/src/visitpy/visit_utils/src/status.py
+++ b/src/visitpy/visit_utils/src/status.py
@@ -21,7 +21,7 @@ __ofile = None
 
 def __center(sval,ident):
     """ Helper for centering a string. """
-    pad = (80 - len(ident) - len(sval))/2 - 1
+    pad = int((80 - len(ident) - len(sval))/2 - 1)
     res = "".join(" " for i in range(pad))
     return res + sval
 

--- a/src/visitpy/visit_utils/tests/_data/visit_min.vpq
+++ b/src/visitpy/visit_utils/tests/_data/visit_min.vpq
@@ -16,7 +16,7 @@ class PythonMinQuery(SimplePythonQuery):
         ncells = ds_in.GetNumberOfCells()
         if ncells > 0:
             varr = ds_in.GetCellData().GetArray(self.input_var_names[0])
-            vals = [varr.GetTuple1(i) for i in xrange(ncells)]
+            vals = [varr.GetTuple1(i) for i in range(ncells)]
             cmin = min(vals)
             self.vmin = min(self.vmin,cmin)
     def post_execute(self):

--- a/src/visitpy/visit_utils/tests/_data/visit_sq.vpe
+++ b/src/visitpy/visit_utils/tests/_data/visit_sq.vpe
@@ -18,7 +18,7 @@ class PythonSqExpression(SimplePythonExpression):
         res = vtk.vtkFloatArray()
         res.SetNumberOfComponents(1)
         res.SetNumberOfTuples(ncells)
-        for i in xrange(ncells):
+        for i in range(ncells):
             rval = varr.GetTuple1(i)
             rval *= rval
             res.SetTuple1(i,rval)

--- a/src/visitpy/visit_utils/tests/test_property_tree.py
+++ b/src/visitpy/visit_utils/tests/test_property_tree.py
@@ -85,7 +85,10 @@ class TestPropertyTree(unittest.TestCase):
         p.there.now = 4.0
         p.deeper.test.path  = 5.0
         props = list(p.properties().keys())
-        self.assertEqual(props,['deeper/test/path', 'there/now','here'])
+        # ordering may be different between python 2 and 3
+        # sort to avoid issues comparing
+        props.sort()
+        self.assertEqual(props,['deeper/test/path','here','there/now',])
     def test_09_prop_update(self):
         p = PropertyTree()
         p.here = 3.0
@@ -98,7 +101,10 @@ class TestPropertyTree(unittest.TestCase):
         p2.update(p)
         print(p2)
         props = list(p2.properties().keys())
-        self.assertEqual(props,['deeper/test/path', 'there/now','last','value','here'])
+        # ordering may be different between python 2 and 3
+        # sort to avoid issues comparing
+        props.sort()
+        self.assertEqual(props,['deeper/test/path','here','last', 'there/now','value'])
         self.assertEqual(p2.value,True)
         self.assertEqual(p2.last,False)
         self.assertEqual(p2.here,3.0)

--- a/src/visitpy/visit_utils/tests/test_windows.py
+++ b/src/visitpy/visit_utils/tests/test_windows.py
@@ -109,6 +109,7 @@ class TestWindow(unittest.TestCase):
         self.cleanup_windows()
     @visit_test
     def test_render_resize(self):
+        # NOTE -- VIEWER IS CRASHING HERE, NOT SURE WHY:
         sw1 = SimpleWindow()
         sw1.render(obase=pjoin(output_dir,"test.window.render.1"),res=[50,50],ores=[200,200])
         self.assertTrue(os.path.isfile(pjoin(output_dir,"test.window.render.1.png")))


### PR DESCRIPTION
### Description

* adds a lsf option to `visit_utils.engine.open()` (resolves #5198)
* adds example `visit_utils.engine.open()` usage to its doc string
* updates visit_utils module testing to run under python 3
* adds gen of helper scripts that call the visit_utils module testing with configured python and visit. 

The gen of the helper scripts make this easier to test, however the tests are still run in the source dir vs the build dir. Should be possible to avoid that, this helps us in that direction. 

### Type of change

Bug fix + new feature. 

### How Has This Been Tested?

I tested the visit_utils module tests on my mac laptop.  One of the rendering unit tests fails (viewer crash)

I tested new lsf logic on LLNL lassen.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have updated the release notes~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have added debugging support to my changes~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing unit tests pass locally with my changes~~
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
