### PR TITLE
Add building the manuals to the regression suite.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -95,6 +95,10 @@
 #
 #   Eric Brugger, Mon Dec 21 09:11:31 PST 2020
 #   Update cmakeCmd to use CMake 3.14.7, required by new VTKm.
+#
+#   Eric Brugger, Fri Jan  8 11:12:04 PST 2021
+#   I modified the script to also make the manuals before making the package
+#   since the manuals are now required to make the package.
 
 #
 # Determine the users name and e-mail address.
@@ -337,6 +341,8 @@ else
         ../src >> ../../buildlog 2>&1
 fi
 rm -f ../make.out ../make.err
+make -k -j 36 1>../make.out 2>../make.err
+make -k manuals 1>../make.out 2>../make.err
 make -k -j 36 package 1>../make.out 2>../make.err
 if test $? -ne 0; then
     echo "Source build FAILED at: \`date\`" | mail -s "Source build FAILED" $userEmail


### PR DESCRIPTION
### Description

I modified the regression test script to build the manuals before building the package since the manuals are now required to build the package. This should fix the existing test suite failures.

### Type of change

Bug fix.

### How Has This Been Tested?

I manually built the manuals and then built the package and the make package succeeded

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
~~- [] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have updated the release notes~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have added debugging support to my changes~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing unit tests pass locally with my changes~~
~~- [ ] I have added any new baselines to the repo~~
- [ X] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).