### PR TITLE
Cell-centered tecplot fix on 3.1RC

### DIFF
--- a/data/tecplot_test_data.7z
+++ b/data/tecplot_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c888a87d4ba9c5441aa0b9ee8d16452dfab0eed5c433e5d29fde3440334a1b07
-size 11487393
+oid sha256:a2c231069f28ef0ba1d35b7113c671f9f9e8a54db1760ea48cc04e919892daaf
+size 11474250

--- a/src/databases/Tecplot/TecplotFile.C
+++ b/src/databases/Tecplot/TecplotFile.C
@@ -2147,6 +2147,9 @@ operator << (ostream &os, const TecplotDataRecord &obj)
 //   Kathleen Biagas, Wed Oct 21, 2015
 //   Use long long for offsets, so large files can be read on Windows.
 //
+//   Phil Chiu @whophil, Fri Jan 8, 2021
+//   Account for the variable "location" (node or cell center) when computing
+//   data offsets in FE zones (was already done for ordered zones).
 // ****************************************************************************
 
 void
@@ -2211,6 +2214,7 @@ TecplotDataRecord::CalculateOffsets(const TecplotZone &zone)
     else
     {
         int numNodes = zone.GetNumNodes();
+        int numElements = zone.GetNumElements();
         int centering, numItems;
         long long offset = 0;
         for(size_t i = 0; i < variables.size(); ++i)
@@ -2226,7 +2230,10 @@ TecplotDataRecord::CalculateOffsets(const TecplotZone &zone)
                 continue;
             }
             centering = zone.centering[i];
-            numItems = numNodes;
+            if(centering == TecplotZone::NodeCentered)
+                numItems = numNodes;
+            else
+                numItems = numElements;
             if(zone.zoneType == ORDERED)
             {
             TecplotOrderedZone *z = (TecplotOrderedZone *)zone.zoneData;

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Histogram Plot where <i>Use Current Plot</i> will now use the actual data extents.</li>
   <li>Fixed a problem reading double precision data from boxlib files.</li>
   <li>Fixed a bug in the Silo database plugin that resulted in VisIt crashing whenever negative material numbers were encountered. VisIt will now display an error message noting that negative material numbers are not supported.</li>
+  <li>Tecplot reader was fixed for handling cell-centered data (Thank you <a href="https://github.com/whophil">Phil Chiu!</a>).</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/databases/tecplot.py
+++ b/src/test/tests/databases/tecplot.py
@@ -296,4 +296,22 @@ DrawPlots()
 Test("tecplot_25")
 DeleteAllPlots()
 
+DeleteAllPlots();
+CloseDatabase(data_path("tecplot_test_data/pointmesh.tec"))
+
+# binary file containing both node and cell data in block format
+OpenDatabase(data_path("tecplot_test_data/two_triangles_node_and_cell.plt"))
+
+AddPlot("Pseudocolor","nodal_field")
+ResetView()
+DrawPlots()
+Test("tecplot_26")
+DeleteAllPlots()
+
+AddPlot("Pseudocolor","cell_field")
+ResetView()
+DrawPlots()
+Test("tecplot_27")
+DeleteAllPlots()
+
 Exit()

--- a/test/baseline/databases/tecplot/tecplot_26.png
+++ b/test/baseline/databases/tecplot/tecplot_26.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2846b1069a2d0c889b9ac44b9103aabb92c8e2d690d78c1b24779f9e6d293a
+size 3233

--- a/test/baseline/databases/tecplot/tecplot_27.png
+++ b/test/baseline/databases/tecplot/tecplot_27.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80f3addc7e8b8f3468df949874d26842c7ad461c8dcbb24ff172ee3b7a2b5bac
+size 1283


### PR DESCRIPTION
### Description

Puts #5369 on 3.1RC including tests and relnotes update. 

@whophil pls feel free to add any review comments here.

### Type of change

Feature enhancement. Addes cell-centered support to tecplot reader.

### How Has This Been Tested?

Locally on my macOS system. I expect newly added baseline images might fail in tonights test. Will rebase if so.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the release notes
- :x: I have made corresponding changes to the documentation
- :x: I have added debugging support to my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added any new baselines to the repo
- [x] I have assigned reviewers (see [VisIt's PR procedures](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers) for more information).
