### PR TITLE
Fix gui crash opening SaveMovie wizard.

### DIFF
--- a/src/gui/MovieSequenceFactory.C
+++ b/src/gui/MovieSequenceFactory.C
@@ -382,10 +382,8 @@ MovieSequenceFactory::SequencePixmap(int id, QPixmap &pix) const
         key.asprintf("%s_%d", 
             it->second->SequenceName().c_str(),
             it->second->SequenceId());
-        QPixmap *p = NULL;
-        if(QPixmapCache::find(key, p))
+        if(QPixmapCache::find(key, pix))
         {
-            pix = *p;
             return true;
         }
 


### PR DESCRIPTION
Fix call to QPixmapCache::find

### Description

Resolves #5396

### How Has This Been Tested?

I tried opening the Save Movie wizard and it no longer crashes.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
