### PR TITLE
Fix gui issues related to use of QString::asprintf

### DIFF
--- a/src/gui/MovieSequenceFactory.C
+++ b/src/gui/MovieSequenceFactory.C
@@ -19,7 +19,7 @@ MovieSequenceFactory *MovieSequenceFactory::instance = 0;
 // ****************************************************************************
 // Method: MovieSequenceFactory::Instance
 //
-// Purpose: 
+// Purpose:
 //   Static method that makes this class a singleton.
 //
 // Returns:    The only instance of the class.
@@ -28,7 +28,7 @@ MovieSequenceFactory *MovieSequenceFactory::instance = 0;
 // Creation:   Tue Nov 14 10:29:33 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 MovieSequenceFactory *
@@ -43,7 +43,7 @@ MovieSequenceFactory::Instance()
 // ****************************************************************************
 // Method: MovieSequenceFactory::MovieSequenceFactory
 //
-// Purpose: 
+// Purpose:
 //   Constructor.
 //
 // Note:       We keep a list of movie sequences and use their NewInstance
@@ -53,7 +53,7 @@ MovieSequenceFactory::Instance()
 // Creation:   Tue Nov 14 10:30:02 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 MovieSequenceFactory::MovieSequenceFactory() : sequenceTypes()
@@ -100,14 +100,14 @@ MovieSequenceFactory::MovieSequenceFactory() : sequenceTypes()
 // ****************************************************************************
 // Method: MovieSequenceFactory::~MovieSequenceFactory
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:30:59 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 MovieSequenceFactory::~MovieSequenceFactory()
@@ -120,7 +120,7 @@ MovieSequenceFactory::~MovieSequenceFactory()
 // ****************************************************************************
 // Method: MovieSequenceFactory::NumSequenceTypes
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of sequence types.
 //
 // Returns:    Returns the number of sequence types.
@@ -129,7 +129,7 @@ MovieSequenceFactory::~MovieSequenceFactory()
 // Creation:   Tue Nov 14 10:31:11 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -141,8 +141,8 @@ MovieSequenceFactory::NumSequenceTypes() const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequenceIdForIndex
 //
-// Purpose: 
-//   Returns the sequence id for a given index into the number of registered 
+// Purpose:
+//   Returns the sequence id for a given index into the number of registered
 //   sequence types.
 //
 // Arguments:
@@ -155,7 +155,7 @@ MovieSequenceFactory::NumSequenceTypes() const
 // Creation:   Tue Nov 14 10:31:38 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -177,7 +177,7 @@ MovieSequenceFactory::SequenceIdForIndex(int index, int &id) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequenceNameToId
 //
-// Purpose: 
+// Purpose:
 //   Returns a sequence id given a sequence name.
 //
 // Arguments:
@@ -186,13 +186,13 @@ MovieSequenceFactory::SequenceIdForIndex(int index, int &id) const
 //
 // Returns:    True on success; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:32:50 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -214,7 +214,7 @@ MovieSequenceFactory::SequenceNameToId(const std::string &name, int &id) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequenceName
 //
-// Purpose: 
+// Purpose:
 //   Returns the id'th sequence name.
 //
 // Arguments:
@@ -223,13 +223,13 @@ MovieSequenceFactory::SequenceNameToId(const std::string &name, int &id) const
 //
 // Returns:    True on success; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:33:38 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -248,7 +248,7 @@ MovieSequenceFactory::SequenceName(int id, std::string &name) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequenceMenuName
 //
-// Purpose: 
+// Purpose:
 //   Returns the id'th sequence menu name.
 //
 // Arguments:
@@ -257,7 +257,7 @@ MovieSequenceFactory::SequenceName(int id, std::string &name) const
 //
 // Returns:    True on success; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:33:38 PDT 2006
@@ -284,7 +284,7 @@ MovieSequenceFactory::SequenceMenuName(int id, QString &name) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequenceProvidesMenu
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the id'th sequence provides a menu.
 //
 // Arguments:
@@ -292,13 +292,13 @@ MovieSequenceFactory::SequenceMenuName(int id, QString &name) const
 //
 // Returns:    True if the sequence provides a menu; False otherwise
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:33:38 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -316,7 +316,7 @@ MovieSequenceFactory::SequenceProvidesMenu(int id) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequenceSubMenuIndex
 //
-// Purpose: 
+// Purpose:
 //   Returns the index of the sub menu that a sequence will occupy.
 //
 // Arguments:
@@ -332,7 +332,7 @@ MovieSequenceFactory::SequenceProvidesMenu(int id) const
 // Creation:   Tue Nov 14 10:33:38 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -353,7 +353,7 @@ MovieSequenceFactory::SequenceSubMenuIndex(int id, int &index) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::SequencePixmap
 //
-// Purpose: 
+// Purpose:
 //   Finds the pixmap for the id'th sequence.
 //
 // Arguments:
@@ -362,13 +362,15 @@ MovieSequenceFactory::SequenceSubMenuIndex(int id, int &index) const
 //
 // Returns:    True on success; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:37:09 PDT 2006
 //
 // Modifications:
-//   
+//   Kathleen Biagas, Thu Jan 21 2021
+//   Swap use of QString::sprintf for Qtring.arg as suggested in Qt docs.
+//
 // ****************************************************************************
 
 bool
@@ -378,14 +380,12 @@ MovieSequenceFactory::SequencePixmap(int id, QPixmap &pix) const
     if(it != sequenceTypes.end())
     {
         // Look in the cache for it and return
-        QString key;
-        key.asprintf("%s_%d", 
-            it->second->SequenceName().c_str(),
-            it->second->SequenceId());
-        QPixmap *p = NULL;
-        if(QPixmapCache::find(key, p))
+        QString key = QString("%1_%2")
+            .arg(it->second->SequenceName().c_str())
+            .arg(it->second->SequenceId());
+
+        if(QPixmapCache::find(key, pix))
         {
-            pix = *p;
             return true;
         }
 
@@ -397,7 +397,7 @@ MovieSequenceFactory::SequencePixmap(int id, QPixmap &pix) const
         {
             QPixmapCache::insert(key, pix);
         }
-      
+
         return true;
     }
 
@@ -407,7 +407,7 @@ MovieSequenceFactory::SequencePixmap(int id, QPixmap &pix) const
 // ****************************************************************************
 // Method: MovieSequenceFactory::Create
 //
-// Purpose: 
+// Purpose:
 //   Factory method for creating new sequences of a given type.
 //
 // Arguments:
@@ -415,13 +415,13 @@ MovieSequenceFactory::SequencePixmap(int id, QPixmap &pix) const
 //
 // Returns:    A new instance of the specified class.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 10:38:20 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 MovieSequence *

--- a/src/gui/QvisAppearanceWindow.C
+++ b/src/gui/QvisAppearanceWindow.C
@@ -21,7 +21,7 @@
 // ****************************************************************************
 // Method: QvisAppearanceWindow::QvisAppearanceWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisAppearanceWindow class.
 //
 // Programmer: Brad Whitlock
@@ -47,14 +47,14 @@ QvisAppearanceWindow::QvisAppearanceWindow(AppearanceAttributes *subj,
 // ****************************************************************************
 // Method: QvisAppearanceWindow::~QvisAppearanceWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisAppearanceWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Sep 6 12:28:27 PDT 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisAppearanceWindow::~QvisAppearanceWindow()
@@ -65,7 +65,7 @@ QvisAppearanceWindow::~QvisAppearanceWindow()
 // ****************************************************************************
 // Method: QvisAppearanceWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -103,7 +103,7 @@ QvisAppearanceWindow::CreateWindowContents()
     topLayout->addLayout(mainLayout);
 
     int row = 0;
-    
+
     useSysDefaultCheckBox = new QCheckBox(central);
     connect(useSysDefaultCheckBox , SIGNAL(toggled(bool)),
             this, SLOT(useSysDefaultChanged(bool)));
@@ -111,7 +111,7 @@ QvisAppearanceWindow::CreateWindowContents()
       tr("Use default system appearance"));
     mainLayout->addWidget(useSysDefaultCheckBox,row,0,1,3);
     row++;
-    
+
     // Create the background color button.
     backgroundColorButton = new QvisColorButton(central);
     connect(backgroundColorButton, SIGNAL(selectedColor(const QColor &)),
@@ -131,7 +131,7 @@ QvisAppearanceWindow::CreateWindowContents()
     foregroundColorLabel->setBuddy(foregroundColorButton);
     mainLayout->addWidget(foregroundColorLabel, row, 0);
     row++;
-    
+
     // Create the style combo box.
     styleComboBox = new QComboBox(central);
     for(int i = 0; i < styleNames.size(); ++i)
@@ -171,7 +171,7 @@ QvisAppearanceWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisAppearanceWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the appearance attributes are updated.
 //
 // Arguments:
@@ -299,14 +299,14 @@ QvisAppearanceWindow::UpdateWindow(bool doAll)
             break;
         }
     }
-    
+
     UpdateWindowSensitivity();
 }
 
 // ****************************************************************************
 // Method: QvisAppearanceWindow::UpdateWindowSensitivity
 //
-// Purpose: 
+// Purpose:
 //   This method is called to update window sensitivity
 //
 //
@@ -331,13 +331,13 @@ QvisAppearanceWindow::UpdateWindowSensitivity()
     styleComboBox->setEnabled(val);
     styleLabel->setEnabled(val);
     orientationComboBox->setEnabled(val);
-    orientationLabel->setEnabled(val);   
+    orientationLabel->setEnabled(val);
 }
 
 // ****************************************************************************
 // Method: QvisAppearanceWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   This method gets the current values from line edits.
 //
 // Arguments:
@@ -360,7 +360,7 @@ QvisAppearanceWindow::GetCurrentValues(int which)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This method applies the changes to the appearance.
 //
 // Programmer: Brad Whitlock
@@ -389,14 +389,14 @@ QvisAppearanceWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the apply button is clicked.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Sep 6 13:16:09 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -408,7 +408,7 @@ QvisAppearanceWindow::apply()
 // ****************************************************************************
 // Method: QvisAppearanceWindow::ColorsNotTooClose
 //
-// Purpose: 
+// Purpose:
 //   Prevents bad colors from being used together.
 //
 // Arguments:
@@ -423,7 +423,7 @@ QvisAppearanceWindow::apply()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-// 
+//
 // ****************************************************************************
 
 bool
@@ -459,8 +459,8 @@ QvisAppearanceWindow::ColorsNotTooClose(const QColor &c0, const char *c1str)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::useSysDefaultChanged
 //
-// Purpose: 
-//   This is a Qt slot function that is called when the user changes the 
+// Purpose:
+//   This is a Qt slot function that is called when the user changes the
 //   the "Use System Default Appearance" Check Box.
 //
 // Arguments:
@@ -485,7 +485,7 @@ QvisAppearanceWindow::useSysDefaultChanged(bool val)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::backgroundChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the user changes the GUI
 //   background color via the color button.
 //
@@ -499,6 +499,9 @@ QvisAppearanceWindow::useSysDefaultChanged(bool val)
 //   Brad Whitlock, Fri Oct 3 10:03:19 PDT 2003
 //   Prevented bad colors from being used together.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Swap use of asprintf for getting the hex directly from QColor::name.
+//
 // ****************************************************************************
 
 void
@@ -508,8 +511,7 @@ QvisAppearanceWindow::backgroundChanged(const QColor &bg)
 
     if(ColorsNotTooClose(bg, atts->GetForeground().c_str()))
     {
-        QString tmp;
-        tmp.asprintf("#%02x%02x%02x", bg.red(), bg.green(), bg.blue());
+        QString tmp(bg.name());
         atts->SetBackground(tmp.toStdString());
         SetUpdate(false);
         Apply();
@@ -519,7 +521,7 @@ QvisAppearanceWindow::backgroundChanged(const QColor &bg)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::foregroundChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the user changes the GUI
 //   foreground color via the color button.
 //
@@ -532,7 +534,10 @@ QvisAppearanceWindow::backgroundChanged(const QColor &bg)
 // Modifications:
 //   Brad Whitlock, Fri Oct 3 10:03:19 PDT 2003
 //   Prevented bad colors from being used together.
-//   
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Swap use of asprintf for getting the hex directly from QColor::name.
+//
 // ****************************************************************************
 
 void
@@ -542,8 +547,7 @@ QvisAppearanceWindow::foregroundChanged(const QColor &fg)
 
     if(ColorsNotTooClose(fg, atts->GetBackground().c_str()))
     {
-        QString tmp;
-        tmp.asprintf("#%02x%02x%02x", fg.red(), fg.green(), fg.blue());
+        QString tmp(fg.name());
         atts->SetForeground(tmp.toStdString());
         SetUpdate(false);
         Apply();
@@ -553,7 +557,7 @@ QvisAppearanceWindow::foregroundChanged(const QColor &fg)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::styleChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the user changes the style.
 //
 // Arguments:
@@ -583,7 +587,7 @@ QvisAppearanceWindow::styleChanged(int index)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::fontNameChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the Font... button is
 //   clicked.
 //
@@ -608,7 +612,7 @@ QvisAppearanceWindow::fontNameChanged(const QString &newFont)
 // ****************************************************************************
 // Method: QvisAppearanceWindow::orientationChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the orientation is changed.
 //
 // Arguments:
@@ -618,7 +622,7 @@ QvisAppearanceWindow::fontNameChanged(const QString &newFont)
 // Creation:   Tue Jan 29 13:21:26 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -43,7 +43,7 @@
 // ****************************************************************************
 // Method: QvisColorTableWindow::QvisColorTableWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisColorTableWindow class.
 //
 // Arguments:
@@ -87,7 +87,7 @@ QvisColorTableWindow::QvisColorTableWindow(
 // ****************************************************************************
 // Method: QvisColorTableWindow::~QvisColorTableWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisColorTableWindow class.
 //
 // Programmer: Brad Whitlock
@@ -108,7 +108,7 @@ QvisColorTableWindow::~QvisColorTableWindow()
 // ****************************************************************************
 // Method: QvisColorTableWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -130,7 +130,7 @@ QvisColorTableWindow::~QvisColorTableWindow()
 //
 //   Jeremy Meredith, Fri Aug 11 17:14:32 EDT 2006
 //   Refactoring of color grid widget caused index to lose "color" in names.
-//   
+//
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
 //
@@ -159,6 +159,9 @@ QvisColorTableWindow::~QvisColorTableWindow()
 //
 //   Kathleen Biagas, Mon Jun 22 10:08:41 PDT 2020
 //   Change colorNumColors spin box max to 256.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Remove unused var 'QString n'.
 //
 // ****************************************************************************
 
@@ -201,7 +204,7 @@ QvisColorTableWindow::CreateWindowContents()
     colorTableWidgetGroup->setTitle(tr("Manager"));
     topLayout->addWidget(colorTableWidgetGroup,5);
     QVBoxLayout *innerColorTableLayout = new QVBoxLayout(colorTableWidgetGroup);
-    
+
     // Create the color management widgets.
     QGridLayout *mgLayout = new QGridLayout();
     innerColorTableLayout->addLayout(mgLayout);
@@ -242,7 +245,7 @@ QvisColorTableWindow::CreateWindowContents()
     colorWidgetGroup->setTitle(tr("Editor"));
     topLayout->addWidget(colorWidgetGroup, 100);
     QVBoxLayout *innerColorLayout = new QVBoxLayout(colorWidgetGroup);
-    
+
     // Create controls to set the number of colors in the color table.
     QGridLayout *colorInfoLayout = new QGridLayout();
     innerColorLayout->addLayout(colorInfoLayout);
@@ -267,12 +270,12 @@ QvisColorTableWindow::CreateWindowContents()
     colorInfoLayout->addWidget(rb, 1, 2);
     connect(colorTableTypeGroup, SIGNAL(buttonClicked(int)),
             this, SLOT(setColorTableType(int)));
-    
+
 
     // Create the buttons that help manipulate the spectrum bar.
     QHBoxLayout *seLayout = new QHBoxLayout();
     innerColorLayout->addLayout(seLayout);
-    
+
     alignPointButton = new QPushButton(tr("Align"), colorWidgetGroup);
     connect(alignPointButton, SIGNAL(clicked()),
             this, SLOT(alignControlPoints()));
@@ -350,20 +353,16 @@ QvisColorTableWindow::CreateWindowContents()
     cnames[3] = tr("Alpha");
     for(int j = 0; j < 4; ++j)
     {
-        QString n;
-        n.asprintf("componentSliders[%d]", j);
         componentSliders[j] = new QSlider(Qt::Horizontal,colorWidgetGroup);
         componentSliders[j]->setRange(0, 255);
         componentSliders[j]->setPageStep(10);
         componentSliders[j]->setValue(0);
-        
+
         discreteLayout->addWidget(componentSliders[j], j, 1);
 
-        n.asprintf("componentLabels[%d]", j);
         componentLabels[j] = new QLabel(cnames[j], colorWidgetGroup);
         discreteLayout->addWidget(componentLabels[j], j, 0);
 
-        n.asprintf("discreteLineEdits[%d]", j);
         componentSpinBoxes[j] = new QSpinBox(colorWidgetGroup);
         componentSpinBoxes[j]->setKeyboardTracking(false);
         componentSpinBoxes[j]->setRange(0,255);
@@ -417,7 +416,7 @@ QvisColorTableWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisColorTableWindow::CreateNode
 //
-// Purpose: 
+// Purpose:
 //   Saves the windows settings.
 //
 // Arguments:
@@ -438,7 +437,7 @@ QvisColorTableWindow::CreateNode(DataNode *parentNode)
     // Call the base class's method to save the generic window attributes.
     QvisPostableWindowSimpleObserver::CreateNode(parentNode);
 
-    if(saveWindowDefaults && 
+    if(saveWindowDefaults &&
        !currentColorTable.isEmpty() &&
        currentColorTable != "none")
     {
@@ -453,7 +452,7 @@ QvisColorTableWindow::CreateNode(DataNode *parentNode)
 // ****************************************************************************
 // Method: QvisColorTableWindow::SetFromNode
 //
-// Purpose: 
+// Purpose:
 //   Gets the window's settings.
 //
 // Programmer: Brad Whitlock
@@ -486,7 +485,7 @@ QvisColorTableWindow::SetFromNode(DataNode *parentNode, const int *borders)
 // ****************************************************************************
 // Method: QvisColorTableWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the window's subject is changed. The
 //   subject tells this window what attributes changed and we put the
 //   new values into those widgets.
@@ -495,9 +494,9 @@ QvisColorTableWindow::SetFromNode(DataNode *parentNode, const int *borders)
 //   doAll : If this flag is true, update all the widgets regardless
 //           of whether or not they are selected.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Jun 11 12:07:55 PDT 2001
@@ -624,7 +623,7 @@ QvisColorTableWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisColorTableWindow::UpdateEditor
 //
-// Purpose: 
+// Purpose:
 //   Updates the editor area of the window.
 //
 // Programmer: Brad Whitlock
@@ -698,7 +697,7 @@ QvisColorTableWindow::UpdateEditor()
 // ****************************************************************************
 // Method: QvisColorTableWindow::UpdateNames
 //
-// Purpose: 
+// Purpose:
 //   This method takes the list of names in the color table attributes and
 //   puts it into the color table name list box.
 //
@@ -812,7 +811,7 @@ QvisColorTableWindow::UpdateNames()
 // ****************************************************************************
 // Method: QvisColorTableWindow::GetActiveColorControlPoints
 //
-// Purpose: 
+// Purpose:
 //   Returns a const pointer to the color control points of our active
 //   color table.
 //
@@ -823,7 +822,7 @@ QvisColorTableWindow::UpdateNames()
 // Creation:   Thu Nov 21 14:19:43 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 const ColorControlPointList *
@@ -835,7 +834,7 @@ QvisColorTableWindow::GetActiveColorControlPoints() const
 // ****************************************************************************
 // Method: QvisColorTableWindow::GetActiveColorControlPoints
 //
-// Purpose: 
+// Purpose:
 //   Returns a pointer to the color control points of our active
 //   color table.
 //
@@ -846,7 +845,7 @@ QvisColorTableWindow::GetActiveColorControlPoints() const
 // Creation:   Thu Nov 21 14:19:43 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 ColorControlPointList *
@@ -858,7 +857,7 @@ QvisColorTableWindow::GetActiveColorControlPoints()
 // ****************************************************************************
 // Method: QvisColorTableWindow::UpdateColorControlPoints
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the color control points must be updated.
 //
 // Programmer: Brad Whitlock
@@ -912,7 +911,7 @@ QvisColorTableWindow::UpdateColorControlPoints()
                 spectrumBar->setControlPointColor(i, ctmp);
                 spectrumBar->setControlPointPosition(i, cpts[i].GetPosition());
             }
-    
+
             // We need to add control points.
             for(i = spectrumBar->numControlPoints(); i < cpts.GetNumControlPoints(); ++i)
             {
@@ -979,7 +978,7 @@ QvisColorTableWindow::UpdateColorControlPoints()
 // ****************************************************************************
 // Method: QvisColorTableWindow::UpdateDiscreteSettings
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets associated with discrete color tables.
 //
 // Programmer: Brad Whitlock
@@ -1055,7 +1054,7 @@ QvisColorTableWindow::UpdateDiscreteSettings()
 // ****************************************************************************
 // Method: QvisColorTableWindow::PopupColorSelect
 //
-// Purpose: 
+// Purpose:
 //   This is method pops up the color selection widget.
 //
 // Arguments:
@@ -1103,7 +1102,7 @@ QvisColorTableWindow::PopupColorSelect(const QColor &c, const QPoint &p)
     else if(menuY + menuH > QApplication::desktop()->height())
         menuY -= ((menuY + menuH) - QApplication::desktop()->height());
 
-    // Show the popup menu.         
+    // Show the popup menu.
     colorSelect->move(menuX, menuY);
     colorSelect->show();
 }
@@ -1111,7 +1110,7 @@ QvisColorTableWindow::PopupColorSelect(const QColor &c, const QPoint &p)
 // ****************************************************************************
 // Method: QvisColorTableWindow::ShowSelectedColor
 //
-// Purpose: 
+// Purpose:
 //   Makes the discrete color widgets display the specified color.
 //
 // Arguments:
@@ -1123,7 +1122,7 @@ QvisColorTableWindow::PopupColorSelect(const QColor &c, const QPoint &p)
 // Modifications:
 //    Jeremy Meredith, Fri Aug 11 17:14:32 EDT 2006
 //    Refactoring of color grid widget caused index to lose "color" in names.
-//   
+//
 //   Jeremy Meredith, Fri Feb 20 15:03:25 EST 2009
 //   Added alpha channel support.
 //
@@ -1179,7 +1178,7 @@ QvisColorTableWindow::ShowSelectedColor(const QColor &c)
 // ****************************************************************************
 // Method: QvisColorTableWindow::ChangeSelectedColor
 //
-// Purpose: 
+// Purpose:
 //   Change the active discrete color to the specified color.
 //
 // Arguments:
@@ -1191,7 +1190,7 @@ QvisColorTableWindow::ShowSelectedColor(const QColor &c)
 // Modifications:
 //    Jeremy Meredith, Fri Aug 11 17:14:32 EDT 2006
 //    Refactoring of color grid widget caused index to lose "color" in names.
-//   
+//
 //    Jeremy Meredith, Fri Feb 20 15:03:25 EST 2009
 //    Added alpha channel support.
 //
@@ -1207,7 +1206,7 @@ QvisColorTableWindow::ChangeSelectedColor(const QColor &c)
         int index;
 
         if(ccpl->GetDiscreteFlag())
-        { 
+        {
             // Use the selected color in the discreteColors widget to determine
             // which color needs to be replaced in the color control point list.
             index = discreteColors->selectedIndex();
@@ -1244,7 +1243,7 @@ QvisColorTableWindow::ChangeSelectedColor(const QColor &c)
 // ****************************************************************************
 // Method: QvisColorTableWindow::GetNextColor
 //
-// Purpose: 
+// Purpose:
 //   Returns the next color in the sequence.
 //
 // Returns:    A color.
@@ -1253,7 +1252,7 @@ QvisColorTableWindow::ChangeSelectedColor(const QColor &c)
 // Creation:   Wed Feb 26 15:11:49 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QColor
@@ -1283,7 +1282,7 @@ QvisColorTableWindow::GetNextColor()
 // ****************************************************************************
 // Method: QvisColorTableWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values from certain widgets and stores the values in the
 //   state object.
 //
@@ -1393,7 +1392,7 @@ QvisColorTableWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisColorTableWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the Apply button is clicked.
 //
 // Programmer: Brad Whitlock
@@ -1429,7 +1428,7 @@ QvisColorTableWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisColorTableWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the window's Apply
 //   button is clicked.
 //
@@ -1437,7 +1436,7 @@ QvisColorTableWindow::Apply(bool ignore)
 // Creation:   Mon Jun 11 13:42:22 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1449,7 +1448,7 @@ QvisColorTableWindow::apply()
 // ****************************************************************************
 // Method: QvisColorTableWindow::alignControlPoints
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the spectrum bar to align its
 //   control points.
 //
@@ -1479,7 +1478,7 @@ QvisColorTableWindow::alignControlPoints()
 // ****************************************************************************
 // Method: QvisColorTableWindow::controlPointMoved
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the spectrum bar's control
 //   points are moved.
 //
@@ -1487,7 +1486,7 @@ QvisColorTableWindow::alignControlPoints()
 // Creation:   Mon Jun 11 11:39:32 PDT 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1502,7 +1501,7 @@ QvisColorTableWindow::controlPointMoved(int, float)
 // ****************************************************************************
 // Method: QvisColorTableWindow::chooseContinuousColor
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a color control point
 //   in the spectrum bar is clicked such that the color selection widget
 //   needs to be activated in order to select a new color.
@@ -1515,7 +1514,7 @@ QvisColorTableWindow::controlPointMoved(int, float)
 // Creation:   Thu Nov 21 13:06:47 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1528,7 +1527,7 @@ QvisColorTableWindow::chooseContinuousColor(int index, const QPoint &p)
 // ****************************************************************************
 // Method: QvisColorTableWindow::chooseDiscreteColor
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a discrete color is clicked
 //   such that the color selection widget needs to be activated in order to
 //   select a new color.
@@ -1541,7 +1540,7 @@ QvisColorTableWindow::chooseContinuousColor(int index, const QPoint &p)
 // Creation:   Thu Nov 21 13:06:47 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1555,7 +1554,7 @@ QvisColorTableWindow::chooseDiscreteColor(const QColor &c, int, int,
 // ****************************************************************************
 // Method: QvisColorTableWindow::selectedColor
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called by the color popup menu when
 //   a new color has been selected.
 //
@@ -1602,7 +1601,7 @@ QvisColorTableWindow::selectedColor(const QColor &color)
 // ****************************************************************************
 // Method: QvisColorTableWindow::smoothingMethodChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the window's smooth
 //   combobox is activated.
 //
@@ -1632,15 +1631,15 @@ QvisColorTableWindow::smoothingMethodChanged(int val)
 // ****************************************************************************
 // Method: QvisColorTableWindow::showIndexHintsToggled
 //
-// Purpose: 
-//   This is a Qt slot function that is called when the window's 
+// Purpose:
+//   This is a Qt slot function that is called when the window's
 //   show index hints toggle is clicked.
 //
 // Programmer: Jeremy Meredith
 // Creation:   December 31, 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1652,7 +1651,7 @@ QvisColorTableWindow::showIndexHintsToggled(bool val)
 // ****************************************************************************
 // Method: QvisColorTableWindow::equalSpacingToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the window's equal spacing
 //   toggle is clicked.
 //
@@ -1660,7 +1659,7 @@ QvisColorTableWindow::showIndexHintsToggled(bool val)
 // Creation:   Mon Jun 11 15:38:06 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1680,7 +1679,7 @@ QvisColorTableWindow::equalSpacingToggled(bool)
 // ****************************************************************************
 // Method: QvisColorTableWindow::addColorTable
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that adds a new color table that, if possible,
 //   is based on the current colortable.
 //
@@ -1747,8 +1746,8 @@ QvisColorTableWindow::addColorTable()
     else
     {
         QString tmp;
-        tmp = tr("The color table ") + 
-              QString("\"") + currentColorTable + QString("\"") + 
+        tmp = tr("The color table ") +
+              QString("\"") + currentColorTable + QString("\"") +
               tr(" is already in the color table list. You must provide a "
                  "unique name for the new color table before it can be added.");
         Error(tmp);
@@ -1758,7 +1757,7 @@ QvisColorTableWindow::addColorTable()
 // ****************************************************************************
 // Method: QvisColorTableWindow::deleteColorTable
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to delete a color table.
 //
 // Programmer: Brad Whitlock
@@ -1786,7 +1785,7 @@ QvisColorTableWindow::deleteColorTable()
 // ****************************************************************************
 // Method: QvisColorTableWindow::highlightColorTable
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a color table is
 //   highligted. It serves to make the highlighted plot the new active color
 //   table.
@@ -1832,7 +1831,7 @@ QvisColorTableWindow::highlightColorTable(QTreeWidgetItem *current,
 // ****************************************************************************
 // Method: QvisColorTableWindow::setColorTableType
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the type of the color table.
 //
 // Arguments:
@@ -1842,7 +1841,7 @@ QvisColorTableWindow::highlightColorTable(QTreeWidgetItem *current,
 // Creation:   Wed Feb 26 11:10:52 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1863,7 +1862,7 @@ QvisColorTableWindow::setColorTableType(int index)
 // ****************************************************************************
 // Method: QvisColorTableWindow::activateContinuousColor
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we click on a new
 //   color control point in the spectrum bar. This function updates the
 //   color sliders to the right values when we select a new control point.
@@ -1875,7 +1874,7 @@ QvisColorTableWindow::setColorTableType(int index)
 // Creation:   Mon Nov 25 12:49:41 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1887,7 +1886,7 @@ QvisColorTableWindow::activateContinuousColor(int index)
 // ****************************************************************************
 // Method: QvisColorTableWindow::activateDiscreteColor
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we click on a discrete
 //   color thus making it active.
 //
@@ -1900,7 +1899,7 @@ QvisColorTableWindow::activateContinuousColor(int index)
 // Creation:   Thu Nov 21 14:43:38 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1912,7 +1911,7 @@ QvisColorTableWindow::activateDiscreteColor(const QColor &c, int)
 // ****************************************************************************
 // Method: QvisColorTableWindow::redValueChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the active discrete color
 //   changes due to the red slider or spin box.
 //
@@ -1925,7 +1924,7 @@ QvisColorTableWindow::activateDiscreteColor(const QColor &c, int)
 // Modifications:
 //   Jeremy Meredith, Fri Feb 20 15:03:25 EST 2009
 //   Added alpha channel support.
-//   
+//
 // ****************************************************************************
 
 void
@@ -1949,7 +1948,7 @@ QvisColorTableWindow::redValueChanged(int r)
 // ****************************************************************************
 // Method: QvisColorTableWindow::greenValueChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the active discrete color
 //   changes due to the green slider or spin box.
 //
@@ -1962,7 +1961,7 @@ QvisColorTableWindow::redValueChanged(int r)
 // Modifications:
 //   Jeremy Meredith, Fri Feb 20 15:03:25 EST 2009
 //   Added alpha channel support.
-//   
+//
 // ****************************************************************************
 
 void
@@ -1986,7 +1985,7 @@ QvisColorTableWindow::greenValueChanged(int g)
 // ****************************************************************************
 // Method: QvisColorTableWindow::blueValueChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the active discrete color
 //   changes due to the blue slider or spin box.
 //
@@ -1999,7 +1998,7 @@ QvisColorTableWindow::greenValueChanged(int g)
 // Modifications:
 //   Jeremy Meredith, Fri Feb 20 15:03:25 EST 2009
 //   Added alpha channel support.
-//   
+//
 // ****************************************************************************
 
 void
@@ -2023,7 +2022,7 @@ QvisColorTableWindow::blueValueChanged(int b)
 // ****************************************************************************
 // Method: QvisColorTableWindow::alphaValueChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the active discrete color
 //   changes due to the alpha slider or spin box.
 //
@@ -2034,7 +2033,7 @@ QvisColorTableWindow::blueValueChanged(int b)
 // Creation:   February 20, 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2058,7 +2057,7 @@ QvisColorTableWindow::alphaValueChanged(int a)
 // ****************************************************************************
 // Method: QvisColorTableWindow::sliderPressed
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the window that the slider is
 //   being dragged so we can prevent the window from sending Updates to the
 //   viewer for each grad event.
@@ -2067,7 +2066,7 @@ QvisColorTableWindow::alphaValueChanged(int a)
 // Creation:   Mon Nov 25 10:53:43 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2079,7 +2078,7 @@ QvisColorTableWindow::sliderPressed()
 // ****************************************************************************
 // Method: QvisColorTableWindow::sliderReleased
 //
-// Purpose: 
+// Purpose:
 //   Tells the window that the slider was released and that changes were made
 //   so we should update.
 //
@@ -2087,7 +2086,7 @@ QvisColorTableWindow::sliderPressed()
 // Creation:   Mon Nov 25 10:55:18 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2101,7 +2100,7 @@ QvisColorTableWindow::sliderReleased()
 // ****************************************************************************
 // Method: QvisColorTableWindow::setActiveContinuous
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that sets the active continuous color table.
 //
 // Arguments:
@@ -2111,7 +2110,7 @@ QvisColorTableWindow::sliderReleased()
 // Creation:   Mon Nov 25 10:55:53 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2124,7 +2123,7 @@ QvisColorTableWindow::setActiveContinuous(const QString &ct)
 // ****************************************************************************
 // Method: QvisColorTableWindow::setActiveDiscrete
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that sets the active discrete color table.
 //
 // Arguments:
@@ -2134,7 +2133,7 @@ QvisColorTableWindow::setActiveContinuous(const QString &ct)
 // Creation:   Mon Nov 25 10:55:53 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2147,7 +2146,7 @@ QvisColorTableWindow::setActiveDiscrete(const QString &ct)
 // ****************************************************************************
 // Method: QvisColorTableWindow::resizeColorTable
 //
-// Purpose: 
+// Purpose:
 //   This routine resizes the color table.
 //
 // Arguments:
@@ -2191,7 +2190,7 @@ QvisColorTableWindow::resizeColorTable(int size)
                 }
 
                 colorAtts->SelectColorTables();
-                Apply();   
+                Apply();
             }
             else if(size > ccpl->GetNumControlPoints())
             {
@@ -2235,7 +2234,7 @@ QvisColorTableWindow::resizeColorTable(int size)
 
                 GetCurrentValues(0);
                 SetUpdate(false);
-                Apply();   
+                Apply();
             }
             else if(size > spectrumBar->numControlPoints())
             {
@@ -2253,13 +2252,13 @@ QvisColorTableWindow::resizeColorTable(int size)
                 Apply();
             }
         }
-    }    
+    }
 }
 
 // ****************************************************************************
 // Method: QvisColorTableWindow::exportColorTable
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells the viewer to export the currently
 //   selected color table.
 //
@@ -2267,7 +2266,7 @@ QvisColorTableWindow::resizeColorTable(int size)
 // Creation:   Tue Jul 1 16:40:39 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2280,14 +2279,14 @@ QvisColorTableWindow::exportColorTable()
 // ****************************************************************************
 // Method: QvisColorTableWindow::groupingToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that tells modifies the grouping.
 //
-// Programmer: Kathleen Biagas 
-// Creation:   August 8, 2013 
+// Programmer: Kathleen Biagas
+// Creation:   August 8, 2013
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2301,14 +2300,14 @@ QvisColorTableWindow::groupingToggled(bool val)
 // ****************************************************************************
 // Method: QvisColorTableWindow::ApplyCategoryChange
 //
-// Purpose: 
+// Purpose:
 //   Ensures the color control points use the correct category.
 //
-// Programmer: Kathleen Biagas 
-// Creation:   August 8, 2013 
+// Programmer: Kathleen Biagas
+// Creation:   August 8, 2013
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisCommandWindow.C
+++ b/src/gui/QvisCommandWindow.C
@@ -35,7 +35,7 @@
 // ****************************************************************************
 // Method: QvisCommandWindow::QvisCommandWindow
 //
-// Purpose: 
+// Purpose:
 //   QvisCommandWindow constructor.
 //
 // Programmer: Brad Whitlock
@@ -57,7 +57,7 @@
 // ****************************************************************************
 
 QvisCommandWindow::QvisCommandWindow(const QString &captionString,
-    const QString &shortName, QvisNotepadArea *n) : 
+    const QString &shortName, QvisNotepadArea *n) :
     QvisPostableWindow(captionString, shortName, n)
 {
     executeButtonsGroup = 0;
@@ -83,7 +83,7 @@ QvisCommandWindow::QvisCommandWindow(const QString &captionString,
 // ****************************************************************************
 // Method: QvisCommandWindow::~QvisCommandWindow
 //
-// Purpose: 
+// Purpose:
 //   QvisCommandWindow destructor.
 //
 // Programmer: Brad Whitlock
@@ -94,7 +94,7 @@ QvisCommandWindow::QvisCommandWindow(const QString &captionString,
 //   Delete new widgets.
 //
 //   Cyrus Harrison, Wed Aug 27 08:31:25 PDT 2008
-//   Ensured all of button groups have parents, so we don't need to 
+//   Ensured all of button groups have parents, so we don't need to
 //   explicitly delete them.
 //
 //   Cyrus Harrison, Mon Feb  8 15:40:54 PST 2010
@@ -114,7 +114,7 @@ QvisCommandWindow::~QvisCommandWindow()
 // ****************************************************************************
 // Method: QvisCommandWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the window contents.
 //
 // Programmer: Brad Whitlock
@@ -141,6 +141,9 @@ QvisCommandWindow::~QvisCommandWindow()
 //
 //   Cyrus Harrison, Mon Feb  8 15:40:54 PST 2010
 //   Added python syntax highlighter.
+//
+//   Kathleen Biagas, Thu Jan 21 2021
+//   Swap use of QString::asprintf for simpler QString.setNum.
 //
 // ****************************************************************************
 
@@ -197,7 +200,7 @@ QvisCommandWindow::CreateWindowContents()
     mLayout->addWidget(macroStorageComboBox, 0, 1);
     mLayout->addWidget(new QLabel(tr("Store commands in"),macroBox), 0, 0);
 
-    macroAppendCheckBox = new QCheckBox(tr("Append commands to existing text"), 
+    macroAppendCheckBox = new QCheckBox(tr("Append commands to existing text"),
                                         macroBox);
     connect(macroAppendCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(macroAppendClicked(bool)));
@@ -268,7 +271,7 @@ QvisCommandWindow::CreateWindowContents()
         addMacroButtonsGroup->addButton(addMacroButtons[i], i);
 
         // Add the top vbox as a new tab.
-        n.asprintf("%d", i+1);
+        n.setNum(i+1);
         tabWidget->addTab(widget, n);
     }
 
@@ -307,7 +310,7 @@ QvisCommandWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisCommandWindow::CreateNode
 //
-// Purpose: 
+// Purpose:
 //   This method is called when we're saving settings. We save the scripts
 //   if the window has been created.
 //
@@ -347,7 +350,7 @@ QvisCommandWindow::CreateNode(DataNode *node)
 // ****************************************************************************
 // Method: QvisCommandWindow::SetFromNode
 //
-// Purpose: 
+// Purpose:
 //   Reads the macro storage mode and append mode from the log.
 //
 // Programmer: Brad Whitlock
@@ -390,7 +393,7 @@ QvisCommandWindow::SetFromNode(DataNode *parentNode, const int *borders)
 // ****************************************************************************
 // Method: QvisCommandWindow::UpdateMacroCheckBoxes
 //
-// Purpose: 
+// Purpose:
 //   Updates the macro check boxes.
 //
 // Note:       If anymore code is added to this method, you must check to
@@ -427,7 +430,7 @@ QvisCommandWindow::UpdateMacroCheckBoxes()
 // ****************************************************************************
 // Method: QvisCommandWindow::fileName
 //
-// Purpose: 
+// Purpose:
 //   Creates a filename for a script.
 //
 // Arguments:
@@ -437,21 +440,23 @@ QvisCommandWindow::UpdateMacroCheckBoxes()
 // Creation:   Wed Jun 22 16:38:05 PST 2005
 //
 // Modifications:
-//   
+//   Kathleen Biagas, Thu Jan 21 2021
+//   Swap use of QString::asprintf for QString::arg as suggested in Qt docs.
+//
 // ****************************************************************************
 
 QString
 QvisCommandWindow::fileName(int index) const
 {
-    QString n;
-    n.asprintf("%sscript%d.py", GetUserVisItDirectory().c_str(), index);
+    QString n =
+      QString("%1script%2.py").arg(GetUserVisItDirectory().c_str()).arg(index);
     return n;
 }
 
 // ****************************************************************************
 // Method: QvisCommandWindow::RCFileName
 //
-// Purpose: 
+// Purpose:
 //   Returns the name of the "visitrc" file.
 //
 // Returns:    The name of the visitrc file.
@@ -460,7 +465,7 @@ QvisCommandWindow::fileName(int index) const
 // Creation:   Fri Jun 15 14:08:47 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QString
@@ -472,7 +477,7 @@ QvisCommandWindow::RCFileName() const
 // ****************************************************************************
 // Method: QvisCommandWindow::LoadScripts
 //
-// Purpose: 
+// Purpose:
 //   Loads the scripts into the window.
 //
 // Programmer: Brad Whitlock
@@ -548,7 +553,7 @@ QvisCommandWindow::LoadScripts()
 // ****************************************************************************
 // Method: QvisCommandWindow::SaveScripts
 //
-// Purpose: 
+// Purpose:
 //   Saves the window's scripts.
 //
 // Programmer: Brad Whitlock
@@ -584,7 +589,7 @@ QvisCommandWindow::SaveScripts()
 // ****************************************************************************
 // Method: CreateMacroFromText
 //
-// Purpose: 
+// Purpose:
 //   Converts the supplied text to a macro, prompting the user for names, and
 //   adds the new macro text to the macro tab.
 //
@@ -629,7 +634,7 @@ QvisCommandWindow::CreateMacroFromText(const QString &s)
     }
     while(macroName.isEmpty());
 
-    // Now, make a func name from the macro name, replacing any non 
+    // Now, make a func name from the macro name, replacing any non
     // alpha/digit/space with '_'. The user can always edit the function name
     // before it gets applied.
     std::string fname("user_macro_");
@@ -668,7 +673,7 @@ QvisCommandWindow::CreateMacroFromText(const QString &s)
 // ****************************************************************************
 // Method: QvisCommandWindow::executeClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that gets called when we click on one of the
 //   execute buttons.
 //
@@ -693,7 +698,7 @@ QvisCommandWindow::executeClicked(int index)
 // ****************************************************************************
 // Method: QvisCommandWindow::clearClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that clears the text for a line edit when
 //   its clear button gets clicked.
 //
@@ -716,7 +721,7 @@ QvisCommandWindow::clearClicked(int index)
 // ****************************************************************************
 // Method: QvisCommandWindow::textChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that makes sure that the execute buttons are
 //   only enabled when the text edit is not empty.
 //
@@ -753,7 +758,7 @@ TEXT_CHANGED(7)
 // ****************************************************************************
 // Method: void QvisCommandWindow::macroRecordClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we click on the button
 //   to start recording a macro.
 //
@@ -766,7 +771,7 @@ TEXT_CHANGED(7)
 // Creation:   Fri Jan 6 15:14:45 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -782,14 +787,14 @@ QvisCommandWindow::macroRecordClicked()
 // ****************************************************************************
 // Method: QvisCommandWindow::macroPauseClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that pauses macro recording.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Jan 6 15:15:42 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -801,14 +806,14 @@ QvisCommandWindow::macroPauseClicked()
 // ****************************************************************************
 // Method: QvisCommandWindow::macroEndClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that ends macro recording.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Jan 6 15:17:49 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -835,7 +840,7 @@ QvisCommandWindow::macroStorageActivated(int val)
 // ****************************************************************************
 // Method: QvisCommandWindow::acceptRecordedMacro
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that pastes a recorded macro into the active
 //   tab's line edit.
 //
@@ -910,14 +915,14 @@ QvisCommandWindow::acceptRecordedMacro(const QString &s)
 // ****************************************************************************
 // Method: QvisCommandWindow::macroClearClicked
 //
-// Purpose: 
+// Purpose:
 //   Clear the macros tab.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Jun 15 14:14:53 PST 2007
 //
 // Modifications:
-//   
+//
 //    Hank Childs, Wed May  7 11:44:01 PDT 2008
 //    Add a warning so users know that simply clicking clear will not suffice
 //    in clearing out their macros.
@@ -936,7 +941,7 @@ QvisCommandWindow::macroClearClicked()
 // ****************************************************************************
 // Method: QvisCommandWindow::macroUpdateClicked
 //
-// Purpose: 
+// Purpose:
 //   Update the macros by executing the visitrc again.
 //
 // Programmer: Brad Whitlock
@@ -945,7 +950,7 @@ QvisCommandWindow::macroClearClicked()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-// 
+//
 //   Cyrus Harrison, Tue Jun 10 15:00:05 PDT 2008
 //   Initial Qt4 Port.
 //
@@ -976,12 +981,12 @@ QvisCommandWindow::macroUpdateClicked()
            // the changes that have been put into place.
            QString command("ClearMacros()\nSource(\"%1\")\n");
 #ifdef WIN32
-           // On windows, the string passed to the python commands needs to 
+           // On windows, the string passed to the python commands needs to
            // have it's back-slash's escaped.
            QString tmp(rcFileName);
            tmp.replace("\\", "\\\\");
            command = command.arg(tmp);
-           
+
 #else
            command = command.arg(rcFileName);
 #endif
@@ -1006,15 +1011,15 @@ QvisCommandWindow::macroUpdateClicked()
 // ****************************************************************************
 // Method: QvisCommandWindow::macroCreate
 //
-// Purpose: 
+// Purpose:
 //   Creates a macro from the code defined in the specified tab.
 //
 // Arguments:
 //   tab : The tab whose code will become a macro.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Jun 15 14:19:28 PST 2007

--- a/src/gui/QvisDatabaseCorrelationListWindow.C
+++ b/src/gui/QvisDatabaseCorrelationListWindow.C
@@ -25,7 +25,7 @@
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::QvisDatabaseCorrelationListWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisDatabaseCorrelationListWindow class.
 //
 // Programmer: Brad Whitlock
@@ -52,14 +52,14 @@ QvisDatabaseCorrelationListWindow::QvisDatabaseCorrelationListWindow(
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::~QvisDatabaseCorrelationListWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisDatabaseCorrelationListWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Mar 29 12:15:28 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisDatabaseCorrelationListWindow::~QvisDatabaseCorrelationListWindow()
@@ -79,7 +79,7 @@ QvisDatabaseCorrelationListWindow::~QvisDatabaseCorrelationListWindow()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -88,7 +88,7 @@ QvisDatabaseCorrelationListWindow::~QvisDatabaseCorrelationListWindow()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Tue Jun 10 15:00:05 PDT 2008
 //   Initial Qt4 Port.
 //
@@ -175,7 +175,7 @@ QvisDatabaseCorrelationListWindow::CreateWindowContents()
     connect(defaultCorrelationMethod, SIGNAL(activated(int)),
             this, SLOT(defaultCorrelationMethodChanged(int)));
     adcLayout->addWidget(defaultCorrelationMethod, 2,1);
-    adcLayout->addWidget(new QLabel(tr("Default correlation method"), 
+    adcLayout->addWidget(new QLabel(tr("Default correlation method"),
                                     automaticCorrelationGroup), 2, 0);
     topLayout->addStretch(2);
 }
@@ -183,7 +183,7 @@ QvisDatabaseCorrelationListWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the correlation list changes and the window
 //   must update itself.
 //
@@ -276,15 +276,15 @@ QvisDatabaseCorrelationListWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::UpdateButtons
 //
-// Purpose: 
+// Purpose:
 //   Updates the buttons so we can't ever do something inappropriate with
 //   correlations.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Mar 29 12:17:18 PDT 2004
@@ -338,14 +338,14 @@ QvisDatabaseCorrelationListWindow::UpdateButtons()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Sends the database correlation list to the viewer.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Mar 29 12:18:09 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -361,14 +361,14 @@ QvisDatabaseCorrelationListWindow::Apply(bool)
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the Apply button is clicked.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Mar 29 12:18:29 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -380,7 +380,7 @@ QvisDatabaseCorrelationListWindow::apply()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::showMinimized
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the window is iconified.
 //
 // Notes:      The window iconifies its correlation windows.
@@ -389,7 +389,7 @@ QvisDatabaseCorrelationListWindow::apply()
 // Creation:   Mon Mar 29 12:18:29 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -405,7 +405,7 @@ QvisDatabaseCorrelationListWindow::showMinimized()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::showNormal
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the window is deiconified.
 //
 // Notes:      The window deiconifies its correlation windows.
@@ -414,7 +414,7 @@ QvisDatabaseCorrelationListWindow::showMinimized()
 // Creation:   Mon Mar 29 12:18:29 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -430,7 +430,7 @@ QvisDatabaseCorrelationListWindow::showNormal()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::newCorrelation
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to create a new
 //   database correlation.
 //
@@ -440,9 +440,12 @@ QvisDatabaseCorrelationListWindow::showNormal()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Tue Jun 10 15:00:05 PDT 2008
 //   Initial Qt4 Port.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Swap use of QString::asprintf for QString::arg as suggested in Qt docs.
 //
 // ****************************************************************************
 
@@ -457,7 +460,8 @@ QvisDatabaseCorrelationListWindow::newCorrelation()
     QString newName;
     do
     {
-        newName.asprintf("Correlation%02d", newCorrelationCounter++);
+        newName = QString("Correlation%1")
+            .arg(newCorrelationCounter++,2,10,QLatin1Char('0'));
     } while(correlationList->FindCorrelation(newName.toStdString()) != 0);
 
     //
@@ -478,7 +482,7 @@ QvisDatabaseCorrelationListWindow::newCorrelation()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::editCorrelation
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to edit an
 //   existing database correlation.
 //
@@ -488,7 +492,7 @@ QvisDatabaseCorrelationListWindow::newCorrelation()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Tue Jun 10 15:00:05 PDT 2008
 //   Initial Qt4 Port.
 //
@@ -526,7 +530,7 @@ QvisDatabaseCorrelationListWindow::editCorrelation()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::deleteCorrelation
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to delete a
 //   database correlation.
 //
@@ -556,7 +560,7 @@ QvisDatabaseCorrelationListWindow::deleteCorrelation()
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::promptUserChecked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the "Prompt user" button
 //   is clicked.
 //
@@ -567,7 +571,7 @@ QvisDatabaseCorrelationListWindow::deleteCorrelation()
 // Creation:   Mon Mar 29 12:21:12 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -605,7 +609,7 @@ QvisDatabaseCorrelationListWindow::highlightCorrelation(int index)
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::deleteWindow
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that allows the window to safely delete its
 //   child windows.
 //
@@ -616,7 +620,7 @@ QvisDatabaseCorrelationListWindow::highlightCorrelation(int index)
 // Creation:   Mon Mar 29 12:22:30 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -641,7 +645,7 @@ QvisDatabaseCorrelationListWindow::deleteWindow(QvisWindowBase *win)
 // ****************************************************************************
 // Method: QvisDatabaseCorrelationListWindow::delayedDeleteWindows
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that lets you delete some database correlation
 //   windows.
 //
@@ -649,7 +653,7 @@ QvisDatabaseCorrelationListWindow::deleteWindow(QvisWindowBase *win)
 // Creation:   Mon Mar 29 12:23:28 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisEngineWindow.C
+++ b/src/gui/QvisEngineWindow.C
@@ -24,7 +24,7 @@ using std::vector;
 // ****************************************************************************
 // Method: QvisEngineWindow::QvisEngineWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisEngineWindow class.
 //
 // Programmer: Brad Whitlock
@@ -50,7 +50,7 @@ QvisEngineWindow::QvisEngineWindow(EngineList *engineList,
 // ****************************************************************************
 // Method: QvisEngineWindow::~QvisEngineWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisEngineWindow class.
 //
 // Programmer: Brad Whitlock
@@ -65,15 +65,15 @@ QvisEngineWindow::QvisEngineWindow(EngineList *engineList,
 QvisEngineWindow::~QvisEngineWindow()
 {
     // Delete the status attributes in the status map.
-    
+
     QMapIterator<QString, StatusAttributes*> itr(statusMap);
-    
+
     while(itr.hasNext())
     {
         itr.next();
         delete itr.value();
     }
-    
+
     // Detach from the status atts if they are still around.
     if(statusAtts)
         statusAtts->Detach(this);
@@ -82,7 +82,7 @@ QvisEngineWindow::~QvisEngineWindow()
 // ****************************************************************************
 // Method: QvisEngineWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -196,7 +196,7 @@ QvisEngineWindow::CreateWindowContents()
 
     QHBoxLayout *buttonLayout1 = new QHBoxLayout();
     topLayout->addLayout(buttonLayout1);
-    
+
     clearCacheButton = new QPushButton(tr("Clear cache"), central);
     connect(clearCacheButton, SIGNAL(clicked()), this, SLOT(clearCache()));
     clearCacheButton->setEnabled(false);
@@ -213,7 +213,7 @@ QvisEngineWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisEngineWindow::Update
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the subjects that the window observes are
 //   modified.
 //
@@ -241,7 +241,7 @@ QvisEngineWindow::Update(Subject *TheChangedSubject)
 // ****************************************************************************
 // Method: QvisEngineWindow::SubjectRemoved
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the subjects observed by the window are
 //   destructed.
 //
@@ -252,7 +252,7 @@ QvisEngineWindow::Update(Subject *TheChangedSubject)
 // Creation:   Wed May 2 16:33:44 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -267,7 +267,7 @@ QvisEngineWindow::SubjectRemoved(Subject *TheRemovedSubject)
 // ****************************************************************************
 // Method: QvisEngineWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called to update the window's widgets when the subjects
 //   change.
 //
@@ -287,8 +287,8 @@ QvisEngineWindow::SubjectRemoved(Subject *TheRemovedSubject)
 //   Jeremy Meredith, Mon Apr  4 16:02:22 PDT 2005
 //   I made better names for simulations.
 //
-//   Kathleen Bonnell, Tue Apr 26 16:42:17 PDT 2005 
-//   Don't enable interruptEngineButton until the process has been fixed. 
+//   Kathleen Bonnell, Tue Apr 26 16:42:17 PDT 2005
+//   Don't enable interruptEngineButton until the process has been fixed.
 //
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
@@ -298,6 +298,9 @@ QvisEngineWindow::SubjectRemoved(Subject *TheRemovedSubject)
 //
 //   Alister Maguire, Thu Nov 12 09:58:35 PST 2020
 //   Remove interrupt engine logic.
+//
+//   Kathlen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString::arg as suggested in Qt docs.
 //
 // ****************************************************************************
 
@@ -341,11 +344,9 @@ QvisEngineWindow::UpdateWindow(bool doAll)
             {
                 current = 0;
                 engineCombo->setCurrentIndex(0);
-                if (sim[0]=="")
-                    activeEngine = QString().asprintf("%s",host[0].c_str());
-                else
-                    activeEngine = QString().asprintf("%s:%s",host[0].c_str(),
-                                                     sim[0].c_str());
+                activeEngine = QString(host[0].c_str()); 
+                if (sim[0]!="")
+                    activeEngine += QString(":%1").arg(sim[0].c_str());
 
                 // Add an entry if needed.
                 AddStatusEntry(activeEngine);
@@ -377,7 +378,7 @@ QvisEngineWindow::UpdateWindow(bool doAll)
         QString key(statusAtts->GetSender().c_str());
 
         if(key != QString("viewer"))
-        {    
+        {
             UpdateStatusEntry(key);
 
             // If the sender of the status message is the engine that we're
@@ -393,7 +394,7 @@ QvisEngineWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisEngineWindow::UpdateInformation
 //
-// Purpose: 
+// Purpose:
 //   Updates the engine information.
 //
 // Arguments:
@@ -444,7 +445,7 @@ QvisEngineWindow::UpdateInformation(int index)
 
         if(props.GetNumNodes() == -1)
             engineNN->setText(tr("Default"));
-        else 
+        else
             engineNN->setText(QString("%1").arg(props.GetNumNodes()));
 
         engineNP->setText(QString("%1").arg(props.GetNumProcessors()));
@@ -468,8 +469,8 @@ QvisEngineWindow::UpdateInformation(int index)
 // ****************************************************************************
 // Method: QvisEngineWindow::UpdateStatusArea
 //
-// Purpose: 
-//   Updates the window so it reflects the status information for the 
+// Purpose:
+//   Updates the window so it reflects the status information for the
 //   currently selected engine.
 //
 // Programmer: Brad Whitlock
@@ -479,7 +480,7 @@ QvisEngineWindow::UpdateInformation(int index)
 //    Jeremy Meredith, Fri Jun 29 15:12:08 PDT 2001
 //    Separated the single status/progress bar into one which reports
 //    total status and one which reports current stage progress.
-//   
+//
 //    Jeremy Meredith, Thu Jul  5 12:40:30 PDT 2001
 //    Added an explicit cast to avoid a warning.
 //
@@ -494,10 +495,10 @@ QvisEngineWindow::UpdateInformation(int index)
 void
 QvisEngineWindow::UpdateStatusArea()
 {
-    
+
     if(!statusMap.contains(activeEngine))
         return;
-        
+
     StatusAttributes *s = statusMap[activeEngine];
     if(s->GetClearStatus())
     {
@@ -527,8 +528,7 @@ QvisEngineWindow::UpdateStatusArea()
         }
         else if (s->GetMessageType() == 2)
         {
-            QString msg;
-            msg.asprintf("%d/%d", s->GetCurrentStage(), s->GetMaxStage());
+            QString msg = QString("%1/%1").arg(s->GetCurrentStage()).arg(s->GetMaxStage());
             msg = tr("Total Status: Stage ") + msg;
             totalStatusLabel->setText(msg);
             msg = tr("Stage Status: ") + QString(s->GetCurrentStageName().c_str());
@@ -544,7 +544,7 @@ QvisEngineWindow::UpdateStatusArea()
 // ****************************************************************************
 // Method: QvisEngineWindow::ConnectStatusAttributes
 //
-// Purpose: 
+// Purpose:
 //   Connects the status attributes subject that the window will observe.
 //
 // Arguments:
@@ -554,7 +554,7 @@ QvisEngineWindow::UpdateStatusArea()
 // Creation:   Wed May 2 16:31:48 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -570,7 +570,7 @@ QvisEngineWindow::ConnectStatusAttributes(StatusAttributes *s)
 // ****************************************************************************
 // Method: QvisEngineWindow::AddStatusEntry
 //
-// Purpose: 
+// Purpose:
 //   Adds an engine to the internal status map.
 //
 // Arguments:
@@ -580,7 +580,7 @@ QvisEngineWindow::ConnectStatusAttributes(StatusAttributes *s)
 // Creation:   Wed May 2 16:35:50 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -599,7 +599,7 @@ QvisEngineWindow::AddStatusEntry(const QString &key)
 // ****************************************************************************
 // Method: QvisEngineWindow::RemoveStatusEntry
 //
-// Purpose: 
+// Purpose:
 //   Removes an engine from the internal status map.
 //
 // Arguments:
@@ -619,7 +619,7 @@ QvisEngineWindow::RemoveStatusEntry(const QString &key)
 {
     // If the entry is not in the map, return.
     if(!statusMap.contains(key))
-        return;    
+        return;
 
     // Delete the status attributes that are in the map.
     delete statusMap[key];
@@ -630,7 +630,7 @@ QvisEngineWindow::RemoveStatusEntry(const QString &key)
 // ****************************************************************************
 // Method: QvisEngineWindow::UpdateStatusEntry
 //
-// Purpose: 
+// Purpose:
 //   Makes the specified entry in the status map update to the current status
 //   in the status attributes.
 //
@@ -653,7 +653,7 @@ QvisEngineWindow::UpdateStatusEntry(const QString &key)
     // If the sender is in the status map, copy the status into the map entry.
     // If the sender is not in the map, add it.
     QMapIterator<QString, StatusAttributes*> itr(statusMap);
-    
+
     if(statusMap.contains(activeEngine))
     {
         *statusMap[activeEngine] = *statusAtts;
@@ -669,7 +669,7 @@ QvisEngineWindow::UpdateStatusEntry(const QString &key)
 // ****************************************************************************
 // Method: QvisEngineWindow::closeEngine
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the "Close engine" button
 //   is clicked. Its job is to tell the viewer to close the engine being
 //   displayed by the window.
@@ -728,7 +728,7 @@ QvisEngineWindow::closeEngine()
 // ****************************************************************************
 // Method: QvisEngineWindow::clearCache
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to tell the current engine
 //   to clear its cache.
 //
@@ -762,7 +762,7 @@ QvisEngineWindow::clearCache()
 // ****************************************************************************
 // Method: QvisEngineWindow::selectEngine
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when selecting a new engine
 //   to display.
 //
@@ -784,13 +784,9 @@ QvisEngineWindow::clearCache()
 void
 QvisEngineWindow::selectEngine(int index)
 {
-    if (engines->GetSimulationName()[index]=="")
-        activeEngine = QString().asprintf("%s",
-                                         engines->GetEngineName()[index].c_str());
-    else
-        activeEngine = QString().asprintf("%s:%s",
-                                  engines->GetEngineName()[index].c_str(),
-                                  engines->GetSimulationName()[index].c_str());
+    activeEngine = QString(engines->GetEngineName()[index].c_str());
+    if (engines->GetSimulationName()[index]!="")
+        activeEngine += QString(":%1").arg(engines->GetSimulationName()[index].c_str());
 
     // Update the rest of the widgets using the information for the
     // active engine.

--- a/src/gui/QvisFilePanel.C
+++ b/src/gui/QvisFilePanel.C
@@ -11,10 +11,10 @@
 #include <QLabel>
 #include <QMenu>
 #include <QTreeWidget>
-#include <QTreeWidgetItem> 
+#include <QTreeWidgetItem>
 #include <QLayout>
 #include <QPushButton>
-#include <QLineEdit> 
+#include <QLineEdit>
 #include <QTimer>
 
 #include <QvisFilePanel.h>
@@ -159,7 +159,7 @@ const int FileTree::FileTreeNode::DATABASE_NODE = 3;
 // ****************************************************************************
 // Method: QvisFilePanel::QvisFilePanel
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisFilePanel class.
 //
 // Arguments:
@@ -220,7 +220,7 @@ const int FileTree::FileTreeNode::DATABASE_NODE = 3;
 // ****************************************************************************
 
 QvisFilePanel::QvisFilePanel(QWidget *parent) :
-   QGroupBox(tr("Selected Files"),parent), SimpleObserver(), GUIBase(), 
+   QGroupBox(tr("Selected Files"),parent), SimpleObserver(), GUIBase(),
    displayInfo(),
    timeStateFormat()
 {
@@ -241,9 +241,9 @@ QvisFilePanel::QvisFilePanel(QWidget *parent) :
     connect(fileTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem *,int)),
             this, SLOT(openFileDblClick(QTreeWidgetItem *)));
     /*
-    connect(fileListView, 
+    connect(fileListView,
             SIGNAL(rightButtonClicked(QListViewItem *,const QPoint &,int)),
-            this, 
+            this,
             SLOT(showFilePopup(QListViewItem *, const QPoint &, int)));
     */
     connect(fileTree, SIGNAL(currentItemChanged(QTreeWidgetItem *,QTreeWidgetItem *)),
@@ -297,7 +297,7 @@ QvisFilePanel::QvisFilePanel(QWidget *parent) :
 // ****************************************************************************
 // Method: QvisFilePanel::~QvisFilePanel
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisFilePanel class.
 //
 // Programmer: Brad Whitlock
@@ -329,11 +329,11 @@ QvisFilePanel::~QvisFilePanel()
 // ****************************************************************************
 // Method: QvisFilePanel::SetTimeStateFormat
 //
-// Purpose: 
+// Purpose:
 //   Sets the display mode for the file panel. We can make it display files
 //   using cycle information or we can make it use time information.
 //
-// Arguments: 
+// Arguments:
 //   m : The new timestate display mode.
 //
 // Notes:      This method resets the text on the expanded databases, which
@@ -434,7 +434,7 @@ QvisFilePanel::SetTimeStateFormat(const TimeFormat &m)
 // ****************************************************************************
 // Method: QvisFilePanel::GetTimeStateFormat
 //
-// Purpose: 
+// Purpose:
 //   Returns the time state format.
 //
 // Returns:    The time state format.
@@ -443,7 +443,7 @@ QvisFilePanel::SetTimeStateFormat(const TimeFormat &m)
 // Creation:   Mon Oct 13 17:19:20 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 const TimeFormat &
@@ -455,7 +455,7 @@ QvisFilePanel::GetTimeStateFormat() const
 // ****************************************************************************
 // Method: QvisFilePanel::Update
 //
-// Purpose: 
+// Purpose:
 //   This method tells the widget to update itself when the subject
 //   changes.
 //
@@ -486,7 +486,7 @@ QvisFilePanel::Update(Subject *TheChangedSubject)
 // ****************************************************************************
 // Method: QvisFilePanel::UpdateFileList
 //
-// Purpose: 
+// Purpose:
 //   This method updates the widget to reflect the new state stored
 //   in the FileServerList that this widget is watching.
 //
@@ -531,7 +531,7 @@ QvisFilePanel::UpdateFileList(bool doAll)
 // ****************************************************************************
 // Method: QvisFilePanel::RepopulateFileList
 //
-// Purpose: 
+// Purpose:
 //   Clears out the selected files and refills the list with the new list
 //   of selected files.
 //
@@ -637,8 +637,8 @@ QvisFilePanel::RepopulateFileList()
             char separator = fileServer->GetSeparator(hpos->first);
             QualifiedFilename hostOnly(hpos->first, "(host)", "(host)");
             hostOnly.separator = separator;
-            
-            QTreeWidgetItem *newFile = new QvisFilePanelItem(root, 
+
+            QTreeWidgetItem *newFile = new QvisFilePanelItem(root,
                                                              QString(hpos->first.c_str()),
                                                              hostOnly,
                                                              QvisFilePanelItem::HOST_NODE);
@@ -692,7 +692,7 @@ QvisFilePanel::RepopulateFileList()
         {
             // Create the root for the host list.
             QualifiedFilename rootName(f[0].host, "(host)", "(host)");
-            QTreeWidgetItem *root = new QvisFilePanelItem(fileTree, 
+            QTreeWidgetItem *root = new QvisFilePanelItem(fileTree,
                                                           QString(f[0].host.c_str()),
                                                           rootName,
                                                           QvisFilePanelItem::ROOT_NODE);
@@ -733,7 +733,7 @@ QvisFilePanel::RepopulateFileList()
 // ****************************************************************************
 // Method: QvisFilePanel::UpdateWindowInfo
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the GlobalAttributes subject that this
 //   widget watches is updated.
 //
@@ -815,7 +815,7 @@ QvisFilePanel::UpdateWindowInfo(bool doAll)
         {
             OpenActiveSourceInFileServer();
         }
-    
+
         //
         // If the active source, time slider, or time slider states change then
         // we need to update the file selection. Note - without this code, the
@@ -842,7 +842,7 @@ QvisFilePanel::UpdateWindowInfo(bool doAll)
 // ****************************************************************************
 // Method: QvisFilePanel::ExpandDatabases
 //
-// Purpose: 
+// Purpose:
 //   This method traverses the listviewitem tree and looks for the
 //   selected file. When it finds the selected file, it turns it into
 //   a database if the file has more than 1 state.
@@ -895,7 +895,7 @@ debug5 << "In QvisFilePanel::ExpandDatabases " << endl;
     // iterator is invalidated.
     QList<QvisFilePanelItem*> items;
     QTreeWidgetItemIterator itr(fileTree);
-    while(*itr) 
+    while(*itr)
     {
         items.append((QvisFilePanelItem*)*itr);
         ++itr;
@@ -955,7 +955,7 @@ debug5 << "In QvisFilePanel::ExpandDatabases " << endl;
                         for(j = 0; j < item->childCount(); ++j, ++it)
                         {
                             // Reset the label so that it shows the right values.
-                            (*it)->setText(0, CreateItemLabel(md, j,useVirtualDBInfo)); 
+                            (*it)->setText(0, CreateItemLabel(md, j,useVirtualDBInfo));
                         }
 
                         // Remember that the item now has the correct information
@@ -1015,14 +1015,14 @@ debug5 << "In QvisFilePanel::ExpandDatabases " << endl;
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
 QvisFilePanel::ExpandDatabaseItem(QvisFilePanelItem *item)
 {
     //
-    // It could be that this method is being called on the child timestate of 
+    // It could be that this method is being called on the child timestate of
     // a previously expanded database. If that is the case, then the parent
     // will exist and it will have the same filename as the item.
     //
@@ -1043,7 +1043,7 @@ QvisFilePanel::ExpandDatabaseItem(QvisFilePanelItem *item)
 // ****************************************************************************
 // Method: QvisFilePanel::ExpandDatabaseItemUsingMetaData
 //
-// Purpose: 
+// Purpose:
 //   Expands a database item as a database, which means that it uses the
 //   number of time states to display the database.
 //
@@ -1066,7 +1066,7 @@ QvisFilePanel::ExpandDatabaseItem(QvisFilePanelItem *item)
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -1087,7 +1087,7 @@ QvisFilePanel::ExpandDatabaseItemUsingMetaData(QvisFilePanelItem *item)
             for(int i = 0; i < md->GetNumStates(); ++i)
             {
                 QvisFilePanelItem *fi = new QvisFilePanelItem(
-                                   item, 
+                                   item,
                                    CreateItemLabel(md, i, useVirtualDBInfo),
                                    item->file, QvisFilePanelItem::FILE_NODE, i);
                 fi->setExpanded(false);
@@ -1113,7 +1113,7 @@ QvisFilePanel::ExpandDatabaseItemUsingMetaData(QvisFilePanelItem *item)
 // ****************************************************************************
 // Method: QvisFilePanel::ExpandDatabaseItemUsingVirtualDBDefinition
 //
-// Purpose: 
+// Purpose:
 //   Expands a database item as a virtual database when possible. Otherwise, if
 //   the virtual database has more time states than files, it is displayed
 //   as a database.
@@ -1127,7 +1127,7 @@ QvisFilePanel::ExpandDatabaseItemUsingMetaData(QvisFilePanelItem *item)
 // Modifications:
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -1167,7 +1167,7 @@ QvisFilePanel::ExpandDatabaseItemUsingVirtualDBDefinition(QvisFilePanelItem *ite
 // ****************************************************************************
 // Method: QvisFilePanel::CreateItemLabel
 //
-// Purpose: 
+// Purpose:
 //   Creates the label for the item at the requested database timestate.
 //
 // Arguments:
@@ -1178,7 +1178,7 @@ QvisFilePanel::ExpandDatabaseItemUsingVirtualDBDefinition(QvisFilePanelItem *ite
 //
 // Returns:    A string to use in the file panel to help display the file.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Oct 13 15:42:17 PST 2003
@@ -1250,7 +1250,7 @@ QvisFilePanel::CreateItemLabel(const avtDatabaseMetaData *md, int ts,
 // ****************************************************************************
 // Method: QvisFilePanel::FormattedCycleString
 //
-// Purpose: 
+// Purpose:
 //   Returns a formatted cycle string.
 //
 // Arguments:
@@ -1258,27 +1258,28 @@ QvisFilePanel::CreateItemLabel(const avtDatabaseMetaData *md, int ts,
 //
 // Returns:    A formatted cycle string.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Oct 14 11:31:42 PDT 2003
 //
 // Modifications:
-//   
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg as suggested in Qt docs.
+//
 // ****************************************************************************
 
 QString
 QvisFilePanel::FormattedCycleString(const int cycle) const
 {
-    QString retval;
-    retval.asprintf("%04d", cycle);
+    QString retval = QString("%1").arg(cycle,4,10,QLatin1Char('0'));
     return retval;
 }
 
 // ****************************************************************************
 // Method: QvisFilePanel::FormattedTimeString
 //
-// Purpose: 
+// Purpose:
 //   Returns a formatted time string.
 //
 // Arguments:
@@ -1292,7 +1293,9 @@ QvisFilePanel::FormattedCycleString(const int cycle) const
 // Creation:   Mon Oct 13 16:03:37 PST 2003
 //
 // Modifications:
-//   
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg as suggested in Qt docs.
+//
 // ****************************************************************************
 
 QString
@@ -1301,9 +1304,7 @@ QvisFilePanel::FormattedTimeString(const double t, bool accurate) const
     QString retval("?");
     if(accurate)
     {
-        QString formatString;
-        formatString.asprintf("%%.%dg", timeStateFormat.GetPrecision());
-        retval.asprintf(formatString.toStdString().c_str(), t);
+        retval = QString("%1").arg(t,0,'g',timeStateFormat.GetPrecision());
     }
     return retval;
 }
@@ -1311,7 +1312,7 @@ QvisFilePanel::FormattedTimeString(const double t, bool accurate) const
 // ****************************************************************************
 // Method: QvisFilePanel::DisplayVirtualDBInformation
 //
-// Purpose: 
+// Purpose:
 //   Returns whether or not we should display a virtual database as a
 //   virtual database. Sometimes, virtual databases have more states than
 //   files. In that case, we want to show them as databases instead of
@@ -1321,7 +1322,7 @@ QvisFilePanel::FormattedTimeString(const double t, bool accurate) const
 // Creation:   Mon Dec 29 11:28:59 PDT 2003
 //
 // Modifications:
-//   
+//
 //   Mark C. Miller, Wed Aug  2 19:58:44 PDT 2006
 //   Changed interface to FileServerList::GetMetaData
 // ****************************************************************************
@@ -1347,7 +1348,7 @@ QvisFilePanel::DisplayVirtualDBInformation(const QualifiedFilename &file) const
 // ****************************************************************************
 // Method: QvisFilePanel::UpdateFileSelection
 //
-// Purpose: 
+// Purpose:
 //   Highlights the selected file in the file list view.
 //
 // Programmer: Brad Whitlock
@@ -1380,10 +1381,10 @@ QvisFilePanel::DisplayVirtualDBInformation(const QualifiedFilename &file) const
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 //   Cyrus Harrison, Thu Dec  4 08:09:20 PST 2008
-//   Made sure the current item is visible via scroll to item. 
-// 
+//   Made sure the current item is visible via scroll to item.
+//
 //   Jeremy Meredith, Tue Feb  5 16:00:12 EST 2013
 //   This can take a while if we have lots and lots of time steps.
 //   Don't update the selection if the file panel is not visible.  We
@@ -1481,14 +1482,14 @@ QvisFilePanel::UpdateFileSelection()
             {
                 // Check if the current item is for the current time state.
                 bool currentTimeState = item->timeState == dbStateForActiveSource;
-                
+
                 // If we have information for this file and it turns out that
                 // the file is not expanded, then check to see if the item is
                 // the root of the database.
                 if(HaveFileInformation(item->file) && !FileIsExpanded(item->file))
                 {
                     //
-                    // The time states are not expanded. If the time state 
+                    // The time states are not expanded. If the time state
                     // that we're looking at is not -1 then it is a time
                     // step in the database but since the file is not
                     // expanded, we want to instead highlight the parent.
@@ -1555,7 +1556,7 @@ QvisFilePanel::UpdateFileSelection()
 // ****************************************************************************
 // Method: QvisFilePanel::HighlightedItemIsInvalid
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the currently highlighted item is an invalid selection.
 //
 // Returns:    True if the highlighted item is not valid; false otherwise.
@@ -1564,13 +1565,13 @@ QvisFilePanel::UpdateFileSelection()
 // Creation:   Tue Apr 13 14:00:08 PST 2004
 //
 // Modifications:
-//   
+//
 //   Mark C. Miller, Wed Aug  2 19:58:44 PDT 2006
 //   Changed interface to FileServerList::GetMetaData
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 bool
@@ -1615,14 +1616,14 @@ QvisFilePanel::HighlightedItemIsInvalid() const
 // ****************************************************************************
 // Method: QvisFilePanel::UpdateReplaceButtonEnabledState
 //
-// Purpose: 
+// Purpose:
 //   This method updates the enabled state of the Replace button.
 //
 // Arguments:
 //
 // Returns:    True if the button was enabled; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Dec 20 16:17:55 PST 2004
@@ -1633,7 +1634,7 @@ QvisFilePanel::HighlightedItemIsInvalid() const
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 //   Cyrus Harrison, Tue Apr 14 14:24:08 PDT 2009
 //   Refactored to use common CheckIfReplaceIsValid() method.
 //
@@ -1650,9 +1651,9 @@ QvisFilePanel::UpdateReplaceButtonEnabledState()
 // ****************************************************************************
 // Method: QvisFilePanel::CheckIfReplaceIsValid
 //
-// Purpose: 
+// Purpose:
 //   This method tells us if replace/replace selected are valid operations.
-// 
+//
 //
 //   Note: Refactored from UpdateReplaceButtonEnabledState(), so the core
 //    logic could be used both in UpdateReplaceButtonEnabledState() and
@@ -1664,7 +1665,7 @@ QvisFilePanel::UpdateReplaceButtonEnabledState()
 // Creation:   Tue Apr 14 14:23:11 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -1730,7 +1731,7 @@ QvisFilePanel::CheckIfReplaceIsValid()
 // ****************************************************************************
 // Method: QvisFilePanel::SubjectRemoved
 //
-// Purpose: 
+// Purpose:
 //   Removes the windowInfo or fileserver subjects that this widget
 //   observes.
 //
@@ -1782,7 +1783,7 @@ QvisFilePanel::ConnectWindowInformation(WindowInformation *wi)
 // ****************************************************************************
 // Method: QvisFilePanel::OpenFile
 //
-// Purpose: 
+// Purpose:
 //   Tells the file server to open the selected file and notify all
 //   observers that the file was opened.
 //
@@ -1857,7 +1858,7 @@ QvisFilePanel::OpenFile(const QualifiedFilename &qf, int timeState, bool reOpen)
 // ****************************************************************************
 // Method: QvisFilePanel::ReplaceFile
 //
-// Purpose: 
+// Purpose:
 //   Tells the file server to replace the current file with the
 //   selected file and notify all observers that the file changed.
 //
@@ -2019,7 +2020,7 @@ QvisFilePanel::RemoveExpandedFile(const QualifiedFilename &filename)
 // Creation:   Fri May 16 12:40:29 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2031,7 +2032,7 @@ QvisFilePanel::SetFileExpanded(const QualifiedFilename &filename, bool val)
 // ****************************************************************************
 // Method: QvisFilePanel::HaveFileInformation
 //
-// Purpose: 
+// Purpose:
 //   Returns whether or not we have file information for a file.
 //
 // Arguments:
@@ -2043,7 +2044,7 @@ QvisFilePanel::SetFileExpanded(const QualifiedFilename &filename, bool val)
 // Creation:   Fri May 16 13:11:19 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -2074,7 +2075,7 @@ bool
 QvisFilePanel::FileIsExpanded(const QualifiedFilename &filename) const
 {
     bool retval = true;
-    FileDisplayInformationMap::const_iterator pos = 
+    FileDisplayInformationMap::const_iterator pos =
         displayInfo.find(filename.FullName());
     if(pos != displayInfo.end())
         retval = pos->second.expanded;
@@ -2106,7 +2107,7 @@ QvisFilePanel::FileShowsCorrectData(const QualifiedFilename &filename)
 // ****************************************************************************
 // Method: QvisFilePanel::SetFileShowsCorrectData
 //
-// Purpose: 
+// Purpose:
 //   Sets the flag that indicates whether or not we're showing the right
 //   cycles for a file.
 //
@@ -2132,7 +2133,7 @@ QvisFilePanel::SetFileShowsCorrectData(const QualifiedFilename &filename,
 // ****************************************************************************
 // Method: QvisFilePanel::contextMenuEvent
 //
-// Purpose: 
+// Purpose:
 //   Shows file popup menu.
 //
 //
@@ -2148,7 +2149,7 @@ QvisFilePanel::contextMenuEvent(QContextMenuEvent *e)
 {
     QvisFilePanelItem *file_item=(QvisFilePanelItem*)fileTree->currentItem();
     if(file_item == NULL || !file_item->isFile())
-        return;    
+        return;
 
     // update popup menu with proper commands
     bool file_opened_before = fileServer->HaveOpenedFile(file_item->file);
@@ -2227,7 +2228,7 @@ QvisFilePanel::SetAllowFileSelectionChange(bool val)
 //
 // ****************************************************************************
 
-bool 
+bool
 QvisFilePanel::GetAllowFileSelectionChange() const
 {
     return allowFileSelectionChange;
@@ -2236,7 +2237,7 @@ QvisFilePanel::GetAllowFileSelectionChange() const
 // ****************************************************************************
 // Method: QvisFilePanel::UpdateOpenButtonState
 //
-// Purpose: 
+// Purpose:
 //   Updates the text and enabled state of the Open button based on what
 //   file is currently selected in the list view.
 //
@@ -2246,7 +2247,7 @@ QvisFilePanel::GetAllowFileSelectionChange() const
 // Modifications:
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2269,7 +2270,7 @@ QvisFilePanel::UpdateOpenButtonState()
 // ****************************************************************************
 // Method: QvisFilePanel::internalUpdateFileList
 //
-// Purpose: 
+// Purpose:
 //   Updates the file list.
 //
 // Note:       This method should only be called on a timer because updating
@@ -2279,7 +2280,7 @@ QvisFilePanel::UpdateOpenButtonState()
 // Creation:   Fri Dec 19 17:02:15 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2292,7 +2293,7 @@ QvisFilePanel::internalUpdateFileList()
 // ****************************************************************************
 // Method: QvisFilePanel::fileCollapsed
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that collapses a file and thus removes it
 //   from the expanded files list.
 //
@@ -2312,7 +2313,7 @@ QvisFilePanel::internalUpdateFileList()
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2351,7 +2352,7 @@ QvisFilePanel::fileCollapsed(QTreeWidgetItem *item)
 // ****************************************************************************
 // Method: QvisFilePanel::fileExpanded
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that expands a file thus adding it to the
 //   expanded file list.
 //
@@ -2372,10 +2373,10 @@ QvisFilePanel::fileCollapsed(QTreeWidgetItem *item)
 //
 //   Mark C. Miller, Wed Aug  2 19:58:44 PDT 2006
 //   Changed interface to FileServerList::GetMetaData
-// 
+//
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2404,7 +2405,7 @@ QvisFilePanel::fileExpanded(QTreeWidgetItem *item)
 // ****************************************************************************
 // Method: QvisFilePanel::highlightFile
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the enabled flag on the
 //   open, replace, overlay buttons depending on whether or not the
 //   highlighted file is the active file.
@@ -2450,7 +2451,7 @@ QvisFilePanel::fileExpanded(QTreeWidgetItem *item)
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2474,7 +2475,7 @@ QvisFilePanel::highlightFile(QTreeWidgetItem *item)
 // ****************************************************************************
 // Method: QvisFilePanel::UpdateOpenButtonState
 //
-// Purpose: 
+// Purpose:
 //   Updates the state of the Open button based on what item is highlighted.
 //
 // Arguments:
@@ -2486,7 +2487,7 @@ QvisFilePanel::highlightFile(QTreeWidgetItem *item)
 // Modifications:
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2516,7 +2517,7 @@ QvisFilePanel::UpdateOpenButtonState(QvisFilePanelItem *fileItem)
 // ****************************************************************************
 // Method: QvisFilePanel::openFile
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that opens a file when the Open button
 //   is clicked.
 //
@@ -2539,7 +2540,7 @@ QvisFilePanel::UpdateOpenButtonState(QvisFilePanelItem *fileItem)
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2596,7 +2597,7 @@ QvisFilePanel::openFile()
 // ****************************************************************************
 // Method: QvisFilePanel::openFileDblClick
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that opens a file when the filename
 //   is double clicked.
 //
@@ -2634,7 +2635,7 @@ QvisFilePanel::openFile()
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2654,7 +2655,7 @@ QvisFilePanel::openFileDblClick(QTreeWidgetItem *item)
 
             //
             // If the correlation for the active time slider does not use the
-            // database that we just double-clicked, 
+            // database that we just double-clicked,
             //
             WindowInformation *windowInfo = GetViewerState()->GetWindowInformation();
             int activeTS = windowInfo->GetActiveTimeSlider();
@@ -2697,7 +2698,7 @@ QvisFilePanel::openFileDblClick(QTreeWidgetItem *item)
 // ****************************************************************************
 // Method: QvisFilePanel::replaceFile
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that replaces a file when the Replace
 //   button is clicked.
 //
@@ -2725,7 +2726,7 @@ QvisFilePanel::openFileDblClick(QTreeWidgetItem *item)
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -2748,7 +2749,7 @@ QvisFilePanel::replaceFile()
 // ****************************************************************************
 // Method: QvisFilePanel::replaceSelected
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that replaces active when the Replace
 //   Selected menu option from the file popup menu is clicked.
 //
@@ -2756,7 +2757,7 @@ QvisFilePanel::replaceFile()
 // Creation:   Tue Apr 14 16:43:13 PDT 2009
 //
 // Modifications:
-// 
+//
 // ****************************************************************************
 
 void
@@ -2781,7 +2782,7 @@ QvisFilePanel::replaceSelected()
 // ****************************************************************************
 // Method: QvisFilePanel::overlayFile
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that overlays a file when the Overlay
 //   button is clicked.
 //
@@ -2794,7 +2795,7 @@ QvisFilePanel::replaceSelected()
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 //   Brad Whitlock, Thu Jul 24 09:16:23 PDT 2008
 //   Make it possible to overlay at a particular time step.
 //
@@ -2820,14 +2821,14 @@ QvisFilePanel::overlayFile()
 // ****************************************************************************
 // Method: QvisFilePanel::closeFile
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that overlays a file when the Overlay
 //   button is clicked. TODO
 //
 // Programmer: Cyrus Harrison
 // Creation:   Tue Apr 14 16:43:13 PDT 2009
 //
-// Modifications: 
+// Modifications:
 //
 //   Jeremy Meredith, Fri Mar 19 13:22:13 EDT 2010
 //   Added extra parameter telling ClearFile whether or not we want it
@@ -2856,7 +2857,7 @@ QvisFilePanel::closeFile()
 // ****************************************************************************
 // Method: FileTree::FileTree
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the FileTree class.
 //
 // Programmer: Brad Whitlock
@@ -2881,14 +2882,14 @@ FileTree::FileTree(QvisFilePanel *fp)
 // ****************************************************************************
 // Method: FileTree::~FileTree
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the FileTree class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 22 16:49:42 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 FileTree::~FileTree()
@@ -2899,7 +2900,7 @@ FileTree::~FileTree()
 // ****************************************************************************
 // Method: FileTree::Add
 //
-// Purpose: 
+// Purpose:
 //   Adds the specified file to the file tree. This includes building the path
 //   nodes in the file tree that need to be built.
 //
@@ -2956,7 +2957,7 @@ FileTree::Add(const QualifiedFilename &fileName, char separator_)
                 directory += fileName.path[index];
                 if(index == len - 1)
                     mode = PROCESS_MODE;
-                else 
+                else
                     ++index;
             }
         }
@@ -2998,7 +2999,7 @@ FileTree::Add(const QualifiedFilename &fileName, char separator_)
 // ****************************************************************************
 // Method: FileTree::Reduce
 //
-// Purpose: 
+// Purpose:
 //   Simplifies the file tree. This means condensing nodes with only one child
 //   into its parent node.
 //
@@ -3059,14 +3060,14 @@ FileTree::Reduce()
 // ****************************************************************************
 // Method: FileTree::Size
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of nodes in the file tree. This includes the root node.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 22 16:51:59 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -3078,14 +3079,14 @@ FileTree::Size() const
 // ****************************************************************************
 // Method: FileTree::TreeContainsDirectories
 //
-// Purpose: 
+// Purpose:
 //   Searches the file tree to determine if it contains directories.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 22 16:52:22 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -3104,7 +3105,7 @@ FileTree::TreeContainsDirectories() const
 // ****************************************************************************
 // Method: FileTree::AddElementsToTreeItem
 //
-// Purpose: 
+// Purpose:
 //   This method adds adds the appropriate list view items for the file tree
 //   to the parent list view item.
 //
@@ -3126,7 +3127,7 @@ FileTree::TreeContainsDirectories() const
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -3140,14 +3141,14 @@ FileTree::AddElementsToTreeItem(QTreeWidgetItem *item, int &fileIndex,
 // ****************************************************************************
 // Method: FileTree::AddElementsToTree
 //
-// Purpose: 
+// Purpose:
 //   This method adds adds the appropriate list view items for the file tree
 //   to the parent list view.
 //
 // Arguments:
 //   item : The list view that will be the parent of the new nodes.
 //   fileIndex : The index of the file being added.
-// 
+//
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 22 16:52:52 PST 2001
 //
@@ -3157,7 +3158,7 @@ FileTree::AddElementsToTreeItem(QTreeWidgetItem *item, int &fileIndex,
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -3171,7 +3172,7 @@ FileTree::AddElementsToTree(QTreeWidget *tree, int &fileIndex,
 // ****************************************************************************
 // Method: FileTree::HasNodeNameExceeding
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the nodes in the tree have a node name that exceeds the
 //   specified length.
 //
@@ -3179,7 +3180,7 @@ FileTree::AddElementsToTree(QTreeWidget *tree, int &fileIndex,
 // Creation:   Thu Aug 5 17:34:58 PST 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -3191,7 +3192,7 @@ FileTree::HasNodeNameExceeding(int len) const
 // ****************************************************************************
 // Method: FileTree::operator <<
 //
-// Purpose: 
+// Purpose:
 //   Prints the FileTree to a stream.
 //
 // Arguments:
@@ -3201,7 +3202,7 @@ FileTree::HasNodeNameExceeding(int len) const
 // Creation:   Thu Jul 29 10:08:20 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 ostream &
@@ -3216,7 +3217,7 @@ operator <<(ostream &os, const FileTree &t)
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::FileTreeNode
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the FileTree::FileTreeNode class.
 //
 // Arguments:
@@ -3226,7 +3227,7 @@ operator <<(ostream &os, const FileTree &t)
 // Creation:   Thu Mar 22 16:55:21 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 FileTree::FileTreeNode::FileTreeNode(int nodeT) : nodeName()
@@ -3239,14 +3240,14 @@ FileTree::FileTreeNode::FileTreeNode(int nodeT) : nodeName()
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::~FileTreeNode
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the FileTree::FileTreeNode class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 22 16:56:05 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 FileTree::FileTreeNode::~FileTreeNode()
@@ -3257,14 +3258,14 @@ FileTree::FileTreeNode::~FileTreeNode()
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::Destroy
 //
-// Purpose: 
+// Purpose:
 //   Recursively (indirect) destroys all child nodes.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 22 16:56:32 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3284,7 +3285,7 @@ FileTree::FileTreeNode::Destroy()
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::Add
 //
-// Purpose: 
+// Purpose:
 //   Adds a new node of the specified type to the current node.
 //
 // Arguments:
@@ -3374,7 +3375,7 @@ FileTree::FileTreeNode::Add(int nType, const std::string &name,
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::Find
 //
-// Purpose: 
+// Purpose:
 //   Searches for the node with the given path name.
 //
 // Arguments:
@@ -3386,7 +3387,7 @@ FileTree::FileTreeNode::Add(int nType, const std::string &name,
 // Creation:   Thu Mar 22 16:58:52 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 FileTree::FileTreeNode *
@@ -3410,7 +3411,7 @@ FileTree::FileTreeNode::Find(const std::string &path)
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::Reduce
 //
-// Purpose: 
+// Purpose:
 //   Simplifies the file tree.
 //
 // Programmer: Brad Whitlock
@@ -3485,7 +3486,7 @@ FileTree::FileTreeNode::Reduce()
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::Size
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of children in the node.
 //
 // Returns:    The number of children in the node.
@@ -3494,7 +3495,7 @@ FileTree::FileTreeNode::Reduce()
 // Creation:   Thu Mar 22 17:00:21 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -3514,7 +3515,7 @@ FileTree::FileTreeNode::Size() const
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::HasChildrenOfType
 //
-// Purpose: 
+// Purpose:
 //   Recursively determines whether the node has any children of the
 //   specified type.
 //
@@ -3527,7 +3528,7 @@ FileTree::FileTreeNode::Size() const
 // Creation:   Thu Mar 22 17:00:48 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -3551,8 +3552,8 @@ FileTree::FileTreeNode::HasChildrenOfType(int type)
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::HasNodeNameExceeding
 //
-// Purpose: 
-//   Returns whether any of the nodes in the tree have a node name that is 
+// Purpose:
+//   Returns whether any of the nodes in the tree have a node name that is
 //   longer than the specified length.
 //
 // Arguments:
@@ -3562,7 +3563,7 @@ FileTree::FileTreeNode::HasChildrenOfType(int type)
 // Creation:   Thu Aug 5 17:32:29 PST 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -3577,14 +3578,14 @@ FileTree::FileTreeNode::HasNodeNameExceeding(int len) const
         if(children[i]->HasNodeNameExceeding(len))
             return true;
     }
- 
+
     return false;
 }
 
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::AddElementsToTreeItem
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets used to represent the file tree.
 //
 // Arguments:
@@ -3618,7 +3619,10 @@ FileTree::FileTreeNode::HasNodeNameExceeding(int len) const
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg as suggested in Qt docs.
+//
 // ****************************************************************************
 
 void
@@ -3659,7 +3663,7 @@ FileTree::FileTreeNode::AddElementsToTreeItem(QTreeWidgetItem *item,
             // Add a directory node.
             QString temp;
             if(nodeName == fileName.path && nodeName[0] != separator)
-                temp.asprintf("%c%s", separator, nodeName.c_str());
+                temp = QString("%1%2").arg(separator).arg(nodeName.c_str());
             else
                 temp = QString(nodeName.c_str());
             root = new QvisFilePanelItem(item, temp, fileName,
@@ -3677,13 +3681,13 @@ FileTree::FileTreeNode::AddElementsToTreeItem(QTreeWidgetItem *item,
                                                folderPixmap, databasePixmap,
                                                filePanel);
         }
-    }        
+    }
 }
 
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::AddElementsToTree
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets used to represent the file tree.
 //
 // Arguments:
@@ -3706,7 +3710,7 @@ FileTree::FileTreeNode::AddElementsToTreeItem(QTreeWidgetItem *item,
 //
 //   Cyrus Harrison, Tue Jul  1 16:04:25 PDT 2008
 //   Initial Qt4 Port.
-// 
+//
 // ****************************************************************************
 
 void
@@ -3755,7 +3759,7 @@ FileTree::FileTreeNode::AddElementsToTree(QTreeWidget *tree,
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::NumberedFilename
 //
-// Purpose: 
+// Purpose:
 //   Creates a string that contains the file index and the filename.
 //
 // Arguments:
@@ -3767,7 +3771,9 @@ FileTree::FileTreeNode::AddElementsToTree(QTreeWidget *tree,
 // Creation:   Thu Mar 22 17:04:48 PST 2001
 //
 // Modifications:
-//   
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg as suggested in Qt docs.
+//
 // ****************************************************************************
 
 QString
@@ -3775,11 +3781,11 @@ FileTree::FileTreeNode::NumberedFilename(int fileIndex) const
 {
     QString label;
     if(fileIndex < 10)
-        label.asprintf("  %d: %s", fileIndex, nodeName.c_str());
+        label = QString("  %1: %2").arg(fileIndex).arg(nodeName.c_str());
     else if(fileIndex < 100)
-        label.asprintf(" %d: %s", fileIndex, nodeName.c_str());
+        label = QString(" %1: %2").arg(fileIndex).arg(nodeName.c_str());
     else
-        label.asprintf("%d: %s", fileIndex, nodeName.c_str());
+        label = QString("%1: %2").arg(fileIndex).arg(nodeName.c_str());
 
     return label;
 }
@@ -3787,7 +3793,7 @@ FileTree::FileTreeNode::NumberedFilename(int fileIndex) const
 // ****************************************************************************
 // Method: FileTree::FileTreeNode::Print
 //
-// Purpose: 
+// Purpose:
 //   Prints the node to a stream.
 //
 // Arguments:
@@ -3798,7 +3804,7 @@ FileTree::FileTreeNode::NumberedFilename(int fileIndex) const
 // Creation:   Thu Jul 29 10:08:58 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisFileWindowBase.C
+++ b/src/gui/QvisFileWindowBase.C
@@ -49,13 +49,13 @@ using std::string;
 //   Delegate for QListWidget that draws the icon in the right place for
 //   virtual databases.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 15 11:53:30 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 class VirtualDBDelegate : public QItemDelegate
@@ -71,8 +71,8 @@ public:
 
 protected:
     virtual void drawDecoration(
-        QPainter *painter, 
-        const QStyleOptionViewItem &option, 
+        QPainter *painter,
+        const QStyleOptionViewItem &option,
         const QRect &rect,
         const QPixmap &pixmap) const
     {
@@ -95,14 +95,14 @@ protected:
 // ****************************************************************************
 // Method: QvisFileWindowBase::QvisFileWindowBase
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 15 12:05:08 PDT 2008
@@ -111,7 +111,7 @@ protected:
 //
 //   Tom Fogal, Sun Jan 24 16:54:13 MST 2010
 //   Apply patch from Andreas Kloeckner to set appropriate window role.
-//   
+//
 // ****************************************************************************
 
 QvisFileWindowBase::QvisFileWindowBase(const QString &winCaption) :
@@ -152,14 +152,14 @@ QvisFileWindowBase::QvisFileWindowBase(const QString &winCaption) :
 // ****************************************************************************
 // Method: QvisFileWindowBase::~QvisFileWindowBase
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 15 12:05:22 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisFileWindowBase::~QvisFileWindowBase()
@@ -177,7 +177,7 @@ QvisFileWindowBase::~QvisFileWindowBase()
 // ****************************************************************************
 // Method: QvisFileWindowBase::SubjectRemoved
 //
-// Purpose: 
+// Purpose:
 //   Called when observed subjects are deleted so they can be removed from
 //   observation.
 //
@@ -188,7 +188,7 @@ QvisFileWindowBase::~QvisFileWindowBase()
 // Creation:   Tue Jul 15 12:05:36 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -203,7 +203,7 @@ QvisFileWindowBase::SubjectRemoved(Subject *TheRemovedSubject)
 // ****************************************************************************
 // Method: QvisFileWindowBase::ConnectSubjects
 //
-// Purpose: 
+// Purpose:
 //   Connect subjects for observation.
 //
 // Arguments:
@@ -213,7 +213,7 @@ QvisFileWindowBase::SubjectRemoved(Subject *TheRemovedSubject)
 // Creation:   Tue Jul 15 12:06:25 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -229,7 +229,7 @@ QvisFileWindowBase::ConnectSubjects(HostProfileList *hpl)
 // ****************************************************************************
 // Method: QvisFileWindowBase::GetDirectoryStrings
 //
-// Purpose: 
+// Purpose:
 //   Creates the current directory and up directory strings based on the
 //   current host.
 //
@@ -257,13 +257,13 @@ QvisFileWindowBase::GetDirectoryStrings(QString &curDir, QString &upDir)
 // ****************************************************************************
 // Method: QvisFileWindowBase::ProgressCallback
 //
-// Purpose: 
+// Purpose:
 //   This is a progress callback function for the FileServerList class and
 //   eventually RemoteProcess. It is called when we have to connect to a new
 //   mdserver. It prevents the user from changing anything in the window plus
 //   the window is modal so the rest of the GUI cannot be changed.
 //
-// Arguments:  
+// Arguments:
 //   data  : A void pointer to the file selection window.
 //   stage : The stage of the process launch.
 //
@@ -321,7 +321,7 @@ QvisFileWindowBase::ProgressCallback(void *data, int stage)
 // ****************************************************************************
 // Method: QvisFileWindowBase::UpdateComboBox
 //
-// Purpose: 
+// Purpose:
 //   Populates the specified combo box with the appropriate entries.
 //
 // Arguments:
@@ -373,15 +373,15 @@ QvisFileWindowBase::UpdateComboBox(QComboBox *cb, const stringVector &s,
 // ****************************************************************************
 // Method: QvisFileWindowBase::CreateHostPathFilterControls
 //
-// Purpose: 
-//   Creates the top portion of the file selection window (host,path,filter) 
+// Purpose:
+//   Creates the top portion of the file selection window (host,path,filter)
 //   and some other controls.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 15 12:07:15 PDT 2008
@@ -437,7 +437,7 @@ QvisFileWindowBase::CreateHostPathFilterControls()
     QHBoxLayout *pathLayout2 = new QHBoxLayout;
     pathLayout2->setSpacing(5);
     pathLayout2->setMargin(0);
-    
+
     QLabel *pathLabel = new QLabel(tr("Path"), central);
     QLabel *pathImageLabel = new QLabel(central);
     pathImageLabel->setPixmap(*folderPixmap);
@@ -519,7 +519,7 @@ QvisFileWindowBase::CreateHostPathFilterControls()
 // ****************************************************************************
 // Method: QvisFileWindowBase::CreateListWidget
 //
-// Purpose: 
+// Purpose:
 //   Creates a new list widget that uses a special delegate to aid in
 //   rendering.
 //
@@ -528,13 +528,13 @@ QvisFileWindowBase::CreateHostPathFilterControls()
 //
 // Returns:    A new QListWidget.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 15 11:58:07 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QListWidget *
@@ -548,14 +548,14 @@ QvisFileWindowBase::CreateFileListWidget(QWidget *parent) const
 // ****************************************************************************
 // method: QvisFileWindowBase::UpdateWindowFromFiles
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the window is notified by the
 //   FileServerList object that there is a new file list or there is
 //   a new path, filter, etc. This function is responsible for putting
 //   the new values into the window's widgets.
 //
 // Arguments:
-//   doAll : If this is true, ignore any partial selection on the 
+//   doAll : If this is true, ignore any partial selection on the
 //           FileServerList's attributes and update all the widgets in
 //           the window.
 //
@@ -661,7 +661,7 @@ QvisFileWindowBase::UpdateWindowFromFiles(bool doAll)
 // ****************************************************************************
 // Method: QvisFileWindowBase::UpdateHostComboBox
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the host profile list changes. The purpose is
 //   to add any new host names into the host combo box so they are easily
 //   accessible.
@@ -733,7 +733,7 @@ QvisFileWindowBase::UpdateHostComboBox()
 // ****************************************************************************
 // Method: QvisFileWindowBase::UpdateDirectoryList
 //
-// Purpose: 
+// Purpose:
 //   This method adds all of the directories in the FileServer's
 //   file list to the window's directory listbox.
 //
@@ -817,7 +817,7 @@ QvisFileWindowBase::UpdateDirectoryList()
 // ****************************************************************************
 // Method: QvisFileWindowBase::AddFileItem
 //
-// Purpose: 
+// Purpose:
 //   Adds a file item to a list widget. The file item is initialized from a
 //   qualified filename.
 //
@@ -826,15 +826,17 @@ QvisFileWindowBase::UpdateDirectoryList()
 //   displayName : The name to show for the item.
 //   fileInfo    : Information about the file that will ride along with the item.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jul 10 15:59:10 PDT 2008
 //
 // Modifications:
-//   
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg as suggested by Qt docs.
+//
 // ****************************************************************************
 
 void
@@ -857,8 +859,8 @@ QvisFileWindowBase::AddFileItem(QListWidget *parent, const QString &displayName,
         stringVector names(fileServer->GetVirtualFileDefinition(fileInfo));
         if(names.size() > (MAX_DISPLAYED_NAMES*2))
         {
-            QString nFilesString;
-            nFilesString.asprintf("(%d total files)", (int)names.size());
+            QString nFilesString =
+                QString("(%1 total files)").arg(names.size());
             itemText += QString("\n") + nFilesString;
 
             for(i = 0; i < MAX_DISPLAYED_NAMES; ++i)
@@ -884,7 +886,7 @@ QvisFileWindowBase::AddFileItem(QListWidget *parent, const QString &displayName,
 // ****************************************************************************
 // Method: QvisFileWindowBase::UpdateFileList
 //
-// Purpose: 
+// Purpose:
 //   This method gets the filtered file list from the file server and
 //   adds it to the list of files for the current directory.
 //
@@ -893,7 +895,7 @@ QvisFileWindowBase::AddFileItem(QListWidget *parent, const QString &displayName,
 //
 // Modifications:
 //   Brad Whitlock, Wed Oct 4 16:39:13 PST 2000
-//   I rewrote the code since the file filtering now happens in the 
+//   I rewrote the code since the file filtering now happens in the
 //   file server.
 //
 //   Brad Whitlock, Thu May 9 17:08:17 PST 2002
@@ -925,7 +927,7 @@ QvisFileWindowBase::UpdateFileList()
 // ****************************************************************************
 // Method: QvisFileWindowBase::RemoveComboBoxItem
 //
-// Purpose: 
+// Purpose:
 //   Removes an item from a combo box and makes another item active.
 //
 // Arguments:
@@ -958,7 +960,7 @@ QvisFileWindowBase::RemoveComboBoxItem(QComboBox *cb,
 // ****************************************************************************
 // Method: QvisFileWindowBase::ActivateComboBoxItem
 //
-// Purpose: 
+// Purpose:
 //   Makes an entry in the combo box active.
 //
 // Arguments:
@@ -991,7 +993,7 @@ QvisFileWindowBase::ActivateComboBoxItem(QComboBox *cb,
 // ****************************************************************************
 // Method: QvisFileWindowBase::HighlightComboBox
 //
-// Purpose: 
+// Purpose:
 //   Highlights the combo box by selecting its text and giving it focus.
 //
 // Arguments:
@@ -1001,7 +1003,7 @@ QvisFileWindowBase::ActivateComboBoxItem(QComboBox *cb,
 // Creation:   Wed Sep 11 17:45:50 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1016,17 +1018,17 @@ QvisFileWindowBase::HighlightComboBox(QComboBox *cb)
 // ****************************************************************************
 // Method: QvisFileWindowBase::AddFile
 //
-// Purpose: 
+// Purpose:
 //   Adds a filename to the intermediate selected file list if
 //   the filename is not already in the list.
 //
 // Arguments:
 //   newFile : The file to add to the intermediate file list.
 //
-// Returns:    
+// Returns:
 //   true is the file had to be added, false otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Aug 29 13:53:06 PST 2000
@@ -1062,7 +1064,7 @@ QvisFileWindowBase::AddFile(const QualifiedFilename &newFile)
 // ****************************************************************************
 // Method: QvisFileWindowBase::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values for the host, path, and filter and applies the
 //   ones that have changed.
 //
@@ -1120,7 +1122,7 @@ QvisFileWindowBase::GetCurrentValues(bool allowPathChange)
 // ****************************************************************************
 // Method: QvisFileWindowBase::ChangeHosts
 //
-// Purpose: 
+// Purpose:
 //   This method is called to change hosts.
 //
 // Returns:    true is there was an error.
@@ -1280,7 +1282,7 @@ QvisFileWindowBase::ChangeHosts()
 // ****************************************************************************
 // Method: QvisFileWindowBase::ChangePath
 //
-// Purpose: 
+// Purpose:
 //   This method is called to change the path.
 //
 // Arguments:
@@ -1396,7 +1398,7 @@ QvisFileWindowBase::ChangePath(bool allowPathChange)
 // ****************************************************************************
 // Method: QvisFileSelectionWindow::ChangeFilter
 //
-// Purpose: 
+// Purpose:
 //   This method is called to change filters.
 //
 // Returns:    true is there was an error.
@@ -1491,7 +1493,7 @@ QvisFileWindowBase::ChangeFilter()
 // ****************************************************************************
 // Method: QvisFileWindowBase::GetVirtualDatabaseDefinitions
 //
-// Purpose: 
+// Purpose:
 //   Populates a map with virtual database definitions.
 //
 // Arguments:
@@ -1501,7 +1503,7 @@ QvisFileWindowBase::ChangeFilter()
 // Creation:   Tue Jul 27 11:52:16 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1516,7 +1518,7 @@ QvisFileWindowBase::GetVirtualDatabaseDefinitions(
     {
         if(files[i].IsVirtual())
         {
-            defs[files[i].FullName()] = 
+            defs[files[i].FullName()] =
                 fileServer->GetVirtualFileDefinition(files[i].FullName());
         }
     }
@@ -1525,20 +1527,20 @@ QvisFileWindowBase::GetVirtualDatabaseDefinitions(
 // ****************************************************************************
 // Method: QvisFileWindowBase::CheckForNewStates
 //
-// Purpose: 
+// Purpose:
 //   Checks open virtual databases for new states.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Jul 15 12:07:55 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1560,7 +1562,7 @@ QvisFileWindowBase::CheckForNewStates()
         if(intermediateFileList[i].IsVirtual())
         {
             std::string fileName(intermediateFileList[i].FullName());
-            StringStringVectorMap::const_iterator oldDef = 
+            StringStringVectorMap::const_iterator oldDef =
                 currentVirtualDatabaseDefinitions.find(fileName);
             StringStringVectorMap::const_iterator newDef =
                 newDefinitions.find(fileName);
@@ -1608,7 +1610,7 @@ QvisFileWindowBase::CheckForNewStates()
 // ****************************************************************************
 // Method: QvisFileWindowBase::filterChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the contents of
 //   filter text field change.
 //
@@ -1630,7 +1632,7 @@ QvisFileWindowBase::filterChanged()
 // ****************************************************************************
 // Method: QvisFileWindowBase::hostChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the contents of
 //   the host text field change. This tells the FileServerList to
 //   switch MetaData servers.
@@ -1654,7 +1656,7 @@ QvisFileWindowBase::hostChanged(int)
 // ****************************************************************************
 // Method: QvisFileWindowBase::pathChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the contents of
 //   the path text field change.
 //
@@ -1663,7 +1665,7 @@ QvisFileWindowBase::hostChanged(int)
 //
 // Modifications:
 //   Brad Whitlock, Wed Aug 30 15:56:45 PST 2000
-//   Caught some exceptions that are now propagated from the 
+//   Caught some exceptions that are now propagated from the
 //   FileServerList's Notify method. When I catch them, I display
 //   an error message.
 //
@@ -1687,7 +1689,7 @@ QvisFileWindowBase::pathChanged(int)
 // ****************************************************************************
 // Method: QvisFileWindowBase::changeDirectory
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when an item in the
 //   directory menu is double clicked.
 //
@@ -1729,7 +1731,7 @@ QvisFileWindowBase::pathChanged(int)
 // ****************************************************************************
 
 void
-QvisFileWindowBase::changeDirectory(QListWidgetItem *item) 
+QvisFileWindowBase::changeDirectory(QListWidgetItem *item)
 {
     // make sure current item is not null
     if(!item)
@@ -1761,7 +1763,7 @@ QvisFileWindowBase::changeDirectory(QListWidgetItem *item)
                     if(curPath[1] == ':')
                         newPath = "My Computer";
                 }
-                else 
+                else
                 {
                     size_t separatorPos = newPath.rfind(separator);
                     // If the last character is a slash, remove it.
@@ -1834,7 +1836,7 @@ QvisFileWindowBase::changeDirectory(QListWidgetItem *item)
 // ****************************************************************************
 // Method: QvisFileWindowBase::refreshFiles
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that refreshes the list of files in the
 //   current directory.
 //
@@ -1864,7 +1866,7 @@ QvisFileWindowBase::refreshFiles()
 // ****************************************************************************
 // Method: QvisFileWindowBase::currentDir
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the "UseCurrentDirectory" flag
 //   in the file server.
 //
@@ -1875,7 +1877,7 @@ QvisFileWindowBase::refreshFiles()
 // Creation:   Fri Jul 26 14:04:21 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1887,7 +1889,7 @@ QvisFileWindowBase::currentDir(bool val)
 // ****************************************************************************
 // Method: QvisFileWindowBase::showDotFiles
 //
-// Purpose: 
+// Purpose:
 //   Set the new state for the show dot files check box.
 //
 // Arguments:
@@ -1897,7 +1899,7 @@ QvisFileWindowBase::currentDir(bool val)
 // Creation:   Wed Sep 12 15:33:59 PDT 2012
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1910,7 +1912,7 @@ QvisFileWindowBase::showDotFiles(bool val)
 // ****************************************************************************
 // Method: QvisFileWindowBase::fileGroupingChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the AutomaticFileGrouping flag in
 //   the file server and updates the file list.
 //
@@ -1951,14 +1953,14 @@ QvisFileWindowBase::fileGroupingChanged(int val)
 // ****************************************************************************
 // Method: QvisFileWindowBase::showMinimized
 //
-// Purpose: 
+// Purpose:
 //   Iconifies the window.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 10 16:50:12 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1972,14 +1974,14 @@ QvisFileWindowBase::showMinimized()
 // ****************************************************************************
 // Method: QvisFileWindowBase::showNormal
 //
-// Purpose: 
+// Purpose:
 //   De-iconifies the window.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 10 16:50:12 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1996,7 +1998,7 @@ QvisFileWindowBase::showNormal()
 // ****************************************************************************
 // Method: QvisFileWindowBase::closeEvent
 //
-// Purpose: 
+// Purpose:
 //   Closes the window and also makes sure that the recentPathRemoval window
 //   gets closed if it is open.
 //
@@ -2009,7 +2011,7 @@ QvisFileWindowBase::showNormal()
 // Note: Taken largely from QvisFileSelectWindow
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2017,7 +2019,7 @@ QvisFileWindowBase::closeEvent(QCloseEvent *e)
 {
     if(recentPathsRemovalWindow && recentPathsRemovalWindow->isVisible())
         recentPathsRemovalWindow->hide();
-    
+
     QvisDelayedWindowSimpleObserver::closeEvent(e);
 }
 
@@ -2028,7 +2030,7 @@ QvisFileWindowBase::closeEvent(QCloseEvent *e)
 // ****************************************************************************
 // Method: EncodeQualifiedFilename
 //
-// Purpose: 
+// Purpose:
 //   Encodes QualifiedFilename into a QVariant that we can store in the
 //   QListWidgetItem's user data.
 //
@@ -2037,13 +2039,13 @@ QvisFileWindowBase::closeEvent(QCloseEvent *e)
 //
 // Returns:    A QVariant representation of the filename.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jul 10 15:57:11 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QVariant
@@ -2061,7 +2063,7 @@ EncodeQualifiedFilename(const QualifiedFilename &filename)
 // ****************************************************************************
 // Method: DecodeQualifiedFilename
 //
-// Purpose: 
+// Purpose:
 //   Decodes a QVariant into a QualifiedFilename.
 //
 // Arguments:
@@ -2069,13 +2071,13 @@ EncodeQualifiedFilename(const QualifiedFilename &filename)
 //
 // Returns:    A QualifiedFilename initialized from the QVariant data.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jul 10 15:57:58 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QualifiedFilename
@@ -2098,20 +2100,20 @@ DecodeQualifiedFilename(const QVariant &v)
 // ****************************************************************************
 // Method: QvisFileWindowBase::SetHideOptions
 //
-// Purpose: 
+// Purpose:
 //   If true, will tell the window to hide fields not needed by the Session
 //   dialog.
 //
 // Arguments:
 //   value : true or false to show or hide fields.
 //
-// Returns:    
+// Returns:
 //
 // Programmer: David Camp
 // Creation:   Thu Aug 27 09:40:00 PDT 2015
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -4585,6 +4585,9 @@ QvisGUIApplication::SaveSession()
 //   Kathleen Biagas, Thu May 18, 2018
 //   Support UNC style paths on Windows.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg as suggested by Qt docs.
+//
 // ****************************************************************************
 
 void
@@ -4594,16 +4597,23 @@ QvisGUIApplication::SaveSessionAs()
     QString defaultFile;
     if(sessionHost.empty())
     {
-        defaultFile.asprintf("%svisit%04d.session", sessionDir.c_str(), sessionCount);
+        defaultFile = QString("%1visit%2.session")
+            .arg(sessionDir.c_str())
+            .arg(sessionCount,4,10,QLatin1Char('0'));
     }
     else
     {
 #ifdef WIN32
         if (sessionDir.substr(0,2) == "\\\\")
-            defaultFile.asprintf("%svisit%04d.session", sessionDir.c_str(), sessionCount);
+            defaultFile = QString("%1visit%2.session")
+                .arg(sessionDir.c_str())
+                .arg(sessionCount,4,10,QLatin1Char('0'));
         else
 #endif
-        defaultFile.asprintf("%s:%svisit%04d.session", sessionHost.c_str(), sessionDir.c_str(), sessionCount);
+        defaultFile = QString("%1:%2visit%3.session")
+                .arg(sessionHost.c_str())
+                .arg(sessionDir.c_str())
+                .arg(sessionCount,4,10,QLatin1Char('0'));
     }
 
     // Get the name of the file that the user saved.
@@ -7363,6 +7373,9 @@ QvisGUIApplication::HandleMetaDataUpdate()
 //   Hank Childs, Tue Aug 31 10:10:39 PDT 2010
 //   Move Rob's auto-add operator code to the viewer.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Remove unused var 'QString wName'.
+//
 // ****************************************************************************
 
 void
@@ -7378,7 +7391,6 @@ QvisGUIApplication::AddPlot(int plotType, const QString &varName)
     const avtDatabaseMetaData *md =
         fileServer->GetMetaData(qf, GetStateForSource(qf),
         !FileServerList::ANY_STATE, !FileServerList::GET_NEW_MD);
-    QString wName; wName.asprintf("plot_wizard_%d", plotType);
     QvisWizard *wiz = GUIInfo->CreatePluginWizard(
         GetViewerState()->GetPlotAttributes(plotType), mainWin, varName.toStdString(),
         md, GetViewerState()->GetExpressionList());
@@ -7452,6 +7464,9 @@ QvisGUIApplication::AddPlot(int plotType, const QString &varName)
 //   ViewerPlotList), we need to ensure that plots get  redrawn if auto update
 //   is enabled.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Remove unused var 'QString wName'.
+//
 // ****************************************************************************
 
 void
@@ -7463,7 +7478,6 @@ QvisGUIApplication::AddOperator(int operatorType)
         operatorPluginManager->GetEnabledID(operatorType));
 
     // Try and create a wizard for the desired operator type.
-    QString wName; wName.asprintf("operator_wizard_%d", operatorType);
     QvisWizard *wiz = GUIInfo->CreatePluginWizard(
         GetViewerState()->GetOperatorAttributes(operatorType), mainWin);
 
@@ -8338,6 +8352,10 @@ QvisGUIApplication::SaveMovie()
 //   Brad Whitlock, Wed Dec  8 11:38:05 PST 2010
 //   Add a stride for saving movies.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString::arg as suggested in Qt docs,
+//   and with setNum in the simpler cases.
+//
 // ****************************************************************************
 
 void
@@ -8417,10 +8435,13 @@ QvisGUIApplication::SaveMovieMain()
                 const char *stereoNames[] = {"off", "leftright",
                     "redblue", "redgreen"};
                 int si = (stereos[i] < 0 || stereos[i] > 3) ? 0 : stereos[i];
-                QString order;
-                order.asprintf("    movie.RequestFormat(\"%s\", %d, %d, \"%s\")\n",
-                    formats[i].c_str(), widths[i], heights[i],
-                    stereoNames[si]);
+                QString order =
+                    QString("    movie.RequestFormat(\"%1\", %2, %3 \"%4\")\n")
+                    .arg(formats[i].c_str())
+                    .arg(widths[i])
+                    .arg(heights[i])
+                    .arg(stereoNames[si]);
+
                 code += order;
             }
 
@@ -8456,22 +8477,21 @@ QvisGUIApplication::SaveMovieMain()
 
             // Add fps and start/end index
             QString tmp;
-            tmp.asprintf("%d", movieAtts->GetFps());
+            tmp.setNum(movieAtts->GetFps());
             code += "    movie.fps = " + tmp + "\n";
-
-            tmp.asprintf("%d", movieAtts->GetStartIndex());
+            tmp.setNum(movieAtts->GetStartIndex());
             code += "    movie.frameStart = " + tmp + "\n";
 
             if (movieAtts->GetEndIndex() != 1000000000)
             {
-                tmp.asprintf("%d", movieAtts->GetEndIndex());
+                tmp.setNum(movieAtts->GetEndIndex());
                 code += "    movie.frameEnd = " + tmp + "\n";
             }
 
-            tmp.asprintf("%d", movieAtts->GetStride());
+            tmp.setNum(movieAtts->GetStride());
             code += "    movie.frameStep = " + tmp + "\n";
 
-            tmp.asprintf("%d", movieAtts->GetInitialFrameValue());
+            tmp.setNum(movieAtts->GetInitialFrameValue());
             code += "    movie.initialFrameValue = " + tmp + "\n";
 
             // If we want e-mail notification, add that info here.

--- a/src/gui/QvisGlobalLineoutWindow.C
+++ b/src/gui/QvisGlobalLineoutWindow.C
@@ -19,7 +19,7 @@
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::QvisGlobalLineoutWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Programmer: xml2window
@@ -46,14 +46,14 @@ QvisGlobalLineoutWindow::QvisGlobalLineoutWindow(
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::~QvisGlobalLineoutWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: xml2window
 // Creation:   Fri Nov 19 10:46:23 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisGlobalLineoutWindow::~QvisGlobalLineoutWindow()
@@ -64,7 +64,7 @@ QvisGlobalLineoutWindow::~QvisGlobalLineoutWindow()
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: xml2window
@@ -74,15 +74,15 @@ QvisGlobalLineoutWindow::~QvisGlobalLineoutWindow()
 //   Brad Whitlock, Wed Dec 15 11:07:46 PDT 2004
 //   I ifdef'd some code so it builds with Qt versions older than 3.2.
 //
-//   Kathleen Bonnell, Thu Feb  3 15:51:06 PST 2005 
-//   Added curveOptions and colorOptions for Dynamic mode. 
+//   Kathleen Bonnell, Thu Feb  3 15:51:06 PST 2005
+//   Added curveOptions and colorOptions for Dynamic mode.
 //
 //   Kathleen Bonnell, Mon Feb 27 12:36:41 PST 2006
-//   Added more text to createWindow label, to clarify intent. 
-//   
-//   Kathleen Bonnell, Thu Nov  2 14:01:01 PST 2006 
+//   Added more text to createWindow label, to clarify intent.
+//
+//   Kathleen Bonnell, Thu Nov  2 14:01:01 PST 2006
 //   Added freezInTime.
-//   
+//
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
 //
@@ -99,7 +99,7 @@ QvisGlobalLineoutWindow::CreateWindowContents()
     //
     // CreateWindow
     //
-    createWindow = new QCheckBox(tr("Use 1st unused window or create\nnew one. All  subsequent lineouts\nwill use this same window."), 
+    createWindow = new QCheckBox(tr("Use 1st unused window or create\nnew one. All  subsequent lineouts\nwill use this same window."),
                                   central);
     connect(createWindow, SIGNAL(toggled(bool)),
             this, SLOT(createWindowChanged(bool)));
@@ -123,7 +123,7 @@ QvisGlobalLineoutWindow::CreateWindowContents()
     mainLayout->addWidget(freezeInTime,2,0,1,2);
 
     //
-    // Dynamic 
+    // Dynamic
     //
     dynamic = new QGroupBox(tr("Synchronize with originating plot"),central);
     dynamic->setCheckable(true);
@@ -177,8 +177,8 @@ QvisGlobalLineoutWindow::CreateWindowContents()
     QGridLayout *qgrid = new QGridLayout();
     blayout->addLayout(qgrid);
     qgrid->setMargin(5);
-    
-    QLabel *msg = new QLabel(gbox); 
+
+    QLabel *msg = new QLabel(gbox);
     msg->setText(tr("These items can be overridden\nby the Lineout operator"));
     msg->setAlignment(Qt::AlignCenter);
     qgrid->addWidget(msg, 0,0,1,2);
@@ -217,17 +217,17 @@ QvisGlobalLineoutWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets in the window when the subject changes.
 //
 // Programmer: xml2window
 // Creation:   Fri Nov 19 10:46:23 PDT 2004
 //
 // Modifications:
-//   Kathleen Bonnell, Thu Feb  3 15:51:06 PST 2005 
-//   Added curveOptions and colorOptions for Dynamic mode. 
+//   Kathleen Bonnell, Thu Feb  3 15:51:06 PST 2005
+//   Added curveOptions and colorOptions for Dynamic mode.
 //
-//   Kathleen Bonnell, Thu Nov  2 14:01:01 PST 2006 
+//   Kathleen Bonnell, Thu Nov  2 14:01:01 PST 2006
 //   Added freezInTime.
 //
 //   Brad Whitlock, Fri Dec 14 17:22:35 PST 2007
@@ -235,6 +235,9 @@ QvisGlobalLineoutWindow::CreateWindowContents()
 //
 //   Cyrus Harrison, Wed Jun 11 13:19:35 PDT 2008
 //   Initial Qt4 Port.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with simpler QString::setNum.
 //
 // ****************************************************************************
 
@@ -258,14 +261,14 @@ QvisGlobalLineoutWindow::UpdateWindow(bool doAll)
             dynamic->setChecked(atts->GetDynamic());
             if (atts->GetDynamic())
             {
-                freezeInTime->setChecked(false); 
+                freezeInTime->setChecked(false);
             }
-            freezeInTime->setEnabled(!atts->GetDynamic()); 
+            freezeInTime->setEnabled(!atts->GetDynamic());
             curveOptions->setEnabled(atts->GetDynamic()) ;
             curveLabel->setEnabled(atts->GetDynamic()) ;
-            colorOptions->setEnabled(atts->GetDynamic() && 
+            colorOptions->setEnabled(atts->GetDynamic() &&
                 atts->GetCurveOption() == GlobalLineoutAttributes::CreateCurve);
-            colorLabel->setEnabled(atts->GetDynamic() && 
+            colorLabel->setEnabled(atts->GetDynamic() &&
                 atts->GetCurveOption() == GlobalLineoutAttributes::CreateCurve);
             break;
           case GlobalLineoutAttributes::ID_createWindow:
@@ -282,7 +285,7 @@ QvisGlobalLineoutWindow::UpdateWindow(bool doAll)
             createWindow->setChecked(atts->GetCreateWindow());
             break;
           case GlobalLineoutAttributes::ID_windowId:
-            temp.asprintf("%d", atts->GetWindowId());
+            temp.setNum(atts->GetWindowId());
             windowId->setText(temp);
             break;
           case GlobalLineoutAttributes::ID_samplingOn:
@@ -299,7 +302,7 @@ QvisGlobalLineoutWindow::UpdateWindow(bool doAll)
             samplingOn->setChecked(atts->GetSamplingOn());
             break;
           case GlobalLineoutAttributes::ID_numSamples:
-            temp.asprintf("%d", atts->GetNumSamples());
+            temp.setNum(atts->GetNumSamples());
             numSamples->setText(temp);
             break;
           case GlobalLineoutAttributes::ID_createReflineLabels:
@@ -309,9 +312,9 @@ QvisGlobalLineoutWindow::UpdateWindow(bool doAll)
             curveOptions->setCurrentIndex(atts->GetCurveOption());
             curveOptions->setEnabled(atts->GetDynamic()) ;
             curveLabel->setEnabled(atts->GetDynamic()) ;
-            colorOptions->setEnabled(atts->GetDynamic() && 
+            colorOptions->setEnabled(atts->GetDynamic() &&
                 atts->GetCurveOption() == GlobalLineoutAttributes::CreateCurve);
-            colorLabel->setEnabled(atts->GetDynamic() && 
+            colorLabel->setEnabled(atts->GetDynamic() &&
                 atts->GetCurveOption() == GlobalLineoutAttributes::CreateCurve);
             break;
           case GlobalLineoutAttributes::ID_colorOption:
@@ -331,7 +334,7 @@ QvisGlobalLineoutWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets values from certain widgets and stores them in the subject.
 //
 // Programmer: xml2window
@@ -340,7 +343,7 @@ QvisGlobalLineoutWindow::UpdateWindow(bool doAll)
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 // ****************************************************************************
 
 void
@@ -421,14 +424,14 @@ QvisGlobalLineoutWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Called to apply changes in the subject.
 //
 // Programmer: xml2window
 // Creation:   Fri Nov 19 10:46:23 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -454,14 +457,14 @@ QvisGlobalLineoutWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisGlobalLineoutWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when apply button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Fri Nov 19 10:46:23 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisHelpWindow.C
+++ b/src/gui/QvisHelpWindow.C
@@ -43,7 +43,7 @@
 // ****************************************************************************
 // Method: QvisHelpWindow::QvisHelpWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisHelpWindow class.
 //
 // Arguments:
@@ -76,8 +76,8 @@ QvisHelpWindow::QvisHelpWindow(const QString &captionString) :
     // Set the help path from an environment variable.
     helpPath = QString(GetVisItResourcesDirectory(VISIT_RESOURCES_HELP).c_str());
 
-    // Create a path to locate the manual from the helpPath. 
-    manualPath = QString("manual") + QString(VISIT_SLASH_STRING) + 
+    // Create a path to locate the manual from the helpPath.
+    manualPath = QString("manual") + QString(VISIT_SLASH_STRING) +
         QString("index.html");
 
     firstShow = true;
@@ -87,14 +87,14 @@ QvisHelpWindow::QvisHelpWindow(const QString &captionString) :
 // ****************************************************************************
 // Method: QvisHelpWindow::~QvisHelpWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisHelpWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Jul 12 12:57:38 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisHelpWindow::~QvisHelpWindow()
@@ -104,21 +104,21 @@ QvisHelpWindow::~QvisHelpWindow()
 // ****************************************************************************
 // Method: QvisHelpWindow::SetLocale
 //
-// Purpose: 
+// Purpose:
 //   Set the locale to be used when searching for help files.
 //
 // Arguments:
 //   s : The locale to use.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Apr 21 15:25:26 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -130,7 +130,7 @@ QvisHelpWindow::SetLocale(const QString &s)
 // ****************************************************************************
 // Method: QvisHelpWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the help window.
 //
 // Programmer: Brad Whitlock
@@ -251,19 +251,19 @@ QvisHelpWindow::CreateWindowContents()
     connect(helpBrowser, SIGNAL(anchorClicked(const QUrl &)),
             this, SLOT(anchorClicked(const QUrl &)));
 
-    QAction *backAction = tb->addAction(QIcon(backIcon), tr("Back"), 
+    QAction *backAction = tb->addAction(QIcon(backIcon), tr("Back"),
         helpBrowser, SLOT(backward()));
     backAction->setShortcut(QKeySequence(Qt::Key_Control, Qt::Key_Left));
     connect(helpBrowser, SIGNAL(backwardAvailable(bool)),
             backAction, SLOT(setEnabled(bool)));
 
-    QAction *forwardAction = tb->addAction(QIcon(forwardIcon), tr("Forward"), 
+    QAction *forwardAction = tb->addAction(QIcon(forwardIcon), tr("Forward"),
         helpBrowser, SLOT(forward()));
     forwardAction->setShortcut(QKeySequence(Qt::Key_Control, Qt::Key_Right));
     connect(helpBrowser, SIGNAL(forwardAvailable(bool)),
             forwardAction, SLOT(setEnabled(bool)));
 
-    QAction *homeAction = tb->addAction(QIcon(homeIcon), tr("Home"), 
+    QAction *homeAction = tb->addAction(QIcon(homeIcon), tr("Home"),
         helpBrowser, SLOT(home()));
     homeAction->setShortcut(QKeySequence(Qt::Key_Control, Qt::Key_Home));
 
@@ -298,18 +298,18 @@ QvisHelpWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisHelpWindow::ReleaseNotesFile
 //
-// Purpose: 
+// Purpose:
 //   Returns the name of the release notes file.
 //
 // Returns:    The name of the release notes file.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Apr 21 15:05:10 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QString
@@ -325,7 +325,7 @@ QvisHelpWindow::ReleaseNotesFile() const
 // ****************************************************************************
 // Method: QvisHelpWindow::LoadHelp
 //
-// Purpose: 
+// Purpose:
 //   Loads the help index file and populates the help widgets with information
 //   from the index file.
 //
@@ -363,7 +363,7 @@ QvisHelpWindow::ReleaseNotesFile() const
 //   Brad Whitlock, Thu Jun 19 16:39:30 PDT 2008
 //   Qt 4.
 //
-//   Kathleen Bonnell, Sat Aug 28 13:17:45 MST 2010 
+//   Kathleen Bonnell, Sat Aug 28 13:17:45 MST 2010
 //   Added ultrawrapper document.
 //
 //   Alister Maguire, Wed Nov  6 08:11:16 PST 2019
@@ -440,7 +440,7 @@ QvisHelpWindow::LoadHelp(const QString &fileName)
 // ****************************************************************************
 // Method: QvisHelpWindow::BuildContents
 //
-// Purpose: 
+// Purpose:
 //   Scans through the contents of the XML tree and populates the contents
 //   tab and the index.
 //
@@ -474,7 +474,7 @@ QvisHelpWindow::BuildContents(QTreeWidgetItem *parentItem,
                 thisItem = new QTreeWidgetItem(helpContents);
             else
                 thisItem = new QTreeWidgetItem(parentItem);
-        
+
             thisItem->setText(0, node.toElement().attribute("topic"));
             thisItem->setData(0, Qt::UserRole, node.toElement().attribute("doc"));
 
@@ -498,7 +498,7 @@ QvisHelpWindow::BuildContents(QTreeWidgetItem *parentItem,
 // ****************************************************************************
 // Method: QvisHelpWindow::BuildIndex
 //
-// Purpose: 
+// Purpose:
 //   Populates the index list box.
 //
 // Programmer: Brad Whitlock
@@ -545,7 +545,7 @@ QvisHelpWindow::BuildIndex()
 // ****************************************************************************
 // Method: QvisHelpWindow::AddToIndex
 //
-// Purpose: 
+// Purpose:
 //   Adds a topic to the index.
 //
 // Arguments:
@@ -613,14 +613,14 @@ QvisHelpWindow::AddToIndex(const QString &topic, const QString &doc)
 // ****************************************************************************
 // Method: QvisHelpWindow::BuildBookmarks
 //
-// Purpose: 
+// Purpose:
 //   Adds all of the book marks to the bookmark widget.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Jul 12 13:24:22 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -644,7 +644,7 @@ QvisHelpWindow::BuildBookmarks()
 // ****************************************************************************
 // Method: QvisHelpWindow::CreateNode
 //
-// Purpose: 
+// Purpose:
 //   Writes the window's extra information to the config file.
 //
 // Arguments:
@@ -656,6 +656,9 @@ QvisHelpWindow::BuildBookmarks()
 // Modifications:
 //   Brad Whitlock, Thu Jun 19 15:20:40 PDT 2008
 //   Qt 4.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -678,8 +681,7 @@ QvisHelpWindow::CreateNode(DataNode *parentNode)
         for(it = bookmarks.begin(); it != bookmarks.end(); ++it, ++i)
         {
             // Create a node for the bookmark.
-            QString bmName;
-            bmName.asprintf("Bookmark%d", i);
+            QString bmName = QString("Bookmark%1").arg(i);
             DataNode *bmNode = new DataNode(bmName.toStdString());
 
             // Add the topic and the doc to the bookmark node.
@@ -694,7 +696,7 @@ QvisHelpWindow::CreateNode(DataNode *parentNode)
 // ****************************************************************************
 // Method: QvisHelpWindow::SetFromNode
 //
-// Purpose: 
+// Purpose:
 //   Reads window attributes from the DataNode representation of the config
 //   file.
 //
@@ -707,7 +709,10 @@ QvisHelpWindow::CreateNode(DataNode *parentNode)
 // Modifications:
 //   Brad Whitlock, Thu Jun 19 15:20:46 PDT 2008
 //   Qt 4.
-//  
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString::asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -731,8 +736,7 @@ QvisHelpWindow::SetFromNode(DataNode *parentNode, const int *borders)
     bool bmFound = false;
     do
     {
-        QString bmName;
-        bmName.asprintf("Bookmark%d", i);
+        QString bmName = QString("Bookmark%1").arg(i);
         DataNode *bmNode = winNode->GetNode(bmName.toStdString());
         bmFound = (bmNode != 0);
         if(bmFound)
@@ -758,7 +762,7 @@ QvisHelpWindow::SetFromNode(DataNode *parentNode, const int *borders)
 // ****************************************************************************
 // Method: QvisHelpWindow::TopicFromDoc
 //
-// Purpose: 
+// Purpose:
 //   Returns the topic name given the document name.
 //
 // Arguments:
@@ -796,7 +800,7 @@ QvisHelpWindow::TopicFromDoc(const QString &doc)
 // ****************************************************************************
 // Method: QvisHelpWindow::TopicFromDocHelper
 //
-// Purpose: 
+// Purpose:
 //   This is a helper function for TopicFromDoc that recursively searches
 //   the contents for the topic associated with the doc.
 //
@@ -842,7 +846,7 @@ QvisHelpWindow::TopicFromDocHelper(QString &str, const QString &doc,
 // ****************************************************************************
 // Method: QvisHelpWindow::completeFileName
 //
-// Purpose: 
+// Purpose:
 //   Prepends the help directory to the filename and returns the string.
 //
 // Arguments:
@@ -862,15 +866,15 @@ QvisHelpWindow::TopicFromDocHelper(QString &str, const QString &doc,
 QString
 QvisHelpWindow::CompleteFileName(const QString &page) const
 {
-    QString file(helpPath + QString(VISIT_SLASH_STRING) + 
-                 locale + QString(VISIT_SLASH_STRING) + 
+    QString file(helpPath + QString(VISIT_SLASH_STRING) +
+                 locale + QString(VISIT_SLASH_STRING) +
                  page);
     if(!QFile(file).exists())
     {
         // The page did not exist for the desired locale, revert to the
         // en_US page.
-        file = QString(helpPath + QString(VISIT_SLASH_STRING) + 
-                       QString("en_US") + QString(VISIT_SLASH_STRING) + 
+        file = QString(helpPath + QString(VISIT_SLASH_STRING) +
+                       QString("en_US") + QString(VISIT_SLASH_STRING) +
                        page);
     }
 
@@ -884,7 +888,7 @@ QvisHelpWindow::CompleteFileName(const QString &page) const
 // ****************************************************************************
 // Method: QvisHelpWindow::show
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that shows the window.
 //
 // Programmer: Brad Whitlock
@@ -939,7 +943,7 @@ QvisHelpWindow::show()
 // ****************************************************************************
 // Method: QvisHelpWindow::activeTabChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the active tab changes.
 //
 // Programmer: Brad Whitlock
@@ -984,7 +988,7 @@ QvisHelpWindow::activateBookmarkTab()
 // ****************************************************************************
 // Method: QvisHelpWindow::openHelp
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when an item in the contents
 //   listview is clicked. We display the page associated with the item.
 //
@@ -1074,7 +1078,7 @@ QvisHelpWindow::openHelp(const QString& entry)
                                                 query_nospaces, -1, Qt::MatchContains | Qt::MatchRecursive);
         words.pop_back();
     }
-        
+
     if(list.size() == 0)
     {
         displayTitle(entry + " help not found...");
@@ -1112,7 +1116,7 @@ QvisHelpWindow::openHelp(const QString& entry)
 // ****************************************************************************
 // Method: QvisHelpWindow::topicExpanded
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when an item in the contents
 //   listview is expanded. We display the page associated with the item and
 //   make sure the item gets selected.
@@ -1150,7 +1154,7 @@ QvisHelpWindow::topicExpanded(QTreeWidgetItem *item)
 // ****************************************************************************
 // Method: QvisHelpWindow::topicCollapsed
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when an item in the contents
 //   listview is collapsed. We display the page associated with the item and
 //   make sure the item gets selected.
@@ -1188,7 +1192,7 @@ QvisHelpWindow::topicCollapsed(QTreeWidgetItem *item)
 // ****************************************************************************
 // Method: QvisHelpWindow::displayNoHelp
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays a "not found" message.
 //
 // Programmer: Brad Whitlock
@@ -1197,14 +1201,14 @@ QvisHelpWindow::topicCollapsed(QTreeWidgetItem *item)
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 // ****************************************************************************
 
 void
 QvisHelpWindow::displayNoHelp()
 {
     QString html = QString("<html><body background=\"#ffffff\"><center><b><h1>") +
-                   tr("Help topic not found!") + 
+                   tr("Help topic not found!") +
                    QString("</h1></b></center></body></html>");
     helpBrowser->setText(html);
     helpFile = "none";
@@ -1213,7 +1217,7 @@ QvisHelpWindow::displayNoHelp()
 // ****************************************************************************
 // Method: QvisHelpWindow::displayTitle
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays a title.
 //
 // Arguments:
@@ -1225,14 +1229,14 @@ QvisHelpWindow::displayNoHelp()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 // ****************************************************************************
 
 void
 QvisHelpWindow::displayTitle(const QString &title)
 {
     QString html = QString("<html><body background=\"#ffffff\"><center><b><h1>") +
-                   title + 
+                   title +
                    QString("</h1></b></center></body></html>");
     helpBrowser->setText(html);
     helpFile = "none";
@@ -1241,7 +1245,7 @@ QvisHelpWindow::displayTitle(const QString &title)
 // ****************************************************************************
 // Method: QvisHelpWindow::displayCopyright
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays VisIt's copyright information.
 //
 // Programmer: Brad Whitlock
@@ -1268,7 +1272,7 @@ QvisHelpWindow::displayCopyright()
 // ****************************************************************************
 // Method: QvisHelpWindow::displayContributors
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays VisIt's contributors.
 //
 // Programmer: Brad Whitlock
@@ -1290,7 +1294,7 @@ QvisHelpWindow::displayContributors()
 // ****************************************************************************
 // Method: QvisHelpWindow::displayReleaseNotesHelper
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that display's VisIt's release notes for the
 //   current version of VisIt.
 //
@@ -1360,7 +1364,7 @@ QvisHelpWindow::displayReleaseNotesIfAvailable()
 // ****************************************************************************
 // Method: QvisHelpWindow::displayHome
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays the VisIt home page.
 //
 // Programmer: Brad Whitlock
@@ -1369,7 +1373,7 @@ QvisHelpWindow::displayReleaseNotesIfAvailable()
 // Modifications:
 //   Brad Whitlock, Thu Feb 17 12:11:49 PDT 2005
 //   Added code to synchronize the contents.
-//   
+//
 // ****************************************************************************
 
 void
@@ -1383,7 +1387,7 @@ QvisHelpWindow::displayHome()
 // ****************************************************************************
 // Method: QvisHelpWindow::displayPage
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays a help HTML page.
 //
 // Arguments:
@@ -1431,7 +1435,7 @@ QvisHelpWindow::displayPage(const QString &page, bool reload)
 // ****************************************************************************
 // Method: QvisHelpWindow::synchronizeContents
 //
-// Purpose: 
+// Purpose:
 //   Synchronizes the contents to the page being displayed.
 //
 // Arguments:
@@ -1479,7 +1483,7 @@ QvisHelpWindow::synchronizeContents(const QString &page)
 // ****************************************************************************
 // Method: QvisHelpWindow::increaseFontSize
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that increases the font size of the help page.
 //
 // Programmer: Brad Whitlock
@@ -1489,7 +1493,7 @@ QvisHelpWindow::synchronizeContents(const QString &page)
 //   Brad Whitlock, Tue Sep 10 16:29:49 PST 2002
 //   I added code to make the page redraw with the new font size.
 //
-//   Kathleen Bonnell, Wed Jun 27 12:42:47 PDT 2007 
+//   Kathleen Bonnell, Wed Jun 27 12:42:47 PDT 2007
 //   Removed Q_WS_WIN specific code.
 //
 //   Brad Whitlock, Thu Jun 19 15:09:21 PDT 2008
@@ -1508,7 +1512,7 @@ QvisHelpWindow::increaseFontSize()
 // ****************************************************************************
 // Method: QvisHelpWindow::decreaseFontSize
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that decreases the font size of the help page.
 //
 // Programmer: Brad Whitlock
@@ -1517,8 +1521,8 @@ QvisHelpWindow::increaseFontSize()
 // Modifications:
 //   Brad Whitlock, Tue Sep 10 16:29:49 PST 2002
 //   I added code to make the page redraw with the new font size.
-//   
-//   Kathleen Bonnell, Wed Jun 27 12:42:47 PDT 2007 
+//
+//   Kathleen Bonnell, Wed Jun 27 12:42:47 PDT 2007
 //   Removed Q_WS_WIN specific code.
 //
 //   Brad Whitlock, Thu Jun 19 15:09:33 PDT 2008
@@ -1541,7 +1545,7 @@ QvisHelpWindow::decreaseFontSize()
 // ****************************************************************************
 // Method: QvisHelpWindow::displayIndexTopic
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays the help topic when an item in
 //   the index list is clicked.
 //
@@ -1574,7 +1578,7 @@ QvisHelpWindow::displayIndexTopic()
 // ****************************************************************************
 // Method: QvisHelpWindow::lookForIndexTopic
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the user types into the
 //   index text field. The purpose is to try and match what the user types
 //   with a help document. If there is a match, we display the help page.
@@ -1637,7 +1641,7 @@ QvisHelpWindow::lookForIndexTopic(const QString &topic)
 // ****************************************************************************
 // Method: QvisHelpWindow::displayBookmarkTopic
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that displays a bookmarked topic.
 //
 // Programmer: Brad Whitlock
@@ -1669,7 +1673,7 @@ QvisHelpWindow::displayBookmarkTopic()
 // ****************************************************************************
 // Method: QvisHelpWindow::addBookmark
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that adds a bookmark to the bookmark list.
 //
 // Programmer: Brad Whitlock
@@ -1678,7 +1682,7 @@ QvisHelpWindow::displayBookmarkTopic()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Brad Whitlock, Thu Jun 19 15:30:47 PDT 2008
 //   Qt 4.
 //
@@ -1689,7 +1693,7 @@ QvisHelpWindow::addBookmark()
 {
     if(!helpFile.isEmpty() && helpFile != "none")
     {
-        // Search through the help contents for the topic that matches the 
+        // Search through the help contents for the topic that matches the
         // active page.
         QString helpTopic = TopicFromDoc(helpFile);
         if(!helpTopic.isEmpty())
@@ -1724,7 +1728,7 @@ QvisHelpWindow::addBookmark()
 // ****************************************************************************
 // Method: QvisHelpWindow::removeBookmark
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that removes the currently selected bookmark.
 //
 // Programmer: Brad Whitlock
@@ -1768,22 +1772,22 @@ QvisHelpWindow::removeBookmark()
 // ****************************************************************************
 // Method: QvisHelpWindow::anchorClicked
 //
-// Purpose: 
+// Purpose:
 //   Set the source of the help browser when a link is clicked. For external
 //   links, we open the user's default web browser.
 //
 // Arguments:
 //   link : The link that was clicked.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Aug 31 10:31:35 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisHostProfileWindow.C
+++ b/src/gui/QvisHostProfileWindow.C
@@ -58,7 +58,7 @@
 // ****************************************************************************
 // Method: QvisHostProfileWindow::QvisHostProfileWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisHostProfileWindow class.
 //
 // Arguments:
@@ -107,11 +107,11 @@ QvisHostProfileWindow::QvisHostProfileWindow(HostProfileList *profiles,
 // ****************************************************************************
 // Method: QvisHostProfileWindow::~QvisHostProfileWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisHostProfileWindow class.
 //
-// Programmer: 
-// Creation:   
+// Programmer:
+// Creation:
 //
 // Modifications:
 //
@@ -324,7 +324,7 @@ QvisHostProfileWindow::ListWidgetDropEvent(QDropEvent *event)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the window's widgets and hooks up the slot
 //   methods.
 //
@@ -878,7 +878,7 @@ QvisHostProfileWindow::CreateMachineSettingsGroup()
     cLayout->addWidget(chnParseFromSSHClient, cRow, 1, 1, 3);
     cRow++;
     cLayout->addWidget(chnSpecifyManually, cRow, 1, 1, 1);
-    
+
     clientHostName = new QLineEdit(connectionGroup);
     connect(clientHostName, SIGNAL(textChanged(const QString &)),
             this, SLOT(clientHostNameChanged(const QString &)));
@@ -1029,7 +1029,7 @@ QvisHostProfileWindow::CreateBasicSettingsGroup()
     tmpLayout->addLayout(layout);
     layout->setSpacing(7);
     tmpLayout->addStretch(5);
-    
+
     profileName = new QLineEdit(currentGroup);
     connect(profileName, SIGNAL(textChanged(const QString&)),
             this, SLOT(processProfileNameText(const QString&)));
@@ -1075,7 +1075,7 @@ QvisHostProfileWindow::CreateBasicSettingsGroup()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::CreateParallelSettingsGroup
 //
-// Purpose: 
+// Purpose:
 //   Create the parallel options together on this tab.
 //
 // Returns:    The widget that contains the parallel options.
@@ -1084,7 +1084,7 @@ QvisHostProfileWindow::CreateBasicSettingsGroup()
 // Creation:   Thu Oct  6 11:59:12 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QWidget *
@@ -1161,7 +1161,7 @@ QvisHostProfileWindow::CreateLaunchSettingsGroup()
     layout->setMargin(0);
     layout->setSpacing(HOST_PROFILE_SPACING+2);
     tmpLayout->addStretch(5);
-    
+
     launchMethod = new QComboBox(currentGroup);
     launchMethod->addItem(tr("(default)"));
     launchMethod->addItem("aprun");
@@ -1243,7 +1243,7 @@ QvisHostProfileWindow::CreateLaunchSettingsGroup()
     numNodes->setKeyboardTracking(false);
     numNodes->setRange(1,999999);
     numNodes->setSingleStep(1);
-    
+
     connect(numNodes, SIGNAL(valueChanged(int)),
             this, SLOT(numNodesChanged(int)));
     numNodesCheckBox = new QCheckBox(tr("Number of nodes"), defaultGroup);
@@ -1449,7 +1449,7 @@ QvisHostProfileWindow::CreateHWAccelSettingsGroup()
     layout->setMargin(5);
 
     QString str1(
-       QString("<i>") + 
+       QString("<i>") +
        tr("These options are for hardware accelerating the scalable rendering "
           "feature on a compute cluster. In other modes, VisIt will automatically "
           "use hardware acceleration. This tab only needs to be modified for "
@@ -1518,7 +1518,7 @@ QvisHostProfileWindow::CreateHWAccelSettingsGroup()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method updates the window so it reflects the current state
 //   of the HostProfileList object.
 //
@@ -1664,7 +1664,7 @@ QvisHostProfileWindow::UpdateMachineProfile()
 
         // Replace any localhost machine names.
         ReplaceLocalHost();
-    
+
         machineTabs->setEnabled(true);
 
         // Update the contents of the machine settings tab
@@ -1847,7 +1847,7 @@ QvisHostProfileWindow::UpdateLaunchProfile()
     {
         profileName->setText("");
         numProcessors->setValue(1);
-        
+
         parallelCheckBox->setChecked(false);
         launchCheckBox->setChecked(false);
         launchMethod->setCurrentIndex(0);
@@ -1998,7 +1998,7 @@ QvisHostProfileWindow::UpdateLaunchProfile()
               temp += "\"";
               temp += QString(pos->c_str());
               temp += "\" ";
-              
+
               laFlag = false;
             }
         }
@@ -2074,7 +2074,7 @@ QvisHostProfileWindow::UpdateLaunchProfile()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::ReplaceLocalHost
 //
-// Purpose: 
+// Purpose:
 //   Looks through the host profile list and replaces all hosts that are
 //   "localhost" with the correct local hostname.
 //
@@ -2102,7 +2102,7 @@ QvisHostProfileWindow::ReplaceLocalHost()
         MachineProfile &current = profiles->operator[](i);
         if(current.GetHost() == "localhost")
         {
-            current.SetHost(GetViewerProxy()->GetLocalHostName()); 
+            current.SetHost(GetViewerProxy()->GetLocalHostName());
         }
     }
 }
@@ -2110,7 +2110,7 @@ QvisHostProfileWindow::ReplaceLocalHost()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::UpdateWindowSensitivity
 //
-// Purpose: 
+// Purpose:
 //   This method sets the sensitivity of the window's widgets.
 //
 // Programmer: Brad Whitlock
@@ -2158,7 +2158,7 @@ QvisHostProfileWindow::ReplaceLocalHost()
 //    Jeremy Meredith, Thu Jun 28 13:19:55 EDT 2007
 //    Disable client host name method determination widgets when SSH tunneling
 //    is enabled.
-// 
+//
 //    Cyrus Harrison, Wed Jun 25 11:01:46 PDT 2008
 //    Initial Qt4 Port.
 //
@@ -2242,7 +2242,7 @@ QvisHostProfileWindow::UpdateWindowSensitivity()
     maxNodes->setEnabled(hostEnabled && currentMachine->GetMaximumNodesValid());
     maxProcessorsCheckBox->setEnabled(hostEnabled);
     maxProcessors->setEnabled(hostEnabled && currentMachine->GetMaximumProcessorsValid());
-    
+
 
     profileNameLabel->setEnabled(launchEnabled);
     profileName->setEnabled(launchEnabled);
@@ -2311,7 +2311,7 @@ QvisHostProfileWindow::UpdateWindowSensitivity()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values from the widgets in the active profile area.
 //
 // Arguments:
@@ -2444,7 +2444,7 @@ QvisHostProfileWindow::GetCurrentValues()
             std::string newHost(temp.toStdString());
             if(newHost == "localhost")
             {
-                newHost = GetViewerProxy()->GetLocalHostName(); 
+                newHost = GetViewerProxy()->GetLocalHostName();
                 hostName->setText(newHost.c_str());
             }
             if (newHost != currentMachine->GetHost())
@@ -2567,7 +2567,7 @@ QvisHostProfileWindow::GetCurrentValues()
                 // NOTE: if the quotes are missing the compositing
                 // will go to the last arg.  This may not be correct
                 // but that is what is interperted and does not fail.
-                else 
+                else
                 {
                     // Save the -la argument as normal.
                     arguments.push_back(std::string(str[i].toStdString()));
@@ -2588,7 +2588,7 @@ QvisHostProfileWindow::GetCurrentValues()
                         {
                           std::string tmp(str[i].toStdString());
                           composite += std::string(" ") + tmp;
-                          
+
                           // Strip the quote as it will get added back
                           // in when it is processed. Then quit.
                           if( composite.find(terminal) == composite.size()-1 )
@@ -2823,7 +2823,7 @@ QvisHostProfileWindow::GetCurrentValues()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This method is called when we want to apply the values from the window
 //   to the state object.
 //
@@ -2836,7 +2836,7 @@ QvisHostProfileWindow::GetCurrentValues()
 // Modifications:
 //    Jeremy Meredith, Thu Feb 18 15:25:27 EST 2010
 //    Split HostProfile int MachineProfile and LaunchProfile. Rewrote window.
-//   
+//
 // ****************************************************************************
 
 void
@@ -2861,7 +2861,7 @@ QvisHostProfileWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that gets the current values for all
 //   of the widgets in the window and then calls Notify to tell the
 //   viewer.
@@ -2885,7 +2885,7 @@ QvisHostProfileWindow::apply()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::userNameChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the username for the active
 //   host profile.
 //
@@ -2897,7 +2897,7 @@ QvisHostProfileWindow::apply()
 //   Prevented the window from being updated.
 //
 //    Jeremy Meredith, Mon Aug 18 13:36:20 PDT 2003
-//    Made it apply without a return press, and 
+//    Made it apply without a return press, and
 //    renamed the method appropriately.
 //
 //    Jeremy Meredith, Thu Oct  9 15:48:43 PDT 2003
@@ -2950,7 +2950,7 @@ QvisHostProfileWindow::processDirectoryText(const QString &d)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleLaunch
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the launch method widget.
 //
 // Programmer: Jeremy Meredith
@@ -2980,7 +2980,7 @@ QvisHostProfileWindow::toggleLaunch(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processLaunchMethodText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the launch method for the active
 //   host profile.
 //
@@ -3015,7 +3015,7 @@ QvisHostProfileWindow::launchMethodChanged(const QString &method)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::numProcessorsChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the number of processors
 //   for the active host profile.
 //
@@ -3046,7 +3046,7 @@ QvisHostProfileWindow::numProcessorsChanged(int value)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::timeoutChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the timeout for the active host
 //   profile.
 //
@@ -3072,7 +3072,7 @@ QvisHostProfileWindow::timeoutChanged(int value)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::threadsChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the threads for the active host
 //   profile.
 //
@@ -3096,7 +3096,7 @@ QvisHostProfileWindow::threadsChanged(int value)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleNumNodes
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the NumNodes widget.
 //
 // Programmer: Jeremy Meredith
@@ -3126,7 +3126,7 @@ QvisHostProfileWindow::toggleNumNodes(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::numNodesChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the number of nodes
 //   for the active host profile.
 //
@@ -3156,7 +3156,7 @@ QvisHostProfileWindow::numNodesChanged(int n)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::togglePartitionName
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the PartitionName widget.
 //
 // Programmer: Jeremy Meredith
@@ -3186,7 +3186,7 @@ QvisHostProfileWindow::togglePartitionName(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processPartitionNameText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the partition name for the active
 //   host profile.
 //
@@ -3196,7 +3196,7 @@ QvisHostProfileWindow::togglePartitionName(bool state)
 // Modifications:
 //   Brad Whitlock, Mon Sep 24 09:29:16 PDT 2001
 //   Prevented the window from updating.
-//   
+//
 //   Jeremy Meredith, Thu Feb 18 15:25:27 EST 2010
 //   Split HostProfile int MachineProfile and LaunchProfile. Rewrote window.
 //
@@ -3216,7 +3216,7 @@ QvisHostProfileWindow::processPartitionNameText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleBankName
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the BankName widget.
 //
 // Programmer: Jeremy Meredith
@@ -3243,7 +3243,7 @@ QvisHostProfileWindow::toggleBankName(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processBankNameText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the bank name for the active
 //   host profile.
 //
@@ -3270,7 +3270,7 @@ QvisHostProfileWindow::processBankNameText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleTimeLimit
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the TimeLimit widget.
 //
 // Programmer: Jeremy Meredith
@@ -3297,7 +3297,7 @@ QvisHostProfileWindow::toggleTimeLimit(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processTimeLimitText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the timeLimit name for the active
 //   host profile.
 //
@@ -3324,7 +3324,7 @@ QvisHostProfileWindow::processTimeLimitText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleMachinefile
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the Machinefile widget.
 //
 // Programmer: Jeremy Meredith
@@ -3351,7 +3351,7 @@ QvisHostProfileWindow::toggleMachinefile(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processMachinefileText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the machinefile name for the active
 //   host profile.
 //
@@ -3378,7 +3378,7 @@ QvisHostProfileWindow::processMachinefileText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleLaunchArgs
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the launchArgs widget.
 //
 // Programmer: Jeremy Meredith
@@ -3405,7 +3405,7 @@ QvisHostProfileWindow::toggleLaunchArgs(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processLaunchArgsText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the launch args for the active
 //   host profile.
 //
@@ -3432,7 +3432,7 @@ QvisHostProfileWindow::processLaunchArgsText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleSublaunchArgs
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the sublaunchArgs widget.
 //
 // Programmer: Eric Brugger
@@ -3459,7 +3459,7 @@ QvisHostProfileWindow::toggleSublaunchArgs(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processSublaunchArgsText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the sublaunch args for the active
 //   host profile.
 //
@@ -3486,7 +3486,7 @@ QvisHostProfileWindow::processSublaunchArgsText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleSublaunchPreCmd
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the sublaunchPreCmd widget.
 //
 // Programmer: Dave Bremer
@@ -3513,8 +3513,8 @@ QvisHostProfileWindow::toggleSublaunchPreCmd(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processSublaunchPreCmdText
 //
-// Purpose: 
-//   This is a Qt slot function that sets the sublaunch pre-mpi command for 
+// Purpose:
+//   This is a Qt slot function that sets the sublaunch pre-mpi command for
 //   the active host profile.
 //
 // Programmer: Dave Bremer
@@ -3540,7 +3540,7 @@ QvisHostProfileWindow::processSublaunchPreCmdText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleSublaunchPostCmd
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables the sublaunchPostCmd widget.
 //
 // Programmer: Dave Bremer
@@ -3567,8 +3567,8 @@ QvisHostProfileWindow::toggleSublaunchPostCmd(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processSublaunchPostCmdText
 //
-// Purpose: 
-//   This is a Qt slot function that sets the sublaunch post-mpi command for 
+// Purpose:
+//   This is a Qt slot function that sets the sublaunch post-mpi command for
 //   the active host profile.
 //
 // Programmer: Dave Bremer
@@ -3577,7 +3577,7 @@ QvisHostProfileWindow::toggleSublaunchPostCmd(bool state)
 // Modifications:
 //   Jeremy Meredith, Thu Feb 18 15:25:27 EST 2010
 //   Split HostProfile int MachineProfile and LaunchProfile. Rewrote window.
-//   
+//
 // ****************************************************************************
 
 void
@@ -3594,7 +3594,7 @@ QvisHostProfileWindow::processSublaunchPostCmdText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleParallel
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that enables parallelism.
 //
 // Programmer: Jeremy Meredith
@@ -3644,7 +3644,7 @@ QvisHostProfileWindow::toggleParallel(bool state)
 //
 // ****************************************************************************
 
-void 
+void
 QvisHostProfileWindow::loadBalancingChanged(int val)
 {
     if (currentLaunch == NULL)
@@ -3673,7 +3673,7 @@ QvisHostProfileWindow::loadBalancingChanged(int val)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::hostNameChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a slot function that sets the host name for the current profile.
 //
 // Programmer: Jeremy Meredith
@@ -3724,7 +3724,7 @@ QvisHostProfileWindow::hostNameChanged(const QString &n)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::hostAliasesChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a slot function that sets the host aliases for the current
 //   profile.
 //
@@ -3749,7 +3749,7 @@ QvisHostProfileWindow::hostAliasesChanged(const QString &aliases)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::hostNicknameChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a slot function that sets the host nickname for the current
 //   profile.
 //
@@ -3801,7 +3801,7 @@ QvisHostProfileWindow::hostNicknameChanged(const QString &nickname)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::processEngineArgumentsText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the engine arguments for
 //   the active host profile.
 //
@@ -3833,7 +3833,7 @@ QvisHostProfileWindow::processEngineArgumentsText(const QString &tmp)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleShareMDServer
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is activated when the Share MDServer
 //   check box is toggled.
 //
@@ -3845,7 +3845,7 @@ QvisHostProfileWindow::processEngineArgumentsText(const QString &tmp)
 //   Split HostProfile int MachineProfile and LaunchProfile. Rewrote window.
 //
 //   Brad Whitlock, Thu Dec  1 11:41:23 PST 2011
-//   Indicate that sharing a batch job does not work with ssh tunneling 
+//   Indicate that sharing a batch job does not work with ssh tunneling
 //   right now.
 //
 // ****************************************************************************
@@ -3877,7 +3877,7 @@ QvisHostProfileWindow::toggleShareMDServer(bool state)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleUseVisItScriptForEnv
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is activated when the Use VisIt
 //   to Set up Environment check box is toggled.
 //
@@ -4232,7 +4232,7 @@ QvisHostProfileWindow::clientHostNameChanged(const QString &h)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleTunnelSSH
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is activated when the tunnel SSH
 //   check box is toggled.
 //
@@ -4254,7 +4254,7 @@ QvisHostProfileWindow::clientHostNameChanged(const QString &h)
 //   Split HostProfile int MachineProfile and LaunchProfile. Rewrote window.
 //
 //   Brad Whitlock, Thu Dec  1 11:41:23 PST 2011
-//   Indicate that sharing a batch job does not work with ssh tunneling 
+//   Indicate that sharing a batch job does not work with ssh tunneling
 //   right now.
 //
 // ****************************************************************************
@@ -4695,6 +4695,9 @@ QvisHostProfileWindow::copyMachineProfile()
 //   Brad Whitlock, Thu Oct 27 14:54:28 PDT 2011
 //   Set focus on the first thing you'd edit.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 void
 QvisHostProfileWindow::addLaunchProfile()
@@ -4704,7 +4707,7 @@ QvisHostProfileWindow::addLaunchProfile()
 
     LaunchProfile lp;
     QString name(tr("New profile"));
-    QString num; num.asprintf(" #%d", profileCounter++);
+    QString num = QString(" #%1").arg(profileCounter++);
     name += num;
     lp.SetProfileName(name.toStdString());
 
@@ -4765,7 +4768,7 @@ QvisHostProfileWindow::delLaunchProfile()
     currentLaunch = NULL;
     Apply();
 }
-    
+
 // ****************************************************************************
 // Method:  QvisHostProfileWindow::copyLaunchProfile
 //
@@ -4836,7 +4839,7 @@ QvisHostProfileWindow::makeDefaultLaunchProfile()
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleUseMaxNodes
 //
-// Purpose: 
+// Purpose:
 //   Called when we click on the max nodes check box.
 //
 // Arguments:
@@ -4846,7 +4849,7 @@ QvisHostProfileWindow::makeDefaultLaunchProfile()
 // Creation:   Thu Oct  6 11:15:23 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -4864,7 +4867,7 @@ QvisHostProfileWindow::toggleUseMaxNodes(bool val)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::maxNodesChanged
 //
-// Purpose: 
+// Purpose:
 //   Set a new max # nodes.
 //
 // Arguments:
@@ -4874,7 +4877,7 @@ QvisHostProfileWindow::toggleUseMaxNodes(bool val)
 // Creation:   Thu Oct  6 11:16:24 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -4890,7 +4893,7 @@ QvisHostProfileWindow::maxNodesChanged(int val)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::toggleUseMaxProcessors
 //
-// Purpose: 
+// Purpose:
 //   Called when we click on the max processors check box.
 //
 // Arguments:
@@ -4900,7 +4903,7 @@ QvisHostProfileWindow::maxNodesChanged(int val)
 // Creation:   Thu Oct  6 11:15:23 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -4918,7 +4921,7 @@ QvisHostProfileWindow::toggleUseMaxProcessors(bool val)
 // ****************************************************************************
 // Method: QvisHostProfileWindow::maxProcessorsChanged
 //
-// Purpose: 
+// Purpose:
 //   Set a new max # processors.
 //
 // Arguments:
@@ -4928,7 +4931,7 @@ QvisHostProfileWindow::toggleUseMaxProcessors(bool val)
 // Creation:   Thu Oct  6 11:16:24 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -4950,9 +4953,9 @@ QvisHostProfileWindow::maxProcessorsChanged(int val)
 // Arguments:
 //   newsize : the new size.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Oct 22 16:43:01 PDT 2014
@@ -5014,7 +5017,7 @@ QvisHostProfileWindow::ResizeNodeProcs(int newSize, bool blank)
 // Method: QvisHostProfileWindow::allowableNodeProcsAddRow
 //
 // Purpose:
-//   This is a Qt slot function called when we want to add a row to the 
+//   This is a Qt slot function called when we want to add a row to the
 //   allowableNodeProcs table.
 //
 // Programmer: Brad Whitlock
@@ -5036,7 +5039,7 @@ QvisHostProfileWindow::allowableNodeProcsAddRow()
 // Method: QvisHostProfileWindow::allowableNodeProcsDeleteRow
 //
 // Purpose:
-//   This is a Qt slot function called when we want to delete a row from the 
+//   This is a Qt slot function called when we want to delete a row from the
 //   allowableNodeProcs table.
 //
 // Programmer: Brad Whitlock

--- a/src/gui/QvisKeyframeWindow.C
+++ b/src/gui/QvisKeyframeWindow.C
@@ -264,7 +264,7 @@ QvisKeyframeWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisKeyframeWindow::GetCurrentFrame
 //
-// Purpose: 
+// Purpose:
 //   Returns the current frame for animation.
 //
 // Returns:    The current animation frame.
@@ -321,6 +321,9 @@ QvisKeyframeWindow::GetCurrentFrame() const
 //    Brad Whitlock, Mon Nov 10 11:36:20 PST 2008
 //    Qt 4.
 //
+//    Kathleen Biagas, Thu Jan 21, 2021
+//    Replace QString.asprintf with simpler QString.setNum.
+//
 // ****************************************************************************
 
 void
@@ -345,7 +348,7 @@ QvisKeyframeWindow::UpdateWindowInformation()
     {
         numFrames = 1;
     }
-    temp.asprintf("%d", numFrames);
+    temp.setNum(numFrames);
     nFrames->blockSignals(true);
     nFrames->setText(temp);
     nFrames->blockSignals(false);
@@ -629,9 +632,9 @@ QvisKeyframeWindow::apply()
 // ****************************************************************************
 // Method: QvisKeyframeWindow::userSetNFrames
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the number of frames
-//   changes. The purpose is only to record that the user entered a number 
+//   changes. The purpose is only to record that the user entered a number
 //   of frames so it is not okay to automatically calculate a number of
 //   frames.
 //
@@ -639,7 +642,7 @@ QvisKeyframeWindow::apply()
 // Creation:   Tue Apr 6 23:50:53 PST 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -695,14 +698,14 @@ QvisKeyframeWindow::keyframeEnabledToggled(bool k)
 // ****************************************************************************
 // Method: QvisKeyframeWindow::addViewKeyframe
 //
-// Purpose: 
+// Purpose:
 //   Add a view keyframe.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov  4 16:48:16 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -714,14 +717,14 @@ QvisKeyframeWindow::addViewKeyframe()
 // ****************************************************************************
 // Method: QvisKeyframeWindow::useViewKFClicked
 //
-// Purpose: 
+// Purpose:
 //   Tells VisIt to use the view keyframes for setting the view.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Nov 10 14:02:26 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisLegendAttributesInterface.C
+++ b/src/gui/QvisLegendAttributesInterface.C
@@ -509,7 +509,11 @@ QvisLegendAttributesInterface::UpdateControls()
         suppliedLabels->horizontalHeaderItem(0)->setText(tr("Values"));
         for (int i = 0; i < size; ++i)
         {
-            temp.asprintf(fmt.toStdString().c_str(), sv[i]);
+            // Qt recommends that asprintf not be used, they recommend
+            // QTextStream or QString.arg. But neither of these will take
+            // the formatString in its current form. Would have to rethink
+            // the format interface.
+            temp = QString::asprintf(fmt.toStdString().c_str(), sv[i]);
             suppliedLabels->item(i, 0)->setText(temp.simplified());
             suppliedLabels->item(i, 0)->setFlags(
                      Qt::ItemIsSelectable|Qt::ItemIsEditable|Qt::ItemIsEnabled);
@@ -605,7 +609,10 @@ QvisLegendAttributesInterface::UpdateControls()
     drawMinmaxCheckBox->blockSignals(false);
 
     // Set the font height
-    fontHeight->setText(QString().asprintf("%g", annot->GetOptions().GetEntry("fontHeight")->AsDouble()));
+    // QString.arg  default format spec for double is '%g', so don't need
+    // to send format specifiers since that's what is wanted here.
+    QString fh = QString("%1").arg(annot->GetOptions().GetEntry("fontHeight")->AsDouble());
+    fontHeight->setText(fh);
 
     // Set the use foreground color check box.
     useForegroundColorCheckBox->blockSignals(true);

--- a/src/gui/QvisLightingWindow.C
+++ b/src/gui/QvisLightingWindow.C
@@ -30,7 +30,7 @@
 // ****************************************************************************
 // Method: QvisLightingWindow::QvisLightingWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisLightingWindow class.
 //
 // Arguments:
@@ -76,7 +76,7 @@ QvisLightingWindow::QvisLightingWindow(LightList *subj, const QString &caption,
 // ****************************************************************************
 // Method: QvisLightingWindow::~QvisLightingWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisLightingWindow class.
 //
 // Programmer: Brad Whitlock
@@ -98,7 +98,7 @@ QvisLightingWindow::~QvisLightingWindow()
 // ****************************************************************************
 // Method: QvisLightingWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the window's widgets.
 //
 // Programmer: Brad Whitlock
@@ -247,7 +247,7 @@ QvisLightingWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisLightingWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method updates the window's widgets when the light list changes.
 //
 // Programmer: Brad Whitlock
@@ -263,6 +263,9 @@ QvisLightingWindow::CreateWindowContents()
 //
 //   Cyrus Harrison, Tue Jun 10 10:04:26 PDT 20
 //   Initial Qt4 Port.
+//
+//   Kathleen Biagas, Jan 21, 2021
+//   Replace QString.asprintf with simpler QString.setNum and QString.arg.
 //
 // ****************************************************************************
 
@@ -283,7 +286,7 @@ QvisLightingWindow::UpdateWindow(bool)
     {
         bool enabled = lights->GetLight(i).GetEnabledFlag();
         QString num;
-        num.asprintf("%d", i + 1);
+        num.setNum(i + 1);
         if(enabled)
         {
             activeLightComboBox->setItemText(i,num);
@@ -310,10 +313,10 @@ QvisLightingWindow::UpdateWindow(bool)
     lightEnabledCheckBox->blockSignals(false);
 
     // Update the light direction line edit.
-    QString tmp;
-    tmp.asprintf("%1.3g %1.3g %1.3g", light.GetDirection()[0],
-                                     light.GetDirection()[1],
-                                     light.GetDirection()[2]);
+    QString tmp = QString("%1 %2 %3")
+        .arg(light.GetDirection()[0], 1, 'g', 3)
+        .arg(light.GetDirection()[1], 1, 'g', 3)
+        .arg(light.GetDirection()[2], 1, 'g', 3);
     lightDirectionLineEdit->setText(tmp);
     bool val = (light.GetType() != LightAttributes::Ambient);
     lightDirectionLineEdit->setEnabled(val);
@@ -344,7 +347,7 @@ QvisLightingWindow::UpdateWindow(bool)
 // ****************************************************************************
 // Method: QvisLightingWindow::UpdateLightWidget
 //
-// Purpose: 
+// Purpose:
 //   Updates the light widget using the state in the light list.
 //
 // Programmer: Brad Whitlock
@@ -353,10 +356,10 @@ QvisLightingWindow::UpdateWindow(bool)
 // Modifications:
 //   Kathleen Bonnell, Tue Dec 28 16:20:47 PST 2004
 //   Cast args for QColor constructor to int to prevent comiler warnings.
-//   
-//   Kathleen Bonnell, Mon Feb  6 16:58:40 PST 2006 
-//   Removed unnecessary code that counted 'numEnabled' as it was not used. 
-//   
+//
+//   Kathleen Bonnell, Mon Feb  6 16:58:40 PST 2006
+//   Removed unnecessary code that counted 'numEnabled' as it was not used.
+//
 // ****************************************************************************
 
 void
@@ -371,7 +374,7 @@ QvisLightingWindow::UpdateLightWidget()
         for(int i = 0; i < lights->NumLights(); ++i)
         {
             const LightAttributes &light = lights->GetLight(i);
-           
+
             if(light.GetEnabledFlag())
             {
                 QColor c2((int)(light.GetColor().Red() * light.GetBrightness()),
@@ -407,7 +410,7 @@ QvisLightingWindow::UpdateLightWidget()
 // ****************************************************************************
 // Method: QvisLightingWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   This method is called in order to get the state for the direction text.
 //
 // Arguments:
@@ -419,9 +422,12 @@ QvisLightingWindow::UpdateLightWidget()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 09:27:26 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Tue Jun 10 10:04:26 PDT 20
 //   Initial Qt4 Port.
+//
+//   Kathleen Biagas, Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -452,7 +458,7 @@ QvisLightingWindow::GetCurrentValues(int which_widget)
         if(!okay)
         {
             const double *d = light.GetDirection();
-            QString num; num.asprintf("<%g %g %g>.", d[0], d[1], d[2]);
+            QString num = QString("<%1 %2 %3>.").arg(d[0]).arg(d[1]).arg(d[2]);
             msg = tr("The direction vector was invalid. "
                      "Resetting to the last good value %1.").arg(num);
             Message(msg);
@@ -465,7 +471,7 @@ QvisLightingWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisLightingWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This method applies the light list.
 //
 // Arguments:
@@ -484,7 +490,7 @@ void
 QvisLightingWindow::Apply(bool ignore)
 {
     // This is a little different from how it is normally done in a window
-    // but we're setting attributes for an individual object in a list of 
+    // but we're setting attributes for an individual object in a list of
     // objects and we have to get the current values all the time in case
     // some of them changed because a full update is going to cause all
     // light attributes for the active light to be selected, which could
@@ -518,7 +524,7 @@ QvisLightingWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisLightingWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the apply button is
 //   clicked.
 //
@@ -526,7 +532,7 @@ QvisLightingWindow::Apply(bool ignore)
 // Creation:   Fri Oct 19 16:15:41 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -538,7 +544,7 @@ QvisLightingWindow::apply()
 // ****************************************************************************
 // Method: QvisLightingWindow::makeDefault
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the "make default" button
 //   is clicked.
 //
@@ -546,7 +552,7 @@ QvisLightingWindow::apply()
 // Creation:   Fri Oct 19 16:16:22 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -561,7 +567,7 @@ QvisLightingWindow::makeDefault()
 // ****************************************************************************
 // Method: QvisLightingWindow::reset
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the "reset" button is
 //   clicked.
 //
@@ -569,7 +575,7 @@ QvisLightingWindow::makeDefault()
 // Creation:   Fri Oct 19 16:17:03 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -581,7 +587,7 @@ QvisLightingWindow::reset()
 // ****************************************************************************
 // Method: QvisLightingWindow::activeLightComboBoxChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we change the active light.
 //
 // Arguments:
@@ -591,7 +597,7 @@ QvisLightingWindow::reset()
 // Creation:   Fri Oct 19 16:18:13 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -605,7 +611,7 @@ QvisLightingWindow::activeLightComboBoxChanged(int index)
 // ****************************************************************************
 // Method: QvisLightingWindow::brightnessChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the brightness changes.
 //
 // Arguments:
@@ -657,7 +663,7 @@ QvisLightingWindow::brightnessChanged2(int val)
 // ****************************************************************************
 // Method: QvisLightingWindow::enableToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the light is enabled or
 //   disabled.
 //
@@ -668,7 +674,7 @@ QvisLightingWindow::brightnessChanged2(int val)
 // Creation:   Fri Oct 19 16:19:27 PST 2001
 //
 // Modifications:
-//   
+//
 //   Hank Childs, Fri Aug  6 07:13:17 PDT 2010
 //   Store that the enable button has been toggled.
 //
@@ -687,7 +693,7 @@ QvisLightingWindow::enableToggled(bool val)
 // ****************************************************************************
 // Method: QvisLightingWindow::lightMoved
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the active light is
 //   moved interactively.
 //
@@ -712,6 +718,9 @@ QvisLightingWindow::enableToggled(bool val)
 //   Brad Whitlock, Tue May 20 15:03:27 PST 2003
 //   Made it work with updated LightAttributes.
 //
+//   Kathleen Biagas, Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -728,8 +737,8 @@ QvisLightingWindow::lightMoved(double x, double y, double z)
             lights->SelectLight(activeLight);
             // Set the light direction into the direction line edit so
             // it works when autoupdate is on.
-            QString direction;
-            direction.asprintf("%1.3g %1.3g %1.3g", x, y, z);
+            QString direction = QString("%1 %2 %3")
+              .arg(x,1,'g',3).arg(y,1,'g',3).arg(z,1,'g',3);
             lightDirectionLineEdit->setText(direction);
             SetUpdate(false);
             Apply();
@@ -740,7 +749,7 @@ QvisLightingWindow::lightMoved(double x, double y, double z)
 // ****************************************************************************
 // Method: QvisLightingWindow::lightTypeComboBoxChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the light type is changed.
 //
 // Arguments:
@@ -750,7 +759,7 @@ QvisLightingWindow::lightMoved(double x, double y, double z)
 // Creation:   Fri Oct 19 16:21:16 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -765,7 +774,7 @@ QvisLightingWindow::lightTypeComboBoxChanged(int newType)
 // ****************************************************************************
 // Method: QvisLightingWindow::modeClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to change the
 //   window's mode from edit<->preview.
 //
@@ -776,7 +785,7 @@ QvisLightingWindow::lightTypeComboBoxChanged(int newType)
 // Creation:   Fri Oct 19 16:21:52 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -796,14 +805,14 @@ QvisLightingWindow::modeClicked(int index)
 // ****************************************************************************
 // Method: QvisLightingWindow::processLineDirectionText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the direction text changes.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 19 16:22:40 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -816,7 +825,7 @@ QvisLightingWindow::processLineDirectionText()
 // ****************************************************************************
 // Method: QvisLightingWindow::selectedLightColor
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the light color changes.
 //
 // Arguments:
@@ -826,7 +835,7 @@ QvisLightingWindow::processLineDirectionText()
 // Creation:   Fri Oct 19 16:23:09 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisLine3DInterface.C
+++ b/src/gui/QvisLine3DInterface.C
@@ -275,6 +275,10 @@ QvisLine3DInterface::GetMenuText(const AnnotationObject &annot) const
 //   Kathleen Biagas, Tue Jul 14 16:39:07 PDT 2015
 //   Add support for arrow and tube style lines.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg, and QString.setNum
+//   for simpler cases.
+//
 // ****************************************************************************
 
 void
@@ -282,18 +286,17 @@ QvisLine3DInterface::UpdateControls()
 {
     // Set the start position.
     const MapNode &opts = annot->GetOptions();
-    QString pos;
-    pos.asprintf("%lg %lg %lg",
-        annot->GetPosition()[0],
-        annot->GetPosition()[1],
-        annot->GetPosition()[2]);
+    QString pos = QString("%1 %2 %3")
+        .arg(annot->GetPosition()[0])
+        .arg(annot->GetPosition()[1])
+        .arg(annot->GetPosition()[2]);
     point1Edit->setText(pos);
 
     // Set the end position.
-    pos.asprintf("%lg %lg %lg",
-        annot->GetPosition2()[0],
-        annot->GetPosition2()[1],
-        annot->GetPosition2()[2]);
+    pos = QString("%1 %2 %3")
+        .arg(annot->GetPosition2()[0])
+        .arg(annot->GetPosition2()[1])
+        .arg(annot->GetPosition2()[2]);
     point2Edit->setText(pos);
 
     lineType->blockSignals(true);
@@ -318,7 +321,7 @@ QvisLine3DInterface::UpdateControls()
     tubeQuality->blockSignals(false);
 
     tubeRadius->blockSignals(true);
-    pos.asprintf("%lg", opts.GetEntry("tubeRadius")->AsDouble());
+    pos.setNum(opts.GetEntry("tubeRadius")->AsDouble());
     tubeRadius->setText(pos);
     tubeRadius->setEnabled(lineType->currentIndex() == 1);
     tubeRadius->setVisible(lineType->currentIndex() == 1);
@@ -370,14 +373,14 @@ QvisLine3DInterface::UpdateControls()
 
 
     arrow1Radius->blockSignals(true);
-    pos.asprintf("%lg", opts.GetEntry("arrow1Radius")->AsDouble());
+    pos.setNum(opts.GetEntry("arrow1Radius")->AsDouble());
     arrow1Radius->setText(pos);
     arrow1Radius->setEnabled(beginArrow->isChecked());
     rad1Label->setEnabled(beginArrow->isChecked());
     arrow1Radius->blockSignals(false);
 
     arrow1Height->blockSignals(true);
-    pos.asprintf("%lg", opts.GetEntry("arrow1Height")->AsDouble());
+    pos.setNum(opts.GetEntry("arrow1Height")->AsDouble());
     arrow1Height->setText(pos);
     arrow1Height->setEnabled(beginArrow->isChecked());
     height1Label->setEnabled(beginArrow->isChecked());
@@ -394,7 +397,7 @@ QvisLine3DInterface::UpdateControls()
     arrow2Resolution->blockSignals(false);
 
     arrow2Radius->blockSignals(true);
-    pos.asprintf("%lg", opts.GetEntry("arrow2Radius")->AsDouble());
+    pos.setNum(opts.GetEntry("arrow2Radius")->AsDouble());
     arrow2Radius->setText(pos);
     arrow2Radius->setEnabled(endArrow->isChecked());
     rad2Label->setEnabled(endArrow->isChecked());
@@ -403,7 +406,7 @@ QvisLine3DInterface::UpdateControls()
     arrow2Height->blockSignals(true);
     if (opts.HasEntry("arrow2Height"))
     {
-        pos.asprintf("%lg", opts.GetEntry("arrow2Height")->AsDouble());
+        pos.setNum(opts.GetEntry("arrow2Height")->AsDouble());
         arrow2Height->setText(pos);
     }
     else

--- a/src/gui/QvisMainWindow.C
+++ b/src/gui/QvisMainWindow.C
@@ -1232,6 +1232,9 @@ QvisMainWindow::CreateGlobalArea(QWidget *par)
 //   Cyrus Harrison, Mon Jun 30 14:14:59 PDT 2008
 //   Initial Qt4 Port.
 //
+//   Kathleen Biagas, Thu Jun 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -1281,10 +1284,12 @@ QvisMainWindow::Update(Subject *TheChangedSubject)
 
                 QString done(tr("done"));
                 QString ofStage(tr("of stage"));
-                QString totalPct; totalPct.asprintf("%d%% ", total);
-                QString progress; progress.asprintf(" (%d%% ", statusAtts->GetPercent());
-                QString progress2; progress2.asprintf(" %d/%d)", statusAtts->GetCurrentStage(),
-                    statusAtts->GetMaxStage());
+                QString totalPct = QString("%1% ").arg(total);
+                QString progress = QString(" (%1% ")
+                    .arg(statusAtts->GetPercent());
+                QString progress2 = QString(" %1/%2)")
+                    .arg(statusAtts->GetCurrentStage())
+                    .arg(statusAtts->GetMaxStage());
                 statusMsg = totalPct + done + ": " +
                             StatusAttributes_GetStatusMessage(*statusAtts) +
                             progress + ofStage + progress2;
@@ -1565,6 +1570,9 @@ QvisMainWindow::UpdateFileMenuPopup(QMenu *m, QAction *action)
 //   Cyrus Harrison, Mon Jun 30 14:14:59 PDT 2008
 //   Initial Qt4 Port.
 //
+//   Kathleen Biagas, Thu Jun 21, 2021
+//   Replace QString.asprintf with QString.setNum.
+//
 // ****************************************************************************
 
 void
@@ -1585,7 +1593,7 @@ QvisMainWindow::UpdateWindowList(bool doList)
             activeWindowComboBox->clear();
             for(size_t i = 0; i < indices.size(); ++i)
             {
-                QString temp; temp.asprintf("%d", indices[i]);
+                QString temp; temp.setNum(indices[i]);
                 activeWindowComboBox->addItem(temp);
             }
 
@@ -1593,7 +1601,7 @@ QvisMainWindow::UpdateWindowList(bool doList)
             activeWindowPopup->clear();
             for(size_t i = 0; i < indices.size(); ++i)
             {
-                QString str; str.asprintf("%d", indices[i]);
+                QString str; str.setNum(indices[i]);
                 QAction *act = activeWindowPopup->addAction(tr("Window ") + str);
                 act->setChecked(indices[i] == index);
             }
@@ -1654,6 +1662,9 @@ QvisMainWindow::UpdateWindowList(bool doList)
 //   Sets the text of the 'connect to DDT' action depending on if
 //   the viewer will connect or disconnect to/from DDT.
 //
+//   Kathleen Biagas, Thu Jun 21, 2021
+//   Replace QString.asprintf with QString.setNum.
+//
 // ****************************************************************************
 
 void
@@ -1679,7 +1690,7 @@ QvisMainWindow::UpdateWindowMenu(bool updateNumbers)
                     continue;
 
                 QString str;
-                str.asprintf("%d", indices[j]);
+                str.setNum(indices[j]);
                 copyPopup[i]->addAction(tr("Window ") + str);
                 n++;
             }

--- a/src/gui/QvisMaterialWindow.C
+++ b/src/gui/QvisMaterialWindow.C
@@ -20,7 +20,7 @@ using std::string;
 // ****************************************************************************
 // Method: QvisMaterialWindow::QvisMaterialWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Programmer: Jeremy Meredith
@@ -47,14 +47,14 @@ QvisMaterialWindow::QvisMaterialWindow(MaterialAttributes *subj,
 // ****************************************************************************
 // Method: QvisMaterialWindow::~QvisMaterialWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: xml2window
 // Creation:   Thu Oct 24 10:03:40 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisMaterialWindow::~QvisMaterialWindow()
@@ -65,7 +65,7 @@ QvisMaterialWindow::~QvisMaterialWindow()
 // ****************************************************************************
 // Method: QvisMaterialWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Jeremy Meredith
@@ -74,7 +74,7 @@ QvisMaterialWindow::~QvisMaterialWindow()
 // Modifications:
 //    Jeremy Meredith, Wed Jul 30 10:46:51 PDT 2003
 //    Added a toggle for forcing full connectivity.
-//   
+//
 //    Jeremy Meredith, Mon Sep 15 17:16:55 PDT 2003
 //    Added a toggle for the new material algorithm.
 //
@@ -155,7 +155,7 @@ QvisMaterialWindow::CreateWindowContents()
             this, SLOT(cleanZonesOnlyChanged(bool)));
     mainLayout->addWidget(cleanZonesOnly, 4,0);
 
-    simplifyHeavilyMixedZones = new QCheckBox(tr("Simplify heavily mixed zones"), 
+    simplifyHeavilyMixedZones = new QCheckBox(tr("Simplify heavily mixed zones"),
                                               central);
     connect(simplifyHeavilyMixedZones, SIGNAL(toggled(bool)),
             this, SLOT(simplifyHeavilyMixedZonesChanged(bool)));
@@ -170,7 +170,7 @@ QvisMaterialWindow::CreateWindowContents()
             SLOT(maxMatsPerZoneProcessText()));
     mainLayout->addWidget(maxMatsPerZone, 6, 1);
 
-    isoVolumeFractionLabel = new QLabel(tr("Volume fraction for isovolume"), 
+    isoVolumeFractionLabel = new QLabel(tr("Volume fraction for isovolume"),
                                         central);
     mainLayout->addWidget(isoVolumeFractionLabel,7,0);
     isoVolumeFraction = new QNarrowLineEdit(central);
@@ -179,13 +179,13 @@ QvisMaterialWindow::CreateWindowContents()
     mainLayout->addWidget(isoVolumeFraction, 7,1);
 
     // Iteration options
-    enableIteration = new QCheckBox(tr("Enable iteration (Equi-Z, Isovolume only)"), 
+    enableIteration = new QCheckBox(tr("Enable iteration (Equi-Z, Isovolume only)"),
                                               central);
     connect(enableIteration, SIGNAL(toggled(bool)),
             this, SLOT(enableIterationChanged(bool)));
     mainLayout->addWidget(enableIteration, 8,0);
 
-    numIterationsLabel = new QLabel(tr("Number of iterations"), 
+    numIterationsLabel = new QLabel(tr("Number of iterations"),
                                         central);
     mainLayout->addWidget(numIterationsLabel,9,0);
     numIterations = new QNarrowLineEdit(central);
@@ -193,7 +193,7 @@ QvisMaterialWindow::CreateWindowContents()
             this, SLOT(numIterationsProcessText()));
     mainLayout->addWidget(numIterations, 9,1);
 
-    iterationDampingLabel = new QLabel(tr("Convergence rate (>0)"), 
+    iterationDampingLabel = new QLabel(tr("Convergence rate (>0)"),
                                         central);
     mainLayout->addWidget(iterationDampingLabel,10,0);
     iterationDamping = new QNarrowLineEdit(central);
@@ -214,7 +214,7 @@ QvisMaterialWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisMaterialWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets in the window when the subject changes.
 //
 // Programmer: Jeremy Meredith
@@ -223,7 +223,7 @@ QvisMaterialWindow::CreateWindowContents()
 // Modifications:
 //    Jeremy Meredith, Wed Jul 30 10:46:51 PDT 2003
 //    Added a toggle for forcing full connectivity.
-//   
+//
 //    Jeremy Meredith, Mon Sep 15 17:20:57 PDT 2003
 //    Added a toggle for the new MIR algorithm.
 //
@@ -248,6 +248,9 @@ QvisMaterialWindow::CreateWindowContents()
 //
 //    Jeremy Meredith, Thu Mar 25 12:27:49 EDT 2010
 //    Renamed some algorithms.
+//
+//    Kathleen Biagas, Thu Jan 21, 2021
+//    Replace QString.asprintf with QString.setNum.
 //
 // ****************************************************************************
 
@@ -306,7 +309,7 @@ QvisMaterialWindow::UpdateWindow(bool doAll)
             }
             annealingTime->setEnabled(atts->GetAlgorithm() == MaterialAttributes::Discrete);
             annealingTimeLabel->setEnabled(atts->GetAlgorithm() == MaterialAttributes::Discrete);
-                
+
             smoothing->setEnabled(
                    atts->GetAlgorithm()==MaterialAttributes::EquiZ ||
                    atts->GetAlgorithm()==MaterialAttributes::EquiT);
@@ -340,7 +343,7 @@ QvisMaterialWindow::UpdateWindow(bool doAll)
             maxMatsPerZoneLabel->setEnabled(atts->GetSimplifyHeavilyMixedZones());
             break;
           case MaterialAttributes::ID_maxMaterialsPerZone:
-            temp.asprintf("%d", atts->GetMaxMaterialsPerZone());
+            temp.setNum(atts->GetMaxMaterialsPerZone());
             maxMatsPerZone->setText(temp);
             break;
           case MaterialAttributes::ID_isoVolumeFraction:
@@ -399,7 +402,7 @@ QvisMaterialWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisMaterialWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets values from certain widgets and stores them in the subject.
 //
 // Programmer: xml2window
@@ -408,7 +411,7 @@ QvisMaterialWindow::UpdateWindow(bool doAll)
 // Modifications:
 //    Jeremy Meredith, Wed Jul 30 10:46:51 PDT 2003
 //    Added a toggle for forcing full connectivity.
-//   
+//
 //    Jeremy Meredith, Mon Sep 15 17:17:12 PDT 2003
 //    Added the toggle for the new MIR algorithm.
 //
@@ -600,7 +603,7 @@ QvisMaterialWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisMaterialWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Called to apply changes in the subject.
 //
 // Programmer: xml2window
@@ -652,14 +655,14 @@ QvisMaterialWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisMaterialWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when apply button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Thu Oct 24 10:03:40 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -672,14 +675,14 @@ QvisMaterialWindow::apply()
 // ****************************************************************************
 // Method: QvisMaterialWindow::makeDefault
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when "Make default" button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Thu Oct 24 10:03:40 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -694,14 +697,14 @@ QvisMaterialWindow::makeDefault()
 // ****************************************************************************
 // Method: QvisMaterialWindow::reset
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when reset button is clicked.
 //
 // Programmer: Jeremy Meredith
 // Creation:   October 24, 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisOpacitySlider.C
+++ b/src/gui/QvisOpacitySlider.C
@@ -23,7 +23,7 @@ static int sliderStartVal = 0;
 // ****************************************************************************
 // Method: QvisOpacitySlider::QvisOpacitySlider
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisOpacitySlider class.
 //
 // Arguments:
@@ -40,7 +40,7 @@ static int sliderStartVal = 0;
 //
 // ****************************************************************************
 
-QvisOpacitySlider::QvisOpacitySlider(QWidget *parent, const void *data) : 
+QvisOpacitySlider::QvisOpacitySlider(QWidget *parent, const void *data) :
     QAbstractSlider(parent)
 {
     init();
@@ -50,7 +50,7 @@ QvisOpacitySlider::QvisOpacitySlider(QWidget *parent, const void *data) :
 // ****************************************************************************
 // Method: QvisOpacitySlider::QvisOpacitySlider
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisOpacitySlider class.
 //
 // Arguments:
@@ -87,14 +87,14 @@ QvisOpacitySlider::QvisOpacitySlider(int minValue, int maxValue, int step,
 // ****************************************************************************
 // Method: QvisOpacitySlider::~QvisOpacitySlider
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisOpacitySlider class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:18:17 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisOpacitySlider::~QvisOpacitySlider()
@@ -105,14 +105,14 @@ QvisOpacitySlider::~QvisOpacitySlider()
 // ****************************************************************************
 // Method: QvisOpacitySlider::init
 //
-// Purpose: 
+// Purpose:
 //   Initializes certain object attributes.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:18:36 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -136,14 +136,14 @@ QvisOpacitySlider::init()
 // ****************************************************************************
 // Method: QvisOpacitySlider::initTicks
 //
-// Purpose: 
+// Purpose:
 //   Does what's needed when someone changes the tickmark status.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:19:28 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -155,7 +155,7 @@ QvisOpacitySlider::initTicks()
 // ****************************************************************************
 // Method: QvisOpacitySlider::positionFromValue
 //
-// Purpose: 
+// Purpose:
 //   Calculates slider position corresponding to a value.
 //
 // Arguments:
@@ -167,7 +167,7 @@ QvisOpacitySlider::initTicks()
 // Creation:   Thu Dec 7 12:20:07 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -180,7 +180,7 @@ QvisOpacitySlider::positionFromValue(int value) const
 // ****************************************************************************
 // Method: QvisOpacitySlider::available
 //
-// Purpose: 
+// Purpose:
 //   Returns the available space in which the slider can move.
 //
 // Returns:    The available space in which the slider can move
@@ -203,7 +203,7 @@ QvisOpacitySlider::available() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::valueFromPosition
 //
-// Purpose: 
+// Purpose:
 //   Calculates value corresponding to slider position.
 //
 // Returns:    Value corresponding to slider position.
@@ -212,7 +212,7 @@ QvisOpacitySlider::available() const
 // Creation:   Thu Dec 7 12:22:34 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -226,14 +226,14 @@ QvisOpacitySlider::valueFromPosition(int position) const
 // ****************************************************************************
 // Method: QvisOpacitySlider::rangeChange
 //
-// Purpose: 
+// Purpose:
 //   Implements the virtual QAbstractSlider function.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:23:15 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -247,7 +247,7 @@ QvisOpacitySlider::rangeChange()
 // ****************************************************************************
 // Method: QvisOpacitySlider::paletteChange
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the palette changes. The slider uses this
 //   opportunity to redraw with its new gradient.
 //
@@ -255,7 +255,7 @@ QvisOpacitySlider::rangeChange()
 // Creation:   Thu Sep 6 14:55:16 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -268,7 +268,7 @@ QvisOpacitySlider::paletteChange(const QPalette &)
 // ****************************************************************************
 // Method: QvisOpacitySlider::sliderRect
 //
-// Purpose: 
+// Purpose:
 //   Returns the slider handle rectangle.
 //
 // Returns:    The slider handle rectangle.
@@ -277,7 +277,7 @@ QvisOpacitySlider::paletteChange(const QPalette &)
 // Creation:   Thu Dec 7 12:26:38 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QRect
@@ -289,7 +289,7 @@ QvisOpacitySlider::sliderRect() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::reallyMoveSlider
 //
-// Purpose: 
+// Purpose:
 //   Performs the actual moving of the slider.
 //
 // Arguments:
@@ -307,7 +307,7 @@ QvisOpacitySlider::sliderRect() const
 //
 // ****************************************************************************
 
-void 
+void
 QvisOpacitySlider::reallyMoveSlider(int newPos)
 {
     QRect oldR = sliderRect();
@@ -331,7 +331,7 @@ QvisOpacitySlider::reallyMoveSlider(int newPos)
 // ****************************************************************************
 // Method: QvisOpacitySlider::sliderLength
 //
-// Purpose: 
+// Purpose:
 //   Returns the width of the slider handle.
 //
 // Returns:    The width of the slider handle.
@@ -340,7 +340,7 @@ QvisOpacitySlider::reallyMoveSlider(int newPos)
 // Creation:   Thu Dec 7 12:38:54 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -356,7 +356,7 @@ QvisOpacitySlider::sliderLength() const
 // Creation:   Thu Dec 7 12:39:24 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -368,7 +368,7 @@ QvisOpacitySlider::maximumSliderDragDistance() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::paintSlider
 //
-// Purpose: 
+// Purpose:
 //   Paints the slider button.
 //
 // Arguments:
@@ -379,7 +379,7 @@ QvisOpacitySlider::maximumSliderDragDistance() const
 // Creation:   Thu Dec 7 12:27:21 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -396,7 +396,7 @@ QvisOpacitySlider::paintSlider( QPainter *p, const QPalette &,
 // ****************************************************************************
 // Method: QvisOpacitySlider::drawSliderGroove
 //
-// Purpose: 
+// Purpose:
 //   Draws the groove on which the slider handle slides.
 //
 // Arguments:
@@ -428,7 +428,7 @@ QvisOpacitySlider::drawSliderGroove(QPainter *p, int x, int y, int w, int,
 // ****************************************************************************
 // Method: QvisOpacitySlider::drawSlider
 //
-// Purpose: 
+// Purpose:
 //   Draws the slider handle.
 //
 // Arguments:
@@ -501,7 +501,7 @@ QvisOpacitySlider::drawSlider(QPainter *p, int x, int y, int w, int h)
 // ****************************************************************************
 // Method: QvisOpacitySlider::drawTicks
 //
-// Purpose: 
+// Purpose:
 //   Draws the slider's tick marks.
 //
 // Arguments:
@@ -514,7 +514,7 @@ QvisOpacitySlider::drawSlider(QPainter *p, int x, int y, int w, int h)
 // Creation:   Thu Dec 7 13:13:53 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -526,7 +526,7 @@ QvisOpacitySlider::drawTicks(QPainter *p, int dist, int w, int i) const
 // ****************************************************************************
 // Method: QvisOpacitySlider::drawTicks
 //
-// Purpose: 
+// Purpose:
 //   Draws the slider's tick marks.
 //
 // Arguments:
@@ -563,7 +563,7 @@ QvisOpacitySlider::drawTicks( QPainter *p, const QPalette& g, int dist,
 // ****************************************************************************
 // Method: QvisOpacitySlider::textPadding
 //
-// Purpose: 
+// Purpose:
 //   Returns the distance from the slider to the text.
 //
 // Returns:    The distance from the slider to the text.
@@ -572,7 +572,7 @@ QvisOpacitySlider::drawTicks( QPainter *p, const QPalette& g, int dist,
 // Creation:   Thu Nov 13 10:23:56 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -584,7 +584,7 @@ QvisOpacitySlider::textPadding() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::imageWidth
 //
-// Purpose: 
+// Purpose:
 //   Returns the width of the pixmap area, which is the width of the whole
 //   widget minus the width if the text that we want to display.
 //
@@ -594,7 +594,7 @@ QvisOpacitySlider::textPadding() const
 // Creation:   Thu Nov 13 09:45:41 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -606,7 +606,7 @@ QvisOpacitySlider::imageWidth() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::paintValueText
 //
-// Purpose: 
+// Purpose:
 //   Draws the value text at the specified location.
 //
 // Arguments:
@@ -621,6 +621,9 @@ QvisOpacitySlider::imageWidth() const
 //   Brad Whitlock, Thu Jun  5 14:29:03 PDT 2008
 //   Qt 4.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -630,7 +633,7 @@ QvisOpacitySlider::paintValueText(QPainter *p, const QPalette &cg, int x,
     // Create the text that we have to display.
     int v = (state == Dragging) ? (valueFromPosition(sliderPos)) : value();
     float t = float(v - minimum()) / float(maximum() - minimum());
-    QString txt; txt.asprintf("%d%%", int(t * 100.f));
+    QString txt = QString("%1%").arg(int(t * 100.f));
 
     // Figure out the y offset.
     int dy = h - fontMetrics().height();
@@ -644,8 +647,8 @@ QvisOpacitySlider::paintValueText(QPainter *p, const QPalette &cg, int x,
 // ****************************************************************************
 // Method: QvisOpacitySlider::createGradientImage
 //
-// Purpose: 
-//   Creates the opacity gradient pixmap that is used as the slider's 
+// Purpose:
+//   Creates the opacity gradient pixmap that is used as the slider's
 //   background pixmap.
 //
 // Programmer: Brad Whitlock
@@ -724,14 +727,14 @@ QvisOpacitySlider::createGradientImage()
 // ****************************************************************************
 // Method: QvisOpacitySlider::deleteGradientImage
 //
-// Purpose: 
+// Purpose:
 //   Delete the gradient pixmap.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:31:26 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -747,7 +750,7 @@ QvisOpacitySlider::deleteGradientImage()
 // ****************************************************************************
 // Method: QvisOpacitySlider::setGradientColor
 //
-// Purpose: 
+// Purpose:
 //   Sets the color used to generate the gradient pixmap.
 //
 // Arguments:
@@ -779,14 +782,14 @@ QvisOpacitySlider::setGradientColor(const QColor &color)
 // ****************************************************************************
 // Method: QvisOpacitySlider::resizeEvent
 //
-// Purpose: 
+// Purpose:
 //   Called when the widget needs to be resized.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:24:59 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -803,7 +806,7 @@ QvisOpacitySlider::resizeEvent(QResizeEvent *)
 // ****************************************************************************
 // Method: QvisOpacitySlider::paintEvent
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the widget gets a paint event. It redraws the
 //   widget.
 //
@@ -833,7 +836,7 @@ QvisOpacitySlider::paintEvent(QPaintEvent *)
         createGradientImage();
     p.drawImage(0, tickOffset, *gradientImage);
 
-    // Draw the groove on which the slider slides.    
+    // Draw the groove on which the slider slides.
     drawSliderGroove(&p, 0, tickOffset, imageWidth(), thickness(), mid);
 
     // Figure out the interval between the tick marks.
@@ -863,7 +866,7 @@ QvisOpacitySlider::paintEvent(QPaintEvent *)
     {
         QStyleOptionFocusRect so;
         so.initFrom(this);
-        style()->drawPrimitive(QStyle::PE_FrameFocusRect, 
+        style()->drawPrimitive(QStyle::PE_FrameFocusRect,
                                &so,
                                &p);
     }
@@ -872,7 +875,7 @@ QvisOpacitySlider::paintEvent(QPaintEvent *)
 // ****************************************************************************
 // Method: QvisOpacitySlider::mousePressEvent
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the mouse is pressed in this widget.
 //
 // Arguments:
@@ -936,7 +939,7 @@ QvisOpacitySlider::mousePressEvent(QMouseEvent *e)
 // ****************************************************************************
 // Method: QvisOpacitySlider::mouseMoveEvent
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the mouse is moved in this widget.
 //
 // Arguments:
@@ -946,7 +949,7 @@ QvisOpacitySlider::mousePressEvent(QMouseEvent *e)
 // Creation:   Thu Dec 7 12:46:37 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -974,7 +977,7 @@ QvisOpacitySlider::mouseMoveEvent(QMouseEvent *e)
 // ****************************************************************************
 // Method: QvisOpacitySlider::wheelEvent
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the widget gets a wheel event.
 //
 // Arguments:
@@ -984,7 +987,7 @@ QvisOpacitySlider::mouseMoveEvent(QMouseEvent *e)
 // Creation:   Thu Dec 7 12:48:10 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1007,14 +1010,14 @@ QvisOpacitySlider::wheelEvent(QWheelEvent * e)
 // ****************************************************************************
 // Method: QvisOpacitySlider::mouseReleaseEvent
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the mouse button is released in the widget.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:48:56 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1026,7 +1029,7 @@ QvisOpacitySlider::mouseReleaseEvent(QMouseEvent *)
 // ****************************************************************************
 // Method: QvisOpacitySlider::moveSlider
 //
-// Purpose: 
+// Purpose:
 //   Moves the left (or top) edge of the slider to position pos. Performs
 //   snapping.
 //
@@ -1037,7 +1040,7 @@ QvisOpacitySlider::mouseReleaseEvent(QMouseEvent *)
 // Creation:   Thu Dec 7 12:51:00 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1054,14 +1057,14 @@ QvisOpacitySlider::moveSlider(int pos)
 // ****************************************************************************
 // Method: QvisOpacitySlider::resetState
 //
-// Purpose: 
+// Purpose:
 //   Resets all state information and stops the timer
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:52:13 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1092,14 +1095,14 @@ QvisOpacitySlider::resetState()
 // ****************************************************************************
 // Method: QvisOpacitySlider::keyPressEvent
 //
-// Purpose: 
+// Purpose:
 //   Called when the widget needs to respond to a key press.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:53:45 PDT 2000
@@ -1147,7 +1150,7 @@ QvisOpacitySlider::keyPressEvent(QKeyEvent *e)
 // ****************************************************************************
 // Method: QvisOpacitySlider::setValue
 //
-// Purpose: 
+// Purpose:
 //   Makes QAbstractSlider::setValue() available as a slot.
 //
 // Arguments:
@@ -1177,7 +1180,7 @@ QvisOpacitySlider::setValue(int value)
 // ****************************************************************************
 // Method: QvisOpacitySlider::setEnabled
 //
-// Purpose: 
+// Purpose:
 //   Sets the widget's enabled state and causes it to repaint if necessary.
 //
 // Arguments:
@@ -1187,7 +1190,7 @@ QvisOpacitySlider::setValue(int value)
 // Creation:   Thu Jan 31 09:25:55 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1202,14 +1205,14 @@ QvisOpacitySlider::setEnabled(bool val)
 // ****************************************************************************
 // Method: QvisOpacitySlider::addStep
 //
-// Purpose: 
+// Purpose:
 //   Moves the slider one pageStep() upwards.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 13:20:52 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1221,14 +1224,14 @@ QvisOpacitySlider::addStep()
 // ****************************************************************************
 // Method: QvisOpacitySlider::subtractStep
 //
-// Purpose: 
+// Purpose:
 //   Moves the slider one pageStep() downwards.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 13:21:16 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1240,14 +1243,14 @@ QvisOpacitySlider::subtractStep()
 // ****************************************************************************
 // Method: QvisOpacitySlider::repeatTimeout
 //
-// Purpose: 
+// Purpose:
 //   Waits for autorepeat.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 13:21:35 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1267,7 +1270,7 @@ QvisOpacitySlider::repeatTimeout()
 // ****************************************************************************
 // Method: QvisOpacitySlider::sizeHint
 //
-// Purpose: 
+// Purpose:
 //   Returns the widget's preferred size.
 //
 // Returns:    The widget's preferred size.
@@ -1276,7 +1279,7 @@ QvisOpacitySlider::repeatTimeout()
 // Creation:   Thu Dec 7 13:20:15 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QSize
@@ -1295,7 +1298,7 @@ QvisOpacitySlider::sizeHint() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::minimumSizeHint
 //
-// Purpose: 
+// Purpose:
 //   Returns the widget's minimum size.
 //
 // Returns:    The widget's minimum size.
@@ -1304,7 +1307,7 @@ QvisOpacitySlider::sizeHint() const
 // Creation:   Thu Dec 7 13:19:43 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QSize
@@ -1319,7 +1322,7 @@ QvisOpacitySlider::minimumSizeHint() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::sizePolicy
 //
-// Purpose: 
+// Purpose:
 //   Returns the widget's size policy.
 //
 // Returns:    The widget's size policy.
@@ -1328,7 +1331,7 @@ QvisOpacitySlider::minimumSizeHint() const
 // Creation:   Thu Dec 7 13:17:36 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QSizePolicy
@@ -1340,7 +1343,7 @@ QvisOpacitySlider::sizePolicy() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::thickness
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of pixels to use for the business part of the
 //    slider (i.e. the non-tickmark portion). The remaining space is shared
 //    equally between the tickmark regions. This function and  sizeHint()
@@ -1351,7 +1354,7 @@ QvisOpacitySlider::sizePolicy() const
 // Creation:   Thu Dec 7 13:18:07 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -1370,7 +1373,7 @@ QvisOpacitySlider::thickness() const
 // ****************************************************************************
 // Method: QvisOpacitySlider::setTickInterval
 //
-// Purpose: 
+// Purpose:
 //   Sets a new tick interval.
 //
 // Arguments:
@@ -1380,7 +1383,7 @@ QvisOpacitySlider::thickness() const
 // Creation:   Thu Dec 7 13:18:58 PST 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1417,14 +1420,14 @@ QvisOpacitySlider::subtractLine()
 // ****************************************************************************
 // Method: QvisOpacitySlider::valueChanged
 //
-// Purpose: 
+// Purpose:
 //   Implements the virtual QAbstractSlider function.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Dec 7 12:23:57 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisPickWindow.C
+++ b/src/gui/QvisPickWindow.C
@@ -1032,6 +1032,9 @@ QvisPickWindow::UpdateTimeOptions()
 //   Added call to ResizeTabs, in case user changed #tabs without clicking
 //   'Apply' before perfoming picks.  It's a no-op if #tabs hasn't changed.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -1053,7 +1056,7 @@ QvisPickWindow::UpdatePage()
 
         // Change the tab heading.
         lastLetter = pickLetter;
-        temp.asprintf(" %s ", pickAtts->GetPickLetter().c_str());
+        temp = QString(" %1 ").arg(pickAtts->GetPickLetter().c_str());
         resultsTabWidget->setTabText(nextPage, temp);
 
         //
@@ -2105,6 +2108,9 @@ QvisPickWindow::ResizeTabs()
 //   Kathleen Biagas, Wed Oct 29 11:59:46 PDT 2014
 //   Add PickLetter (tab text) to output, add newlines between picks.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -2113,8 +2119,7 @@ QvisPickWindow::savePickText()
     QString saveExtension(".txt");
 
     // Create the name of a VisIt save file to use.
-    QString defaultFile;
-    defaultFile.asprintf("visit%04d", saveCount);
+    QString defaultFile=QString("visit%1").arg(saveCount,4,10,QLatin1Char('0'));
     defaultFile += saveExtension;
 
     QString useDir;

--- a/src/gui/QvisPlotListBoxItem.C
+++ b/src/gui/QvisPlotListBoxItem.C
@@ -27,7 +27,7 @@ QPixmap *QvisPlotListBoxItem::selectionIcon = 0;
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::QvisPlotListBoxItem
 //
-// Purpose: 
+// Purpose:
 //   Constructor for QvisPlotListBoxItem.
 //
 // Arguments:
@@ -53,7 +53,7 @@ QPixmap *QvisPlotListBoxItem::selectionIcon = 0;
 //   Initial Qt4 Port.
 //
 //   Cyrus Harrison, Thu Dec  4 08:28:50 PST 2008
-//   Removed unnecessary todo comment. 
+//   Removed unnecessary todo comment.
 //
 //   Brad Whitlock, Fri Jul 23 14:55:53 PDT 2010
 //   I added selectionName.
@@ -63,7 +63,7 @@ QPixmap *QvisPlotListBoxItem::selectionIcon = 0;
 //
 // ****************************************************************************
 
-QvisPlotListBoxItem::QvisPlotListBoxItem(const Plot &p, const QString &prefix_, 
+QvisPlotListBoxItem::QvisPlotListBoxItem(const Plot &p, const QString &prefix_,
     const QString &selectionName_)
     : QListWidgetItem(), plot(p), prefix(prefix_), selectionName(selectionName_),
       clickable()
@@ -144,7 +144,7 @@ QvisPlotListBoxItem::QvisPlotListBoxItem(const Plot &p, const QString &prefix_,
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::~QvisPlotListBoxItem
 //
-// Purpose: 
+// Purpose:
 //   Destructor for QvisPlotListBoxItem.
 //
 // Programmer: Brad Whitlock
@@ -167,7 +167,7 @@ QvisPlotListBoxItem::~QvisPlotListBoxItem()
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::height
 //
-// Purpose: 
+// Purpose:
 //   Returns the height of a line of text.
 //
 // Arguments:
@@ -184,7 +184,7 @@ QvisPlotListBoxItem::~QvisPlotListBoxItem()
 //   Initial Qt4 Port.
 //
 //   Brad Whitlock, Fri Jul 23 13:44:54 PDT 2010
-//   I increased the size, depending on whether a selection is applied or 
+//   I increased the size, depending on whether a selection is applied or
 //   created by this plot.
 //
 // ****************************************************************************
@@ -213,7 +213,7 @@ QvisPlotListBoxItem::height(const QListWidget *lb) const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::width
 //
-// Purpose: 
+// Purpose:
 //   Returns the width of this line.
 //
 // Arguments:
@@ -223,7 +223,7 @@ QvisPlotListBoxItem::height(const QListWidget *lb) const
 // Creation:   Mon Sep 11 11:45:01 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -235,7 +235,7 @@ QvisPlotListBoxItem::width(const QListWidget *lb) const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::textX
 //
-// Purpose: 
+// Purpose:
 //   Returns the x location of where we start drawing text.
 //
 // Returns:    The x coordinate of where we start drawing text.
@@ -244,7 +244,7 @@ QvisPlotListBoxItem::width(const QListWidget *lb) const
 // Creation:   Thu Oct 22 10:23:01 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -263,7 +263,7 @@ QvisPlotListBoxItem::textX() const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::paint
 //
-// Purpose: 
+// Purpose:
 //   Draws the item in the listbox. It is drawn in different colors
 //   depending on the state of the plot.
 //
@@ -426,7 +426,7 @@ void QvisPlotListBoxItem::paint(QPainter *painter)
         QString dbName;
         bool prefixIsNumeric = false;
         prefix.left(prefix.length() - 1).toInt(&prefixIsNumeric);
-        if(prefixIsNumeric) 
+        if(prefixIsNumeric)
         {
             // The prefix is a number so get the db name.
             QualifiedFilename name(plot.GetDatabaseName());
@@ -710,7 +710,7 @@ void QvisPlotListBoxItem::paint(QPainter *painter)
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::setTextPen
 //
-// Purpose: 
+// Purpose:
 //   Sets the text pen according to the state of the plot and the highlightText
 //   argument.
 //
@@ -747,7 +747,7 @@ QvisPlotListBoxItem::setTextPen(QPainter *painter, bool highlightText) const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::drawButtonSurface
 //
-// Purpose: 
+// Purpose:
 //   Draws a button with no contents in the specified rectangle.
 //
 // Arguments:
@@ -792,7 +792,7 @@ QvisPlotListBoxItem::drawButtonSurface(QPainter *painter, const QRect &r) const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::drawUpDownButton
 //
-// Purpose: 
+// Purpose:
 //   Draws an up/down button in the specified rectangle.
 //
 // Arguments:
@@ -810,7 +810,7 @@ QvisPlotListBoxItem::drawButtonSurface(QPainter *painter, const QRect &r) const
 // ****************************************************************************
 
 void
-QvisPlotListBoxItem::drawUpDownButton(QPainter *painter, const QRect &r, 
+QvisPlotListBoxItem::drawUpDownButton(QPainter *painter, const QRect &r,
     bool up) const
 {
     painter->save();
@@ -832,7 +832,7 @@ QvisPlotListBoxItem::drawUpDownButton(QPainter *painter, const QRect &r,
         int x = r.x() + center + 2;
         tri.setPoint(0, x, y);
         tri.setPoint(1, x-d, y+d);
-        tri.setPoint(2, x+d, y+d);        
+        tri.setPoint(2, x+d, y+d);
     }
     else
     {
@@ -853,7 +853,7 @@ QvisPlotListBoxItem::drawUpDownButton(QPainter *painter, const QRect &r,
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::drawDeleteButton
 //
-// Purpose: 
+// Purpose:
 //   Draws a delete button in the specified rectangle.
 //
 // Arguments:
@@ -893,14 +893,14 @@ QvisPlotListBoxItem::drawDeleteButton(QPainter *painter, const QRect &r) const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::clicked
 //
-// Purpose: 
+// Purpose:
 //   This method checks a clicked position against any significant things in
 //   the item. If anything significant is clicked, return a value other than
 //   -1.
 //
 // Arguments:
 //   pos           : The location of the click.
-//   doubleClicked : Whether we're calling this routine in response to a 
+//   doubleClicked : Whether we're calling this routine in response to a
 //                   double mouse click.
 //   id            : The int in which to return an identifier.
 //
@@ -1002,7 +1002,7 @@ QvisPlotListBoxItem::clicked(const QPoint &pos, bool doubleClicked, int &id)
             // Activate the plot attributes.
             id = plot.GetPlotType();
             return 2;
-        }         
+        }
     }
     else if(doubleClicked)
     {
@@ -1017,7 +1017,7 @@ QvisPlotListBoxItem::clicked(const QPoint &pos, bool doubleClicked, int &id)
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::AddClickableRectangle
 //
-// Purpose: 
+// Purpose:
 //   Adds a rectangle to the list of clickable rectangles so that we can check
 //   it when the user clicks on the item.
 //
@@ -1030,7 +1030,7 @@ QvisPlotListBoxItem::clicked(const QPoint &pos, bool doubleClicked, int &id)
 // Creation:   Thu Apr 10 15:32:08 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1044,7 +1044,7 @@ QvisPlotListBoxItem::AddClickableRectangle(int id, const QRect &r,
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::GetOperatorPixmap
 //
-// Purpose: 
+// Purpose:
 //   Gets the specified operator pixmap or creates one if necessary.
 //
 // Arguments:
@@ -1061,6 +1061,9 @@ QvisPlotListBoxItem::AddClickableRectangle(int id, const QRect &r,
 //   Cyrus Harrison, Mon Jul  7 13:39:58 PDT 2008
 //   Initial Qt4 Port.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -1070,7 +1073,7 @@ QvisPlotListBoxItem::GetOperatorPixmap(int operatorType, QPixmap &pm)
     GUIOperatorPluginInfo *info = oMgr->GetGUIPluginInfo(
         oMgr->GetEnabledID(operatorType));
 
-    QString key; key.asprintf("operator_icon_%s", info->GetName());
+    QString key = QString("operator_icon_%1").arg(info->GetName());
     if(!QPixmapCache::find(key, pm))
     {
         if(info->XPMIconData())
@@ -1085,7 +1088,7 @@ QvisPlotListBoxItem::GetOperatorPixmap(int operatorType, QPixmap &pm)
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::GetPlotPixmap
 //
-// Purpose: 
+// Purpose:
 //   Gets the specified plot pixmap or creates one if necessary.
 //
 // Arguments:
@@ -1098,9 +1101,12 @@ QvisPlotListBoxItem::GetOperatorPixmap(int operatorType, QPixmap &pm)
 // Modifications:
 //   Brad Whitlock, Tue Jun 24 12:15:26 PDT 2008
 //   Get the plugin manager from the viewer proxy.
-//  
+//
 //   Cyrus Harrison, Mon Jul  7 13:39:58 PDT 2008
 //   Initial Qt4 Port.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -1111,7 +1117,7 @@ QvisPlotListBoxItem::GetPlotPixmap(int plotType, QPixmap &pm)
     GUIPlotPluginInfo *info = pMgr->GetGUIPluginInfo(
         pMgr->GetEnabledID(plotType));
 
-    QString key; key.asprintf("plot_icon_%s", info->GetName());
+    QString key = QString("plot_icon_%1").arg(info->GetName());
     if(!QPixmapCache::find(key, pm))
     {
         if(info->XPMIconData())
@@ -1126,14 +1132,14 @@ QvisPlotListBoxItem::GetPlotPixmap(int plotType, QPixmap &pm)
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::GetDisplayString
 //
-// Purpose: 
+// Purpose:
 //   Adds the applied operators to the plot variable and returns the
 //   resulting QString.
 //
 // Arguments:
 //   plot : The Plot for which we're creating the plot variable.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 25 12:48:30 PDT 2000
@@ -1187,7 +1193,7 @@ QvisPlotListBoxItem::GetDisplayString(const Plot &plot, const QString &prefix)
     QString plotVar;
     for(i = plot.GetNumOperators(); i > 0; --i)
     {
-        GUIOperatorPluginInfo *operatorInfo = 
+        GUIOperatorPluginInfo *operatorInfo =
             operatorPluginManager->GetGUIPluginInfo(
                   operatorPluginManager->GetEnabledID(plot.GetOperator(i-1)));
         s = operatorInfo->GetMenuName();
@@ -1210,7 +1216,7 @@ QvisPlotListBoxItem::GetDisplayString(const Plot &plot, const QString &prefix)
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::isExpanded
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the item is expanded.
 //
 // Returns:    True if the item is expanded; false otherwise.
@@ -1219,7 +1225,7 @@ QvisPlotListBoxItem::GetDisplayString(const Plot &plot, const QString &prefix)
 // Creation:   Thu Apr 17 09:28:36 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -1231,7 +1237,7 @@ QvisPlotListBoxItem::isExpanded() const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::activeOperatorIndex
 //
-// Purpose: 
+// Purpose:
 //   Returns the active operator index.
 //
 // Returns:    The active operator index.
@@ -1240,7 +1246,7 @@ QvisPlotListBoxItem::isExpanded() const
 // Creation:   Thu Apr 17 09:29:06 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -1252,21 +1258,21 @@ QvisPlotListBoxItem::activeOperatorIndex() const
 // ****************************************************************************
 // Method: QvisPlotListBoxItem::setApplyOperators
 //
-// Purpose: 
+// Purpose:
 //   Called just before paint() to set whether operators should be applied
 //   to all plots.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Mar 14 15:42:39 PDT 2013
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1304,7 +1310,7 @@ QvisPlotListBoxItem::ClickableRectangle::~ClickableRectangle()
 }
 
 void
-QvisPlotListBoxItem::ClickableRectangle::operator = ( 
+QvisPlotListBoxItem::ClickableRectangle::operator = (
     const QvisPlotListBoxItem::ClickableRectangle &obj)
 {
     r = obj.r;

--- a/src/gui/QvisQueryOverTimeWindow.C
+++ b/src/gui/QvisQueryOverTimeWindow.C
@@ -23,7 +23,7 @@ using std::string;
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::QvisQueryOverTimeWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Programmer: xml2window
@@ -55,14 +55,14 @@ QvisQueryOverTimeWindow::QvisQueryOverTimeWindow(
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::~QvisQueryOverTimeWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: xml2window
 // Creation:   Wed Mar 31 08:46:20 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisQueryOverTimeWindow::~QvisQueryOverTimeWindow()
@@ -73,7 +73,7 @@ QvisQueryOverTimeWindow::~QvisQueryOverTimeWindow()
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: xml2window
@@ -81,17 +81,17 @@ QvisQueryOverTimeWindow::~QvisQueryOverTimeWindow()
 //
 // Modifications:
 //   Kathleen Bonnell, Mon Feb 27 12:36:41 PST 2006
-//   Added more text to createWindow label, to clarify intent. 
+//   Added more text to createWindow label, to clarify intent.
 //
 //   Brad Whitlock, Tue Apr  8 15:26:49 PDT 2008
 //   Support for internationalization.
-//   
+//
 //    Cyrus Harrison, Tue Jun 24 11:15:28 PDT 2008
 //    Initial Qt4 Port.
 //
 //   Kathleen Bonnell, Mon Feb  7 13:07:25 PST 2011
 //   Added comments that explicitly state start/end times are TimeStates.
-//   And that the 'Cycles' 'Times' and 'Timestate' options only apply to 
+//   And that the 'Cycles' 'Times' and 'Timestate' options only apply to
 //   values displayed for x-axis.
 //
 //   Kathleen Biagas, Fri Aug 26 17:12:13 PDT 2011
@@ -108,8 +108,8 @@ QvisQueryOverTimeWindow::CreateWindowContents()
     QGroupBox *timeTypeBox = new QGroupBox(central);
     timeTypeBox->setTitle(tr("X-axis"));
     topLayout->addWidget(timeTypeBox);
-   
-    QGridLayout *timeTypeBoxLayout = new QGridLayout(timeTypeBox);    
+
+    QGridLayout *timeTypeBoxLayout = new QGridLayout(timeTypeBox);
 
     QLabel *mLabel = new QLabel(tr("Choices entered here only apply to values displayed in the x-axis of the time curve."), central);
     mLabel->setWordWrap(true);
@@ -132,12 +132,12 @@ QvisQueryOverTimeWindow::CreateWindowContents()
     timeTypeLayout->addWidget(timestep);
 
     timeTypeBoxLayout->addLayout(timeTypeLayout, 1, 0);
-    
+
     QGridLayout *mainLayout = new QGridLayout();
     topLayout->addLayout(mainLayout);
 
     //
-    // CreateWindow 
+    // CreateWindow
     //
     createWindow = new QCheckBox(tr("Use 1st unused window or create new\none. All subsequent queries will use this\nsame window."),
                                   central);
@@ -146,7 +146,7 @@ QvisQueryOverTimeWindow::CreateWindowContents()
     mainLayout->addWidget(createWindow, 0,0,3,2);
 
     //
-    // WindowId 
+    // WindowId
     //
     windowIdLabel = new QLabel(tr("Window #"), central);
     mainLayout->addWidget(windowIdLabel,3,0);
@@ -161,7 +161,7 @@ QvisQueryOverTimeWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets in the window when the subject changes.
 //
 // Programmer: xml2window
@@ -176,6 +176,9 @@ QvisQueryOverTimeWindow::CreateWindowContents()
 //
 //   Kathleen Biagas, Fri Aug 26 17:12:13 PDT 2011
 //   Removed start/end times and stride.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.setNum.
 //
 // ****************************************************************************
 
@@ -213,7 +216,7 @@ QvisQueryOverTimeWindow::UpdateWindow(bool doAll)
             createWindow->setChecked(atts->GetCreateWindow());
             break;
           case QueryOverTimeAttributes::ID_windowId:
-            temp.asprintf("%d", atts->GetWindowId());
+            temp.setNum(atts->GetWindowId());
             windowId->setText(temp);
             break;
           default:
@@ -226,7 +229,7 @@ QvisQueryOverTimeWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets values from certain widgets and stores them in the subject.
 //
 // Programmer: xml2window
@@ -235,7 +238,7 @@ QvisQueryOverTimeWindow::UpdateWindow(bool doAll)
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 15:26:49 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Kathleen Biagas, Fri Aug 26 17:12:13 PDT 2011
 //   Removed start/end times and stride.
 //
@@ -286,14 +289,14 @@ QvisQueryOverTimeWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Called to apply changes in the subject.
 //
 // Programmer: xml2window
 // Creation:   Wed Mar 31 08:46:20 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -319,14 +322,14 @@ QvisQueryOverTimeWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when apply button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Wed Mar 31 08:46:20 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -339,14 +342,14 @@ QvisQueryOverTimeWindow::apply()
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::makeDefault
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when "Make default" button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Wed Mar 31 08:46:20 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -361,14 +364,14 @@ QvisQueryOverTimeWindow::makeDefault()
 // ****************************************************************************
 // Method: QvisQueryOverTimeWindow::reset
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when reset button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Wed Mar 31 08:46:20 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisQueryWindow.C
+++ b/src/gui/QvisQueryWindow.C
@@ -48,7 +48,7 @@ using std::string;
 // ****************************************************************************
 // Method: QvisQueryWindow::QvisQueryWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisQueryWindow class.
 //
 // Arguments:
@@ -60,9 +60,9 @@ using std::string;
 // Creation:   Mon Sep 9 16:47:41 PST 2002
 //
 // Modifications:
-//   Kathleen Bonnell, Mon Sep 30 14:38:33 PDT 2002 
+//   Kathleen Bonnell, Mon Sep 30 14:38:33 PDT 2002
 //   Initialize queryAtts.
-// 
+//
 //   Brad Whitlock, Fri Nov 7 17:24:42 PST 2003
 //   Prevented extra buttons from being created.
 //
@@ -81,9 +81,9 @@ using std::string;
 //
 // ****************************************************************************
 
-QvisQueryWindow::QvisQueryWindow(const QString &caption, 
-    const QString &shortName, QvisNotepadArea *n) : 
-    QvisPostableWindowSimpleObserver(caption, shortName, n, NoExtraButtons, 
+QvisQueryWindow::QvisQueryWindow(const QString &caption,
+    const QString &shortName, QvisNotepadArea *n) :
+    QvisPostableWindowSimpleObserver(caption, shortName, n, NoExtraButtons,
                                      false),
     currentFloatFormat()
 {
@@ -106,16 +106,16 @@ QvisQueryWindow::QvisQueryWindow(const QString &caption,
 // ****************************************************************************
 // Method: QvisQueryWindow::~QvisQueryWindow
 //
-// Purpose: 
+// Purpose:
 //   The destructor for the QvisQueryWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 9 16:48:36 PST 2002
 //
 // Modifications:
-//   Kathleen Bonnell, Mon Sep 30 14:38:33 PDT 2002 
+//   Kathleen Bonnell, Mon Sep 30 14:38:33 PDT 2002
 //   Detach queryAtts.
-//   
+//
 // ****************************************************************************
 
 QvisQueryWindow::~QvisQueryWindow()
@@ -136,7 +136,7 @@ QvisQueryWindow::~QvisQueryWindow()
 // ****************************************************************************
 // Method: QvisQueryWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -146,29 +146,29 @@ QvisQueryWindow::~QvisQueryWindow()
 //   Brad Whitlock, Mon May 12 13:02:32 PST 2003
 //   I added a button to clear out the query results.
 //
-//   Kathleen Bonnell, Thu Nov 26 08:30:49 PST 2003 
-//   I added radio buttons to select between a database query and a 
+//   Kathleen Bonnell, Thu Nov 26 08:30:49 PST 2003
+//   I added radio buttons to select between a database query and a
 //   'current plot' query.  (Only appear if query requests them).
 //
-//   Kathleen Bonnell, Thu Apr  1 18:46:55 PST 2004 
-//   Added TimeQuery push button. 
+//   Kathleen Bonnell, Thu Apr  1 18:46:55 PST 2004
+//   Added TimeQuery push button.
 //
-//   Kathleen Bonnell, Thu Apr 22 15:31:24 PDT 2004 
-//   Made the default for dataOpts be 'actual data'. 
+//   Kathleen Bonnell, Thu Apr 22 15:31:24 PDT 2004
+//   Made the default for dataOpts be 'actual data'.
 //
-//   Kathleen Bonnell, Tue Aug 24 15:31:56 PDT 2004 
-//   Made the default for dataOpts be 'original data'. 
+//   Kathleen Bonnell, Tue Aug 24 15:31:56 PDT 2004
+//   Made the default for dataOpts be 'original data'.
 //
-//   Kathleen Bonnell, Sat Sep  4 11:49:58 PDT 2004 
+//   Kathleen Bonnell, Sat Sep  4 11:49:58 PDT 2004
 //   Added displayMode.
 //
-//   Kathleen Bonnell, Wed Sep  8 10:06:16 PDT 2004 
-//   Remove coordLabel. 
+//   Kathleen Bonnell, Wed Sep  8 10:06:16 PDT 2004
+//   Remove coordLabel.
 //
-//   Kathleen Bonnell, Wed Dec 15 17:16:17 PST 2004 
-//   Added useGlobal checkbox. 
+//   Kathleen Bonnell, Wed Dec 15 17:16:17 PST 2004
+//   Added useGlobal checkbox.
 //
-//   Kathleen Bonnell, Tue Jan 11 16:16:48 PST 2005 
+//   Kathleen Bonnell, Tue Jan 11 16:16:48 PST 2005
 //   Connect useGlobal to its slot.
 //
 //   Hank Childs, Fri Sep  1 16:21:35 PDT 2006
@@ -192,7 +192,7 @@ QvisQueryWindow::~QvisQueryWindow()
 //   that the fourth text line isn't clobbered by the variable controls.
 //
 //   Cyrus Harrison,
-//   Refactoring for python query integration. Most of functionality was 
+//   Refactoring for python query integration. Most of functionality was
 //   moved into the CreateStandardQueryWidget() method.
 //
 // ****************************************************************************
@@ -226,7 +226,7 @@ QvisQueryWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisQueryWindow::CreateStandardQueryWidget
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets for the standard query tab.
 //
 // Programmer: Cyrus Harrison
@@ -250,6 +250,9 @@ QvisQueryWindow::CreateWindowContents()
 //
 //   Kathleen Biagas, Thu Jun  8 12:50:13 PDT 2017
 //   Made the default for dataOpts be 'actual data'.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -311,7 +314,7 @@ QvisQueryWindow::CreateStandardQueryWidget()
     vbLayout->addWidget(varsButton);
 
     varsLineEdit = new QLineEdit(argPanel);
-    varsLineEdit->setText("default"); 
+    varsLineEdit->setText("default");
     varsLineEdit->hide();
     connect(varsLineEdit, SIGNAL(returnPressed()),
             this, SLOT(handleText()));
@@ -324,8 +327,8 @@ QvisQueryWindow::CreateStandardQueryWidget()
     for(int i = 0; i < 6; ++i)
     {
         QString name1, name2;
-        name1.asprintf("queryArgLabel%02d", i);
-        name2.asprintf("queryArgText%02d", i);
+        name1 = QString("queryArgLabel%1").arg(i,2,10,QLatin1Char('0'));
+        name2 = QString("queryArgText%1").arg(i,2,10,QLatin1Char('0'));
         textFields[i] = new QLineEdit(name2,argPanel);
         connect(textFields[i], SIGNAL(returnPressed()),
                 this, SLOT(handleText()));
@@ -337,7 +340,7 @@ QvisQueryWindow::CreateStandardQueryWidget()
     }
 
     useGlobal = new QCheckBox(tr("Use Global Id"), argPanel);
-    connect(useGlobal, SIGNAL(toggled(bool)), this, 
+    connect(useGlobal, SIGNAL(toggled(bool)), this,
             SLOT(useGlobalToggled(bool)));
     useGlobal->hide();
     sLayout->addWidget(useGlobal, 8, 0, 1, 2);
@@ -356,25 +359,25 @@ QvisQueryWindow::CreateStandardQueryWidget()
 
     // Add the dump check box options to the argument panel.
     dumpIndex = new QCheckBox(tr("Dump Index"), argPanel);
-    connect(dumpIndex, SIGNAL(toggled(bool)), this, 
+    connect(dumpIndex, SIGNAL(toggled(bool)), this,
             SLOT(dumpIndexToggled(bool)));
     dumpIndex->hide();
     sLayout->addWidget(dumpIndex, 11, 0, 1, 2);
 
     dumpCoordinates = new QCheckBox(tr("Dump Coordinates"), argPanel);
-    connect(dumpCoordinates, SIGNAL(toggled(bool)), this, 
+    connect(dumpCoordinates, SIGNAL(toggled(bool)), this,
             SLOT(dumpCoordinatesToggled(bool)));
     dumpCoordinates->hide();
     sLayout->addWidget(dumpCoordinates, 12, 0, 1, 2);
 
     dumpArcLength = new QCheckBox(tr("Dump Arc Length"), argPanel);
-    connect(dumpArcLength, SIGNAL(toggled(bool)), this, 
+    connect(dumpArcLength, SIGNAL(toggled(bool)), this,
             SLOT(dumpArcLengthToggled(bool)));
     dumpArcLength->hide();
     sLayout->addWidget(dumpArcLength, 13, 0, 1, 2);
 
     dumpValues = new QCheckBox(tr("Dump Values"), argPanel);
-    connect(dumpValues, SIGNAL(toggled(bool)), this, 
+    connect(dumpValues, SIGNAL(toggled(bool)), this,
             SLOT(dumpValuesToggled(bool)));
     dumpValues->hide();
     sLayout->addWidget(dumpValues, 14, 0, 1, 2);
@@ -403,7 +406,7 @@ QvisQueryWindow::CreateStandardQueryWidget()
     //  PickQueryWidget needs to know when time is toggled, so it
     //  can enable certain of its own time-specific options.
     //
-    connect(timeQueryOptions, SIGNAL(toggled(bool)), 
+    connect(timeQueryOptions, SIGNAL(toggled(bool)),
             pickQueryWidget, SLOT(timeOptionsToggled(bool)));
 
     // Add the query button to the argument panel.
@@ -423,7 +426,7 @@ QvisQueryWindow::CreateStandardQueryWidget()
 // ****************************************************************************
 // Method: QvisQueryWindow::CreatePythonQueryWidget
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets for the python query tab.
 //
 // Programmer: Cyrus Harrison
@@ -478,7 +481,7 @@ QvisQueryWindow::CreatePythonQueryWidget()
 // ****************************************************************************
 // Method: QvisQueryWindow::CreateResultsWidget
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets that display query results.
 //
 // Programmer: Cyrus Harrison
@@ -519,7 +522,7 @@ QvisQueryWindow::CreateResultsWidget()
 // ****************************************************************************
 // Method: QvisQueryWindow::CreateEntireWindow
 //
-// Purpose: 
+// Purpose:
 //   Creates the entire window.
 //
 // Programmer: Brad Whitlock
@@ -569,7 +572,7 @@ QvisQueryWindow::CreateEntireWindow()
     connect(saveResultsButton, SIGNAL(clicked()),
             this, SLOT(saveResultText()));
     buttonLayout->addWidget(saveResultsButton);
-    
+
     buttonLayout->addStretch();
 
     postButton = new QPushButton(tr("Post"), central);
@@ -595,7 +598,7 @@ QvisQueryWindow::CreateEntireWindow()
 // ****************************************************************************
 // Method: QvisQueryWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the window needs to be updated.
 //
 // Arguments:
@@ -605,13 +608,13 @@ QvisQueryWindow::CreateEntireWindow()
 // Creation:   Mon Sep 9 16:49:24 PST 2002
 //
 // Modifications:
-//   Kathleen Bonnell, Wed Sep 25 11:31:41 PDT 2002 
+//   Kathleen Bonnell, Wed Sep 25 11:31:41 PDT 2002
 //   QueryAtts can also be used to update the results.
-//   
-//   Kathleen Bonnell, Thu Apr  1 18:46:55 PST 2004 
+//
+//   Kathleen Bonnell, Thu Apr  1 18:46:55 PST 2004
 //   Call update for timeQueryButton.
-//   
-//   Kathleen Bonnell, Sat Sep  4 11:49:58 PDT 2004 
+//
+//   Kathleen Bonnell, Sat Sep  4 11:49:58 PDT 2004
 //   Removed unncessary argument from UpdateQueryList.
 //
 // ****************************************************************************
@@ -622,7 +625,7 @@ QvisQueryWindow::UpdateWindow(bool doAll)
     if(SelectedSubject() == queries || doAll)
         UpdateQueryList();
 
-    if(SelectedSubject() == queryAtts || 
+    if(SelectedSubject() == queryAtts ||
        SelectedSubject() == pickAtts || doAll)
         UpdateResults(doAll);
 
@@ -636,14 +639,14 @@ QvisQueryWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisQueryWindow::UpdateQueryButton
 //
-// Purpose: 
+// Purpose:
 //   Sets the enabled state for the query button.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 9 16:50:03 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -653,15 +656,15 @@ QvisQueryWindow::UpdateQueryButton()
                (plotList->GetNumPlots() > 0);
     queryButton->setEnabled(val);
 }
- 
+
 // ****************************************************************************
 // Method: QvisQueryWindow::UpdateTimeQueryOptions
 //
-// Purpose: 
+// Purpose:
 //   Sets the enabled state for the time query options widget.
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   April 1, 2004 
+// Programmer: Kathleen Bonnell
+// Creation:   April 1, 2004
 //
 // Modifications:
 //    Kathleen Biagas, Wed Apr 11 19:14:07 PDT 2012
@@ -693,9 +696,9 @@ QvisQueryWindow::UpdateTimeQueryOptions()
 //   Kathleen Bonnell, Tue Nov  8 10:45:43 PST 2005
 //   Reflect changes in queryList -- timeQuery is now queryMode.
 //
-//   Kathleen Bonnell, Fri Sep 28 14:46:09 PDT 2007 
+//   Kathleen Bonnell, Fri Sep 28 14:46:09 PDT 2007
 //   Added 'canBePublic' which when false, allows queries to NOT be added
-//   to this window. 
+//   to this window.
 //
 //   Brad Whitlock, Tue Apr  8 15:26:49 PDT 2008
 //   Support for internationalization.
@@ -721,7 +724,7 @@ QvisQueryWindow::UpdateQueryList()
     int selectedIndex = -1;
     int selectedFunction = displayMode->currentIndex() -1;
     queryList->clear();
-    
+
     for(size_t i = 0; i < names.size(); ++i)
     {
         if (!canBePublic[i])
@@ -770,7 +773,7 @@ QvisQueryWindow::UpdateQueryList()
 // ****************************************************************************
 // Method: QvisQueryWindow::UpdateResults
 //
-// Purpose: 
+// Purpose:
 //   Displays the query results.
 //
 // Note:       This method will change big time when queries are really
@@ -780,9 +783,9 @@ QvisQueryWindow::UpdateQueryList()
 // Creation:   Mon Sep 9 16:55:39 PST 2002
 //
 // Modifications:
-//   Kathleen Bonnell, Wed Sep 25 11:31:41 PDT 2002 
+//   Kathleen Bonnell, Wed Sep 25 11:31:41 PDT 2002
 //   Use pickAtts to set resultText only if the pick was fulfilled.
-//   Also use queryAtts to set resultText. 
+//   Also use queryAtts to set resultText.
 //
 //   Brad Whitlock, Fri May 9 17:27:05 PST 2003
 //   I made it append the query results to the existing text.
@@ -821,7 +824,7 @@ QvisQueryWindow::UpdateResults(bool)
 // ****************************************************************************
 // Method: QvisQueryWindow::UpdateArgumentPanel
 //
-// Purpose: 
+// Purpose:
 //   Shows the widgets to gather query parameters.
 //
 // Arguments:
@@ -833,7 +836,7 @@ QvisQueryWindow::UpdateResults(bool)
 // Modifications:
 //   Kathleen Bonnell, Mon Nov 18 09:42:12 PST 2002
 //   Don't show the variable widget for Eulerian queries.
-//   
+//
 //   Hank Childs, Tue Mar 18 21:30:09 PST 2003
 //   Added revolved surface area.
 //
@@ -905,7 +908,7 @@ QvisQueryWindow::UpdateResults(bool)
 //   Kathleen Bonnell, Tue Jun 24 11:18:13 PDT 2008
 //   Queries that require variables now use varsButton and varsLineEdit.
 //
-//   Kathleen Bonnell, Tue Jun 24 13:38:45 PDT 2008 
+//   Kathleen Bonnell, Tue Jun 24 13:38:45 PDT 2008
 //   Limit the variables for Hohlraum Flux to Scalars and Arrays.
 //
 //   Eric Brugger, Mon May 11 13:48:58 PDT 2009
@@ -1277,7 +1280,7 @@ QvisQueryWindow::ConnectPlotList(PlotList *pl)
 // ****************************************************************************
 // Method: QvisQueryWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This method is called when we actually want to do a query.
 //
 // Arguments:
@@ -1287,8 +1290,8 @@ QvisQueryWindow::ConnectPlotList(PlotList *pl)
 // Creation:   Mon Sep 9 16:58:47 PST 2002
 //
 // Modifications:
-//   Kathleen Bonnell, Fri Nov 15 09:07:36 PST 2002  
-//   Removed call to viewer->SetPickAttributes.   
+//   Kathleen Bonnell, Fri Nov 15 09:07:36 PST 2002
+//   Removed call to viewer->SetPickAttributes.
 //
 //   Brad Whitlock, Thu Dec 26 17:42:37 PST 2002
 //   I made it use stringVectors when passing variables names to the
@@ -1297,14 +1300,14 @@ QvisQueryWindow::ConnectPlotList(PlotList *pl)
 //   Brad Whitlock, Mon May 12 14:26:17 PST 2003
 //   I removed the line of code that cleared the query results.
 //
-//   Kathleen Bonnell, Wed May 14 17:32:20 PDT 2003 
-//   Removed Pick related hack. 
+//   Kathleen Bonnell, Wed May 14 17:32:20 PDT 2003
+//   Removed Pick related hack.
 //
-//   Kathleen Bonnell, Wed Jul 23 16:02:22 PDT 2003 
-//   Added special checks for 'Variable by Zone' query.  
+//   Kathleen Bonnell, Wed Jul 23 16:02:22 PDT 2003
+//   Added special checks for 'Variable by Zone' query.
 //   Include 'sample' in call to viewer->LineQuery.
 //
-//   Kathleen Bonnell, Thu Nov 26 08:30:49 PST 2003 
+//   Kathleen Bonnell, Thu Nov 26 08:30:49 PST 2003
 //   Removed references to specific query names.  Reworked code to
 //   utilize new WindowType ivar.
 //
@@ -1347,7 +1350,7 @@ QvisQueryWindow::ConnectPlotList(PlotList *pl)
 //   Initial Qt4 Port.
 //
 //   Cyrus Harrison, Sat Oct 18 21:33:18 PDT 2008
-//   Fixed parsing error for Connected Components Summary Query, caused by 
+//   Fixed parsing error for Connected Components Summary Query, caused by
 //   migration of GetVars to a new text field widget.
 //
 //   Eric Brugger, Mon May 11 13:48:58 PDT 2009
@@ -1409,7 +1412,7 @@ QvisQueryWindow::Apply(bool ignore)
 // Modifications:
 //   Eric Brugger, Fri Jul  2 15:54:23 PDT 2010
 //   I added the x ray image query.
-//  
+//
 //   Kathleen Bonnell, Tue Mar  1 11:08:16 PST 2011
 //   For TimePicks, send along curvePlotType.
 //
@@ -1459,7 +1462,7 @@ QvisQueryWindow::ExecuteStandardQuery()
             ;//basic queries don't require any more parameters
         }
         else if ((winT == QueryList::DomainZone) ||
-                 (winT == QueryList::DomainNode) || 
+                 (winT == QueryList::DomainNode) ||
                  (winT == QueryList::DomainZoneVars) ||
                  (winT == QueryList::DomainNodeVars))
         {
@@ -1702,7 +1705,7 @@ QvisQueryWindow::ExecutePythonQuery()
 // ****************************************************************************
 // Method: QvisQueryWindow::GetNumber
 //
-// Purpose: 
+// Purpose:
 //   Gets an integer from the i'th text field.
 //
 // Arguments:
@@ -1842,14 +1845,14 @@ QvisQueryWindow::GetVars(stringVector &vars)
 // ****************************************************************************
 // Method: QvisQueryWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the Query button is clicked.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 9 17:57:13 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1862,17 +1865,17 @@ QvisQueryWindow::apply()
 // ****************************************************************************
 // Method: QvisQueryWindow::selectQuery
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we select a new query.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 9 17:57:37 PST 2002
 //
 // Modifications:
-//   Kathleen Bonnell, Sat Sep  4 11:49:58 PDT 2004 
-//   Changed argument to UpdateArgumentPaenl from index to qname -- 
-//   because queryList box may have fewer items than all queries. 
-//   
+//   Kathleen Bonnell, Sat Sep  4 11:49:58 PDT 2004
+//   Changed argument to UpdateArgumentPaenl from index to qname --
+//   because queryList box may have fewer items than all queries.
+//
 //   Cyrus Harrison, Tue Jun 24 16:21:00 PDT 2008
 //   Initial Qt4 Port.
 //
@@ -1889,15 +1892,15 @@ QvisQueryWindow::selectQuery()
 // ****************************************************************************
 // Method: QvisQueryWindow::handleText
 //
-// Purpose: 
-//   This is a Qt slot function that is called when Return is pressed in a 
+// Purpose:
+//   This is a Qt slot function that is called when Return is pressed in a
 //   text field.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 9 17:58:06 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1909,14 +1912,14 @@ QvisQueryWindow::handleText()
 // ****************************************************************************
 // Method: QvisQueryWindow::clearResultText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that clears the results text.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri May 9 17:28:48 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1928,36 +1931,36 @@ QvisQueryWindow::clearResultText()
 // ****************************************************************************
 // Method: QvisQueryWindow::displayModeChanged
 //
-// Purpose: 
-//   Updates the query list when display mode changes. 
+// Purpose:
+//   Updates the query list when display mode changes.
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   September 4, 2004 
+// Programmer: Kathleen Bonnell
+// Creation:   September 4, 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
 QvisQueryWindow::displayModeChanged(int)
 {
-    UpdateQueryList(); 
+    UpdateQueryList();
 }
 
 
 // ****************************************************************************
 // Method: QvisQueryWindow::useGlobalToggled
 //
-// Purpose: 
-//   A slot function called when the useGlobal checkbox is toggled. 
+// Purpose:
+//   A slot function called when the useGlobal checkbox is toggled.
 //   Sets the 'enabled' state of the label and textfield correpsonding
 //   to 'Domain'.
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   January 11, 2005 
+// Programmer: Kathleen Bonnell
+// Creation:   January 11, 2005
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2031,7 +2034,7 @@ QvisQueryWindow::dumpValuesToggled(bool val)
 // ****************************************************************************
 // Method: QvisQueryWindow::saveResultText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that saves the results text in a user selected file.
 //
 // Programmer: Ellen Tarwater
@@ -2040,18 +2043,21 @@ QvisQueryWindow::dumpValuesToggled(bool val)
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 15:26:49 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Tue Jun 24 16:21:00 PDT 2008
 //   Initial Qt4 Port.
 //
 //   Cyrus Harrison, Thu Dec  4 09:38:44 PST 2008
 //   Added default file support to the save as dialog.
-//   Skip file save if no results are available. 
+//   Skip file save if no results are available.
 //
-//    Kathleen Bonnell, Fri May 13 13:28:45 PDT 2011
-//    On Windows, explicitly test writeability of the 'cwd' before passing it 
-//    to getSaveFileName (eg don't present user with a place to save a file if 
-//    they cannot save there!)
+//   Kathleen Bonnell, Fri May 13 13:28:45 PDT 2011
+//   On Windows, explicitly test writeability of the 'cwd' before passing it
+//   to getSaveFileName (eg don't present user with a place to save a file if
+//   they cannot save there!)
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -2059,7 +2065,7 @@ void
 QvisQueryWindow::saveResultText()
 {
     // make sure there are results to save!
-    
+
     QString result_txt( resultText->toPlainText() );
     if ( result_txt.length() == 0 )
     {
@@ -2070,12 +2076,11 @@ QvisQueryWindow::saveResultText()
     QString saveExtension(".txt");
 
     // Create the name of a VisIt save file to use.
-    QString defaultFile;
-    defaultFile.asprintf("visit%04d", saveCount);
+    QString defaultFile = QString("visit%1").arg(saveCount,4,10,QLatin1Char('0'));
     defaultFile += saveExtension;
-    
+
     QString useDir = QDir::current().path();
-  
+
 #ifdef _WIN32
     { // new scope
         // force a temporary file creation in cwd
@@ -2086,12 +2091,12 @@ QvisQueryWindow::saveResultText()
         }
     }
 #endif
-   
+
     defaultFile = useDir + "/" + defaultFile;
 
     // Get the name of the file that the user saved.
     QString sFilter(QString("VisIt ") + tr("save") + QString(" (*") + saveExtension + ")");
-    
+
     QString fileName = QFileDialog::getSaveFileName(this,
                                                     tr("Save Query Results As"),
                                                     defaultFile,
@@ -2101,19 +2106,19 @@ QvisQueryWindow::saveResultText()
     if(!fileName.isNull())
     {
         ++saveCount;
-        
+
         QFile file( fileName );
         if ( file.open(QIODevice::WriteOnly | QIODevice::Text) )
         {
             QTextStream stream( &file );
             stream << result_txt + "\n";
-        
+
             file.close();
         }
         else
             Error(tr("VisIt could not save the query results "
                      "to the selected file"));
-        
+
     }
 }
 
@@ -2121,18 +2126,18 @@ QvisQueryWindow::saveResultText()
 // ****************************************************************************
 // Method: QvisQueryWindow::addVariable
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the user selects a new
 //   variable.
 //
 // Arguments:
 //   var : The variable to add.
 //
-// Programmer: Kathleen Bonnell 
+// Programmer: Kathleen Bonnell
 // Creation:   June 24, 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisRecentPathRemovalWindow.C
+++ b/src/gui/QvisRecentPathRemovalWindow.C
@@ -15,7 +15,7 @@
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::QvisRecentPathRemovalWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisRecentPathRemovalWindow class.
 //
 // Programmer: Brad Whitlock
@@ -36,14 +36,14 @@ QvisRecentPathRemovalWindow::QvisRecentPathRemovalWindow(Subject *s,
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::~QvisRecentPathRemovalWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor for QvisRecentPathRemovalWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 10 16:08:32 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisRecentPathRemovalWindow::~QvisRecentPathRemovalWindow()
@@ -53,7 +53,7 @@ QvisRecentPathRemovalWindow::~QvisRecentPathRemovalWindow()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -62,7 +62,7 @@ QvisRecentPathRemovalWindow::~QvisRecentPathRemovalWindow()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 15:26:49 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Wed Jun 25 16:13:05 PDT 2008
 //   Initial Qt4 Port.
 //
@@ -77,7 +77,7 @@ QvisRecentPathRemovalWindow::CreateWindowContents()
     topLayout->addWidget(removalControlsGroup, 5);
 
     QVBoxLayout *innerTopLayout = new QVBoxLayout(removalControlsGroup);
-    
+
     // Create the listbox that lets us select the paths to remove.
     removalListBox = new QListWidget(removalControlsGroup);
     removalListBox->setSelectionMode(QAbstractItemView::MultiSelection);
@@ -98,7 +98,7 @@ QvisRecentPathRemovalWindow::CreateWindowContents()
     invertSelectionButton = new QPushButton(tr("Invert selection"), removalControlsGroup);
     connect(invertSelectionButton, SIGNAL(clicked()),
             this, SLOT(invertSelection()));
-    hLayout->addWidget(invertSelectionButton);    
+    hLayout->addWidget(invertSelectionButton);
 
     // Create the ok and cancel buttons.
     QHBoxLayout *buttonLayout = new QHBoxLayout();
@@ -117,7 +117,7 @@ QvisRecentPathRemovalWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method gets called when the window must be updated.
 //
 // Arguments:
@@ -127,7 +127,7 @@ QvisRecentPathRemovalWindow::CreateWindowContents()
 // Creation:   Fri Oct 10 16:09:12 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -158,7 +158,7 @@ QvisRecentPathRemovalWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::UpdateWidgets
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets in the window.
 //
 // Programmer: Brad Whitlock
@@ -167,6 +167,9 @@ QvisRecentPathRemovalWindow::UpdateWindow(bool doAll)
 // Modifications:
 //   Cyrus Harrison, Wed Jun 25 16:13:05 PDT 2008
 //   Initial Qt4 Port.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -179,8 +182,7 @@ QvisRecentPathRemovalWindow::UpdateWidgets()
     // Display the file paths for all of the hosts.
     for(size_t i = 0; i < paths.size(); ++i)
     {
-        QString f;
-        f.asprintf("%s:%s", paths[i].host.c_str(), paths[i].path.c_str());
+        QString f = QString("%1:%2").arg(paths[i].host.c_str()).arg(paths[i].path.c_str());
         removalListBox->addItem(f);
     }
 
@@ -198,14 +200,14 @@ QvisRecentPathRemovalWindow::UpdateWidgets()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::show
 //
-// Purpose: 
+// Purpose:
 //   Forces the window to update when it is shown.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 10 16:41:26 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -218,7 +220,7 @@ QvisRecentPathRemovalWindow::show()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::removePaths
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to remove selected
 //   paths from the list.
 //
@@ -248,7 +250,7 @@ QvisRecentPathRemovalWindow::removePaths()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::removeAllPaths
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to remove all
 //   paths from the list.
 //
@@ -256,7 +258,7 @@ QvisRecentPathRemovalWindow::removePaths()
 // Creation:   Fri Oct 10 16:10:14 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -269,7 +271,7 @@ QvisRecentPathRemovalWindow::removeAllPaths()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::invertSelection
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to invert the
 //   selection for the selected paths.
 //
@@ -297,7 +299,7 @@ QvisRecentPathRemovalWindow::invertSelection()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::applyDismiss
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when we want to remove selected
 //   paths from the list.
 //
@@ -305,7 +307,7 @@ QvisRecentPathRemovalWindow::invertSelection()
 // Creation:   Fri Oct 10 16:10:14 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -329,14 +331,14 @@ QvisRecentPathRemovalWindow::applyDismiss()
 // ****************************************************************************
 // Method: QvisRecentPathRemovalWindow::handleCancel
 //
-// Purpose: 
+// Purpose:
 //   Cancels everything and hides the window.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 10 16:13:43 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisRenderingWindow.C
+++ b/src/gui/QvisRenderingWindow.C
@@ -27,7 +27,7 @@
 // ****************************************************************************
 // Method: QvisRenderingWindow::QvisRenderingWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisRenderingWindow class.
 //
 // Arguments:
@@ -42,7 +42,7 @@
 //
 //   Mark C. Miller, Tue Apr 27 14:41:35 PDT 2004
 //   Changed name of scalableThreshold to scalrenActivationMode
-//   
+//
 //   Hank Childs, Sun May  9 15:54:29 PDT 2004
 //   Initialize dlMode.
 //
@@ -77,14 +77,14 @@ QvisRenderingWindow::QvisRenderingWindow(const QString &caption,
 // ****************************************************************************
 // Method: QvisRenderingWindow::~QvisRenderingWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisRenderingWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Sep 23 14:47:29 PST 2002
 //
 // Modifications:
-//   
+//
 //   Mark C. Miller, Tue Apr 27 14:41:35 PDT 2004
 //   Changed name of scalableThreshold to scalrenActivationMode
 //
@@ -386,12 +386,12 @@ QvisRenderingWindow::CreateBasicPage()
 // ****************************************************************************
 // Method: QvisRenderingWindow::CreateAdvancedPage
 //
-// Purpose: 
+// Purpose:
 //   Creates the advanced page widgets
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
 // Note:       Moved from CreateWindowContents.
 //
@@ -404,7 +404,7 @@ QvisRenderingWindow::CreateBasicPage()
 //
 //   Garrett Morrison, Fri May 11 17:57:47 PDT 2018
 //   Added OSPRay option default values
-//   
+//
 // ****************************************************************************
 
 QWidget *
@@ -549,7 +549,7 @@ QvisRenderingWindow::CreateAdvancedPage()
     connect(depthCueingEndEdit, SIGNAL(returnPressed()),
             this, SLOT(depthCueingEndChanged()));
     row++;
-    
+
     // Create color texturing options.
     colorTexturingToggle = new QCheckBox(tr("Apply color using textures"), advancedOptions);
     connect(colorTexturingToggle, SIGNAL(toggled(bool)),
@@ -613,20 +613,20 @@ QvisRenderingWindow::CreateAdvancedPage()
 // ****************************************************************************
 // Method: QvisRenderingWindow::CreateInformationPage
 //
-// Purpose: 
+// Purpose:
 //   Creates the information page.
 //
 // Arguments:
 //
 // Returns:    The information page.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun 19 13:18:51 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QWidget *
@@ -698,7 +698,7 @@ QvisRenderingWindow::CreateInformationPage()
 // ****************************************************************************
 // Method: QvisRenderingWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates all of the window's widgets.
 //
 // Programmer: Brad Whitlock
@@ -735,7 +735,7 @@ QvisRenderingWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisRenderingWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method updates the window's widgets when its subjects update.
 //
 // Arguments:
@@ -760,7 +760,7 @@ QvisRenderingWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisRenderingWindow::UpdateOptions
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets that control the rendering options.
 //
 // Arguments:
@@ -773,8 +773,8 @@ QvisRenderingWindow::UpdateWindow(bool doAll)
 //   Brad Whitlock, Thu Oct 24 13:35:22 PST 2002
 //   I added code to enable/disable the stereo rendering buttons.
 //
-//   Kathleen Bonnell, Wed Dec  4 18:42:48 PST 2002 
-//   Renumber switch cases, to reflect antialisingFrames removed from atts. 
+//   Kathleen Bonnell, Wed Dec  4 18:42:48 PST 2002
+//   Renumber switch cases, to reflect antialisingFrames removed from atts.
 //
 //   Jeremy Meredith, Fri Nov 14 17:44:35 PST 2003
 //   Added specular options.
@@ -795,7 +795,7 @@ QvisRenderingWindow::UpdateWindow(bool doAll)
 //   Mark C. Miller, Tue Jan  4 10:23:19 PST 2005
 //   Fixed problem with updating scalable auto threshold
 //
-//   Kathleen Bonnell, Thu Jun 30 15:29:55 PDT 2005 
+//   Kathleen Bonnell, Thu Jun 30 15:29:55 PDT 2005
 //   Added redgreen radiobutton.
 //
 //   Mark C. Miller, Thu Nov  3 16:59:41 PST 2005
@@ -922,7 +922,7 @@ QvisRenderingWindow::UpdateOptions(bool doAll)
             break;
         case RenderingAttributes::ID_scalableAutoThreshold:
             { // new scope
-            QString suffix;           
+            QString suffix;
             int step, widgetVal;
             int actualVal = renderAtts->GetScalableAutoThreshold();
             InterpretScalableAutoThreshold(actualVal, &step, &suffix, &widgetVal);
@@ -1049,7 +1049,7 @@ QvisRenderingWindow::UpdateOptions(bool doAll)
 //
 //    Cyrus Harrison, Mon Jul 28 15:23:05 PDT 2008
 //    I added code to enable/disable the scalable auto threshold spin box based
-//    on the scalable rendering mode. 
+//    on the scalable rendering mode.
 //
 //    Jeremy Meredith, Fri Apr 30 15:04:34 EDT 2010
 //    Added an automatic start/end setting capability for depth cueing.
@@ -1108,7 +1108,7 @@ QvisRenderingWindow::UpdateWindowSensitivity()
 // ****************************************************************************
 // Method: QvisRenderingWindow::UpdateInformation
 //
-// Purpose: 
+// Purpose:
 //   Updates the information labels with statistics from the viewer.
 //
 // Arguments:
@@ -1120,7 +1120,7 @@ QvisRenderingWindow::UpdateWindowSensitivity()
 // Modifications:
 //   Eric Brugger, Fri Apr 18 11:52:33 PDT 2003
 //   I removed auto center view.
-//   
+//
 //   Jeremy Meredith, Tue Nov 16 11:39:53 PST 2004
 //   Replaced simple QString::sprintf's with a setNum because there seems
 //   to be a bug causing numbers to be incremented by .00001.  See '5263.
@@ -1135,13 +1135,16 @@ QvisRenderingWindow::UpdateWindowSensitivity()
 //   Added a break; statement after case label 16
 //
 //   Mark C. Miller, Wed Nov 16 10:46:36 PST 2005
-//   Added seconds per frame for < 1 fps cases 
+//   Added seconds per frame for < 1 fps cases
 //
 //   Brad Whitlock, Mon Dec 17 10:30:33 PST 2007
 //   Made it use ids.
 //
 //   Brad Whitlock, Tue Apr  8 15:26:49 PDT 2008
 //   Support for internationalization.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg and QString.setNum
 //
 // ****************************************************************************
 
@@ -1193,7 +1196,7 @@ QvisRenderingWindow::UpdateInformation(bool doAll)
                 fps = 1. / windowInfo->GetLastRenderMin();
             else
                 fps = 0.;
-            tmp.asprintf("%1.3g", fps);
+            tmp = QString("%1").arg(fps,0,'g',3);
             fpsMaxLabel->setText(tmp);
             break;
         case WindowInformation::ID_lastRenderAvg:
@@ -1211,7 +1214,7 @@ QvisRenderingWindow::UpdateInformation(bool doAll)
             {
                 fpsLabel->setText(tr("Frames per second:"));
             }
-            tmp.asprintf("%1.3g", fps);
+            tmp = QString("%1").arg(fps,0,'g',3);
             fpsAvgLabel->setText(tmp);
             break;
         case WindowInformation::ID_lastRenderMax:
@@ -1220,11 +1223,11 @@ QvisRenderingWindow::UpdateInformation(bool doAll)
                 fps = 1. / windowInfo->GetLastRenderMax();
             else
                 fps = 0.;
-            tmp.asprintf("%1.3g", fps);
+            tmp = QString("%1").arg(fps,0,'g',3);
             fpsMinLabel->setText(tmp);
             break;
         case WindowInformation::ID_numPrimitives:
-            tmp.asprintf("%d", windowInfo->GetNumPrimitives());
+            tmp.setNum(windowInfo->GetNumPrimitives());
             approxNumPrimitives->setText(tmp);
             break;
         case WindowInformation::ID_extents:
@@ -1241,14 +1244,14 @@ QvisRenderingWindow::UpdateInformation(bool doAll)
         case WindowInformation::ID_windowSize:
         case WindowInformation::ID_winMode:
             break;
-        }            
+        }
     }
 }
 
 // ****************************************************************************
 // Method: QvisRenderingWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Tells the viewer to apply the rendering attributes.
 //
 // Arguments:
@@ -1259,7 +1262,7 @@ QvisRenderingWindow::UpdateInformation(bool doAll)
 // Creation:   Mon Sep 23 14:49:19 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1277,7 +1280,7 @@ QvisRenderingWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisRenderingWindow::SubjectRemoved
 //
-// Purpose: 
+// Purpose:
 //   This method makes sure that we don't Detach from the subject if it is
 //   destroyed first.
 //
@@ -1288,7 +1291,7 @@ QvisRenderingWindow::Apply(bool ignore)
 // Creation:   Mon Sep 23 14:50:04 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1303,7 +1306,7 @@ QvisRenderingWindow::SubjectRemoved(Subject *TheRemovedSubject)
 // ****************************************************************************
 // Method: QvisRenderingWindow::ConnectRenderingAttributes
 //
-// Purpose: 
+// Purpose:
 //   Makes this window observe the rendering attributes.
 //
 // Arguments:
@@ -1313,7 +1316,7 @@ QvisRenderingWindow::SubjectRemoved(Subject *TheRemovedSubject)
 // Creation:   Mon Sep 23 14:51:11 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1326,7 +1329,7 @@ QvisRenderingWindow::ConnectRenderingAttributes(RenderingAttributes *w)
 // ****************************************************************************
 // Method: QvisRenderingWindow::ConnectWindowInformation
 //
-// Purpose: 
+// Purpose:
 //   Makes this window observe the window information.
 //
 // Arguments:
@@ -1336,7 +1339,7 @@ QvisRenderingWindow::ConnectRenderingAttributes(RenderingAttributes *w)
 // Creation:   Mon Sep 23 14:51:11 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1353,7 +1356,7 @@ QvisRenderingWindow::ConnectWindowInformation(WindowInformation *w)
 // ****************************************************************************
 // Method: QvisRenderingWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called by clicking the apply button.
 //
 // Programmer: Brad Whitlock
@@ -1362,7 +1365,7 @@ QvisRenderingWindow::ConnectWindowInformation(WindowInformation *w)
 // Modifications:
 //   Jeremy Meredith, Wed Aug 29 15:27:16 EDT 2007
 //   Added call to GetCurrentValues.
-//   
+//
 // ****************************************************************************
 
 void
@@ -1375,7 +1378,7 @@ QvisRenderingWindow::apply()
 // ****************************************************************************
 // Method: QvisRenderingWindow::antialiasingToggled
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the antialiasing checkbox is clicked.
 //
 // Arguments:
@@ -1385,7 +1388,7 @@ QvisRenderingWindow::apply()
 // Creation:   Mon Sep 23 14:52:07 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1527,7 +1530,7 @@ QvisRenderingWindow::updateAlphaCompositeBlocking()
 // ****************************************************************************
 // Method: QvisRenderingWindow::multiresolutionModeToggled
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the multiresolution mode checkbox is
 //   clicked.
 //
@@ -1538,7 +1541,7 @@ QvisRenderingWindow::updateAlphaCompositeBlocking()
 // Creation:   Tue Oct 25 12:32:40 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1553,7 +1556,7 @@ QvisRenderingWindow::multiresolutionModeToggled(bool val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::processMultiresolutionSmallestCellText
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the multiresolution smallest
 //   cell text is changed.
 //
@@ -1563,7 +1566,7 @@ QvisRenderingWindow::multiresolutionModeToggled(bool val)
 // Creation:   Tue Oct 25 12:32:40 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1584,7 +1587,7 @@ QvisRenderingWindow::processMultiresolutionSmallestCellText()
 // ****************************************************************************
 // Method: QvisRenderingWindow::processMultiresolutionSmallestCellText
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the multiresolution smallest
 //   cell text is changed.
 //
@@ -1594,7 +1597,7 @@ QvisRenderingWindow::processMultiresolutionSmallestCellText()
 // Creation:   Tue Oct 25 12:32:40 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1615,7 +1618,7 @@ QvisRenderingWindow::processMultiresolutionSmallestCellText(const QString &tols)
 // ****************************************************************************
 // Method: QvisRenderingWindow::objectRepresentationChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we change surface representations.
 //
 // Arguments:
@@ -1625,7 +1628,7 @@ QvisRenderingWindow::processMultiresolutionSmallestCellText(const QString &tols)
 // Creation:   Mon Sep 23 14:53:28 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1640,7 +1643,7 @@ QvisRenderingWindow::objectRepresentationChanged(int val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::stereoToggled
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we change turn stereo on/off.
 //
 // Arguments:
@@ -1650,7 +1653,7 @@ QvisRenderingWindow::objectRepresentationChanged(int val)
 // Creation:   Mon Sep 23 14:54:52 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1663,7 +1666,7 @@ QvisRenderingWindow::stereoToggled(bool val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::stereoTypeChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the stereo type changes.
 //
 // Arguments:
@@ -1673,7 +1676,7 @@ QvisRenderingWindow::stereoToggled(bool val)
 // Creation:   Mon Sep 23 14:55:32 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1687,7 +1690,7 @@ QvisRenderingWindow::stereoTypeChanged(int val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::renderNotifyToggled
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the "Query after render" toggle
 //   button is clicked.
 //
@@ -1698,7 +1701,7 @@ QvisRenderingWindow::stereoTypeChanged(int val)
 // Creation:   Mon Sep 23 14:56:12 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1712,21 +1715,21 @@ QvisRenderingWindow::renderNotifyToggled(bool val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::scalrenActivationModeChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the scalable activation mode changes.
 //
 // Arguments:
 //   val : The new scalable activation mode flag.
 //         0 = Auto, 1 = Always, 2 = Never
 //
-// Programmer: Mark C. Miller 
-// Creation:   Wed Nov 20 17:09:59 PST 2002 
+// Programmer: Mark C. Miller
+// Creation:   Wed Nov 20 17:09:59 PST 2002
 //
 // Modifications:
 //
 //   Mark C. Miller, Tue Apr 27 14:41:35 PDT 2004
 //   Added scalrenAutoThreshold spinbox and geometry label
-//   
+//
 //   Mark C. Miller, Tue May 11 20:21:24 PDT 2004
 //   Changed scalable rendering controls to use activation mode and auto
 //   threshold
@@ -1763,10 +1766,10 @@ QvisRenderingWindow::scalrenActivationModeChanged(int val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::InterpretScalableAutoThreshold
 //
-// Purpose: Determine widget controls given scalable auto threshold 
+// Purpose: Determine widget controls given scalable auto threshold
 //
-// Programmer: Mark C. Miller 
-// Creation:   January 4, 2005 
+// Programmer: Mark C. Miller
+// Creation:   January 4, 2005
 //
 // ****************************************************************************
 void
@@ -1786,7 +1789,7 @@ QvisRenderingWindow::InterpretScalableAutoThreshold(int actualVal,
     // compute the divisor for the displayed value in the GUI
     int div;
     if      (*suffix == " KPolys") div = (int) 1e3;
-    else if (*suffix == " MPolys") div = (int) 1e6; 
+    else if (*suffix == " MPolys") div = (int) 1e6;
     else if (*suffix == " GPolys") div = (int) 1e9;
     else                          div = 1;
 
@@ -1796,18 +1799,18 @@ QvisRenderingWindow::InterpretScalableAutoThreshold(int actualVal,
 // ****************************************************************************
 // Method: QvisRenderingWindow::scalrenAutoThresholdChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when the scalable rendering automatic
 //   polygon count threshold changes.
 //
 // Arguments:
 //   val : The new polygon count threshold.
 //
-// Programmer: Mark C. Miller 
-// Creation:   Wed Apr 21 22:42:57 PDT 2004 
+// Programmer: Mark C. Miller
+// Creation:   Wed Apr 21 22:42:57 PDT 2004
 //
 // Modifications:
-//   
+//
 //   Mark C. Miller, Tue May 11 20:21:24 PDT 2004
 //   Changed scalable rendering controls to use activation mode and auto
 //   threshold
@@ -1907,7 +1910,7 @@ QvisRenderingWindow::compactDomainsActivationModeChanged(int mode)
         renderAtts->SetCompactDomainsActivationMode(RenderingAttributes::Always);
     else
         renderAtts->SetCompactDomainsActivationMode(RenderingAttributes::Never);
-    
+
     SetUpdate(false);
     Apply();
     UpdateWindowSensitivity();
@@ -1917,7 +1920,7 @@ QvisRenderingWindow::compactDomainsActivationModeChanged(int mode)
 // Method: QvisRenderingWindow::scalrenCompressModeChanged
 //
 // Programmer: Mark C. Miller
-// Creation:   November 2, 2005 
+// Creation:   November 2, 2005
 //
 // ****************************************************************************
 
@@ -2073,7 +2076,7 @@ QvisRenderingWindow::specularPowerChanged(int val, const void*)
 // ****************************************************************************
 // Method: QvisRenderingWindow::colorTexturingToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the colorTexturing check
 //   box is toggled.
 //
@@ -2084,7 +2087,7 @@ QvisRenderingWindow::specularPowerChanged(int val, const void*)
 // Creation:   Mon Sep 18 10:52:30 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2161,7 +2164,7 @@ QvisRenderingWindow::depthCueingAutoToggled(bool val)
 //    Triggered when return is pressed in the depth cueing start point widget.
 //
 //  Arguments:
-//    
+//
 //
 //  Programmer:  Jeremy Meredith
 //  Creation:    August 29, 2007
@@ -2250,14 +2253,14 @@ QvisRenderingWindow::GetCurrentValues()
 // ****************************************************************************
 // Method: QvisRenderingWindow::osprayRenderingToggled
 //
-// Purpose: 
+// Purpose:
 //    Triggered when ospray rendering is toggled.
 //
 // Programmer:  Garrett Morrison
 // Creation:    Wed May 16 17:42:42 PDT 2018
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2272,17 +2275,17 @@ QvisRenderingWindow::osprayRenderingToggled(bool val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::ospraySPPChanged
 //
-// Purpose: 
+// Purpose:
 //    Triggered when ospray samples per pixel are changed.
 //
 //  Arguments:
-//    val        the new value 
+//    val        the new value
 //
 // Programmer:  Garrett Morrison
 // Creation:    Wed May 16 17:42:42 PDT 2018
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2297,17 +2300,17 @@ QvisRenderingWindow::ospraySPPChanged(int val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::osprayAOChanged
 //
-// Purpose: 
+// Purpose:
 //    Triggered when ospray ambient occlusion samples are changed.
 //
 //  Arguments:
-//    val        the new value 
+//    val        the new value
 //
 // Programmer:  Garrett Morrison
 // Creation:    Wed May 16 17:42:42 PDT 2018
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2322,14 +2325,14 @@ QvisRenderingWindow::osprayAOChanged(int val)
 // ****************************************************************************
 // Method: QvisRenderingWindow::osprayShadowsToggled
 //
-// Purpose: 
+// Purpose:
 //    Triggered when ospray shadows are toggled.
 //
 // Programmer:  Garrett Morrison
 // Creation:    Wed May 16 17:42:42 PDT 2018
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisRotationTransition.C
+++ b/src/gui/QvisRotationTransition.C
@@ -14,7 +14,7 @@
 // ****************************************************************************
 // Method: QvisRotationTransition::QvisRotationTransition
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Arguments:
@@ -60,12 +60,12 @@ QvisRotationTransition::QvisRotationTransition(const QPixmap &pix,
     startAngle->setMinimum(-360 * 100);
     startAngle->setMaximum(360 * 100);
     startAngle->setValue(0);
-    QString deg; deg.asprintf("%c", 176);
+    QString deg = QString::asprintf("%c", 176);
     QString startLabel(tr("Start angle") + deg);
     gLayout->addWidget(
         new QLabel(startLabel, this), 0, 0);
     gLayout->addWidget(startAngle, 0, 1);
-    
+
     endAngle = new QSpinBox(this);
     endAngle->setKeyboardTracking(false);
     endAngle->setMinimum(-360 * 100);
@@ -91,14 +91,14 @@ QvisRotationTransition::QvisRotationTransition(const QPixmap &pix,
 // ****************************************************************************
 // Method: QvisRotationTransition::~QvisRotationTransition
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Nov 14 13:26:39 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisRotationTransition::~QvisRotationTransition()

--- a/src/gui/QvisRotationTransition.C
+++ b/src/gui/QvisRotationTransition.C
@@ -32,6 +32,9 @@
 //   Brad Whitlock, Tue Oct  7 09:37:43 PDT 2008
 //   Qt 4.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Fixed use of QString.asprintf to correct form.
+//
 // ****************************************************************************
 
 QvisRotationTransition::QvisRotationTransition(const QPixmap &pix,

--- a/src/gui/QvisSaveMovieWizard.C
+++ b/src/gui/QvisSaveMovieWizard.C
@@ -2611,6 +2611,9 @@ QvisSaveMovieWizard::page4_UpdateViews(int flags)
 //   Brad Whitlock, Tue Oct 14 11:47:18 PDT 2008
 //   Qt 4.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -2672,8 +2675,7 @@ QvisSaveMovieWizard::page5_Update(int flags)
                     if(sscanf(digits.c_str(), "%d", &number) == 1)
                     {
                         QString pre(name.substr(0, name.size()-digits.size()).c_str());
-                        QString idx;
-                        idx.asprintf("%05d", number);
+                        QString idx = QString("%1").arg(number,5,10,QLatin1Char('0'));
                         itemKey = pre + idx;
                     }
                 }
@@ -2879,6 +2881,9 @@ QvisSaveMovieWizard::page7_Update()
 //   Cameron Christensen, Friday, September 28, 2012
 //   Added Screen Capture
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -2930,15 +2935,15 @@ QvisSaveMovieWizard::page8_UpdateMovieSettings()
         QString tmp;
         if(useCurrent[i] > 0)
         {
-            QString scale; scale.asprintf("%dx",  int(scales[i]));
+            QString scale = QString("%1x").arg(int(scales[i]));
             tmp = QString(FormatToMenuName(formats[i].c_str())) +
                   QString(" ") + tr("Current") + QString(" ") +
                   scale;
         }
         else
         {
-            tmp.asprintf("%s %dx%d",
-                FormatToMenuName(formats[i].c_str()), w[i], h[i]);
+            tmp = QString("%1 %2x%3")
+                .arg(FormatToMenuName(formats[i].c_str())).arg(w[i]).arg(h[i]);
         }
         s += tmp;
         int stereoType = movieAtts->GetStereoFlags()[i];
@@ -3015,11 +3020,11 @@ QvisSaveMovieWizard::page9_UpdateOutputs()
             QString res;
             if(useCurrent[i] > 0)
             {
-                res.asprintf(" %dx", int(scales[i]));
+                res = QString(" %1x").arg(int(scales[i]));
                 res = tr("Current") + res;
             }
             else
-                res.asprintf("%dx%d", w[i], h[i]);
+                res = QString("%1x%2").arg(w[i]).arg(h[i]);
             QTreeWidgetItem *item = new QTreeWidgetItem(page9_outputFormats);
             item->setText(0, FormatToMenuName(formats[i].c_str()));
             item->setText(1, res);
@@ -4468,6 +4473,9 @@ QvisSaveMovieWizard::page9_addOutput()
 //   Cameron Christensen, Friday, September 28, 2012
 //   Added Screen Capture
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -4492,9 +4500,8 @@ QvisSaveMovieWizard::page9_removeOutput()
         for(size_t i = 0; i < formats.size(); ++i)
         {
             QString fmt(FormatToMenuName(formats[i].c_str()));
-            QString res;  res.asprintf("%dx%d", widths[i], heights[i]);
-            QString res2;
-            res2.asprintf(" %dx", int(scales[i]));
+            QString res = QString("%1x%2").arg(widths[i]).arg(heights[i]);
+            QString res2 = QString(" %1x").arg(int(scales[i]));
             res2 = tr("Current") + res2;
             QString stereo(tr("off"));
             if(stereoFlags[i] == 1)

--- a/src/gui/QvisSaveWindow.C
+++ b/src/gui/QvisSaveWindow.C
@@ -50,7 +50,7 @@ static const char *fileFormats[] = {
 "vtk"
 };
 
-// Given a SaveWindowAttributes::FileFormat string name, determine the 
+// Given a SaveWindowAttributes::FileFormat string name, determine the
 // menu index.
 int FileFormatToMenuIndex(const std::string &ext)
 {
@@ -66,7 +66,7 @@ int FileFormatToMenuIndex(const std::string &ext)
 // ****************************************************************************
 // Method: QvisSaveWindow::QvisSaveWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisSaveWindow class.
 //
 // Arguments:
@@ -127,14 +127,14 @@ QvisSaveWindow::QvisSaveWindow(
 // ****************************************************************************
 // Method: QvisSaveWindow::~QvisSaveWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisSaveWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Feb 9 17:10:02 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisSaveWindow::~QvisSaveWindow()
@@ -145,7 +145,7 @@ QvisSaveWindow::~QvisSaveWindow()
 // ****************************************************************************
 // Method: QvisSaveWindow::ConnectSubjects
 //
-// Purpose: 
+// Purpose:
 //   This function connects subjects so that the window observes them.
 //
 // Programmer: Kathleen Biagas
@@ -166,7 +166,7 @@ QvisSaveWindow::ConnectSubjects(DBPluginInfoAttributes *dbp)
 // ****************************************************************************
 // Method: QvisSaveWindow::SubjectRemoved
 //
-// Purpose: 
+// Purpose:
 //   This function is called when a subject is removed.
 //
 // Arguments:
@@ -190,7 +190,7 @@ QvisSaveWindow::SubjectRemoved(Subject *TheRemovedSubject)
 // ****************************************************************************
 // Method: QvisSaveWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets for the Aslice operator window.
 //
 // Programmer: Brad Whitlock
@@ -212,7 +212,7 @@ QvisSaveWindow::SubjectRemoved(Subject *TheRemovedSubject)
 //   Hank Childs, Wed Oct 15 08:58:16 PDT 2003
 //   Added stereo button.
 //
-//   Kathleen Bonnell, Thu Nov 13 12:15:25 PST 2003 
+//   Kathleen Bonnell, Thu Nov 13 12:15:25 PST 2003
 //   Added compression type combo box.
 //
 //   Mark C. Miller, Mon Mar 29 16:21:14 PST 2004
@@ -227,7 +227,7 @@ QvisSaveWindow::SubjectRemoved(Subject *TheRemovedSubject)
 //   I replaced the host line edit with an output directory line edit. I also
 //   added a save button.
 //
-//   Kathleen Bonnell, Wed Dec 15 08:20:11 PST 2004 
+//   Kathleen Bonnell, Wed Dec 15 08:20:11 PST 2004
 //   Changed SLOT for saveButton from 'saveWindow' to 'saveButtonClicked' so
 //   that 'apply' can be called before the save.
 //
@@ -299,7 +299,7 @@ QvisSaveWindow::CreateWindowContents()
 
     outputDirectoryLabel    = new QLabel(tr("Output directory"), nameBox);
     nameLayout->addWidget(outputDirectoryLabel, 2, 0, 1, 2);
-    
+
     QHBoxLayout *outputDirectoryLayout = new QHBoxLayout();
     outputDirectoryLayout->setMargin(0);
     outputDirectoryLayout->setSpacing(0);
@@ -309,7 +309,7 @@ QvisSaveWindow::CreateWindowContents()
     outputDirectorySelectButton = new QPushButton("...", nameBox);
     outputDirectoryLayout->addWidget(outputDirectoryLineEdit);
     outputDirectoryLayout->addWidget(outputDirectorySelectButton);
-    
+
     connect(outputDirectoryLineEdit, SIGNAL(returnPressed()),
             this, SLOT(processOutputDirectoryText()));
 
@@ -345,7 +345,7 @@ QvisSaveWindow::CreateWindowContents()
     qualitySlider = new QSlider(Qt::Horizontal, formatBox);
     qualitySlider->setMinimum(0);
     qualitySlider->setMaximum(100);
-    
+
     connect(qualitySlider, SIGNAL(valueChanged(int)),
             this, SLOT(qualityChanged(int)));
     formatLayout->addWidget(qualitySlider, 1, 1);
@@ -356,7 +356,7 @@ QvisSaveWindow::CreateWindowContents()
     connect(progressiveCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(progressiveToggled(bool)));
     formatLayout->addWidget(progressiveCheckBox, 1, 2, Qt::AlignRight);
-   
+
     compressionTypeLabel = new QLabel(tr("Compression type"),formatBox);
     compressionTypeComboBox = new QComboBox(formatBox);
     compressionTypeComboBox->addItem(tr("None"));     // 0
@@ -371,7 +371,7 @@ QvisSaveWindow::CreateWindowContents()
             this, SLOT(compressionTypeChanged(int)));
     compressionTypeLabel->setBuddy(compressionTypeComboBox);
 
-    // Binary toggle 
+    // Binary toggle
     binaryCheckBox = new QCheckBox(tr("Binary"), central);
     connect(binaryCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(binaryToggled(bool)));
@@ -482,9 +482,9 @@ QvisSaveWindow::CreateWindowContents()
     QGridLayout *multiWindowSaveLayout = new QGridLayout(multiWindowSaveBox);
 
     multiWindowSaveTypeButtonGroup = new QButtonGroup(multiWindowSaveBox);
-    tiledButton    = new QRadioButton(tr("Tiled"),             
+    tiledButton    = new QRadioButton(tr("Tiled"),
                                       multiWindowSaveBox);
-    advancedButton = new QRadioButton(tr("Advanced"),         
+    advancedButton = new QRadioButton(tr("Advanced"),
                                       multiWindowSaveBox);
 
     multiWindowSaveTypeButtonGroup->addButton(tiledButton,0);
@@ -594,7 +594,7 @@ QvisSaveWindow::CreateWindowContents()
     // The save button.
     QHBoxLayout *saveButtonLayout = new QHBoxLayout();
     topLayout->addLayout(saveButtonLayout);
-    
+
     //saveButtonLayout->setSpacing(5);
     QPushButton *saveButton = new QPushButton(tr("Save"), central);
     connect(saveButton, SIGNAL(clicked()),
@@ -611,7 +611,7 @@ QvisSaveWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisSaveWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method updates the window's widgets to reflect changes made
 //   in the SaveWindowAttributes object that the window watches.
 //
@@ -637,8 +637,8 @@ QvisSaveWindow::CreateWindowContents()
 //   Hank Childs, Wed Oct 15 09:03:08 PDT 2003
 //   Only allow the stereo button to be enabled when we have an image format.
 //
-//   Kathleen Bonnell, Thu Nov 13 12:16:06 PST 2003 
-//   Only allow the compression type combo box to be enabled when we 
+//   Kathleen Bonnell, Thu Nov 13 12:16:06 PST 2003
+//   Only allow the compression type combo box to be enabled when we
 //   have a tiff format.
 //
 //   Hank Childs, Thu Jun 17 11:39:35 PDT 2004
@@ -655,7 +655,7 @@ QvisSaveWindow::CreateWindowContents()
 //   Added button to force a merge of parallel geometry.
 //
 //   Dave Bremer, Fri Sep 28 17:18:41 PDT 2007
-//   bool field for "maintain aspect" was changed to an enum 
+//   bool field for "maintain aspect" was changed to an enum
 //   to constrain resolution.
 //
 //   Brad Whitlock, Mon Dec 17 10:38:20 PST 2007
@@ -676,6 +676,9 @@ QvisSaveWindow::CreateWindowContents()
 //   Brad Whitlock, Tue Sep 19 13:21:02 PDT 2017
 //   I changed how the menu items are added for file formats to allow for
 //   conditionally compiled file formats. I added support for pixel data types.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.setNum.
 //
 // ****************************************************************************
 
@@ -730,7 +733,7 @@ QvisSaveWindow::UpdateWindow(bool doAll)
             fileFormatComboBox->blockSignals(false);
             }
 
-            bool isCompressible = 
+            bool isCompressible =
                 saveWindowAtts->GetFormat() == SaveWindowAttributes::TIFF ||
                 saveWindowAtts->GetFormat() == SaveWindowAttributes::JPEG ||
                 saveWindowAtts->GetFormat() == SaveWindowAttributes::ULTRA ||
@@ -748,11 +751,11 @@ QvisSaveWindow::UpdateWindow(bool doAll)
                                       SaveWindowAttributes::JPEG);
             compressionTypeLabel->setEnabled(isCompressible);
 
-            if (saveWindowAtts->GetFormat() 
+            if (saveWindowAtts->GetFormat()
                      == SaveWindowAttributes::VTK
-                || saveWindowAtts->GetFormat() 
+                || saveWindowAtts->GetFormat()
                      == SaveWindowAttributes::STL
-                || saveWindowAtts->GetFormat() 
+                || saveWindowAtts->GetFormat()
                      == SaveWindowAttributes::PLY)
             {
                 binaryCheckBox->setEnabled(true);
@@ -821,11 +824,11 @@ QvisSaveWindow::UpdateWindow(bool doAll)
             break;
         }
         case SaveWindowAttributes::ID_width:
-            temp.asprintf("%d", saveWindowAtts->GetWidth());
+            temp.setNum(saveWindowAtts->GetWidth());
             widthLineEdit->setText(temp);
             break;
         case SaveWindowAttributes::ID_height:
-            temp.asprintf("%d", saveWindowAtts->GetHeight());
+            temp.setNum(saveWindowAtts->GetHeight());
             heightLineEdit->setText(temp);
             break;
         case SaveWindowAttributes::ID_screenCapture:
@@ -907,19 +910,19 @@ QvisSaveWindow::UpdateWindow(bool doAll)
             mwsWindowComboBox->setCurrentIndex(currentWindow);
             mwsWindowComboBox->blockSignals(false);
             mwsIndWidthLineEdit->blockSignals(true);
-            temp.asprintf("%d", atts.GetSize()[0]);
+            temp.setNum(atts.GetSize()[0]);
             mwsIndWidthLineEdit->setText(temp);
             mwsIndWidthLineEdit->blockSignals(false);
             mwsIndHeightLineEdit->blockSignals(true);
-            temp.asprintf("%d", atts.GetSize()[1]);
+            temp.setNum(atts.GetSize()[1]);
             mwsIndHeightLineEdit->setText(temp);
             mwsIndHeightLineEdit->blockSignals(false);
             mwsPosXLineEdit->blockSignals(true);
-            temp.asprintf("%d", atts.GetPosition()[0]);
+            temp.setNum(atts.GetPosition()[0]);
             mwsPosXLineEdit->setText(temp);
             mwsPosXLineEdit->blockSignals(false);
             mwsPosYLineEdit->blockSignals(true);
-            temp.asprintf("%d", atts.GetPosition()[1]);
+            temp.setNum(atts.GetPosition()[1]);
             mwsPosYLineEdit->setText(temp);
             mwsPosYLineEdit->blockSignals(false);
             mwsLayerComboBox->blockSignals(true);
@@ -1048,7 +1051,7 @@ QvisSaveWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisSaveWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values for one or all of the lineEdit widgets.
 //
 // Arguments:
@@ -1151,7 +1154,7 @@ QvisSaveWindow::GetCurrentValues(int which_widget)
             if(okay)
             {
                 okay = (w <= VISIT_RENDERING_SIZE_LIMIT);
-                
+
                 if(okay)
                 {
                     saveWindowAtts->SetWidth(w);
@@ -1181,7 +1184,7 @@ QvisSaveWindow::GetCurrentValues(int which_widget)
             if(okay)
             {
                 okay = (h <= VISIT_RENDERING_SIZE_LIMIT);
-                
+
                 if(okay)
                 {
                     saveWindowAtts->SetHeight(h);
@@ -1236,7 +1239,7 @@ QvisSaveWindow::GetCurrentValues(int which_widget)
             if(okay)
             {
                 okay = (h <= VISIT_RENDERING_SIZE_LIMIT);
-            
+
                 if(okay)
                 {
                     int s[2] = { atts.GetSize()[0], h };
@@ -1297,7 +1300,7 @@ QvisSaveWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisSaveWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This method applies the save image attributes and optionally tells
 //   the viewer to apply them.
 //
@@ -1336,14 +1339,14 @@ QvisSaveWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisSaveWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function to apply the save image attributes.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Feb 9 17:25:59 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1355,14 +1358,14 @@ QvisSaveWindow::apply()
 // ****************************************************************************
 // Method: QvisSaveWindow::processFilenameText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the normal vector.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Feb 9 17:26:26 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1375,7 +1378,7 @@ QvisSaveWindow::processFilenameText()
 // ****************************************************************************
 // Method: QvisSaveWindow::familyToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not the file is to be named as a family of files.
 //
@@ -1386,7 +1389,7 @@ QvisSaveWindow::processFilenameText()
 // Creation:   Fri Feb 9 17:27:07 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1399,7 +1402,7 @@ QvisSaveWindow::familyToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::outputToCurrentDirectoryToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the
 //  "Output to current directory" toggle is clicked.
 //
@@ -1410,7 +1413,7 @@ QvisSaveWindow::familyToggled(bool val)
 // Creation:   Fri Jul 30 15:54:51 PST 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1423,7 +1426,7 @@ QvisSaveWindow::outputToCurrentDirectoryToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::processOutputDirectoryText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the output directory where we'll
 //   save the image.
 //
@@ -1446,7 +1449,7 @@ QvisSaveWindow::processOutputDirectoryText()
 // ****************************************************************************
 // Method: QvisSaveWindow::selectOutputDirectory
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that selects a new output file directory.
 //
 // Programmer: Brad Whitlock
@@ -1489,7 +1492,7 @@ QvisSaveWindow::selectOutputDirectory()
 // ****************************************************************************
 // Method: QvisSaveWindow::fileFormatChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a new file format
 //   is selected.
 //
@@ -1507,7 +1510,7 @@ QvisSaveWindow::selectOutputDirectory()
 //   Made file format be a true enum.
 //
 //   Brad Whitlock, Tue Sep 19 13:17:02 PDT 2017
-//   Changes so the menu names can have a different order than the 
+//   Changes so the menu names can have a different order than the
 //   FileFormat enum.
 //
 //   Kathleen Biagas, Fri Aug 31 13:58:34 PDT 2018
@@ -1518,7 +1521,7 @@ QvisSaveWindow::selectOutputDirectory()
 void
 QvisSaveWindow::fileFormatChanged(int index)
 {
-    // index is a menu index. Let's convert the upper case string name for the 
+    // index is a menu index. Let's convert the upper case string name for the
     // menu back to SaveWindowAttributes::FileFormat type.
     SaveWindowAttributes::FileFormat val = SaveWindowAttributes::PNG;
     SaveWindowAttributes::FileFormat_FromString(
@@ -1531,7 +1534,7 @@ QvisSaveWindow::fileFormatChanged(int index)
         std::string tmp = fileFormatComboBox->currentText().toStdString();
         if (tmp == "curve")
         {
-            int ntypes = dbPluginInfoAtts->GetTypes().size(); 
+            int ntypes = dbPluginInfoAtts->GetTypes().size();
             for (int i = 0; i < ntypes; ++i)
             {
                 if (dbPluginInfoAtts->GetTypes()[i] == "Curve2D")
@@ -1554,7 +1557,7 @@ QvisSaveWindow::fileFormatChanged(int index)
 // ****************************************************************************
 // Method: QvisSaveWindow::qualityChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the quality slider changes.
 //
 // Arguments:
@@ -1579,7 +1582,7 @@ QvisSaveWindow::qualityChanged(int val)
 // ****************************************************************************
 // Method: QvisSaveWindow::progressiveToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the progressive toggle
 //   is clicked.
 //
@@ -1590,7 +1593,7 @@ QvisSaveWindow::qualityChanged(int val)
 // Creation:   Wed Jan 23 15:30:56 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1610,7 +1613,7 @@ QvisSaveWindow::compressionTypeChanged(int index)
 // ****************************************************************************
 // Method: QvisSaveWindow::binaryToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the binary toggle
 //   is clicked.
 //
@@ -1621,7 +1624,7 @@ QvisSaveWindow::compressionTypeChanged(int index)
 // Creation:   Sun May 26 17:31:18 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1634,7 +1637,7 @@ QvisSaveWindow::binaryToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::stereoToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not to save the image in stereo.
 //
@@ -1645,7 +1648,7 @@ QvisSaveWindow::binaryToggled(bool val)
 // Creation:   October 15, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1658,7 +1661,7 @@ QvisSaveWindow::stereoToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::*Toggled
 //
-// Purpose: 
+// Purpose:
 //   Qt slot functions that control the type of pixel data we're requesting.
 //
 // Arguments:
@@ -1668,7 +1671,7 @@ QvisSaveWindow::stereoToggled(bool val)
 // Creation:   Wed Sep 20 18:13:16 PDT 2017
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1734,7 +1737,7 @@ QvisSaveWindow::valueToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::forceMergeToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not it should attempt to merge parallel domains before saving.
 //
@@ -1761,7 +1764,7 @@ QvisSaveWindow::forceMergeToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::aspectRatioChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a new aspect ratio
 //   is selected.
 //
@@ -1814,7 +1817,7 @@ QvisSaveWindow::aspectRatioChanged(int index)
 // ****************************************************************************
 // Method: QvisSaveWindow::processWidthText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the image width changes.
 //
 // Programmer: Brad Whitlock
@@ -1839,7 +1842,7 @@ QvisSaveWindow::processWidthText()
 // ****************************************************************************
 // Method: QvisSaveWindow::processHeightText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the image height changes.
 //
 // Programmer: Brad Whitlock
@@ -1848,7 +1851,7 @@ QvisSaveWindow::processWidthText()
 // Modifications:
 //   Brad Whitlock, Fri Jul 16 14:37:13 PST 2004
 //   Moved some code out of GetCurrentValues.
-//   
+//
 //   Dave Bremer, Fri Sep 28 17:18:41 PDT 2007
 //   Enum in SaveWindowAttributes changed.
 //
@@ -1864,7 +1867,7 @@ QvisSaveWindow::processHeightText()
 // ****************************************************************************
 // Method: QvisSaveWindow::screenCaptureToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not to screen capture the image.
 //
@@ -1875,7 +1878,7 @@ QvisSaveWindow::processHeightText()
 // Creation:   Mon Aug 31 10:38:12 PDT 2015
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1888,7 +1891,7 @@ QvisSaveWindow::screenCaptureToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::multiWindowSaveToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that turns on and off multi window save.
 //
 // Arguments:
@@ -1931,7 +1934,7 @@ QvisSaveWindow::multiWindowSaveToggled(bool val)
 // ****************************************************************************
 // Method: QvisSaveWindow::multiWindowSaveTypeToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the type of multi window save
 //   to do.
 //
@@ -2148,7 +2151,7 @@ void QvisSaveWindow::imageTransparencyChanged(int val)
 // ****************************************************************************
 // Method: QvisSaveWindow::saveWindow
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that is called when the Save button is clicked.
 //
 // Note:       Saves the active vis window and may hide the window.
@@ -2196,11 +2199,11 @@ QvisSaveWindow::saveWindow()
 // ****************************************************************************
 // Method: QvisSaveWindow::saveButtonClicked
 //
-// Purpose: 
-//   This is Qt slot function that is called when the save button is clicked. 
+// Purpose:
+//   This is Qt slot function that is called when the save button is clicked.
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   December 15, 2004 
+// Programmer: Kathleen Bonnell
+// Creation:   December 15, 2004
 //
 // Modifications:
 //   Kathleen Biagas, Wed Jan  7 12:39:12 PST 2015
@@ -2219,11 +2222,11 @@ QvisSaveWindow::saveButtonClicked()
 // ****************************************************************************
 // Method: QvisSaveWindow::saveAndDismissButtonClicked
 //
-// Purpose: 
+// Purpose:
 //   This is Qt slot function that is called when the saveAndDismis button
-//   is clicked. 
+//   is clicked.
 //
-// Programmer: Kathleen Biagas 
+// Programmer: Kathleen Biagas
 // Creation:   January 7, 2015
 //
 // Modifications:

--- a/src/gui/QvisScreenPositionEdit.C
+++ b/src/gui/QvisScreenPositionEdit.C
@@ -19,7 +19,7 @@
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::QvisScreenPositionEdit
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisScreenPositionEdit class.
 //
 // Arguments:
@@ -38,7 +38,7 @@
 //
 // ****************************************************************************
 
-QvisScreenPositionEdit::QvisScreenPositionEdit(QWidget *parent) : 
+QvisScreenPositionEdit::QvisScreenPositionEdit(QWidget *parent) :
     QWidget(parent)
 {
     QHBoxLayout *hLayout = new QHBoxLayout(this);
@@ -77,14 +77,14 @@ QvisScreenPositionEdit::QvisScreenPositionEdit(QWidget *parent) :
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::~QvisScreenPositionEdit
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisScreenPositionEdit class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Dec 2 13:50:35 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisScreenPositionEdit::~QvisScreenPositionEdit()
@@ -94,7 +94,7 @@ QvisScreenPositionEdit::~QvisScreenPositionEdit()
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::setPosition
 //
-// Purpose: 
+// Purpose:
 //   Sets the screen position.
 //
 // Arguments:
@@ -104,7 +104,7 @@ QvisScreenPositionEdit::~QvisScreenPositionEdit()
 // Creation:   Tue Dec 2 13:50:53 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -119,7 +119,7 @@ QvisScreenPositionEdit::setPosition(double x, double y)
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::getPosition
 //
-// Purpose: 
+// Purpose:
 //   Gets the screen position.
 //
 // Arguments:
@@ -127,13 +127,13 @@ QvisScreenPositionEdit::setPosition(double x, double y)
 //
 // Returns:    True if the coordinates are valid, false otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Dec 2 13:51:39 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -156,7 +156,7 @@ QvisScreenPositionEdit::getPosition(double &x, double &y)
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::getCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values from the line edit.
 //
 // Arguments:
@@ -191,7 +191,7 @@ QvisScreenPositionEdit::getCurrentValues(double *newX, double *newY)
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::updateText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that updates the text in the line edit.
 //
 // Arguments:
@@ -201,21 +201,22 @@ QvisScreenPositionEdit::getCurrentValues(double *newX, double *newY)
 // Creation:   Tue Dec 2 13:53:39 PST 2003
 //
 // Modifications:
-//   
+//  Kathleen Biagas, Jan 21, 2021
+//  Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
 QvisScreenPositionEdit::updateText(double x, double y)
 {
-    QString tmp;
-    tmp.asprintf("%g %g", x, y);
+    QString tmp = QString("%1 %2").arg(x).arg(y);
     lineEdit->setText(tmp);
 }
 
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::newScreenPosition
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that emits a screenPositionChanged signal
 //   when the screen coordinate changes for whatever reason.
 //
@@ -226,7 +227,7 @@ QvisScreenPositionEdit::updateText(double x, double y)
 // Creation:   Tue Dec 2 13:54:19 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -243,7 +244,7 @@ QvisScreenPositionEdit::newScreenPosition(double x, double y)
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::popup
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to popup the screen positioner
 //   widget.
 //
@@ -251,7 +252,7 @@ QvisScreenPositionEdit::newScreenPosition(double x, double y)
 // Creation:   Tue Dec 2 13:55:18 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -279,7 +280,7 @@ QvisScreenPositionEdit::popup()
     if(menuY - menuH < 0)
         menuY = menuY - height() - menuH;
 
-    // Show the popup menu.         
+    // Show the popup menu.
     screenPositionPopup->move(menuX, menuY);
     screenPositionPopup->popupShow();
 }
@@ -287,7 +288,7 @@ QvisScreenPositionEdit::popup()
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::closePopup
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called by a timer when the screen
 //   positioner widget has been popped up for too long.
 //
@@ -295,7 +296,7 @@ QvisScreenPositionEdit::popup()
 // Creation:   Tue Dec 2 13:55:47 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -309,7 +310,7 @@ QvisScreenPositionEdit::closePopup()
 // ****************************************************************************
 // Method: QvisScreenPositionEdit::returnPressed
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when return is pressed in the
 //   line edit.
 //
@@ -317,7 +318,7 @@ QvisScreenPositionEdit::closePopup()
 // Creation:   Tue Dec 2 13:56:24 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisSelectionsWindow.C
+++ b/src/gui/QvisSelectionsWindow.C
@@ -50,12 +50,12 @@
 // ****************************************************************************
 // Method: QvisSelectionsWindow::QvisSelectionsWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisSelectionsWindow class.
 //
 // Arguments:
 //   selectionList_  The SelectionList subject to observe
-//   
+//
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Aug  6 15:44:09 PDT 2010
@@ -84,14 +84,14 @@ QvisSelectionsWindow::QvisSelectionsWindow(const QString &caption,
 // ****************************************************************************
 // Method: QvisSelectionsWindow::~QvisSelectionsWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisSelectionsWindow class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Aug  6 15:44:09 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 QvisSelectionsWindow::~QvisSelectionsWindow()
 {
@@ -152,7 +152,7 @@ QvisSelectionsWindow::SubjectRemoved(Subject *s)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Brad Whitlock
@@ -212,15 +212,15 @@ QvisSelectionsWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::CreatePropertiesTab
 //
-// Purpose: 
+// Purpose:
 //   Create the properties tab.
 //
 // Arguments:
 //   parent : The parent widget.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Dec 29 11:17:36 PST 2010
@@ -322,21 +322,21 @@ QvisSelectionsWindow::CreatePropertiesTab(QWidget *parent)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::CreateCQRangeControls
 //
-// Purpose: 
+// Purpose:
 //   Create the CQ controls.
 //
 // Arguments:
 //   parent : The parent widget.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Dec 29 11:17:07 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QWidget *
@@ -366,7 +366,7 @@ QvisSelectionsWindow::CreateCQRangeControls(QWidget *parent)
         "Coordinates plot."));
     lLayout->addWidget(cqInitializeVarButton, 0, 2);
 
-    
+
     updateQueryButton1 = new QPushButton(tr("Update Query"), central);
     connect(updateQueryButton1, SIGNAL(pressed()),
             this, SLOT(updateQuery()));
@@ -392,21 +392,21 @@ QvisSelectionsWindow::CreateCQRangeControls(QWidget *parent)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::CreateTimeControls
 //
-// Purpose: 
+// Purpose:
 //   Create the time controls group box for CQ selections.
 //
 // Arguments:
 //   parent : The parent widget.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Dec 29 11:16:16 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QGroupBox *
@@ -442,14 +442,14 @@ QvisSelectionsWindow::CreateTimeControls(QWidget *parent)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::CreateCQHistogramControls
 //
-// Purpose: 
+// Purpose:
 //   Create the histogram controls for CQ selections.
 //
 // Arguments:
 //
 // Returns:    A widget containing the parent widget.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri May 20 16:06:09 PDT 2011
@@ -561,7 +561,7 @@ QvisSelectionsWindow::CreateCQHistogramControls(QWidget *parent)
     QGridLayout *sLayout = new QGridLayout(summationGroup);
     sLayout->setMargin(5);
 
-    sLayout->addWidget(new QLabel(tr("Type"), central), 0, 0);   
+    sLayout->addWidget(new QLabel(tr("Type"), central), 0, 0);
     cqSummation = new QComboBox(summationGroup);
     cqSummation->addItem(tr("Include cells matching in any time step"));
     cqSummation->addItem(tr("Include cells matching in all time steps"));
@@ -593,21 +593,21 @@ QvisSelectionsWindow::CreateCQHistogramControls(QWidget *parent)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::CreateStatisticsTab
 //
-// Purpose: 
+// Purpose:
 //   Create the widgets for the statistics tab.
 //
 // Arguments:
 //   parent : the parent widget.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Dec 29 11:15:46 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QWidget *
@@ -635,7 +635,7 @@ QvisSelectionsWindow::CreateStatisticsTab(QWidget *parent)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the window's subject is changed. The
 //   subject tells this window what attributes changed and we put the
 //   new values into those widgets.
@@ -687,7 +687,7 @@ QvisSelectionsWindow::UpdateWindow(bool doAll)
         UpdateWindowSingleItem();
     }
 
-    if(SelectedSubject() == plotList || 
+    if(SelectedSubject() == plotList ||
        SelectedSubject() == windowInformation ||
        doAll)
     {
@@ -704,7 +704,7 @@ QvisSelectionsWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the values from text widgets
 //
 // Arguments:
@@ -783,7 +783,7 @@ QvisSelectionsWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the Apply button is clicked.
 //
 // Programmer: Brad Whitlock
@@ -809,7 +809,7 @@ QvisSelectionsWindow::Apply(bool forceUpdate, bool updatePlots, bool caching)
 
         if(selectionListBox->currentItem() != 0)
         {
-            GetViewerMethods()->UpdateNamedSelection(selectionProps.GetName(), 
+            GetViewerMethods()->UpdateNamedSelection(selectionProps.GetName(),
                 selectionProps, updatePlots, allowCaching);
         }
 
@@ -820,7 +820,7 @@ QvisSelectionsWindow::Apply(bool forceUpdate, bool updatePlots, bool caching)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::GetLoadHost
 //
-// Purpose: 
+// Purpose:
 //   Get the host to use for the load button.
 //
 // Arguments:
@@ -834,13 +834,13 @@ QvisSelectionsWindow::Apply(bool forceUpdate, bool updatePlots, bool caching)
 // Creation:   Mon Oct 11 15:15:51 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QString
 QvisSelectionsWindow::GetLoadHost() const
 {
-    QString loadHost; 
+    QString loadHost;
 
     int index = plotList->FirstSelectedIndex();
     if(index != -1)
@@ -851,7 +851,7 @@ QvisSelectionsWindow::GetLoadHost() const
     if(loadHost.isEmpty())
     {
         const stringVector &engines = engineList->GetEngineName();
-        if(engines.size() == 1) 
+        if(engines.size() == 1)
             loadHost = QString(engines[0].c_str());
     }
 
@@ -867,18 +867,18 @@ QvisSelectionsWindow::GetLoadHost() const
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateHistogram
 //
-// Purpose: 
+// Purpose:
 //   Update the histogram on the histogram tab.
 //
 // Programmer: Brad Whitlock
 // Creation:   Sat May 21 00:53:37 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
-QvisSelectionsWindow::UpdateHistogram(const double *values, int nvalues, 
+QvisSelectionsWindow::UpdateHistogram(const double *values, int nvalues,
                                       int minBin, int maxBin, bool useBins,
                                       double minAxisValue, double maxAxisValue )
 {
@@ -900,9 +900,9 @@ QvisSelectionsWindow::UpdateHistogram(const double *values, int nvalues,
 
           minBin = 0;
           maxBin = nvalues-1;
-          
+
           Apply(DEFAULT_FORCE_UPDATE, DEFAULT_UPDATE_PLOTS, ALLOW_CACHING);
-          
+
           UpdateMinMaxBins(true, true, true);
         }
 
@@ -939,13 +939,13 @@ QvisSelectionsWindow::UpdateHistogram(const double *values, int nvalues,
         minstr << std::string("Bin 0 (min = ") << minAxisValue << ")";
         cqHistogramMinAxisLabel->setText(tr(minstr.str().c_str()));
 
-        
+
         std::stringstream maxstr;
         maxstr << std::string("Bin ")
                               << (selectionProps.GetHistogramNumBins() - 1)
                               << " (max = " << maxAxisValue << ")";
         cqHistogramMaxAxisLabel->setText(tr(maxstr.str().c_str()));
-        
+
         std::stringstream labelstr;
 
         if(selectionProps.GetHistogramType() ==
@@ -956,7 +956,7 @@ QvisSelectionsWindow::UpdateHistogram(const double *values, int nvalues,
 
         labelstr << minVal
                  << std::string( "    max : " ) << maxVal;
-                                 
+
         cqHistogramAxisLabel->setText(tr(labelstr.str().c_str()));
     }
 }
@@ -964,19 +964,19 @@ QvisSelectionsWindow::UpdateHistogram(const double *values, int nvalues,
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateHistogram
 //
-// Purpose: 
+// Purpose:
 //   Update the histogram on the histogram tab.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 15:58:43 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
 QvisSelectionsWindow::UpdateHistogram()
-{ 
+{
     int sumIndex = selectionList->GetSelectionSummary(selectionProps.GetName());
 
     // Histogram controls
@@ -991,7 +991,7 @@ QvisSelectionsWindow::UpdateHistogram()
           UpdateHistogram(0,0,0,0,false,0,0);
         else
         {
-            UpdateHistogram(&hist[0], (int)hist.size(), 
+            UpdateHistogram(&hist[0], (int)hist.size(),
                             selectionProps.GetHistogramStartBin(),
                             selectionProps.GetHistogramEndBin(),
                             true,
@@ -1009,20 +1009,20 @@ QvisSelectionsWindow::UpdateHistogram()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateHistogramTitle
 //
-// Purpose: 
+// Purpose:
 //   Update the histogram title based on selectionProps.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 15:59:07 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
 QvisSelectionsWindow::UpdateHistogramTitle()
 {
-    if(selectionProps.GetSelectionType() != 
+    if(selectionProps.GetSelectionType() !=
         SelectionProperties::CumulativeQuerySelection)
         cqHistogramTitle->setText("");
     else if(selectionProps.GetHistogramType() == SelectionProperties::HistogramTime)
@@ -1038,7 +1038,7 @@ QvisSelectionsWindow::UpdateHistogramTitle()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateMinMaxBins
 //
-// Purpose: 
+// Purpose:
 //   Update the min and max limits for the histogram start/end spin boxes.
 //
 // Arguments:
@@ -1050,11 +1050,11 @@ QvisSelectionsWindow::UpdateHistogramTitle()
 // Creation:   Thu Jun  9 15:59:35 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
-QvisSelectionsWindow::UpdateMinMaxBins(bool updateMin, bool updateMax, 
+QvisSelectionsWindow::UpdateMinMaxBins(bool updateMin, bool updateMax,
     bool updateValues)
 {
 //    bool notTime = selectionProps.GetHistogramType() != SelectionProperties::HistogramTime;
@@ -1107,7 +1107,7 @@ QvisSelectionsWindow::UpdateMinMaxBins(bool updateMin, bool updateMax,
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateSelectionProperties
 //
-// Purpose: 
+// Purpose:
 //   Update the property controls using the selectionProps object.
 //
 // Programmer: Brad Whitlock
@@ -1164,7 +1164,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
         nbins << (defaults.GetHistogramNumBins() - 1);
         std::string tmpstr = std::string("Bin ") + nbins.str() + " (0)";
         cqHistogramMaxAxisLabel->setText(tr(tmpstr.c_str()));
- 
+
         cqHistogramNumBins->blockSignals(true);
         cqHistogramNumBins->setValue(defaults.GetHistogramNumBins());
         cqHistogramNumBins->blockSignals(false);
@@ -1177,13 +1177,13 @@ QvisSelectionsWindow::UpdateSelectionProperties()
                         SelectionProperties::HistogramID ||
                         selectionProps.GetHistogramType() ==
                         SelectionProperties::HistogramVariable);
-        
+
         cqHistogramNumBins->setEnabled(setBins &&
           !selectionProps.GetHistogramAutoScaleNumBins());
         cqHistogramNumBinsLabel->setEnabled(setBins &&
           !selectionProps.GetHistogramAutoScaleNumBins());
         cqHistogramAutoScaleNumBins->setEnabled(setBins);
-        
+
         cqHistogramMin->blockSignals(true);
         cqHistogramMin->setValue(defaults.GetHistogramStartBin());
         cqHistogramMin->blockSignals(false);
@@ -1198,7 +1198,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
     }
     else
     {
-        // Update the window based on the working copy of the selection 
+        // Update the window based on the working copy of the selection
         // properties.
         if(selectionProps.GetSource().empty())
             plotNameLabel->setText(tr("none"));
@@ -1230,7 +1230,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
         idVariableButton->setEnabled(idvar == 2);
 
         cqControls->blockSignals(true);
-        cqControls->setChecked(selectionProps.GetSelectionType() == 
+        cqControls->setChecked(selectionProps.GetSelectionType() ==
             SelectionProperties::CumulativeQuerySelection);
         cqControls->blockSignals(false);
 
@@ -1254,7 +1254,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
             float r1 = (float)selectionProps.GetVariableMaxs()[i];
             limits->setSelectedRange(r0, r1);
 
-            // Try and get the variable total min/max and histogram from 
+            // Try and get the variable total min/max and histogram from
             // the selection summary if it exists.
             if(sumIndex >= 0)
             {
@@ -1262,7 +1262,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
                     GetSelectionSummary(sumIndex);
                 for(int s = 0; s < summary.GetNumVariables(); ++s)
                 {
-                    const SelectionVariableSummary &vsummary = 
+                    const SelectionVariableSummary &vsummary =
                         summary.GetVariables(s);
                     if(vsummary.GetName() == varname)
                     {
@@ -1324,17 +1324,17 @@ QvisSelectionsWindow::UpdateSelectionProperties()
                         SelectionProperties::HistogramID ||
                         selectionProps.GetHistogramType() ==
                         SelectionProperties::HistogramVariable);
-        
+
         cqHistogramNumBins->setEnabled(setBins &&
             !selectionProps.GetHistogramAutoScaleNumBins());
         cqHistogramNumBinsLabel->setEnabled(setBins &&
             !selectionProps.GetHistogramAutoScaleNumBins());
         cqHistogramAutoScaleNumBins->setEnabled(setBins);
-        
+
         UpdateMinMaxBins(true, true, true);
 
         cqSummation->blockSignals(true);
-        cqSummation->setCurrentIndex((selectionProps.GetCombineRule() == 
+        cqSummation->setCurrentIndex((selectionProps.GetCombineRule() ==
             SelectionProperties::CombineOr) ? 0 : 1);
         cqSummation->blockSignals(false);
     }
@@ -1351,7 +1351,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::UpdateSelectionSummary
 //
-// Purpose: 
+// Purpose:
 //   Update the selection summary controls using the summary named by selectionProps
 //   and the summary stored in the selectionList.
 //
@@ -1359,7 +1359,7 @@ QvisSelectionsWindow::UpdateSelectionProperties()
 // Creation:   Wed Dec 29 11:38:42 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1376,8 +1376,8 @@ QvisSelectionsWindow::UpdateSelectionSummary()
         statVars->clear();
         statVars->setColumnCount(3);
         QStringList header;
-        header << tr("Variable") 
-               << tr("Minimum") 
+        header << tr("Variable")
+               << tr("Minimum")
                << tr("Maximum");
         statVars->setHorizontalHeaderLabels(header);
 
@@ -1416,7 +1416,7 @@ QvisSelectionsWindow::UpdateSelectionSummary()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::automaticallyApplyToggled
 //
-// Purpose: 
+// Purpose:
 //   Sets the named selection auto apply mode.
 //
 // Arguments:
@@ -1426,7 +1426,7 @@ QvisSelectionsWindow::UpdateSelectionSummary()
 // Creation:   Wed Aug 11 16:22:37 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1479,7 +1479,7 @@ QvisSelectionsWindow::UpdateWindowSingleItem()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::addSelection
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that adds a new Selection that is empty.
 //
 // Programmer: Brad Whitlock
@@ -1488,6 +1488,9 @@ QvisSelectionsWindow::UpdateWindowSingleItem()
 // Modifications:
 //   Brad Whitlock, Sat Nov  5 02:42:04 PDT 2011
 //   I added support for different id types.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -1499,7 +1502,7 @@ QvisSelectionsWindow::addSelection()
     QString newName;
     while (!okay)
     {
-        newName.asprintf("selection%d", selectionCounter);
+        newName = QString("selection%1").arg(selectionCounter);
         if(selectionList->GetSelection(newName.toStdString()) >= 0)
             selectionCounter++;
         else
@@ -1580,22 +1583,22 @@ QvisSelectionsWindow::addSelection()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::NewEnabled
 //
-// Purpose: 
+// Purpose:
 //   Returns plot name and db name that can be used to create new selections.
 //
 // Arguments:
 //   plotName : The name of the plot that might be used to generate a selection.
 //   dbName   : The name of the database that might be used to generate a selection.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 15:24:29 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1617,7 +1620,7 @@ QvisSelectionsWindow::NewEnabled(QString &plotName, QString &dbName)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::delSelection
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to delete a Selection.
 //
 // Programmer: Brad Whitlock
@@ -1640,7 +1643,7 @@ QvisSelectionsWindow::deleteSelection()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::updateQuery
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to update a Selection.
 //
 // Programmer: Brad Whitlock
@@ -1673,7 +1676,7 @@ QvisSelectionsWindow::updateQuery()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::updateSelection
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to update a Selection.
 //
 // Programmer: Brad Whitlock
@@ -1704,7 +1707,7 @@ QvisSelectionsWindow::updateSelection()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::loadSelection
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to load a selection.
 //
 // Programmer: Brad Whitlock
@@ -1741,7 +1744,7 @@ QvisSelectionsWindow::loadSelection()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::saveSelection
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called to save a selection.
 //
 // Programmer: Brad Whitlock
@@ -1764,7 +1767,7 @@ QvisSelectionsWindow::saveSelection()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::highlightSelection
 //
-// Purpose: 
+// Purpose:
 //   Slot function that highlights a specific selection in the list.
 //
 // Arguments:
@@ -1774,7 +1777,7 @@ QvisSelectionsWindow::saveSelection()
 // Creation:   Wed Aug 11 10:52:48 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1788,7 +1791,7 @@ QvisSelectionsWindow::highlightSelection(const QString &selName)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::cumulativeQueryClicked
 //
-// Purpose: 
+// Purpose:
 //   Change the selection type to/from CQ.
 //
 // Arguments:
@@ -1798,7 +1801,7 @@ QvisSelectionsWindow::highlightSelection(const QString &selName)
 // Creation:   Thu Jun  9 16:02:03 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1812,7 +1815,7 @@ QvisSelectionsWindow::cumulativeQueryClicked(bool value)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::addVariable
 //
-// Purpose: 
+// Purpose:
 //   Add a new variable to the CQ selection.
 //
 // Arguments:
@@ -1822,7 +1825,7 @@ QvisSelectionsWindow::cumulativeQueryClicked(bool value)
 // Creation:   Thu Jun  9 16:02:31 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1840,7 +1843,7 @@ QvisSelectionsWindow::addVariable(const QString &var)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::setVariableRange
 //
-// Purpose: 
+// Purpose:
 //   Set the variable range for the specified variable into the selection.
 //
 // Arguments:
@@ -1852,7 +1855,7 @@ QvisSelectionsWindow::addVariable(const QString &var)
 // Creation:   Thu Jun  9 16:02:59 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1874,7 +1877,7 @@ QvisSelectionsWindow::setVariableRange(const QString &var, float r0, float r1)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::deleteVariable
 //
-// Purpose: 
+// Purpose:
 //   Remove a variable from the CQ selection.
 //
 // Arguments:
@@ -1884,7 +1887,7 @@ QvisSelectionsWindow::setVariableRange(const QString &var, float r0, float r1)
 // Creation:   Thu Jun  9 16:03:46 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1918,7 +1921,7 @@ QvisSelectionsWindow::deleteVariable(const QString &var)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::summationChanged
 //
-// Purpose: 
+// Purpose:
 //   Set the summation mode for the selection.
 //
 // Arguments:
@@ -1928,7 +1931,7 @@ QvisSelectionsWindow::deleteVariable(const QString &var)
 // Creation:   Thu Jun  9 16:05:50 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1944,14 +1947,14 @@ QvisSelectionsWindow::summationChanged(int val)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::processTimeMin
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we need to process the min time.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 16:06:27 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1964,14 +1967,14 @@ QvisSelectionsWindow::processTimeMin()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::processTimeMax
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we need to process the max time.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 16:06:27 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1984,14 +1987,14 @@ QvisSelectionsWindow::processTimeMax()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::processTimeStride
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we need to process the time stride.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 16:06:27 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2004,14 +2007,14 @@ QvisSelectionsWindow::processTimeStride()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::initializeVariableList
 //
-// Purpose: 
+// Purpose:
 //   Tell the viewer to get the selection variables from a ParallelCoordinates plot.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Jun  9 16:07:57 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2027,7 +2030,7 @@ QvisSelectionsWindow::initializeVariableList()
 // ****************************************************************************
 // Method: QvisSelectionsWindow::histogramTypeChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we change the histogram type.
 //
 // Arguments:
@@ -2086,7 +2089,7 @@ QvisSelectionsWindow::histogramTypeChanged(int value)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::histogramVariableChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function is called when we change the histogram variable.
 //
 // Arguments:
@@ -2111,7 +2114,7 @@ QvisSelectionsWindow::histogramVariableChanged(const QString &var)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::histogramNumBinsChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot is called when we adjust the number of histogram bins.
 //
 // Arguments:
@@ -2121,7 +2124,7 @@ QvisSelectionsWindow::histogramVariableChanged(const QString &var)
 // Creation:   Thu Jun  9 16:09:28 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2148,7 +2151,7 @@ QvisSelectionsWindow::histogramNumBinsChanged(int index)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::histogramAutoScaleNumBinsToggled
 //
-// Purpose: 
+// Purpose:
 //   Sets the named selection auto apply mode.
 //
 // Arguments:
@@ -2158,7 +2161,7 @@ QvisSelectionsWindow::histogramNumBinsChanged(int index)
 // Creation:   Wed Aug 11 16:22:37 PDT 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2181,7 +2184,7 @@ QvisSelectionsWindow::histogramAutoScaleNumBinsToggled(bool val)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::histogramStartChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot is called when we adjust the histogram start bin.
 //
 // Arguments:
@@ -2191,7 +2194,7 @@ QvisSelectionsWindow::histogramAutoScaleNumBinsToggled(bool val)
 // Creation:   Thu Jun  9 16:10:11 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2208,7 +2211,7 @@ QvisSelectionsWindow::histogramStartChanged(int index)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::histogramEndChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot is called when we adjust the histogram end bin.
 //
 // Arguments:
@@ -2218,7 +2221,7 @@ QvisSelectionsWindow::histogramStartChanged(int index)
 // Creation:   Thu Jun  9 16:10:11 PDT 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2234,7 +2237,7 @@ QvisSelectionsWindow::histogramEndChanged(int index)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::idVariableChanged
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when we change the id variable.
 //
 // Arguments:
@@ -2244,7 +2247,7 @@ QvisSelectionsWindow::histogramEndChanged(int index)
 // Creation:   Mon Nov  7 14:18:45 PST 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2257,7 +2260,7 @@ QvisSelectionsWindow::idVariableChanged(const QString &var)
 // ****************************************************************************
 // Method: QvisSelectionsWindow::idVariableTypeChanged
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when we change the id variable type.
 //
 // Arguments:
@@ -2269,7 +2272,7 @@ QvisSelectionsWindow::idVariableChanged(const QString &var)
 // Creation:   Mon Nov  7 14:20:13 PST 2011
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisSimulationWindow.C
+++ b/src/gui/QvisSimulationWindow.C
@@ -1406,6 +1406,9 @@ QvisSimulationWindow::UpdateStatusArea()
 //   Jean M. Favre, Mon Nov 28 13:04:28 PST 2011
 //   Use current time in some cases.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.setNum.
+//
 // ****************************************************************************
 void
 QvisSimulationWindow::UpdateInformation()
@@ -1476,7 +1479,7 @@ QvisSimulationWindow::UpdateInformation()
             QStringList(timestr.left(timestr.length()-1)));
 
         // Num processors
-        tmp1.asprintf("%d", np);
+        tmp1.setNum(np);
         item = new QTreeWidgetItem(simInfo,
                                    QStringList(tr("Num Processors")) +
                                    QStringList(tmp1));
@@ -1846,6 +1849,8 @@ QvisSimulationWindow::clearStripCharts()
 // Creation:   March 21, 2005
 //
 // Modifications:
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 QString
@@ -1855,7 +1860,7 @@ QvisSimulationWindow::MakeKey(const std::string &host,
     if(sim.empty())
         return QString(host.c_str());
     else
-        return QString().asprintf("%s:%s", host.c_str(), sim.c_str());
+        return QString("%1:%2").arg(host.c_str()).arg(sim.c_str());
 }
 
 // ****************************************************************************

--- a/src/gui/QvisText3DInterface.C
+++ b/src/gui/QvisText3DInterface.C
@@ -38,7 +38,7 @@
 // ****************************************************************************
 // Method: QvisText3DInterface::QvisText3DInterface
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the QvisText3DInterface class.
 //
 // Arguments:
@@ -58,7 +58,7 @@
 //
 // ****************************************************************************
 
-QvisText3DInterface::QvisText3DInterface(QWidget *parent) : 
+QvisText3DInterface::QvisText3DInterface(QWidget *parent) :
     QvisAnnotationObjectInterface(parent)
 {
     // Set the title of the group box.
@@ -203,14 +203,14 @@ QvisText3DInterface::QvisText3DInterface(QWidget *parent) :
 // ****************************************************************************
 // Method: QvisText3DInterface::~QvisText3DInterface
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the QvisText3DInterface class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Nov 7 11:47:58 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisText3DInterface::~QvisText3DInterface()
@@ -220,7 +220,7 @@ QvisText3DInterface::~QvisText3DInterface()
 // ****************************************************************************
 // Method: QvisText3DInterface::GetMenuText
 //
-// Purpose: 
+// Purpose:
 //   Returns the text to use in the annotation list box.
 //
 // Arguments:
@@ -252,7 +252,7 @@ QvisText3DInterface::GetMenuText(const AnnotationObject &annot) const
 // ****************************************************************************
 // Method: QvisText3DInterface::UpdateControls
 //
-// Purpose: 
+// Purpose:
 //   Updates the controls in the interface using the data in the Annotation
 //   object pointed to by the annot pointer.
 //
@@ -265,6 +265,9 @@ QvisText3DInterface::GetMenuText(const AnnotationObject &annot) const
 //
 //   Kathleen Biagas, Mon Jul 13 13:19:45 PDT 2015
 //   Enable/disable textColorLabel along with textColorButton.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg and QString.setNum.
 //
 // ****************************************************************************
 
@@ -279,11 +282,10 @@ QvisText3DInterface::UpdateControls()
         textLineEdit->setText("");
 
     // Set the position.
-    QString pos;
-    pos.asprintf("%lg %lg %lg", 
-        annot->GetPosition()[0],
-        annot->GetPosition()[1],
-        annot->GetPosition()[2]);
+    QString pos = QString("%1 %2 %3")
+        .arg(annot->GetPosition()[0])
+        .arg(annot->GetPosition()[1])
+        .arg(annot->GetPosition()[2]);
     positionEdit->setText(pos);
 
     // Set the height mode
@@ -300,7 +302,7 @@ QvisText3DInterface::UpdateControls()
 
     // Set the value for the fixed height.
     QString tmp;
-    tmp.asprintf("%lg", annot->GetFixedHeight());
+    tmp.setNum(annot->GetFixedHeight());
     fixedHeightEdit->setText(tmp);
 
     // Set the faces camera check box.
@@ -312,13 +314,13 @@ QvisText3DInterface::UpdateControls()
     int rx = (int)annot->GetRotations()[0];
     int ry = (int)annot->GetRotations()[1];
     int rz = (int)annot->GetRotations()[2];
-    rotateX->blockSignals(true); rotateX->setValue(rx); rotateX->blockSignals(false); 
-    rotateY->blockSignals(true); rotateY->setValue(ry); rotateY->blockSignals(false); 
-    rotateZ->blockSignals(true); rotateZ->setValue(rz); rotateZ->blockSignals(false); 
+    rotateX->blockSignals(true); rotateX->setValue(rx); rotateX->blockSignals(false);
+    rotateY->blockSignals(true); rotateY->setValue(ry); rotateY->blockSignals(false);
+    rotateZ->blockSignals(true); rotateZ->setValue(rz); rotateZ->blockSignals(false);
 
     //
     // Set the text color. If we're using the foreground color for the text
-    // color then make the button be white and only let the user change the 
+    // color then make the button be white and only let the user change the
     // opacity.
     //
     textColorOpacity->blockSignals(true);
@@ -357,7 +359,7 @@ QvisText3DInterface::UpdateControls()
 // ****************************************************************************
 // Method: QvisText3DInterface::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values for the text fields.
 //
 // Arguments:
@@ -399,7 +401,7 @@ QvisText3DInterface::GetCurrentValues(int which_widget)
                 arg(DoublesToQString(annot->GetPosition(), 3));
             Error(msg);
             annot->SetPosition(annot->GetPosition());
-        }  
+        }
     }
 
     if(which_widget == 2 || doAll)
@@ -470,15 +472,15 @@ QvisText3DInterface::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisText3DInterface::textChanged
 //
-// Purpose: 
-//   This is a Qt slot function that is called when return is pressed in the 
+// Purpose:
+//   This is a Qt slot function that is called when return is pressed in the
 //   text line edit.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Nov 7 11:49:46 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -491,15 +493,15 @@ QvisText3DInterface::textChanged()
 // ****************************************************************************
 // Method: QvisText3DInterface::positionChanged
 //
-// Purpose: 
-//   This is a Qt slot function that is called when return is pressed in the 
+// Purpose:
+//   This is a Qt slot function that is called when return is pressed in the
 //   position line edit.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Nov 7 11:49:46 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -535,7 +537,7 @@ QvisText3DInterface::fixedHeightChanged()
 // ****************************************************************************
 // Method: QvisText3DInterface::facesCameraToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the faces camera checkbox
 //   is toggled.
 //
@@ -546,7 +548,7 @@ QvisText3DInterface::fixedHeightChanged()
 // Creation:   Thu Nov 8 16:01:03 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -581,7 +583,7 @@ QvisText3DInterface::rotateYChanged(int)
 // ****************************************************************************
 // Method: QvisText3DInterface::textColorChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a new start color is
 //   selected.
 //
@@ -592,7 +594,7 @@ QvisText3DInterface::rotateYChanged(int)
 // Creation:   Wed Nov 7 11:49:46 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -607,7 +609,7 @@ QvisText3DInterface::textColorChanged(const QColor &c)
 // ****************************************************************************
 // Method: QvisText3DInterface::textOpacityChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when a new start opacity is
 //   selected.
 //
@@ -618,7 +620,7 @@ QvisText3DInterface::textColorChanged(const QColor &c)
 // Creation:   Wed Nov 7 11:49:46 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -634,7 +636,7 @@ QvisText3DInterface::textOpacityChanged(int opacity)
 // ****************************************************************************
 // Method: QvisText3DInterface::useForegroundColorToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the useForegroundColor
 //   check box is clicked.
 //
@@ -645,7 +647,7 @@ QvisText3DInterface::textOpacityChanged(int opacity)
 // Creation:   Wed Nov 7 12:34:48 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -658,7 +660,7 @@ QvisText3DInterface::useForegroundColorToggled(bool val)
 // ****************************************************************************
 // Method: QvisText3DInterface::visibilityToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the visibility toggle is
 //   changed.
 //
@@ -669,7 +671,7 @@ QvisText3DInterface::useForegroundColorToggled(bool val)
 // Creation:   Wed Nov 7 11:49:46 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void

--- a/src/gui/QvisTimeSliderControlWidget.C
+++ b/src/gui/QvisTimeSliderControlWidget.C
@@ -544,6 +544,9 @@ QvisTimeSliderControlWidget::UpdateAnimationControlsEnabledState()
 //   Changed set of time field text to use SetTimeFieldText to make sure
 //   long time values remain visible.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.setNum.
+//
 // ****************************************************************************
 
 void
@@ -637,7 +640,7 @@ QvisTimeSliderControlWidget::UpdateTimeFieldText(int timeState)
                 // If we did not set the time yet, do it with the index.
                 if(timeNeedsToBeSet)
                 {
-                    timeString.asprintf("%d", timeState);
+                    timeString.setNum(timeState);
                     SetTimeFieldText(timeString);
                 }
             }
@@ -646,7 +649,7 @@ QvisTimeSliderControlWidget::UpdateTimeFieldText(int timeState)
         {
             // There was no correlation but we know the time state that we want to
             // display so let's show that in the time line edit.
-            timeString.asprintf("%d", timeState);
+            timeString.setNum(timeState);
             SetTimeFieldText(timeString);
         }
     }
@@ -701,14 +704,15 @@ QvisTimeSliderControlWidget::SetTimeFieldText(const QString &text)
 // Creation:   Tue Oct 14 11:31:42 PDT 2003
 //
 // Modifications:
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
 QString
 QvisTimeSliderControlWidget::FormattedCycleString(const int cycle) const
 {
-    QString retval;
-    retval.asprintf("%04d", cycle);
+    QString retval = QString("%1").arg(cycle,4,10,QLatin1Char('0'));
     return retval;
 }
 
@@ -729,6 +733,8 @@ QvisTimeSliderControlWidget::FormattedCycleString(const int cycle) const
 // Creation:   Mon Oct 13 16:03:37 PST 2003
 //
 // Modifications:
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -738,9 +744,7 @@ QvisTimeSliderControlWidget::FormattedTimeString(const double t, bool accurate) 
     QString retval("?");
     if(accurate)
     {
-        QString formatString;
-        formatString.asprintf("%%.%dg", timeStateFormat.GetPrecision());
-        retval.asprintf(formatString.toStdString().c_str(), t);
+        retval = QString("%1").arg(t,0,'g',timeStateFormat.GetPrecision());
     }
     return retval;
 }
@@ -841,6 +845,9 @@ QvisTimeSliderControlWidget::ConnectPlotList(PlotList *pl)
 //   Brad Whitlock, Sun Jan 25 01:39:50 PDT 2004
 //   I made it compare the state against the active time slider's current state.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void
@@ -861,8 +868,7 @@ QvisTimeSliderControlWidget::SetTimeSliderState(int state)
          }
          else
          {
-             QString msg;
-             msg.asprintf(" %d.", state);
+             QString msg =  QString(" %1.").arg(state);
              Message(tr("The active time slider is already at state") + msg);
          }
     }

--- a/src/gui/QvisViewWindow.C
+++ b/src/gui/QvisViewWindow.C
@@ -35,14 +35,14 @@
 // ****************************************************************************
 // Method: QvisViewWindow::QvisViewWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the constructor for the QvisViewWindow class.
 //
 // Arguments:
 //   caption   : The name of the window.
 //   shortName : The posted name for the window.
 //   notepad   : The notepad area into which the window posts.
-//   
+//
 // Programmer: Brad Whitlock
 // Creation:   Fri Jul 27 11:00:57 PDT 2001
 //
@@ -80,7 +80,7 @@ QvisViewWindow::QvisViewWindow(const QString &caption, const QString &shortName,
 // ****************************************************************************
 // Method: QvisViewWindow::~QvisViewWindow
 //
-// Purpose: 
+// Purpose:
 //   The destructor for the QvisViewWindow class.
 //
 // Programmer: Brad Whitlock
@@ -119,7 +119,7 @@ QvisViewWindow::~QvisViewWindow()
 // ****************************************************************************
 // Method: QvisViewWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Create the view attributes window.
 //
 // Programmer: Brad Whitlock
@@ -169,7 +169,7 @@ QvisViewWindow::~QvisViewWindow()
 //   Kathleen Bonnell, Thu Mar 22 16:07:56 PDT 2007
 //   I added radio buttons for log scaling.
 //
-//   Kathleen Bonnell, Wed May  9 11:15:13 PDT 2007 
+//   Kathleen Bonnell, Wed May  9 11:15:13 PDT 2007
 //   I added radio buttons for 2d log scaling.
 //
 //   Jeremy Meredith, Mon Feb  4 13:44:33 EST 2008
@@ -183,7 +183,7 @@ QvisViewWindow::~QvisViewWindow()
 //   Qt 4.
 //
 //   Cyrus Harrison, Thu Dec 18 09:36:57 PST 2008
-//   Changed the signal used and the argument for tabSelected slot to 
+//   Changed the signal used and the argument for tabSelected slot to
 //   an integer for Qt4.
 //
 //   Jeremy Meredith, Wed Feb  3 15:29:17 EST 2010
@@ -676,7 +676,7 @@ QvisViewWindow::ConnectWindowInformation(WindowInformation *w)
 // ****************************************************************************
 // Method: QvisViewWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the window must update itself.
 //
 // Arguments:
@@ -720,7 +720,7 @@ QvisViewWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisViewWindow::UpdateCurve
 //
-// Purpose: 
+// Purpose:
 //   Update the portion of the window for curve views.
 //
 // Programmer: Eric Brugger
@@ -785,7 +785,7 @@ QvisViewWindow::UpdateCurve(bool doAll)
 // ****************************************************************************
 // Method: QvisViewWindow::UpdateAxisArray
 //
-// Purpose: 
+// Purpose:
 //   Update the portion of the window for axis array views.
 //
 // Programmer: Jeremy Meredith
@@ -831,7 +831,7 @@ QvisViewWindow::UpdateAxisArray(bool doAll)
 // ****************************************************************************
 // Method: QvisViewWindow::Update2D
 //
-// Purpose: 
+// Purpose:
 //   Update the portion of the window for 2d views.
 //
 // Programmer: Brad Whitlock
@@ -856,7 +856,7 @@ QvisViewWindow::UpdateAxisArray(bool doAll)
 //   Mark C. Miller, Thu Jul 21 12:52:42 PDT 2005
 //   Added logic for auto full frame mode
 //
-//   Kathleen Bonnell, Wed May  9 11:15:13 PDT 2007 
+//   Kathleen Bonnell, Wed May  9 11:15:13 PDT 2007
 //   I added radio buttons for 2d log scaling.
 //
 //   Brad Whitlock, Mon Dec 17 10:48:04 PST 2007
@@ -921,7 +921,7 @@ QvisViewWindow::Update2D(bool doAll)
 // ****************************************************************************
 // Method: QvisViewWindow::Update3D
 //
-// Purpose: 
+// Purpose:
 //   Update the portion of the window for 3d views.
 //
 // Programmer: Brad Whitlock
@@ -1112,7 +1112,7 @@ QvisViewWindow::Update3D(bool doAll)
 // ****************************************************************************
 // Method: QvisViewWindow::UpdateGlobal
 //
-// Purpose: 
+// Purpose:
 //   Updates the global widgets.
 //
 // Arguments:
@@ -1132,7 +1132,7 @@ QvisViewWindow::Update3D(bool doAll)
 //   I removed auto center view.
 //
 //   Mark C. Miller, Thu Jul 21 12:52:42 PDT 2005
-//   Fixed confusion in indices of members of WindowInformation and case labels 
+//   Fixed confusion in indices of members of WindowInformation and case labels
 //   Added logic for setting tab to whatever the active window's mode is.
 //
 //   Hank Childs, Mon Jun 11 21:51:55 PDT 2007
@@ -1256,7 +1256,7 @@ QvisViewWindow::UpdateEyeAngleSliderFromAtts(void)
             }
         }
     }
-        
+
     eyeAngleSlider->blockSignals(true);
     eyeAngleSlider->setValue(val);
     eyeAngleSlider->blockSignals(false);
@@ -1265,7 +1265,7 @@ QvisViewWindow::UpdateEyeAngleSliderFromAtts(void)
 // ****************************************************************************
 // Method: QvisViewWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Applies the new view.
 //
 // Arguments:
@@ -1277,7 +1277,7 @@ QvisViewWindow::UpdateEyeAngleSliderFromAtts(void)
 // Modifications:
 //   Eric Brugger, Wed Aug 20 14:04:21 PDT 2003
 //   I added support for curve views.
-//   
+//
 //   Jeremy Meredith, Mon Feb  4 13:44:33 EST 2008
 //   Added support for axis-array views.
 //
@@ -1335,7 +1335,7 @@ QvisViewWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisViewWindow::CreateNode
 //
-// Purpose: 
+// Purpose:
 //   Writes the window's extra information to the config file.
 //
 // Arguments:
@@ -1368,7 +1368,7 @@ QvisViewWindow::CreateNode(DataNode *parentNode)
 // ****************************************************************************
 // Method: QvisViewWindow::SetFromNode
 //
-// Purpose: 
+// Purpose:
 //   Reads window attributes from the DataNode representation of the config
 //   file.
 //
@@ -1476,7 +1476,7 @@ QvisViewWindow::GetCurrentValuesAxisArray(int which_widget)
 // ****************************************************************************
 // Method: QvisViewWindow::GetCurrentValuesCurve
 //
-// Purpose: 
+// Purpose:
 //   Get the current values for the curve text fields.
 //
 // Programmer: Eric Brugger
@@ -1545,7 +1545,7 @@ QvisViewWindow::GetCurrentValuesCurve(int which_widget)
 // ****************************************************************************
 // Method: QvisViewWindow::GetCurrentValues2d
 //
-// Purpose: 
+// Purpose:
 //   Get the current values for the 2d text fields.
 //
 // Programmer: Brad Whitlock
@@ -1606,7 +1606,7 @@ QvisViewWindow::GetCurrentValues2d(int which_widget)
 // ****************************************************************************
 // Method: QvisViewWindow::GetCurrentValues3d
 //
-// Purpose: 
+// Purpose:
 //   Get the current values for the 3d text fields.
 //
 // Programmer: Brad Whitlock
@@ -1886,8 +1886,11 @@ QvisViewWindow::GetCurrentValues(int which_widget)
 //   Eric Brugger, Wed Dec 24 10:20:47 PST 2003
 //   I added the commands "xtrans", "ytrans" and "zf".
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
- 
+
 void
 QvisViewWindow::ParseViewCommands(const char *str)
 {
@@ -1899,7 +1902,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
     strcpy(strCopy, str);
 
     //
-    // Loop over the commands, parsing one at a time. 
+    // Loop over the commands, parsing one at a time.
     //
     command = strtok(strCopy, ";");
     while (command != NULL)
@@ -1981,7 +1984,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
         else if(strncmp(command, "rotx ", 5) == 0)
         {
             double angle;
- 
+
             if (sscanf(&command[5], "%lg", &angle) == 1)
             {
                 RotateAxis(0, angle);
@@ -1993,7 +1996,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
         else if(strncmp(command, "rx ", 3) == 0)
         {
             double angle;
- 
+
             if (sscanf(&command[3], "%lg", &angle) == 1)
             {
                 RotateAxis(0, angle);
@@ -2005,7 +2008,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
         else if(strncmp(command, "roty ", 5) == 0)
         {
             double angle;
- 
+
             if (sscanf(&command[5], "%lg", &angle) == 1)
             {
                 RotateAxis(1, angle);
@@ -2017,7 +2020,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
         else if(strncmp(command, "ry ", 3) == 0)
         {
             double angle;
- 
+
             if (sscanf(&command[3], "%lg", &angle) == 1)
             {
                 RotateAxis(1, angle);
@@ -2029,7 +2032,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
         else if(strncmp(command, "rotz ", 5) == 0)
         {
             double angle;
- 
+
             if (sscanf(&command[5], "%lg", &angle) == 1)
             {
                 RotateAxis(2, angle);
@@ -2041,7 +2044,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
         else if(strncmp(command, "rz ", 3) == 0)
         {
             double angle;
- 
+
             if (sscanf(&command[3], "%lg", &angle) == 1)
             {
                 RotateAxis(2, angle);
@@ -2129,16 +2132,14 @@ QvisViewWindow::ParseViewCommands(const char *str)
         }
         else
             okay = false;
- 
+
         if(!okay)
         {
-            QString msg;
-
-            msg.asprintf("Bad command >> %s <<", command);
+            QString msg = QString("Bad command >> %1 <<").arg(command);
             Error(msg);
         }
 
-        command = strtok(NULL, ";"); 
+        command = strtok(NULL, ";");
     }
 
     delete [] strCopy;
@@ -2164,7 +2165,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
 // Creation:   August 6, 2002
 //
 // Modifications:
-//   Eric Brugger, Thu Jun 12 09:59:42 PDT 2003  
+//   Eric Brugger, Thu Jun 12 09:59:42 PDT 2003
 //   Modify the command to change the image pan instead of the focus.
 //
 //   Eric Brugger, Tue Dec 23 07:58:34 PST 2003
@@ -2172,20 +2173,20 @@ QvisViewWindow::ParseViewCommands(const char *str)
 //   they are a fraction of the current image width and height.
 //
 // ****************************************************************************
- 
+
 void
 QvisViewWindow::Pan(double panx, double pany)
 {
     double imagePan[2];
- 
+
     imagePan[0] = view3d->GetImagePan()[0] + panx / view3d->GetImageZoom();
     imagePan[1] = view3d->GetImagePan()[1] + pany / view3d->GetImageZoom();
 
     view3d->SetImagePan(imagePan);
- 
+
     Update3D(true);
 }
- 
+
 // ****************************************************************************
 // Method: QvisViewWindow::RotateAxis
 //
@@ -2213,14 +2214,14 @@ QvisViewWindow::Pan(double panx, double pany)
 //   is specified.
 //
 // ****************************************************************************
- 
+
 void
 QvisViewWindow::RotateAxis(int axis, double angle)
 {
     view3d->RotateAxis(axis, angle);
     Update3D(true);
 }
- 
+
 // ****************************************************************************
 // Method: QvisViewWindow::Zoom
 //
@@ -2234,7 +2235,7 @@ QvisViewWindow::RotateAxis(int axis, double angle)
 // Creation:   August 6, 2002
 //
 // Modifications:
-//   Eric Brugger, Thu Jun 12 09:59:42 PDT 2003  
+//   Eric Brugger, Thu Jun 12 09:59:42 PDT 2003
 //   Modify the command to change the image zoom instead of the parallel
 //   scale.
 //
@@ -2244,7 +2245,7 @@ void
 QvisViewWindow::Zoom(double zoom)
 {
     view3d->SetImageZoom(view3d->GetImageZoom() * zoom);
- 
+
     Update3D(true);
 }
 
@@ -2266,7 +2267,7 @@ void
 QvisViewWindow::Viewport(const double *viewport)
 {
     view2d->SetViewportCoords(viewport);
- 
+
     Update2D(true);
 }
 
@@ -2301,7 +2302,7 @@ QvisViewWindow::Window(const double *window)
         return;
     }
     view2d->SetWindowCoords(window);
- 
+
     Update2D(true);
 }
 
@@ -2312,7 +2313,7 @@ QvisViewWindow::Window(const double *window)
 // ****************************************************************************
 // Method: QvisViewWindow::show
 //
-// Purpose: 
+// Purpose:
 //   Qt slot that is called when the window needs to be shown.
 //
 // Programmer: Brad Whitlock
@@ -2356,11 +2357,11 @@ void
 QvisViewWindow::processCommandText()
 {
     QString temp;
- 
+
     temp = commandLineEdit->displayText().trimmed();
     if(!temp.isEmpty())
     {
-        ParseViewCommands(temp.toStdString().c_str()); 
+        ParseViewCommands(temp.toStdString().c_str());
     }
 
     commandLineEdit->setText("");
@@ -2369,7 +2370,7 @@ QvisViewWindow::processCommandText()
 // ****************************************************************************
 // Method: QvisViewWindow::tabSelected
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the tabs are changed.
 //
 // Arguments:
@@ -2384,7 +2385,7 @@ QvisViewWindow::processCommandText()
 //
 //   Cyrus Harrison, Thu Dec 18 09:35:25 PST 2008
 //   Changed input argument to tab index instead of tab name for Qt4.
-//   
+//
 // ****************************************************************************
 
 void
@@ -2402,21 +2403,21 @@ void
 QvisViewWindow::processViewportAxisArrayText()
 {
     GetCurrentValuesAxisArray(ViewAxisArrayAttributes::ID_viewportCoords);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processDomainAxisArrayText()
 {
     GetCurrentValuesAxisArray(ViewAxisArrayAttributes::ID_domainCoords);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processRangeAxisArrayText()
 {
     GetCurrentValuesAxisArray(ViewAxisArrayAttributes::ID_rangeCoords);
-    Apply();    
+    Apply();
 }
 
 //
@@ -2427,21 +2428,21 @@ void
 QvisViewWindow::processViewportCurveText()
 {
     GetCurrentValuesCurve(ViewCurveAttributes::ID_viewportCoords);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processDomainText()
 {
     GetCurrentValuesCurve(ViewCurveAttributes::ID_domainCoords);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processRangeText()
 {
     GetCurrentValuesCurve(ViewCurveAttributes::ID_rangeCoords);
-    Apply();    
+    Apply();
 }
 
 //
@@ -2452,14 +2453,14 @@ void
 QvisViewWindow::processViewportText()
 {
     GetCurrentValues2d(View2DAttributes::ID_viewportCoords);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processWindowText()
 {
     GetCurrentValues2d(View2DAttributes::ID_windowCoords);
-    Apply();    
+    Apply();
 }
 
 //
@@ -2470,77 +2471,77 @@ void
 QvisViewWindow::processNormalText()
 {
     GetCurrentValues3d(View3DAttributes::ID_viewNormal);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processFocusText()
 {
     GetCurrentValues3d(View3DAttributes::ID_focus);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processUpVectorText()
 {
     GetCurrentValues3d(View3DAttributes::ID_viewUp);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processViewAngleText()
 {
     GetCurrentValues3d(View3DAttributes::ID_viewAngle);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processParallelScaleText()
 {
     GetCurrentValues3d(View3DAttributes::ID_parallelScale);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processNearText()
 {
     GetCurrentValues3d(View3DAttributes::ID_nearPlane);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processFarText()
 {
     GetCurrentValues3d(View3DAttributes::ID_farPlane);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processImagePanText()
 {
     GetCurrentValues3d(View3DAttributes::ID_imagePan);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processImageZoomText()
 {
     GetCurrentValues3d(View3DAttributes::ID_imageZoom);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processShearText()
 {
     GetCurrentValues3d(View3DAttributes::ID_shear);
-    Apply();    
+    Apply();
 }
 
 void
 QvisViewWindow::processEyeAngleText()
 {
     GetCurrentValues3d(View3DAttributes::ID_eyeAngle);
-    Apply();    
+    Apply();
 }
 
 //  Modifications:
@@ -2570,9 +2571,9 @@ QvisViewWindow::eyeAngleSliderChanged(int val)
         int most = (int) (angle*100);
         angle = ((float)most)/100.;
     }
-    
+
     view3d->SetEyeAngle(angle);
- 
+
     QString temp;
     temp.setNum(view3d->GetEyeAngle());
     eyeAngleLineEdit->setText(temp);
@@ -2591,7 +2592,7 @@ QvisViewWindow::perspectiveToggled(bool val)
 // ****************************************************************************
 // Method: QvisViewWindow::viewButtonClicked
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when one of the default view
 //   buttons is clicked.
 //
@@ -2682,14 +2683,14 @@ QvisViewWindow::viewButtonClicked(int index)
 // ****************************************************************************
 // Method: QvisViewWindow::lockedViewChecked
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer to toggle its window locking flag.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Sep 17 15:40:07 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2701,7 +2702,7 @@ QvisViewWindow::lockedViewChecked(bool)
 // ****************************************************************************
 // Method: QvisMainWindow::maintainViewToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that is called when the maintain view limits
 //   checkbox is toggled.
 //
@@ -2709,7 +2710,7 @@ QvisViewWindow::lockedViewChecked(bool)
 // Creation:   February  3, 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2721,14 +2722,14 @@ QvisViewWindow::maintainViewChecked(bool)
 // ****************************************************************************
 // Method: QvisViewWindow::extentTypeChanged
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function sets the viewer's view extent type.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Sep 17 15:40:07 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2740,14 +2741,14 @@ QvisViewWindow::extentTypeChanged(int val)
 // ****************************************************************************
 // Method: QvisViewWindow::resetView
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer to reset the view.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Sep 11 09:34:07 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2759,14 +2760,14 @@ QvisViewWindow::resetView()
 // ****************************************************************************
 // Method: QvisViewWindow::recenterView
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer to recenter the view.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Sep 11 09:34:07 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2778,14 +2779,14 @@ QvisViewWindow::recenterView()
 // ****************************************************************************
 // Method: QvisViewWindow::undoView
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer to undo the last view change.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Sep 17 17:28:00 PST 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2797,14 +2798,14 @@ QvisViewWindow::undoView()
 // ****************************************************************************
 // Method: QvisViewWindow::copyViewFromCameraChecked
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer to change the camera view mode.
 //
 // Programmer: Jeremy Meredith
 // Creation:   February  4, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2816,14 +2817,14 @@ QvisViewWindow::copyViewFromCameraChecked(bool)
 // ****************************************************************************
 // Method: QvisViewWindow::undoView
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer to make a new view keyframe.
 //
 // Programmer: Jeremy Meredith
 // Creation:   February  4, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2835,7 +2836,7 @@ QvisViewWindow::makeViewKeyframe()
 // ****************************************************************************
 // Method: QvisViewWindow::centerChecked
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function tells the viewer that the center of rotation
 //   was set.
 //
@@ -2843,7 +2844,7 @@ QvisViewWindow::makeViewKeyframe()
 // Creation:   February 10, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2857,7 +2858,7 @@ QvisViewWindow::centerChecked(bool val)
 // ****************************************************************************
 // Method: QvisViewWindow::processCenterText
 //
-// Purpose: 
+// Purpose:
 //   This Qt slot function handles the center of rotation changing.
 //
 // Programmer: Eric Brugger
@@ -2879,10 +2880,10 @@ QvisViewWindow::processCenterText()
 // ****************************************************************************
 // Method: QvisViewWindow::fullFrameActivationModeChanged
 //
-// Purpose: Qt slot function to handle changes in full frame mode 
+// Purpose: Qt slot function to handle changes in full frame mode
 //
-// Programmer: Mark C. Miller 
-// Creation:   July 5, 2005 
+// Programmer: Mark C. Miller
+// Creation:   July 5, 2005
 //
 // ****************************************************************************
 void
@@ -2904,8 +2905,8 @@ QvisViewWindow::fullFrameActivationModeChanged(int val)
 //
 // Purpose: Qt slot function to handle changes in domain scale
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   November 29, 2006 
+// Programmer: Kathleen Bonnell
+// Creation:   November 29, 2006
 //
 // ****************************************************************************
 void
@@ -2923,8 +2924,8 @@ QvisViewWindow::domainScaleModeChanged(int val)
 //
 // Purpose: Qt slot function to handle changes in range scale
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   November 29, 2006 
+// Programmer: Kathleen Bonnell
+// Creation:   November 29, 2006
 //
 // ****************************************************************************
 void
@@ -2942,8 +2943,8 @@ QvisViewWindow::rangeScaleModeChanged(int val)
 //
 // Purpose: Qt slot function to handle changes in x scale
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   April 2, 2007 
+// Programmer: Kathleen Bonnell
+// Creation:   April 2, 2007
 //
 // ****************************************************************************
 void
@@ -2961,8 +2962,8 @@ QvisViewWindow::xScaleModeChanged(int val)
 //
 // Purpose: Qt slot function to handle changes in y scale
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   April 2, 2007 
+// Programmer: Kathleen Bonnell
+// Creation:   April 2, 2007
 //
 // ****************************************************************************
 void

--- a/src/gui/QvisViewportWidget.C
+++ b/src/gui/QvisViewportWidget.C
@@ -25,7 +25,7 @@
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 #include <iostream>
@@ -34,18 +34,18 @@ using namespace std;
 class QViewportItem : public QGraphicsRectItem
 {
 public:
-    QViewportItem (const QString &id, 
+    QViewportItem (const QString &id,
                    float llx, float lly,
                    float urx, float ury,
                    QvisViewportWidget *view);
     virtual ~QViewportItem();
-    
-    QString getId() const 
+
+    QString getId() const
     { return id; }
 
-    bool isBackground() const 
+    bool isBackground() const
     { return background; }
-    
+
     void mapRelativeToSize(const QSize &size,
                            float &llx,float &lly,float &urx,float &ury);
 
@@ -53,8 +53,8 @@ public:
                            float llx,float lly,float urx,float ury);
 
 protected:
-    
-    void updateText(); 
+
+    void updateText();
     virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event);
     virtual void hoverMoveEvent(QGraphicsSceneHoverEvent *event);
     virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
@@ -81,12 +81,12 @@ protected:
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
-QViewportItem ::QViewportItem(const QString &id, 
+QViewportItem ::QViewportItem(const QString &id,
                               float llx, float lly,
                               float urx, float ury,
-                              QvisViewportWidget *view) 
+                              QvisViewportWidget *view)
 : QGraphicsRectItem(), id(id), background(false), view(view), resizeMode(0)
 {
     QBrush brush(Qt::SolidPattern);
@@ -114,7 +114,7 @@ QViewportItem ::QViewportItem(const QString &id,
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QViewportItem::~QViewportItem()
@@ -130,10 +130,10 @@ QViewportItem::~QViewportItem()
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
+//
+// ****************************************************************************
 
-void 
+void
 QViewportItem::mapRelativeToSize(const QSize &size,
                                  float &llx,float &lly,float &urx,float &ury)
 {
@@ -157,17 +157,17 @@ QViewportItem::mapRelativeToSize(const QSize &size,
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
+//
+// ****************************************************************************
 
-void 
+void
 QViewportItem::setRelativeToSize(const QSize &size,
                                  float llx,float lly,float urx,float ury)
 {
     // set relative to input
     float w = size.width();
     float h = size.height();
-        
+
     float rel_w = urx - llx;
     float rel_h = ury - lly;
 
@@ -186,8 +186,8 @@ QViewportItem::setRelativeToSize(const QSize &size,
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
+//
+// ****************************************************************************
 
 void
 QViewportItem::updateText()
@@ -207,7 +207,7 @@ QViewportItem::updateText()
             number = name.mid(i,1) + number;
             --i;
         }
-        
+
         if(!number.isNull())
             name = number;
 
@@ -221,7 +221,7 @@ QViewportItem::updateText()
 
     textItem->setPos(rect().width()/2.0- txt_w/2,
                      rect().height()/2.0- txt_h/2);
-}    
+}
 
 // ****************************************************************************
 // Method: QViewportItem::hoverLeaveEvent
@@ -234,16 +234,16 @@ QViewportItem::updateText()
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
+//
+// ****************************************************************************
 
-void 
+void
 QViewportItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
     view->setCursor(QCursor(Qt::ArrowCursor));
     resizeMode = 0;
 }
-   
+
 // ****************************************************************************
 // Method: QViewportItem::hoverMoveEvent
 //
@@ -255,9 +255,9 @@ QViewportItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
- 
+//
+// ****************************************************************************
+
 void
 QViewportItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 {
@@ -265,11 +265,11 @@ QViewportItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
     float y = event->pos().y();
     float w = rect().width();
     float h = rect().height();
-       
+
     float dx = 3;
-        
+
     resizeMode = 0;
-    
+
     if( x - dx <= 0)
     {
         if( y - dx <=0)      // upper left corner
@@ -292,7 +292,7 @@ QViewportItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
         resizeMode = 3;
     else if( y - dx <=0)     // move top
         resizeMode = 7;
-      
+
     if(resizeMode == 1 || resizeMode == 5)       // left & right
         view->setCursor(QCursor(Qt::SizeHorCursor));
     else if(resizeMode == 2 || resizeMode == 6)  // bottom left & upper right
@@ -315,8 +315,8 @@ QViewportItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
+//
+// ****************************************************************************
 
 void
 QViewportItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
@@ -330,7 +330,7 @@ QViewportItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
         setSelected(true);
     }
     else if(event->button() == Qt::RightButton)
-    {   
+    {
         // delete this viewport if the right button is cliced
         view->removeViewport(id);
     }
@@ -351,8 +351,8 @@ QViewportItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 // Creation:   Wed Nov  5 08:22:57 PST 2008
 //
 // Modifications:
-//   
-// ****************************************************************************        
+//
+// ****************************************************************************
 
 void
 QViewportItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
@@ -369,19 +369,19 @@ QViewportItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
         view->viewportUpdated(this);
         return;
     }
-        
+
     // move according to resize mode
     QPointF down = event->buttonDownScenePos(Qt::LeftButton);
     QPointF last = event->lastScenePos();
-        
+
     float dx = down.x() - last.x();
     float dy = down.y() - last.y();
-        
+
     float nx = prevPos.x();
     float ny = prevPos.y();
     float nw = prevRect.width();
     float nh = prevRect.height();
-        
+
     switch(resizeMode)
     {
         case 1:
@@ -427,23 +427,23 @@ QViewportItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
             nh += dy;
             break;
     };
-        
+
     if(nw < 0)
     {
         nx += nw;
         nw = -1 * nw;
     }
-    
+
     if(nh < 0)
     {
         ny += nh;
         nh = -1 * nh;
     }
-        
+
     setPos(nx,ny);
     setRect(0,0,nw,nh);
     updateText();
-        
+
     // signal change
     view->viewportUpdated(this);
 }
@@ -451,7 +451,7 @@ QViewportItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 // ****************************************************************************
 // Method: QvisViewportWidget::QvisViewportWidget
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Arguments:
@@ -472,8 +472,8 @@ QvisViewportWidget::QvisViewportWidget(double aspect,
                                        int minw, int minh,
                                        QWidget *parent)
 : QGraphicsView(parent), minW(minw), minH(minh), aspect(aspect),
-  prevSelected(""), 
-  dragViewportOutline(false), 
+  prevSelected(""),
+  dragViewportOutline(false),
   dragMouseStart(QPointF(0.0,0.0)),
   viewportOutline(0)
 {
@@ -483,7 +483,7 @@ QvisViewportWidget::QvisViewportWidget(double aspect,
 // ****************************************************************************
 // Method: QvisViewportWidget::init
 //
-// Purpose: 
+// Purpose:
 //   Initializes most of the members.
 //
 // Programmer: Brad Whitlock
@@ -511,7 +511,7 @@ QvisViewportWidget::init()
         h = minH - 20;
         w  = int(h / aspect);
     }
-    
+
     scene = new QGraphicsScene(this);
     scene->setBackgroundBrush(Qt::white);
     setScene(scene);
@@ -521,7 +521,7 @@ QvisViewportWidget::init()
     // Set the focus policy to StrongFocus. This means that the widget will
     // accept focus by tabbing and clicking.
     setFocusPolicy(Qt::StrongFocus);
-    
+
     connect(scene,SIGNAL(selectionChanged()),
             this,SLOT(onSceneSelectionChanged()));
 }
@@ -529,7 +529,7 @@ QvisViewportWidget::init()
 // ****************************************************************************
 // Method: QvisViewportWidget::~QvisViewportWidget
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: Brad Whitlock
@@ -552,14 +552,14 @@ QvisViewportWidget::~QvisViewportWidget()
 // ****************************************************************************
 // Method: QvisViewportWidget::sizeHint
 //
-// Purpose: 
+// Purpose:
 //   Returns the desired size.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Sep 29 14:18:51 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QSize
@@ -571,14 +571,14 @@ QvisViewportWidget::sizeHint() const
 // ****************************************************************************
 // Method: QvisViewportWidget::sizePolicy
 //
-// Purpose: 
+// Purpose:
 //   Returns the desired size policy.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Sep 29 14:18:51 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QSizePolicy
@@ -591,7 +591,7 @@ QvisViewportWidget::sizePolicy() const
 // ****************************************************************************
 // Method: QvisViewportWidget::resizeEvent
 //
-// Purpose: 
+// Purpose:
 //   Handle resize and make sure proper viewport aspects are retained.
 //
 // Programmer: Cyrus Harrison
@@ -600,7 +600,7 @@ QvisViewportWidget::sizePolicy() const
 // Modifications:
 //
 // ****************************************************************************
-void 
+void
 QvisViewportWidget::resizeEvent(QResizeEvent *event)
 {
     float llx,lly,urx,ury;
@@ -621,7 +621,7 @@ QvisViewportWidget::resizeEvent(QResizeEvent *event)
 // ****************************************************************************
 // Method: QvisViewportWidget::clear
 //
-// Purpose: 
+// Purpose:
 //   Removes all of the viewports.
 //
 //
@@ -631,7 +631,7 @@ QvisViewportWidget::resizeEvent(QResizeEvent *event)
 // Modifications:
 //   Cyrus Harrison, Fri Nov  7 15:42:13 PST 2008
 //   Qt4 Refactor.
-//   
+//
 // ****************************************************************************
 
 void
@@ -654,7 +654,7 @@ QvisViewportWidget::clear()
 
     connect(scene,SIGNAL(selectionChanged()),
             this,SLOT(onSceneSelectionChanged()));
-    
+
     for(int i = 0; i < ids.size(); ++i)
     {
         emit viewportRemoved(ids[i]);
@@ -664,7 +664,7 @@ QvisViewportWidget::clear()
 // ****************************************************************************
 // Method: QvisViewportWidget::getNumberOfViewports
 //
-// Purpose: 
+// Purpose:
 //   Gets the number of viewports.
 //
 // Returns:    The number of viewports.
@@ -687,7 +687,7 @@ QvisViewportWidget::getNumberOfViewports() const
 // ****************************************************************************
 // Method: QvisViewportWidget::getActiveViewportId
 //
-// Purpose: 
+// Purpose:
 //   Returns the id of the active viewport or empty string.
 //
 // Programmer: Brad Whitlock
@@ -715,7 +715,7 @@ QvisViewportWidget::getActiveViewportId() const
 // ****************************************************************************
 // Method: QvisViewportWidget::setActiveViewport
 //
-// Purpose: 
+// Purpose:
 //   Sets the active viewport.
 //
 // Arguments:
@@ -751,7 +751,7 @@ QvisViewportWidget::setActiveViewport(const QString &id)
 // ****************************************************************************
 // Method: QvisViewportWidget::getViewport
 //
-// Purpose: 
+// Purpose:
 //   Get the viewport associated with the id.
 //
 // Arguments:
@@ -760,7 +760,7 @@ QvisViewportWidget::setActiveViewport(const QString &id)
 //
 // Returns:    True on success; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Sep 29 14:23:16 PST 2006
@@ -768,16 +768,16 @@ QvisViewportWidget::setActiveViewport(const QString &id)
 // Modifications:
 //   Cyrus Harrison, Fri Nov  7 15:42:13 PST 2008
 //   Qt4 Refactor.
-//   
+//
 // ****************************************************************************
 
 bool
-QvisViewportWidget::getViewport(const QString &id, 
+QvisViewportWidget::getViewport(const QString &id,
                                 float &llx, float &lly,
                                 float &urx, float &ury) const
 {
     bool retval = false;
-    
+
     QMapIterator<QString, QViewportItem*> itr(items);
     while(itr.hasNext())
     {
@@ -796,7 +796,7 @@ QvisViewportWidget::getViewport(const QString &id,
 // ****************************************************************************
 // Method: QvisViewportWidget::viewportUpdated
 //
-// Purpose: 
+// Purpose:
 //   Used by Viewport Items to signal an update.
 //
 //
@@ -814,9 +814,9 @@ QvisViewportWidget::viewportUpdated(QViewportItem *item)
 {
     // get values for selected viewport and emit viewportChanged signal
     float llx,lly,urx,ury;
-    
+
     getRelativeSize(item,llx,lly,urx,ury);
-    
+
     emit viewportChanged(item->getId(),llx,lly,urx,ury);
 }
 
@@ -824,7 +824,7 @@ QvisViewportWidget::viewportUpdated(QViewportItem *item)
 // ****************************************************************************
 // Method: QvisViewportWidget::getNextId
 //
-// Purpose: 
+// Purpose:
 //   Gets the id of the next viewport to be created.
 //
 // Returns:    The new viewport id.
@@ -835,9 +835,12 @@ QvisViewportWidget::viewportUpdated(QViewportItem *item)
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 16:29:55 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Fri Nov  7 15:42:13 PST 2008
 //   Qt4 Refactor.
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
 //
 // ****************************************************************************
 
@@ -850,7 +853,7 @@ QvisViewportWidget::getNextId() const
 
     do
     {
-        id.asprintf(" %d", index);
+        id = QString(" %1").arg(index);
         id = tr("Viewport") + id;
 
         found = false;
@@ -873,7 +876,7 @@ QvisViewportWidget::getNextId() const
 // ****************************************************************************
 // Method: QvisViewportWidget::addViewport
 //
-// Purpose: 
+// Purpose:
 //   Adds a new viewport and returns its id.
 //
 // Programmer: Brad Whitlock
@@ -886,7 +889,7 @@ QvisViewportWidget::getNextId() const
 // ****************************************************************************
 
 QString
-QvisViewportWidget::addViewport(float llx, float lly, 
+QvisViewportWidget::addViewport(float llx, float lly,
                                 float urx, float ury)
 {
     return addViewport(getNextId(), llx, lly, urx, ury);
@@ -895,7 +898,7 @@ QvisViewportWidget::addViewport(float llx, float lly,
 // ****************************************************************************
 // Method: QvisViewportWidget::addViewport
 //
-// Purpose: 
+// Purpose:
 //   Adds named viewport and returns its name.
 //
 // Programmer: Brad Whitlock
@@ -907,7 +910,7 @@ QvisViewportWidget::addViewport(float llx, float lly,
 //
 // ****************************************************************************
 QString
-QvisViewportWidget::addViewport(const QString &id, 
+QvisViewportWidget::addViewport(const QString &id,
     float llx, float lly, float urx, float ury)
 {
     // See if the id is already in use. If it is then get a new id.
@@ -915,13 +918,13 @@ QvisViewportWidget::addViewport(const QString &id,
 
     if(items.contains(the_id))
         the_id = getNextId();
-    
+
     // create new viewport
     QViewportItem *item = new QViewportItem(the_id,llx,lly,urx,ury,this);
     item->setZValue(zValue);
     scene->addItem(item);
     zValue +=1.0;
-    
+
     items[the_id] = item;
 
     emit viewportAdded(the_id, llx, lly, urx, ury);
@@ -934,7 +937,7 @@ QvisViewportWidget::addViewport(const QString &id,
 // ****************************************************************************
 // Method: QvisViewportWidget::removeViewport
 //
-// Purpose: 
+// Purpose:
 //   Removes the id'th viewport.
 //
 //
@@ -951,7 +954,7 @@ void
 QvisViewportWidget::removeViewport(const QString &id)
 {
     QMapIterator<QString, QViewportItem*> itr(items);
-    
+
     if(items.contains(id))
     {
         QViewportItem *item = items[id];
@@ -960,7 +963,7 @@ QvisViewportWidget::removeViewport(const QString &id)
         // the item, so make sure to use it BEFORE deleting the item.
         emit viewportRemoved(id);
         delete item;
-       
+
         //if we still have viewports left, activate the first one
         if(!items.isEmpty())
             activateItem(items.values()[0]);
@@ -970,7 +973,7 @@ QvisViewportWidget::removeViewport(const QString &id)
 // ****************************************************************************
 // Method: QvisViewportWidget::getRelativeSize
 //
-// Purpose: 
+// Purpose:
 //   Sends any viewports shaped like the background to the back so we can
 //   see the smaller viewports that should be drawn on top of them.
 //
@@ -978,7 +981,7 @@ QvisViewportWidget::removeViewport(const QString &id)
 // Creation:   Mon Oct 2 12:13:41 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void QvisViewportWidget::getRelativeSize(QViewportItem *item,
@@ -992,7 +995,7 @@ void QvisViewportWidget::getRelativeSize(QViewportItem *item,
 // ****************************************************************************
 // Method: QvisViewportWidget::activateItem
 //
-// Purpose: 
+// Purpose:
 //   Activates the specified viewport.
 //
 // Programmer: Brad Whitlock
@@ -1009,7 +1012,7 @@ QvisViewportWidget::activateItem(QViewportItem *obj)
 {
     if(obj == NULL)
         return;
-        
+
     QMapIterator<QString, QViewportItem*> itr(items);
     while(itr.hasNext())
     {
@@ -1025,7 +1028,7 @@ QvisViewportWidget::activateItem(QViewportItem *obj)
 // ****************************************************************************
 // Method: QvisViewportWidget::mousePressEvent
 //
-// Purpose: 
+// Purpose:
 //   Handles mouse press events.
 //
 // Arguments:
@@ -1050,17 +1053,17 @@ QvisViewportWidget::mousePressEvent(QMouseEvent* e)
         itr.next();
         itr.value()->setSelected(false);
     }
-    
-    // w/ right click delete, this could actually 
+
+    // w/ right click delete, this could actually
     // remove an item, so make sure not to use "itr"
     // after this
     QGraphicsView::mousePressEvent(e);
-    
-    // if no viewports or the "background viewport" is selected, start 
+
+    // if no viewports or the "background viewport" is selected, start
     // drawing of rubber band region for new viewport
-    
+
     bool selected = false;
-    
+
     QMapIterator<QString,QViewportItem*> itr2(items);
     while(itr2.hasNext() && ! selected)
     {
@@ -1074,7 +1077,7 @@ QvisViewportWidget::mousePressEvent(QMouseEvent* e)
                 selected = true;
         }
     }
-    
+
     if(e->button() == Qt::LeftButton && !selected)
     {
         dragViewportOutline = true;
@@ -1085,7 +1088,7 @@ QvisViewportWidget::mousePressEvent(QMouseEvent* e)
 // ****************************************************************************
 // Method: QvisViewportWidget::mouseMoveEvent
 //
-// Purpose: 
+// Purpose:
 //   Handles mouse move events.
 //
 // Arguments:
@@ -1117,19 +1120,19 @@ QvisViewportWidget::mouseMoveEvent(QMouseEvent* e)
             viewportOutline->setZValue(1e32);
             scene->addItem(viewportOutline);
         }
-        
+
         // set rect
         float x = dragMouseStart.x();
         float y = dragMouseStart.y();
         float dx = e->localPos().x() - x;
         float dy = e->localPos().y() - y;
-        
+
         float w = dx;
         float h = dy;
-        
+
         // make sure to keep w/h positive
-        
-        if(dx < 0) 
+
+        if(dx < 0)
         {
             x = x + w;
             w = -dx;
@@ -1140,7 +1143,7 @@ QvisViewportWidget::mouseMoveEvent(QMouseEvent* e)
             y = y + h;
             h = -dy;
         }
-        
+
         viewportOutline->setPos(x,y);
         viewportOutline->setRect(0.0,0.0,w,h);
     }
@@ -1149,7 +1152,7 @@ QvisViewportWidget::mouseMoveEvent(QMouseEvent* e)
 // ****************************************************************************
 // Method: QvisViewportWidget::mouseReleaseEvent
 //
-// Purpose: 
+// Purpose:
 //   Handles mouse release events.
 //
 // Arguments:
@@ -1167,33 +1170,33 @@ void
 QvisViewportWidget::mouseReleaseEvent(QMouseEvent* e)
 {
     QGraphicsView::mouseReleaseEvent(e);
-    
+
     if(dragViewportOutline)
     {
         if(viewportOutline)
         {
             // set a min size for creating a new viewport
             float min_dx = 4;
-            if(viewportOutline->rect().width()  > min_dx && 
+            if(viewportOutline->rect().width()  > min_dx &&
                viewportOutline->rect().height() > min_dx )
             {
                 float w = scene->width();
                 float h = scene->height();
-        
+
                 float llx = viewportOutline->pos().x() / w;
                 float urx = llx + viewportOutline->rect().width() / w;
                 float ury = (h - viewportOutline->pos().y()) / h;
                 float lly = ury - viewportOutline->rect().height() / h;
                 addViewport(llx,lly,urx,ury);
             }
-            
+
             delete viewportOutline;
             viewportOutline = 0;
         }
-        
+
         dragViewportOutline = false;
     }
-    
+
 }
 
 
@@ -1201,7 +1204,7 @@ QvisViewportWidget::mouseReleaseEvent(QMouseEvent* e)
 // ****************************************************************************
 // Method: QvisViewportWidget::keyPressEvent
 //
-// Purpose: 
+// Purpose:
 //   Handles key press events.
 //
 // Arguments:
@@ -1224,14 +1227,14 @@ QvisViewportWidget::keyPressEvent(QKeyEvent *e)
 {
     QViewportItem *item = 0;
     QViewportItem *next = 0;
-    
+
     QMapIterator<QString,QViewportItem*> itr(items);
     while(itr.hasNext())
     {
         itr.next();
         if(next == 0)
             next = itr.value();
-        
+
         if(itr.value()->isSelected())
         {
             item = itr.value();
@@ -1243,12 +1246,12 @@ QvisViewportWidget::keyPressEvent(QKeyEvent *e)
             break;
         }
     }
-    
+
     if(item)
     {
         float dx = 0;
         float dy = 0;
-        
+
         bool shiftApplied = false;
         if((e->modifiers() & Qt::ShiftModifier) > 0)
             shiftApplied = true;
@@ -1276,7 +1279,7 @@ QvisViewportWidget::keyPressEvent(QKeyEvent *e)
                     setActiveViewport(next->getId());
                 break;
         }
-        
+
         if(dx != 0 || dy != 0)
         {
             item->moveBy(dx,dy);
@@ -1292,7 +1295,7 @@ QvisViewportWidget::keyPressEvent(QKeyEvent *e)
 // ****************************************************************************
 // Method: QvisViewportWidget::onSceneSelectionChanged
 //
-// Purpose: 
+// Purpose:
 //   Translates scene selection event to viewportActivated signal.
 //
 //
@@ -1308,7 +1311,7 @@ void QvisViewportWidget::onSceneSelectionChanged()
     bool found = false;
     QMapIterator<QString,QViewportItem*> itr(items);
     QString viewport_name = "";
-    
+
     while(!found && itr.hasNext())
     {
         itr.next();
@@ -1319,7 +1322,7 @@ void QvisViewportWidget::onSceneSelectionChanged()
             found = true;
         }
     }
-    
+
     if(!found)
     {
         prevSelected = "";

--- a/src/gui/SplashScreen.C
+++ b/src/gui/SplashScreen.C
@@ -24,7 +24,7 @@
 // ****************************************************************************
 //  Method: SplashScreen::SplashScreen
 //
-//  Purpose: 
+//  Purpose:
 //    This is the constructor for the SplashScreen class.
 //
 //  Programmer: Sean Ahern
@@ -238,14 +238,17 @@
 //    Eric Brugger, Mon Nov  9 13:08:19 PST 2020
 //    Changed the date on the splash screen to November 2020.
 //
+//    Kathleen Biagas, Thu Jan 21, 2021
+//    Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
 {
 #if defined(Q_OS_MAC)
     setWindowModality(Qt::WindowModal);
-#endif    
-    
+#endif
+
     splashMode = true;
 
     // If the window manager is dumb enough to put decorations on this
@@ -325,22 +328,22 @@ SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
 
     QHBoxLayout *lrLayout = new QHBoxLayout();
     topLayout->addLayout(lrLayout);
-    
+
     lLayout = new QVBoxLayout();
     rLayout = new QVBoxLayout();
     rLayout->addStretch(1);
-    
+
     lrLayout->addLayout(lLayout);
     lrLayout->addLayout(rLayout );
-    
+
 
     QString C(QString("(c) 2000-%1 LLNS. ").arg(QDate::currentDate().year()));
     C += tr("All Rights Reserved");
     C += ".";
     lLayout->addWidget(new QLabel(C, this));
 
-    QString versionText;
-    versionText.asprintf("VisIt %s, ", visitcommon::Version().c_str());
+    QString versionText = QString("VisIt %1, ")
+                          .arg(visitcommon::Version().c_str());
     versionText += QString(visitcommon::VersionControlVersionString().c_str());
 
     // Create a lookup of month names so the internationalization
@@ -387,7 +390,7 @@ SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
 // ****************************************************************************
 // Method: SplashScreen::~SplashScreen
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the SplashScreen class.
 //
 // Programmer: Sean Ahern
@@ -404,7 +407,7 @@ SplashScreen::~SplashScreen()
 // ****************************************************************************
 // Method: SplashScreen::CreateAboutButtons
 //
-// Purpose: 
+// Purpose:
 //   Creates the extra buttons for when the window is used for the About window.
 //
 // Programmer: Brad Whitlock
@@ -413,7 +416,7 @@ SplashScreen::~SplashScreen()
 // Modifications:
 //   Brad Whitlock, Tue Apr  8 16:29:55 PDT 2008
 //   Support for internationalization.
-//   
+//
 //   Cyrus Harrison, Tue Jul  1 10:33:10 PDT 2008
 //   Initial Qt4 Port.
 //
@@ -455,14 +458,14 @@ SplashScreen::CreateAboutButtons()
 // ****************************************************************************
 // Method: SplashScreen::show
 //
-// Purpose: 
+// Purpose:
 //   Shows the widget.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jun 18 17:52:11 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -485,14 +488,14 @@ SplashScreen::show()
 // ****************************************************************************
 // Method: SplashScreen::hide
 //
-// Purpose: 
+// Purpose:
 //   Hides the widget.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jun 18 17:51:55 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -505,7 +508,7 @@ SplashScreen::hide()
 // ****************************************************************************
 // Method: SplashScreen::Progress
 //
-// Purpose: 
+// Purpose:
 //   Shows progress in the splashscreen.
 //
 // Arguments:
@@ -534,14 +537,14 @@ SplashScreen::Progress(const QString &msg, int percent)
 // ****************************************************************************
 // Method: SplashScreen::About
 //
-// Purpose: 
+// Purpose:
 //   Shows the splashscreen as an about box.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jun 18 17:57:09 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -554,7 +557,7 @@ SplashScreen::About()
 // ****************************************************************************
 // Method: SplashScreen::SetDisplayMode
 //
-// Purpose: 
+// Purpose:
 //   Switches between splashscreen mode and about mode.
 //
 // Programmer: Brad Whitlock
@@ -608,7 +611,7 @@ SplashScreen::SetDisplayAsSplashScreen(bool asSplash)
 // ****************************************************************************
 // Method: SplashScreen::nextPicture
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that cycles the images.
 //
 // Programmer: Sean Ahern

--- a/src/gui/WidgetDataNode.C
+++ b/src/gui/WidgetDataNode.C
@@ -280,7 +280,6 @@ DataNodeToQString(const DataNode *node)
         ARRAY_TO_STRING(double, AsDoubleArray);
         break;
     case STRING_ARRAY_NODE:
-// rework this
         {
             const std::string *ptr = node->AsStringArray();
             for(i = 0; i < node->GetLength(); ++i)

--- a/src/gui/WidgetDataNode.C
+++ b/src/gui/WidgetDataNode.C
@@ -3,22 +3,22 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 // ****************************************************************************
-// Purpose:  This file is a set of routines that can set/get values from 
+// Purpose:  This file is a set of routines that can set/get values from
 //           QWidget/DataNode. This allows us to use custom UI components. We
 //           could even use them to create DataNodes that AttributeSubjects
 //           could use to initialize themselves, which would open the door to
 //           plots with UI's created with Qt designer. It would also mean that
 //           we might not need Qt to build new UI's at all, which would be a
 //           plus on systems where you have to pay for QT.
-//   
 //
-// Notes:      
+//
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Oct 6 17:35:57 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 
@@ -45,7 +45,7 @@ ConvertTextToDataNodeSettings(const QString &text, DataNode *node)
 // ****************************************************************************
 // Function: DataNodeToBool
 //
-// Purpose: 
+// Purpose:
 //   Converts a data node value into a bool
 //
 // Arguments:
@@ -53,13 +53,13 @@ ConvertTextToDataNodeSettings(const QString &text, DataNode *node)
 //
 // Returns:    The converted bool value.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Nov 17 10:37:19 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 static bool
@@ -102,7 +102,7 @@ DataNodeToBool(DataNode *node)
 // ****************************************************************************
 // Function: DataNodeToInt
 //
-// Purpose: 
+// Purpose:
 //   Converts a data node into an int.
 //
 // Arguments:
@@ -110,13 +110,13 @@ DataNodeToBool(DataNode *node)
 //
 // Returns:    The int value of the data node.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Nov 17 10:37:54 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 static int
@@ -165,7 +165,7 @@ DataNodeToInt(DataNode *node)
 // ****************************************************************************
 // Function: DataNodeToQString
 //
-// Purpose: 
+// Purpose:
 //   Converts the data node into a QString.
 //
 // Arguments:
@@ -173,13 +173,16 @@ DataNodeToInt(DataNode *node)
 //
 // Returns:    The QString representation of the data node.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Nov 17 10:38:27 PDT 2006
 //
 // Modifications:
-//   
+//
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.setNum where possible.
+//
 // ****************************************************************************
 
 QString
@@ -187,24 +190,26 @@ DataNodeToQString(const DataNode *node)
 {
     QString s, tmp;
     int i;
-#define ARRAY_TO_STRING(Type, Method, Fmt, suffix)\
+
+// These only handle numbers now, and call QString.setNum
+#define ARRAY_TO_STRING(Type, Method)\
         {\
             const Type *ptr = node->Method();\
             for(i = 0; i < node->GetLength(); ++i)\
             {\
-                tmp.asprintf(Fmt, ptr[i] suffix);\
+                tmp.setNum(ptr[i]);\
                 if(i > 0)\
                     s += " ";\
                 s += tmp;\
             }\
         }
 
-#define VECTOR_TO_STRING(Type, Method, Fmt, suffix)\
+#define VECTOR_TO_STRING(Type, Method)\
         {\
             const Type &vec = node->Method();\
             for(size_t i = 0; i < vec.size(); ++i)\
             {\
-                tmp.asprintf(Fmt, vec[i] suffix);\
+                tmp.setNum(vec[i]);\
                 if(i > 0)\
                     s += " ";\
                 s += tmp;\
@@ -215,25 +220,25 @@ DataNodeToQString(const DataNode *node)
     case INTERNAL_NODE:
         break;
     case CHAR_NODE:
-        s.asprintf("%d", (int)node->AsChar());
+        s.setNum((int)node->AsChar());
         break;
     case UNSIGNED_CHAR_NODE:
-        s.asprintf("%d", (int)node->AsUnsignedChar());
+        s.setNum((int)node->AsUnsignedChar());
         break;
     case INT_NODE:
-        s.asprintf("%d", node->AsInt());
+        s.setNum(node->AsInt());
         break;
     case LONG_NODE:
-        s.asprintf("%ld", node->AsLong());
+        s.setNum(node->AsLong());
         break;
     case FLOAT_NODE:
-        s.asprintf("%f", node->AsFloat());
+        s.setNum(node->AsFloat());
         break;
     case DOUBLE_NODE:
-        s.asprintf("%lg", node->AsDouble());
+        s.setNum(node->AsDouble());
         break;
     case STRING_NODE:
-        s.asprintf("%s", node->AsString().c_str());
+        s = QString(node->AsString().c_str());
         break;
     case BOOL_NODE:
         if(node->AsBool()) s = "true"; else s = "false";
@@ -243,7 +248,7 @@ DataNodeToQString(const DataNode *node)
             const char *cptr = node->AsCharArray();
             for(i = 0; i < node->GetLength(); ++i)
             {
-                tmp.asprintf("%d", (int)cptr[i]);
+                tmp.setNum((int)cptr[i]);
                 if(i > 0)
                     s += " ";
                 s += tmp;
@@ -255,7 +260,7 @@ DataNodeToQString(const DataNode *node)
             const unsigned char *cptr = node->AsUnsignedCharArray();
             for(i = 0; i < node->GetLength(); ++i)
             {
-                tmp.asprintf("%d", (int)cptr[i]);
+                tmp.setNum((int)cptr[i]);
                 if(i > 0)
                     s += " ";
                 s += tmp;
@@ -263,19 +268,29 @@ DataNodeToQString(const DataNode *node)
         }
         break;
     case INT_ARRAY_NODE:
-        ARRAY_TO_STRING(int, AsIntArray, "%d",);
+        ARRAY_TO_STRING(int, AsIntArray);
         break;
     case LONG_ARRAY_NODE:
-        ARRAY_TO_STRING(long, AsLongArray, "%ld",);
+        ARRAY_TO_STRING(long, AsLongArray);
         break;
     case FLOAT_ARRAY_NODE:
-        ARRAY_TO_STRING(float, AsFloatArray, "%f",);
+        ARRAY_TO_STRING(float, AsFloatArray);
         break;
     case DOUBLE_ARRAY_NODE:
-        ARRAY_TO_STRING(double, AsDoubleArray, "%lg",);
+        ARRAY_TO_STRING(double, AsDoubleArray);
         break;
     case STRING_ARRAY_NODE:
-        ARRAY_TO_STRING(std::string, AsStringArray, "\"%s\"", .c_str());
+// rework this
+        {
+            const std::string *ptr = node->AsStringArray();
+            for(i = 0; i < node->GetLength(); ++i)
+            {
+                tmp = QString(ptr[i].c_str());
+                if(i > 0)
+                    s += " ";
+                s += tmp;
+            }
+        }
         break;
     case BOOL_ARRAY_NODE:
         {
@@ -297,7 +312,7 @@ DataNodeToQString(const DataNode *node)
             const charVector &vec = node->AsCharVector();
             for(size_t i = 0; i < vec.size(); ++i)
             {
-                tmp.asprintf("%d", (int)vec[i]);
+                tmp.setNum((int)vec[i]);
                 if(i > 0)
                     s += " ";
                 s += tmp;
@@ -309,7 +324,7 @@ DataNodeToQString(const DataNode *node)
             const unsignedCharVector &vec = node->AsUnsignedCharVector();
             for(size_t i = 0; i < vec.size(); ++i)
             {
-                tmp.asprintf("%d", (int)vec[i]);
+                tmp.setNum((int)vec[i]);
                 if(i > 0)
                     s += " ";
                 s += tmp;
@@ -317,19 +332,28 @@ DataNodeToQString(const DataNode *node)
         }
         break;
     case INT_VECTOR_NODE:
-        VECTOR_TO_STRING(intVector, AsIntVector, "%d",);
+        VECTOR_TO_STRING(intVector, AsIntVector);
         break;
     case LONG_VECTOR_NODE:
-        VECTOR_TO_STRING(longVector, AsLongVector, "%ld",);
+        VECTOR_TO_STRING(longVector, AsLongVector);
         break;
     case FLOAT_VECTOR_NODE:
-        VECTOR_TO_STRING(floatVector, AsFloatVector, "%f",);
+        VECTOR_TO_STRING(floatVector, AsFloatVector);
         break;
     case DOUBLE_VECTOR_NODE:
-        VECTOR_TO_STRING(doubleVector, AsDoubleVector, "%lg",);
+        VECTOR_TO_STRING(doubleVector, AsDoubleVector);
         break;
     case STRING_VECTOR_NODE:
-        VECTOR_TO_STRING(stringVector, AsStringVector, "\"%s\"", .c_str());
+        {
+            const stringVector &vec = node->AsStringVector();
+            for(size_t i = 0; i < vec.size(); ++i)
+            {
+                tmp = QString(vec[i].c_str());
+                if(i > 0)
+                    s += " ";
+                s += tmp;
+            }
+        }
         break;
     default:
         break;
@@ -344,7 +368,7 @@ DataNodeToQString(const DataNode *node)
 // ****************************************************************************
 // Function: DataNodeToQColor
 //
-// Purpose: 
+// Purpose:
 //   Converts a data node representation of color into a QColor.
 //
 // Arguments:
@@ -353,13 +377,13 @@ DataNodeToQString(const DataNode *node)
 //
 // Returns:    True on success; False otherwise.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Nov 16 13:34:12 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool DataNodeToQColor(DataNode *node, QColor &color)
@@ -368,7 +392,7 @@ bool DataNodeToQColor(DataNode *node, QColor &color)
     int   i, rgb[3] = {0, 0, 0};
     float f_rgb[3] = {0., 0., 0.};
     bool  fp = false;
-    
+
 #define ARRAY_TO_RGB(Rgb, Type, Method, Cast) \
         if(node->GetLength() >= 3) \
         { \
@@ -459,7 +483,7 @@ bool DataNodeToQColor(DataNode *node, QColor &color)
 // ****************************************************************************
 // Method: QColorToDataNode
 //
-// Purpose: 
+// Purpose:
 //   This function inserts a color into a data node.
 //
 // Arguments:
@@ -471,7 +495,7 @@ bool DataNodeToQColor(DataNode *node, QColor &color)
 // Creation:   Thu Nov 16 13:35:18 PST 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -489,7 +513,7 @@ QColorToDataNode(DataNode *node, const char *key, const QColor &c)
 // ****************************************************************************
 // Method: InitializeQComboBoxFromDataNode
 //
-// Purpose: 
+// Purpose:
 //   Initializes a QComboBox from a DataNode
 //
 // Arguments:
@@ -544,7 +568,7 @@ InitializeQComboBoxFromDataNode(QComboBox *co, DataNode *node)
 // ****************************************************************************
 // Function: InitializeDataNodeFromQComboBox
 //
-// Purpose: 
+// Purpose:
 //   Initializes a data node from the active item in a QComboBox.
 //
 // Arguments:
@@ -582,7 +606,7 @@ InitializeDataNodeFromQComboBox(QComboBox *co, DataNode *node)
             node->AddNode(new DataNode(objectName, co->currentIndex()));
         else if(t == STRING_NODE)
         {
-            node->AddNode(new DataNode(objectName, 
+            node->AddNode(new DataNode(objectName,
                 co->currentText().toStdString()));
         }
     }
@@ -596,7 +620,7 @@ InitializeDataNodeFromQComboBox(QComboBox *co, DataNode *node)
 // ****************************************************************************
 // Function: InitializeQCheckBoxFromDataNode
 //
-// Purpose: 
+// Purpose:
 //   Initializes a QCheckBox from a data node.
 //
 // Arguments:
@@ -607,7 +631,7 @@ InitializeDataNodeFromQComboBox(QComboBox *co, DataNode *node)
 // Creation:   Fri Nov 17 10:40:22 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 static void
@@ -619,7 +643,7 @@ InitializeQCheckBoxFromDataNode(QCheckBox *co, DataNode *node)
 // ****************************************************************************
 // Method: InitializeDataNodeFromQCheckBox
 //
-// Purpose: 
+// Purpose:
 //   Initialize a data node from a QCheckBox.
 //
 // Arguments:
@@ -630,7 +654,7 @@ InitializeQCheckBoxFromDataNode(QCheckBox *co, DataNode *node)
 // Creation:   Fri Nov 17 10:41:00 PDT 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 static void
@@ -644,7 +668,7 @@ InitializeDataNodeFromQCheckBox(QCheckBox *co, DataNode *node)
 // ****************************************************************************
 // Function: InitializeQButtonGroupFromDataNode
 //
-// Purpose: 
+// Purpose:
 //   Initializes a QButtonGroup from a data node.
 //
 // Arguments:
@@ -671,7 +695,7 @@ InitializeQButtonGroupFromDataNode(QButtonGroup *co, DataNode *node)
 // ****************************************************************************
 // Method: InitializeDataNodeFromQButtonGroup
 //
-// Purpose: 
+// Purpose:
 //   Initializes a data node from a QButtonGroup.
 //
 // Arguments:
@@ -724,7 +748,7 @@ InitializeDataNodeFromQButtonGroup(QButtonGroup *co, DataNode *node)
 // ****************************************************************************
 // Function: InitializeWidgetFromDataNode
 //
-// Purpose: 
+// Purpose:
 //   This function initializes a Qt widget (and its children) using a data
 //   node, allowing us to initialize our custom UI's from data node from
 //   saved settings, session files, etc.
@@ -840,7 +864,7 @@ InitializeWidgetFromDataNode(QWidget *ui, DataNode *node)
 // ****************************************************************************
 // Function: InitializeDataNodeFromWidget
 //
-// Purpose: 
+// Purpose:
 //   This function adds the widget data values into the data node structure.
 //
 // Arguments:
@@ -872,7 +896,7 @@ InitializeDataNodeFromWidget(QWidget *ui, DataNode *node)
         DataNode *objValues = node->GetNode(objectName);
         if(objValues)
         {
-            // objValues points to the node in the settings that 
+            // objValues points to the node in the settings that
             // contains the settings for the named widget.
             if(obj->inherits("QButtonGroup"))
             {

--- a/src/operators/CreateBonds/QvisCreateBondsWindow.C
+++ b/src/operators/CreateBonds/QvisCreateBondsWindow.C
@@ -29,14 +29,14 @@ using std::string;
 // ****************************************************************************
 // Method: QvisCreateBondsWindow::QvisCreateBondsWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Programmer: Jeremy Meredith
 // Creation:   August 29, 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisCreateBondsWindow::QvisCreateBondsWindow(const int type,
@@ -53,14 +53,14 @@ QvisCreateBondsWindow::QvisCreateBondsWindow(const int type,
 // ****************************************************************************
 // Method: QvisCreateBondsWindow::~QvisCreateBondsWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: Jeremy Meredith
 // Creation:   August 29, 2006
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisCreateBondsWindow::~QvisCreateBondsWindow()
@@ -71,7 +71,7 @@ QvisCreateBondsWindow::~QvisCreateBondsWindow()
 // ****************************************************************************
 // Method: QvisCreateBondsWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Jeremy Meredith
@@ -116,24 +116,24 @@ QvisCreateBondsWindow::CreateWindowContents()
     listLayout->addWidget(noteLabel);
 
     bondsTree = new QTreeWidget(bondsTreeGroup);
-    
+
     QTreeWidgetItem *header = new QTreeWidgetItem();
     header->setText(0,tr("1st"));
     header->setText(1,tr("2nd"));
     header->setText(2,tr("Min"));
     header->setText(3,tr("Max"));
     bondsTree->setHeaderItem(header);
-    
+
     bondsTree->setSelectionMode(QAbstractItemView::SingleSelection);
-    
+
     bondsTree->setColumnWidth(0, 50);
     bondsTree->setColumnWidth(1, 50);
-    
+
     bondsTree->setRootIsDecorated(false);
     bondsTree->header()->setSectionsClickable(false);
     bondsTree->header()->setSectionsMovable(false);
     bondsTree->setAllColumnsShowFocus(true);
-    
+
     listLayout->addWidget(bondsTree);
 
 
@@ -168,7 +168,7 @@ QvisCreateBondsWindow::CreateWindowContents()
     QVBoxLayout *bondDetailsTopLayout = new QVBoxLayout(bondsDetailsGroup);
     QHBoxLayout *bondDetailsLayout = new QHBoxLayout();
     bondDetailsTopLayout->addLayout(bondDetailsLayout);
-    
+
     firstElement = new QvisElementButton(bondsDetailsGroup);
     secondElement = new QvisElementButton(bondsDetailsGroup);
     bondDetailsLayout->addWidget(new QLabel(tr("1st:"), bondsDetailsGroup));
@@ -181,7 +181,7 @@ QvisCreateBondsWindow::CreateWindowContents()
     bondDetailsLayout2->addWidget(new QLabel(tr("Min:"), bondsDetailsGroup));
     minDist = new QLineEdit(bondsDetailsGroup);
     bondDetailsLayout2->addWidget(minDist);
-    
+
     bondDetailsLayout2->addWidget(new QLabel(tr("Max:"), bondsDetailsGroup));
     maxDist = new QLineEdit(bondsDetailsGroup);
     bondDetailsLayout2->addWidget(maxDist);
@@ -212,12 +212,12 @@ QvisCreateBondsWindow::CreateWindowContents()
 
     QGridLayout *advLayout = new QGridLayout(advTab);
 
-    
+
     elementVariableLabel = new QLabel(tr("Variable for atomic number"),
                                       advTab);
     advLayout->addWidget(elementVariableLabel,0,0);
     int elementVariableMask = QvisVariableButton::Scalars;
-    elementVariable = new QvisVariableButton(true, true, true, 
+    elementVariable = new QvisVariableButton(true, true, true,
                                              elementVariableMask, advTab);
     connect(elementVariable, SIGNAL(activated(const QString&)),
             this, SLOT(elementVariableChanged(const QString&)));
@@ -293,7 +293,7 @@ QvisCreateBondsWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisCreateBondsWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets in the window when the subject changes.
 //
 // Programmer: Jeremy Meredith
@@ -303,7 +303,7 @@ QvisCreateBondsWindow::CreateWindowContents()
 //    Jeremy Meredith, Mon Feb 11 16:52:55 EST 2008
 //    Changed to use IDs.  Added support for atomic number of -1 means "any".
 //    Clear selection after regenerating list if nothing used to be selected.
-//   
+//
 //    Cyrus Harrison, Wed Aug 20 08:27:03 PDT 2008
 //    Qt4 Port.
 //
@@ -341,7 +341,7 @@ QvisCreateBondsWindow::UpdateWindow(bool doAll)
             update_bonds_list = true;
             break;
           case CreateBondsAttributes::ID_maxBondsClamp:
-            maxBonds->setText(QString().asprintf("%d",atts->GetMaxBondsClamp()));
+            maxBonds->setText(QString("%1").arg(atts->GetMaxBondsClamp()));
             break;
           case CreateBondsAttributes::ID_addPeriodicBonds:
             addPeriodicBonds->blockSignals(true);
@@ -418,8 +418,8 @@ QvisCreateBondsWindow::UpdateWindow(bool doAll)
             QTreeWidgetItem *item = new QTreeWidgetItem(bondsTree);
             item->setText(0,el1);
             item->setText(1,el2);
-            item->setText(2,QString().asprintf("%.4f",atts->GetMinDist()[i]));
-            item->setText(3,QString().asprintf("%.4f",atts->GetMaxDist()[i]));
+            item->setText(2,QString("%1").arg(atts->GetMinDist()[i],0,'f',4));
+            item->setText(3,QString("%1").arg(atts->GetMaxDist()[i],0,'f',4));
             if (old_index == i)
                 new_item = item;
         }
@@ -438,7 +438,7 @@ QvisCreateBondsWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisCreateBondsWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets values from certain widgets and stores them in the subject.
 //
 // Programmer: Jeremy Meredith
@@ -589,8 +589,8 @@ void QvisCreateBondsWindow::UpdateWindowSingleItem()
 
     firstElement->setElementNumber(atts->GetAtomicNumber1()[index]);
     secondElement->setElementNumber(atts->GetAtomicNumber2()[index]);
-    minDist->setText(QString().asprintf("%.4f",atts->GetMinDist()[index]));
-    maxDist->setText(QString().asprintf("%.4f",atts->GetMaxDist()[index]));
+    minDist->setText(QString("%1").arg(atts->GetMinDist()[index],0,'f',4));
+    maxDist->setText(QString("%1").arg(atts->GetMaxDist()[index],0,'f',4));
 
     delButton->setEnabled(index>=0 && index<=n-1);
     upButton->setEnabled(index>0 && index<=n-1);
@@ -657,7 +657,7 @@ void QvisCreateBondsWindow::minDistTextChanged(const QString &txt)
         return;
 
     atts->GetMinDist()[index] = minDist->displayText().toFloat();
-    item->setText(2, QString().asprintf("%.4f",atts->GetMinDist()[index]));
+    item->setText(2, QString("%1").arg(atts->GetMinDist()[index],0,'f',4));
     atts->SelectMinDist();
 }
 
@@ -668,9 +668,9 @@ void QvisCreateBondsWindow::maxDistTextChanged(const QString &txt)
     int index = bondsTree->indexOfTopLevelItem(item);
     if (index < 0 || index >= n)
         return;
-    
+
     atts->GetMaxDist()[index] = maxDist->displayText().toFloat();
-    item->setText(3, QString().asprintf("%.4f",atts->GetMaxDist()[index]));
+    item->setText(3, QString("%.1").arg(atts->GetMaxDist()[index],0,'f',4));
     atts->SelectMaxDist();
 }
 
@@ -896,9 +896,9 @@ void QvisCreateBondsWindow::bondsTreeDel()
     atts->SelectAtomicNumber2();
     atts->SelectMinDist();
     atts->SelectMaxDist();
-    
+
     // if we deleted the last one, we want to select the new last element.
-    if(n-1 > 0 && index == n-1) 
+    if(n-1 > 0 && index == n-1)
         bondsTree->setCurrentItem(bondsTree->topLevelItem(index-1));
 }
 

--- a/src/operators/Slice/QvisSliceWindow.C
+++ b/src/operators/Slice/QvisSliceWindow.C
@@ -21,7 +21,7 @@
 // ****************************************************************************
 // Method: QvisSliceWindow::QvisSliceWindow
 //
-// Purpose: 
+// Purpose:
 //   Cconstructor for the QvisSliceWindow class.
 //
 // Arguments:
@@ -56,13 +56,13 @@ QvisSliceWindow::QvisSliceWindow(const int type,
     originTypeGroup = 0;
     normalTypeGroup = 0;
     defaultItem = "default";
-    fileServer->Attach(this);   
+    fileServer->Attach(this);
 }
 
 // ****************************************************************************
 // Method: QvisSliceWindow::~QvisSliceWindow
 //
-// Purpose: 
+// Purpose:
 //   This is the destructor for the QvisSliceWindow class.
 //
 // Programmer: Brad Whitlock
@@ -71,7 +71,7 @@ QvisSliceWindow::QvisSliceWindow(const int type,
 // Modifications:
 //   Kathleen Bonnell, Tue Jan 25 08:15:23 PST 2005
 //   Detach fileServer.
-//   
+//
 // ****************************************************************************
 
 QvisSliceWindow::~QvisSliceWindow()
@@ -83,7 +83,7 @@ QvisSliceWindow::~QvisSliceWindow()
 // ****************************************************************************
 // Method: QvisSliceWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   This method creates the widgets for the Slice operator window.
 //
 // Programmer: Brad Whitlock
@@ -146,11 +146,11 @@ QvisSliceWindow::CreateWindowContents()
     QRadioButton *xAxis = new QRadioButton(tr("X Axis"), normalBox);
     QRadioButton *yAxis = new QRadioButton(tr("Y Axis"), normalBox);
     QRadioButton *zAxis = new QRadioButton(tr("Z Axis"), normalBox);
-    
+
     normalTypeGroup->addButton(xAxis,0);
     normalTypeGroup->addButton(yAxis,1);
     normalTypeGroup->addButton(zAxis,2);
-    
+
     orthogonalLayout->addWidget(xAxis);
     orthogonalLayout->addWidget(yAxis);
     orthogonalLayout->addWidget(zAxis);
@@ -196,16 +196,16 @@ QvisSliceWindow::CreateWindowContents()
     normalLayout->addLayout( thetaPhiLayout, 3, 1 );
 
     // Origin
-    
+
     QGroupBox *originBox = new QGroupBox(central);
     originBox->setTitle(tr("Origin"));
     topLayout->addWidget(originBox);
-    
+
     originTypeGroup = new QButtonGroup(originBox);
     connect(originTypeGroup, SIGNAL(buttonClicked(int)),
             this, SLOT(originTypeChanged(int)));
 
-    
+
     QGridLayout *originLayout = new QGridLayout(originBox);
 
     QHBoxLayout *originTypeLayout = new QHBoxLayout();
@@ -325,7 +325,7 @@ QvisSliceWindow::CreateWindowContents()
     originNodeLayout->addWidget(originNodeDomainLineEdit);
 
     originLayout->addLayout(originNodeLayout, 6,0);
-	
+
     // mesh name
     QHBoxLayout *meshLayout = new QHBoxLayout();
     meshLayout->setMargin(5);
@@ -337,7 +337,7 @@ QvisSliceWindow::CreateWindowContents()
     meshName->addItem(defaultItem);
     meshName->setCurrentIndex(0);
     meshName->setEditText(defaultItem);
-    connect(meshName, SIGNAL(activated(int)),   
+    connect(meshName, SIGNAL(activated(int)),
             this, SLOT(meshNameChanged()));
     meshLayout->addWidget(meshLabel);
     meshLayout->addWidget(meshName);
@@ -372,7 +372,7 @@ QvisSliceWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisSliceWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   This method updates the window's widgets to reflect changes made
 //   in the SliceAttributes object that the window watches.
 //
@@ -563,7 +563,7 @@ QvisSliceWindow::UpdateWindow(bool doAll)
 //    Added a domain number for slice-by-zone and -by-node.
 //
 //    Kathleen Bonnell, Tue Jan 25 08:15:23 PST 2005
-//    Added meshName and meshLabel. 
+//    Added meshName and meshLabel.
 //
 // ****************************************************************************
 void
@@ -639,7 +639,7 @@ QvisSliceWindow::UpdateOriginArea()
 // ****************************************************************************
 // Method: QvisSliceWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets the current values for one or all of the lineEdit widgets.
 //
 // Arguments:
@@ -666,7 +666,7 @@ QvisSliceWindow::UpdateOriginArea()
 //   Completely changed the way "origin" works.
 //
 //   Kathleen Bonnell, Tue May 20 16:02:52 PDT 2003
-//   Disallow (0, 0, 0) for Normal and UpAxis. 
+//   Disallow (0, 0, 0) for Normal and UpAxis.
 //
 //   Jeremy Meredith, Fri Jun 13 12:09:30 PDT 2003
 //   Added a domain number for slice-by-zone and -by-node.
@@ -777,7 +777,7 @@ QvisSliceWindow::GetCurrentValues(int which_widget)
         }
     }
 
-    
+
     // Do the origin (percent)
     if(which_widget == SliceAttributes::ID_originPercent || doAll)
     {
@@ -848,7 +848,7 @@ QvisSliceWindow::GetCurrentValues(int which_widget)
     }
 
 
-    // Do the meshName 
+    // Do the meshName
     if(which_widget == SliceAttributes::ID_meshName || doAll)
     {
         temp = meshName->currentText();
@@ -893,7 +893,7 @@ QvisSliceWindow::GetCurrentValues(int which_widget)
         {
             double theta = sliceAtts->GetTheta();
             double phi = sliceAtts->GetPhi();
-            QString angles; angles.asprintf("<%g %g>", theta, phi);
+            QString angles = QString("<%1 %1>").arg(theta).arg(phi);
             ResettingError(tr("theta-phi angles"), angles);
             sliceAtts->SetTheta(theta);
             sliceAtts->SetPhi(phi);
@@ -908,7 +908,7 @@ QvisSliceWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisSliceWindow::originTypeChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the type of origin being used.
 //
 // Arguments:
@@ -918,7 +918,7 @@ QvisSliceWindow::GetCurrentValues(int which_widget)
 // Creation:   April 28, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -931,14 +931,14 @@ QvisSliceWindow::originTypeChanged(int index)
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the origin vector.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Sep 15 11:41:28 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -951,14 +951,14 @@ QvisSliceWindow::processOriginPointText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginInterceptText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the origin vector.
 //
 // Programmer: Jeremy Meredith
 // Creation:   April 28, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -971,14 +971,14 @@ QvisSliceWindow::processOriginInterceptText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginPercentText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the origin vector.
 //
 // Programmer: Jeremy Meredith
 // Creation:   April 28, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -991,7 +991,7 @@ QvisSliceWindow::processOriginPercentText()
 // ****************************************************************************
 // Method: QvisSliceWindow::originPercentSliderChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the origin vector using a slider.
 //
 // Programmer: Jeremy Meredith
@@ -1057,14 +1057,14 @@ QvisSliceWindow::originPercentSliderReleased()
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginZoneDomainText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets node/zone domain number.
 //
 // Programmer: Jeremy Meredith
 // Creation:   June 13, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1077,14 +1077,14 @@ QvisSliceWindow::processOriginZoneDomainText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginNodeDomainText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets node/zone domain number.
 //
 // Programmer: Jeremy Meredith
 // Creation:   June 13, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1097,14 +1097,14 @@ QvisSliceWindow::processOriginNodeDomainText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginZoneText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the origin vector.
 //
 // Programmer: Jeremy Meredith
 // Creation:   April 28, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1117,14 +1117,14 @@ QvisSliceWindow::processOriginZoneText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processOriginNodeText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the origin vector.
 //
 // Programmer: Jeremy Meredith
 // Creation:   April 28, 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1137,14 +1137,14 @@ QvisSliceWindow::processOriginNodeText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processNormalText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the normal vector.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Sep 15 11:41:28 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1157,14 +1157,14 @@ QvisSliceWindow::processNormalText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processThetaPhiText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the normal vector.
 //
 // Programmer: Dave Pugmire
 // Creation:   Thu Oct 18 08:25:42 EDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1177,14 +1177,14 @@ QvisSliceWindow::processThetaPhiText()
 // ****************************************************************************
 // Method: QvisSliceWindow::processUpAxisText
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the upAxis vector.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Sep 15 11:41:28 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1197,7 +1197,7 @@ QvisSliceWindow::processUpAxisText()
 // ****************************************************************************
 // Method: QvisSliceWindow::flipNormalToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not the normal/upaxis should be set to flip the projected axes.
 //
@@ -1208,7 +1208,7 @@ QvisSliceWindow::processUpAxisText()
 // Creation:   November 17, 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1221,7 +1221,7 @@ QvisSliceWindow::flipNormalToggled(bool val)
 // ****************************************************************************
 // Method: QvisSliceWindow::projectToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not the slice should be projected to 2d.
 //
@@ -1232,7 +1232,7 @@ QvisSliceWindow::flipNormalToggled(bool val)
 // Creation:   Fri Sep 15 11:43:06 PDT 2000
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1245,7 +1245,7 @@ QvisSliceWindow::projectToggled(bool val)
 // ****************************************************************************
 // Method: QvisSliceWindow::interactiveToggled
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the flag indicating whether
 //   or not the slice should be set from the interactive tool.
 //
@@ -1256,7 +1256,7 @@ QvisSliceWindow::projectToggled(bool val)
 // Creation:   Tue Oct 9 17:41:53 PST 2001
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1269,7 +1269,7 @@ QvisSliceWindow::interactiveToggled(bool val)
 // ****************************************************************************
 // Method: QvisSliceWindow::normalTypeChanged
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function that sets the orthogonal normal type.
 //
 // Arguments:
@@ -1307,7 +1307,7 @@ QvisSliceWindow::interactiveToggled(bool val)
 void
 QvisSliceWindow::normalTypeChanged(int index)
 {
-    // If we're switching from arbitrary to orthogonal 
+    // If we're switching from arbitrary to orthogonal
     if (sliceAtts->GetAxisType() == SliceAttributes::Arbitrary &&
         sliceAtts->GetOriginType() == SliceAttributes::Point   &&
         (index==0 || index==1 || index==2))
@@ -1343,12 +1343,12 @@ QvisSliceWindow::normalTypeChanged(int index)
 // ****************************************************************************
 //  Method: QvisSliceWindow::UpdateMeshNames
 //
-//  Purpose: 
+//  Purpose:
 //    This method retrieves the mesh names from the fileServer and stores
 //    them in the meshName combo box.
 //
-//  Programmer: Kathleen Bonnell 
-//  Creation:   January 25, 2005 
+//  Programmer: Kathleen Bonnell
+//  Creation:   January 25, 2005
 //
 //  Modifications:
 //
@@ -1365,9 +1365,9 @@ QvisSliceWindow::UpdateMeshNames()
 {
     meshName->blockSignals(true);
     meshName->clear();
-    if (fileServer) 
+    if (fileServer)
     {
-        const avtDatabaseMetaData *md = 
+        const avtDatabaseMetaData *md =
             fileServer->GetMetaData(fileServer->GetOpenFile(),
                                     GetStateForSource(fileServer->GetOpenFile()),
                                     !FileServerList::ANY_STATE,
@@ -1407,7 +1407,7 @@ QvisSliceWindow::UpdateMeshNames()
         meshName->setEnabled(false);
         meshLabel->setEnabled(false);
     }
-    else 
+    else
     {
         meshName->setEnabled(true);
         meshLabel->setEnabled(true);
@@ -1418,11 +1418,11 @@ QvisSliceWindow::UpdateMeshNames()
 // ****************************************************************************
 //  Method: QvisSliceWindow::meshNameChanged
 //
-//  Purpose: 
-//   This is a Qt slot function that sets the meshName. 
+//  Purpose:
+//   This is a Qt slot function that sets the meshName.
 //
-//  Programmer: Kathleen Bonnell 
-//  Creation:   January 25, 2005 
+//  Programmer: Kathleen Bonnell
+//  Creation:   January 25, 2005
 //
 //  Modifications:
 //

--- a/src/operators/Slice/QvisSliceWindow.C
+++ b/src/operators/Slice/QvisSliceWindow.C
@@ -686,6 +686,9 @@ QvisSliceWindow::UpdateOriginArea()
 //   Brad Whitlock, Wed Jul  9 13:56:57 PDT 2008
 //   Made it use ids and used helper methods.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void

--- a/src/plots/ParallelCoordinates/QvisParallelCoordinatesPlotWindow.C
+++ b/src/plots/ParallelCoordinates/QvisParallelCoordinatesPlotWindow.C
@@ -446,7 +446,7 @@ QvisParallelCoordinatesPlotWindow::UpdateWindow(bool doAll)
                     name = (atts->GetVisualAxisNames()[ax]).c_str();
                 else
                 {
-                    name = QString(" %1").arg(ax,2,10,QLatin1Char('0');
+                    name = QString(" %1").arg(ax,2,10,QLatin1Char('0'));
                     name = tr("Axis") + name;
                 }
                 QTreeWidgetItem *item =

--- a/src/plots/ParallelCoordinates/QvisParallelCoordinatesPlotWindow.C
+++ b/src/plots/ParallelCoordinates/QvisParallelCoordinatesPlotWindow.C
@@ -406,6 +406,9 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
 //    Jeremy Meredith, Tue Oct 27 11:18:23 EDT 2009
 //    Added ability to manually set axis extents to specific values.
 //
+//    Kathleen Biagas, Thu Jan 21, 2021
+//    Replace use of QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 void

--- a/src/plots/ParallelCoordinates/QvisParallelCoordinatesPlotWindow.C
+++ b/src/plots/ParallelCoordinates/QvisParallelCoordinatesPlotWindow.C
@@ -25,14 +25,14 @@
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::QvisParallelCoordinatesPlotWindow
 //
-// Purpose: 
+// Purpose:
 //   Constructor
 //
 // Programmer: xml2window
 // Creation:   Thu Mar 15 13:59:40 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisParallelCoordinatesPlotWindow::QvisParallelCoordinatesPlotWindow(const int type,
@@ -50,14 +50,14 @@ QvisParallelCoordinatesPlotWindow::QvisParallelCoordinatesPlotWindow(const int t
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::~QvisParallelCoordinatesPlotWindow
 //
-// Purpose: 
+// Purpose:
 //   Destructor
 //
 // Programmer: xml2window
 // Creation:   Thu Mar 15 13:59:40 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QvisParallelCoordinatesPlotWindow::~QvisParallelCoordinatesPlotWindow()
@@ -68,7 +68,7 @@ QvisParallelCoordinatesPlotWindow::~QvisParallelCoordinatesPlotWindow()
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::CreateWindowContents
 //
-// Purpose: 
+// Purpose:
 //   Creates the widgets for the window.
 //
 // Programmer: Jeremy Meredith
@@ -78,7 +78,7 @@ QvisParallelCoordinatesPlotWindow::~QvisParallelCoordinatesPlotWindow()
 //    Jeremy Meredith, Wed Mar 21 18:20:47 EDT 2007
 //    Added a checkbox to allow the lines to be hidden when the extents
 //    tool has not limited the viewing range to a focus.
-//   
+//
 //    Jeremy Meredith, Fri Feb  8 12:34:19 EST 2008
 //    Added ability to unify extents across all axes.
 //
@@ -93,7 +93,7 @@ QvisParallelCoordinatesPlotWindow::~QvisParallelCoordinatesPlotWindow()
 //    Added tr()'s
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 //    Jeremy Meredith, Wed Feb 25 12:55:54 EST 2009
 //    Added number of bins for line drawing.
@@ -126,17 +126,17 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
     QGridLayout *axisLayout = new QGridLayout(axisGroup);
 
     // axes list
-    
+
     axisTree = new QTreeWidget(axisGroup);
     axisTree->setSortingEnabled(false);
     axisTree->setRootIsDecorated(false);
-    
+
     QTreeWidgetItem *header = new QTreeWidgetItem();
     header->setText(0,tr("Axis"));
     header->setText(1,tr("Min"));
     header->setText(2,tr("Max"));
     axisTree->setHeaderItem(header);
-        
+
     axisLayout->addWidget(axisTree, 0,0, 4,4);
     connect(axisTree, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)),
             this, SLOT(axisSelected(QTreeWidgetItem*)));
@@ -302,8 +302,8 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
     contextGammaSlider->setRange(0,100);
     contextGammaSlider->setPageStep(5);
     contextGammaSlider->setValue(66);
-    
-                                     
+
+
     connect(contextGammaSlider, SIGNAL(valueChanged(int)),
             this, SLOT(contextGammaSliderChanged(int)));
     connect(contextGammaSlider, SIGNAL(sliderReleased()),
@@ -349,7 +349,7 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::UpdateWindow
 //
-// Purpose: 
+// Purpose:
 //   Updates the widgets in the window when the subject changes.
 //
 // Programmer: Jeremy Meredith
@@ -359,7 +359,7 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
 //    Jeremy Meredith, Wed Mar 21 18:20:47 EDT 2007
 //    Added a checkbox to allow the lines to be hidden when the extents
 //    tool has not limited the viewing range to a focus.
-//   
+//
 //    Jeremy Meredith, Thu Feb  7 17:42:48 EST 2008
 //    For an empty list of axis names, disable critical widgets and
 //    put in a useful message.
@@ -380,7 +380,7 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
 //    Don't enable de/up/down buttons if we were created from an array var.
 //
 //    Cyrus Harrison, Mon Feb 25 13:42:21 PST 2008
-//    Resolved AIX QString init error. 
+//    Resolved AIX QString init error.
 //
 //    Kathleen Bonnell, Thu Mar  6 09:47:34 PST 2008
 //    Cannot convert a std::string to a QString on windows, must use .c_str().
@@ -392,7 +392,7 @@ QvisParallelCoordinatesPlotWindow::CreateWindowContents()
 //    Removed unused variables.
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 //    Jeremy Meredith, Thu Mar 12 13:12:37 EDT 2009
 //    Qt4 port of new additions.
@@ -413,7 +413,7 @@ QvisParallelCoordinatesPlotWindow::UpdateWindow(bool doAll)
 {
     QString temp;
 
-    QString oldAxis = axisTree->currentItem() ? 
+    QString oldAxis = axisTree->currentItem() ?
         axisTree->currentItem()->text(0) : QString("");
 
     for(int i = 0; i < atts->NumAttributes(); ++i)
@@ -446,7 +446,7 @@ QvisParallelCoordinatesPlotWindow::UpdateWindow(bool doAll)
                     name = (atts->GetVisualAxisNames()[ax]).c_str();
                 else
                 {
-                    name.asprintf(" %02ld",ax);
+                    name = QString(" %1").arg(ax,2,10,QLatin1Char('0');
                     name = tr("Axis") + name;
                 }
                 QTreeWidgetItem *item =
@@ -572,9 +572,9 @@ QvisParallelCoordinatesPlotWindow::UpdateWindow(bool doAll)
         axisTree->setCurrentItem(item);
         axisSelected(item);
     }
-    
+
     // Set enabled states
-    
+
     nitems = (int)atts->GetScalarAxisNames().size();
     axisDelButton->setEnabled( nitems > 2 &&
                               axisTree->currentItem()!= NULL);
@@ -591,7 +591,7 @@ QvisParallelCoordinatesPlotWindow::UpdateWindow(bool doAll)
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::GetCurrentValues
 //
-// Purpose: 
+// Purpose:
 //   Gets values from certain widgets and stores them in the subject.
 //
 // Programmer: Jeremy Meredith
@@ -602,7 +602,7 @@ QvisParallelCoordinatesPlotWindow::UpdateWindow(bool doAll)
 //   Added tr()
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 //    Jeremy Meredith, Wed Feb 25 13:00:02 EST 2009
 //    Added number of bins for line drawing.
@@ -718,14 +718,14 @@ QvisParallelCoordinatesPlotWindow::GetCurrentValues(int which_widget)
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::Apply
 //
-// Purpose: 
+// Purpose:
 //   Called to apply changes in the subject.
 //
 // Programmer: xml2window
 // Creation:   Thu Mar 15 13:59:40 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -751,14 +751,14 @@ QvisParallelCoordinatesPlotWindow::Apply(bool ignore)
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::apply
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when apply button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Thu Mar 15 13:59:40 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -771,14 +771,14 @@ QvisParallelCoordinatesPlotWindow::apply()
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::makeDefault
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when "Make default" button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Thu Mar 15 13:59:40 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -793,14 +793,14 @@ QvisParallelCoordinatesPlotWindow::makeDefault()
 // ****************************************************************************
 // Method: QvisParallelCoordinatesPlotWindow::reset
 //
-// Purpose: 
+// Purpose:
 //   Qt slot function called when reset button is clicked.
 //
 // Programmer: xml2window
 // Creation:   Thu Mar 15 13:59:40 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -935,7 +935,7 @@ QvisParallelCoordinatesPlotWindow::resetAxisExtents()
 //    Don't enable del/up/down buttons if we were created from an array var.
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 //    Jeremy Meredith, Tue Oct 27 13:02:24 EDT 2009
 //    Add explicit axis min/max value settings.
@@ -985,7 +985,7 @@ QvisParallelCoordinatesPlotWindow::axisSelected(QTreeWidgetItem*)
 //
 //  Modifications:
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 // ****************************************************************************
 
@@ -1014,7 +1014,7 @@ QvisParallelCoordinatesPlotWindow::addAxis(const QString &axisToAdd)
 //    Changed axis list to QTreeView to support multiple columns.
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 // ****************************************************************************
 
@@ -1022,7 +1022,7 @@ void
 QvisParallelCoordinatesPlotWindow::delAxis()
 {
     if (axisTree->currentItem())
-    { 
+    {
         QString axis = axisTree->currentItem()->text(0);
         atts->DeleteAxis(axis.toStdString(), 2);
         Apply();
@@ -1050,7 +1050,7 @@ QvisParallelCoordinatesPlotWindow::delAxis()
 //    as names of actual scalars instead of just display names.
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 // ****************************************************************************
 
@@ -1100,7 +1100,7 @@ QvisParallelCoordinatesPlotWindow::moveAxisUp()
 //    as names of actual scalars instead of just display names.
 //
 //    Cyrus Harrison, Mon Jul 21 08:33:47 PDT 2008
-//    Initial Qt4 Port. 
+//    Initial Qt4 Port.
 //
 // ****************************************************************************
 
@@ -1111,11 +1111,11 @@ QvisParallelCoordinatesPlotWindow::moveAxisDown()
     int index = GetSelectedAxisIndex();
     if( index < 0)
         return;
-    
+
     // must make a local copy
     stringVector axes = atts->GetScalarAxisNames();
     int naxes = (int)axes.size();
- 
+
     // can't move last axis down in list
     if (index >= naxes-1)
         return;
@@ -1335,7 +1335,7 @@ QvisParallelCoordinatesPlotWindow::unifyAxisExtentsToggled(bool val)
 //
 //  Purpose:
 //    Helper that obtains the index of the currently selected axis, or
-//    -1 if no axis is selected. 
+//    -1 if no axis is selected.
 //
 //
 //  Programmer:  Cyrus Harrison
@@ -1485,7 +1485,7 @@ QvisParallelCoordinatesPlotWindow::axisMinValChanged(const QString &val)
     if (!ok)
         return;
 
-    
+
     atts->GetExtentMinima()[index] = v;
     atts->SelectExtentMinima();
     axisTree->topLevelItem(index)->setText(1, val);
@@ -1530,7 +1530,7 @@ QvisParallelCoordinatesPlotWindow::axisMaxValChanged(const QString &val)
     if (!ok)
         return;
 
-    
+
     atts->GetExtentMaxima()[index] = v;
     atts->SelectExtentMaxima();
     axisTree->topLevelItem(index)->setText(2, val);

--- a/src/plots/Spreadsheet/SpreadsheetTable.C
+++ b/src/plots/Spreadsheet/SpreadsheetTable.C
@@ -40,7 +40,7 @@ bool operator < (const QSize &a, const QSize &b)
 //   This is a subclass of QAbstractItemModel that lets us show vtkDataArray
 //   data in Qt's item view classes. We use QTableView for the SpreadSheet plot.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Aug 28 14:43:57 PDT 2008
@@ -65,7 +65,7 @@ public:
 
     void setCurveData(vtkRectilinearGrid *rgrid);
 
-    void setDataArray(vtkDataArray *arr, 
+    void setDataArray(vtkDataArray *arr,
                       vtkDataArray *ghosts, vtkDataArray *missingData,
                       int d[3], SpreadsheetTable::DisplayMode dm, int sliceindex,
                       int base_index[3]);
@@ -106,7 +106,7 @@ private:
 // ****************************************************************************
 // Method: DataArrayModel::DataArrayModel
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the DataArrayModel class.
 //
 // Arguments:
@@ -142,15 +142,15 @@ DataArrayModel::DataArrayModel(QObject *parent) : QAbstractItemModel(parent),
 // ****************************************************************************
 // Method: DataArrayModel::setCurveData
 //
-// Purpose: 
+// Purpose:
 //   Set curve data into the model.
 //
 // Arguments:
 //   grid : The rectilinear grid that contains the curve data.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Dec  1 16:25:54 PST 2010
@@ -193,7 +193,7 @@ DataArrayModel::setCurveData(vtkRectilinearGrid *grid)
 // ****************************************************************************
 // Method: DataArrayModel::setDataArray
 //
-// Purpose: 
+// Purpose:
 //   Provides data to the model.
 //
 // Arguments:
@@ -206,9 +206,9 @@ DataArrayModel::setCurveData(vtkRectilinearGrid *grid)
 //   base_index : The base_index values to add to i,j,k when displaying the
 //                indices that identify a cell or node.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Aug 28 16:21:31 PDT 2008
@@ -226,7 +226,7 @@ DataArrayModel::setCurveData(vtkRectilinearGrid *grid)
 // ****************************************************************************
 
 void
-DataArrayModel::setDataArray(vtkDataArray *arr, 
+DataArrayModel::setDataArray(vtkDataArray *arr,
     vtkDataArray *ghosts, vtkDataArray *missingData,
     int d[3], SpreadsheetTable::DisplayMode dm, int sliceindex, int baseIndex[3])
 {
@@ -288,7 +288,7 @@ DataArrayModel::setDataArray(vtkDataArray *arr,
 // ****************************************************************************
 // Method: DataArrayModel::clearDataArray
 //
-// Purpose: 
+// Purpose:
 //   Clears out the model's data.
 //
 // Programmer: Brad Whitlock
@@ -320,7 +320,7 @@ DataArrayModel::clearDataArray()
 // ****************************************************************************
 // Method: DataArrayModel::addSelectedCellLabel
 //
-// Purpose: 
+// Purpose:
 //   Adds a selected cell label to the model.
 //
 // Arguments:
@@ -328,15 +328,15 @@ DataArrayModel::clearDataArray()
 //   col   : The column for the cell that will contain the label.
 //   label : The pick label to use.
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Aug 28 16:22:31 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -351,14 +351,14 @@ DataArrayModel::addSelectedCellLabel(int row, int col, const QString &label)
 // ****************************************************************************
 // Method: DataArrayModel::clearSelectedCellLabels
 //
-// Purpose: 
+// Purpose:
 //   Clears the selected cell labels.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Aug 28 16:23:26 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -372,7 +372,7 @@ DataArrayModel::clearSelectedCellLabels()
 // ****************************************************************************
 // Method: DataArrayModel::numSelectedCellLabels
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of selected cell labels.
 //
 // Returns:    The number of selected cell labels.
@@ -381,7 +381,7 @@ DataArrayModel::clearSelectedCellLabels()
 // Creation:   Thu Aug 28 16:23:51 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -397,7 +397,7 @@ DataArrayModel::numSelectedCellLabels() const
 // ****************************************************************************
 // Method: DataArrayModel::columnCount
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of columns in the model.
 //
 // Returns:    The number of columns.
@@ -406,7 +406,7 @@ DataArrayModel::numSelectedCellLabels() const
 // Creation:   Thu Aug 28 16:24:18 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -418,7 +418,7 @@ DataArrayModel::columnCount(const QModelIndex &) const
 // ****************************************************************************
 // Method: DataArrayModel::rowCount
 //
-// Purpose: 
+// Purpose:
 //   Returns the number of rows in the model.
 //
 // Returns:    The number of rows.
@@ -427,7 +427,7 @@ DataArrayModel::columnCount(const QModelIndex &) const
 // Creation:   Thu Aug 28 16:24:40 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 int
@@ -439,7 +439,7 @@ DataArrayModel::rowCount(const QModelIndex &) const
 // ****************************************************************************
 // Method: DataArrayModel::data
 //
-// Purpose: 
+// Purpose:
 //   Returns data for the specified model index.
 //
 // Arguments:
@@ -463,7 +463,7 @@ DataArrayModel::rowCount(const QModelIndex &) const
 //
 //   Gunther H. Weber, Mon Feb  2 15:42:07 PST 2009
 //   Use internalId() instead of internalPointer() to obtain global index of a
-//   spreadsheet element since latter does not work on Linux systems. 
+//   spreadsheet element since latter does not work on Linux systems.
 //
 //   Brad Whitlock, Wed Dec  1 16:39:13 PST 2010
 //   I added support for showing curve data.
@@ -485,7 +485,7 @@ DataArrayModel::data(const QModelIndex &index, int role) const
             double value = 0.;
             if(id < dataArray->GetNumberOfTuples())
                 value = dataArray->GetTuple1(id);
-            QString s; s.asprintf(formatString.toStdString().c_str(), value);
+            QString s = QString::asprintf(formatString.toStdString().c_str(), value);
 
             // See if we need to prepend a pick letter.
             QSize key(index.row(), index.column());
@@ -507,7 +507,7 @@ DataArrayModel::data(const QModelIndex &index, int role) const
             else
                 value = arr->GetTuple1(id);
 
-            QString s; s.asprintf(formatString.toStdString().c_str(), value);
+            QString s = QString::asprintf(formatString.toStdString().c_str(), value);
             return QVariant(s);
         }
     }
@@ -540,7 +540,7 @@ DataArrayModel::data(const QModelIndex &index, int role) const
     }
     else if(role == Qt::BackgroundRole)
     {
-        // This role returns the background brush: gray for ghost, 
+        // This role returns the background brush: gray for ghost,
         // pinkish gray for missing data, default otherwise.
         if(ghostArray != 0)
         {
@@ -557,7 +557,7 @@ DataArrayModel::data(const QModelIndex &index, int role) const
             vtkIdType id = index.internalId();
 
             // By convention, the missing data array contains unsigned char.
-            const unsigned char *missingData = 
+            const unsigned char *missingData =
                 (const unsigned char *)missingDataArray->GetVoidPointer(0);
             if(id < missingDataArray->GetNumberOfTuples() && missingData[id] > 0)
                 return QVariant(QBrush(QColor(255,200,200)));
@@ -570,7 +570,7 @@ DataArrayModel::data(const QModelIndex &index, int role) const
 // ****************************************************************************
 // Method: DataArrayModel::headerData
 //
-// Purpose: 
+// Purpose:
 //   Returns a label for a particular header cell.
 //
 // Arguments:
@@ -580,7 +580,7 @@ DataArrayModel::data(const QModelIndex &index, int role) const
 //
 // Returns:    The header data for a particular header cell.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Aug 28 16:25:59 PDT 2008
@@ -601,37 +601,37 @@ DataArrayModel::headerData(int section, Qt::Orientation orientation, int role) c
         if(displayMode == SpreadsheetTable::SliceX)
         {
             if(orientation == Qt::Horizontal)
-                label.asprintf("k=%d", section + base_index[2]);
+                label = QString("k=%1").arg(section + base_index[2]);
             else
-                label.asprintf("j=%d", dims[1]-1-section + base_index[1]);
+                label = QString("j=%1").arg(dims[1]-1-section + base_index[1]);
         }
         else if(displayMode == SpreadsheetTable::SliceY)
         {
             if(orientation == Qt::Horizontal)
-                label.asprintf("k=%d", section + base_index[2]);
+                label = QString("k=%1").arg(section + base_index[2]);
             else
-                label.asprintf("i=%d", dims[0]-1-section + base_index[0]);
+                label = QString("i=%1").arg(dims[0]-1-section + base_index[0]);
         }
         else if(displayMode == SpreadsheetTable::SliceZ)
         {
             if(orientation == Qt::Horizontal)
-                label.asprintf("i=%d", section + base_index[0]);
+                label = QString("i=%1").arg(section + base_index[0]);
             else
-                label.asprintf("j=%d", dims[1]-1-section + base_index[1]);
+                label = QString("j=%1").arg(dims[1]-1-section + base_index[1]);
         }
         else if(displayMode == SpreadsheetTable::UCDCell)
         {
             if(orientation == Qt::Horizontal)
                 label = tr("cell value");
             else
-                label.asprintf("%d", section + base_index[0]);
+                label.setNum(section + base_index[0]);
         }
         else if(displayMode == SpreadsheetTable::UCDNode)
         {
             if(orientation == Qt::Horizontal)
                 label = tr("node value");
             else
-                label.asprintf("%d", section + base_index[0]);
+                label.setNum(section + base_index[0]);
         }
         else if(displayMode == SpreadsheetTable::CurveData)
         {
@@ -643,7 +643,7 @@ DataArrayModel::headerData(int section, Qt::Orientation orientation, int role) c
                     label = tr("Y");
             }
             else
-                label.asprintf("%d", section);
+                label.setNum(section);
         }
 
         return QVariant(label);
@@ -655,7 +655,7 @@ DataArrayModel::headerData(int section, Qt::Orientation orientation, int role) c
 // ****************************************************************************
 // Method: DataArrayModel::index
 //
-// Purpose: 
+// Purpose:
 //   Constructs a model index for the specified row and column.
 //
 // Arguments:
@@ -674,7 +674,7 @@ DataArrayModel::headerData(int section, Qt::Orientation orientation, int role) c
 // Creation:   Thu Aug 28 16:28:01 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QModelIndex
@@ -715,7 +715,7 @@ DataArrayModel::index(int row, int column, const QModelIndex &) const
 // ****************************************************************************
 // Method: DataArrayModel::parent
 //
-// Purpose: 
+// Purpose:
 //   Returns that no model indices in this model have parents.
 //
 // Returns:    An empty model index.
@@ -724,7 +724,7 @@ DataArrayModel::index(int row, int column, const QModelIndex &) const
 // Creation:   Thu Aug 28 16:30:41 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 QModelIndex
@@ -739,13 +739,13 @@ DataArrayModel::parent(const QModelIndex &) const
 // Purpose:
 //   This special purpose delegate lets us render table cells in color.
 //
-// Notes:      
+// Notes:
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Aug 28 16:31:20 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 class DataArrayDelegate : public QItemDelegate
@@ -769,7 +769,7 @@ private:
 // ****************************************************************************
 // Method: DataArrayDelegate::DataArrayDelegate
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the DataArrayDelegate class.
 //
 // Arguments:
@@ -780,10 +780,10 @@ private:
 // Creation:   Thu Aug 28 16:32:09 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
-DataArrayDelegate::DataArrayDelegate(QAbstractItemModel *m, QObject *parent) : 
+DataArrayDelegate::DataArrayDelegate(QAbstractItemModel *m, QObject *parent) :
     QItemDelegate(parent)
 {
     model = m;
@@ -794,7 +794,7 @@ DataArrayDelegate::DataArrayDelegate(QAbstractItemModel *m, QObject *parent) :
 // ****************************************************************************
 // Method: DataArrayDelegate::paint
 //
-// Purpose: 
+// Purpose:
 //   Override of the paint method that lets us change the text color based
 //   on the model's data value.
 //
@@ -807,11 +807,11 @@ DataArrayDelegate::DataArrayDelegate(QAbstractItemModel *m, QObject *parent) :
 // Creation:   Thu Aug 28 16:33:43 PDT 2008
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
-DataArrayDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
+DataArrayDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
     const QModelIndex &index) const
 {
     if(renderInColor)
@@ -838,7 +838,7 @@ DataArrayDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
 // ****************************************************************************
 // Method: SpreadsheetTable::SpreadsheetTable
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the SpreadsheetTable class.
 //
 // Arguments:
@@ -875,14 +875,14 @@ SpreadsheetTable::SpreadsheetTable(QWidget *parent) : QTableView(parent)
 // ****************************************************************************
 // Method: SpreadsheetTable::~SpreadsheetTable
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the SpreadsheetTable class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Feb 20 15:33:26 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 SpreadsheetTable::~SpreadsheetTable()
@@ -892,7 +892,7 @@ SpreadsheetTable::~SpreadsheetTable()
 // ****************************************************************************
 // Method: SpreadsheetTable::setLUT
 //
-// Purpose: 
+// Purpose:
 //   Sets the LUT that should be used when we need to map data to colors.
 //
 // Arguments:
@@ -916,7 +916,7 @@ SpreadsheetTable::setLUT(avtLookupTable *L)
 // ****************************************************************************
 // Method: SpreadsheetTable::setRenderInColor
 //
-// Purpose: 
+// Purpose:
 //   Sets whether the table should render its text in color.
 //
 // Arguments:
@@ -931,7 +931,7 @@ SpreadsheetTable::setLUT(avtLookupTable *L)
 //
 // ****************************************************************************
 
-void 
+void
 SpreadsheetTable::setRenderInColor(bool ric)
 {
     if(DELEGATE->getRenderInColor() != ric)
@@ -945,7 +945,7 @@ SpreadsheetTable::setRenderInColor(bool ric)
 // ****************************************************************************
 // Method: SpreadsheetTable::setFormatString
 //
-// Purpose: 
+// Purpose:
 //   Sets the format string to use for drawing text.
 //
 // Arguments:
@@ -977,7 +977,7 @@ SpreadsheetTable::setFormatString(const QString &fmt)
 // ****************************************************************************
 // Method: SpreadsheetTable::setCurveData
 //
-// Purpose: 
+// Purpose:
 //   Set the curve data into the model.
 //
 // Arguments:
@@ -987,7 +987,7 @@ SpreadsheetTable::setFormatString(const QString &fmt)
 // Creation:   Mon Dec  6 14:19:38 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1001,7 +1001,7 @@ SpreadsheetTable::setCurveData(vtkRectilinearGrid *rgrid)
 // ****************************************************************************
 // Method: SpreadsheetTable::setDataArray
 //
-// Purpose: 
+// Purpose:
 //   Sets the data array and other parameters used to render the data in
 //   the spreadsheet.
 //
@@ -1028,7 +1028,7 @@ SpreadsheetTable::setCurveData(vtkRectilinearGrid *rgrid)
 // ****************************************************************************
 
 void
-SpreadsheetTable::setDataArray(vtkDataArray *arr, 
+SpreadsheetTable::setDataArray(vtkDataArray *arr,
     vtkDataArray *ghosts, vtkDataArray *missingData,
     int d[3], DisplayMode dm, int sliceindex, int base_index[3])
 {
@@ -1039,7 +1039,7 @@ SpreadsheetTable::setDataArray(vtkDataArray *arr,
 // ****************************************************************************
 // Method: SpreadsheetTable
 //
-// Purpose: 
+// Purpose:
 //   Disassociates the current data and ghost arrays from the spreadsheeet.
 //
 // Programmer: Brad Whitlock
@@ -1061,10 +1061,10 @@ SpreadsheetTable::clearDataArray()
 // ****************************************************************************
 // Method: SpreadsheetTable::selectedCellsAsText
 //
-// Purpose: 
+// Purpose:
 //   Gets the selected cells as text.
 //
-// Returns:    The string containing the text for all selected cells of 
+// Returns:    The string containing the text for all selected cells of
 //             the table.
 //
 // Programmer: Brad Whitlock
@@ -1105,7 +1105,7 @@ SpreadsheetTable::selectedCellsAsText() const
 // ****************************************************************************
 // Method: SpreadsheetTable::selectedCellsSum
 //
-// Purpose: 
+// Purpose:
 //   Sums the data values over the selected cells.
 //
 // Returns:    The sum of the values in the selected cells.
@@ -1134,7 +1134,7 @@ SpreadsheetTable::selectedCellsSum() const
 // ****************************************************************************
 // Method: SpreadsheetTable::selectedCellsAverage
 //
-// Purpose: 
+// Purpose:
 //   Average the values of the selected cells.
 //
 // Returns:    The average of the selected cells.
@@ -1145,7 +1145,7 @@ SpreadsheetTable::selectedCellsSum() const
 // Modifications:
 //   Brad Whitlock, Wed Aug 27 15:59:08 PDT 2008
 //   Rewrote for Qt 4.
-//   
+//
 // ****************************************************************************
 
 double
@@ -1163,7 +1163,7 @@ SpreadsheetTable::selectedCellsAverage() const
 // ****************************************************************************
 // Method: SpreadsheetTable::selectedColumnIndices
 //
-// Purpose: 
+// Purpose:
 //   Return the indices of the column.
 //
 // Arguments:
@@ -1171,13 +1171,13 @@ SpreadsheetTable::selectedCellsAverage() const
 //
 // Returns:    An array of indices.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon May 11 10:51:31 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 vtkIdType *
@@ -1209,7 +1209,7 @@ SpreadsheetTable::selectedColumnIndices(int &nvals) const
 // ****************************************************************************
 // Method: SpreadsheetTable::selectedColumnIndices
 //
-// Purpose: 
+// Purpose:
 //   Return the indices of the column.
 //
 // Arguments:
@@ -1217,13 +1217,13 @@ SpreadsheetTable::selectedColumnIndices(int &nvals) const
 //
 // Returns:    An array of indices.
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon May 11 10:51:31 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 vtkIdType *
@@ -1256,7 +1256,7 @@ SpreadsheetTable::selectedRowIndices(int &nvals) const
 // ****************************************************************************
 // Method: SpreadsheetTable::addSelectedCellLabel()
 //
-// Purpose: 
+// Purpose:
 //   Add a label (pick letter) for a cell, which will be displayed if the
 //   cell is selected.
 //
@@ -1283,7 +1283,7 @@ SpreadsheetTable::addSelectedCellLabel(int row, int col, const QString &label)
 // ****************************************************************************
 // Method: SpreadsheetTable::clearSelectedCellLabels()
 //
-// Purpose: 
+// Purpose:
 //   Clear the list of cell labels (pick letters for cells).
 //
 // Programmer: Gunther H. Weber
@@ -1304,7 +1304,7 @@ SpreadsheetTable::clearSelectedCellLabels()
 // ****************************************************************************
 // Method: SpreadsheetTable::setFont()
 //
-// Purpose: 
+// Purpose:
 //   Update column widths after a font change
 //
 // Programmer: Gunther H. Weber
@@ -1326,7 +1326,7 @@ SpreadsheetTable::setFont(QFont&f)
 // ****************************************************************************
 // Method: SpreadsheetTable::selectAll
 //
-// Purpose: 
+// Purpose:
 //   Selects all of the cells in the table.
 //
 // Programmer: Brad Whitlock
@@ -1351,7 +1351,7 @@ SpreadsheetTable::selectAll()
 // ****************************************************************************
 // Method: SpreadsheetTable::selectNone
 //
-// Purpose: 
+// Purpose:
 //   Removes all of the selections from the table.
 //
 // Programmer: Brad Whitlock
@@ -1372,7 +1372,7 @@ SpreadsheetTable::selectNone()
 // ****************************************************************************
 // Method: SpreadsheetTable::updateColumnWidths
 //
-// Purpose: 
+// Purpose:
 //   Change table column width so that numeric values (and labels) displayed
 //   in cells are not truncated
 //

--- a/src/plots/Spreadsheet/SpreadsheetTable.C
+++ b/src/plots/Spreadsheet/SpreadsheetTable.C
@@ -589,6 +589,9 @@ DataArrayModel::data(const QModelIndex &index, int role) const
 //   Brad Whitlock, Wed Dec  1 16:44:43 PST 2010
 //   I added a CurveData display mode.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace use of QString.asprintf with QString.setNum.
+//
 // ****************************************************************************
 
 QVariant

--- a/src/plots/Spreadsheet/SpreadsheetViewer.C
+++ b/src/plots/Spreadsheet/SpreadsheetViewer.C
@@ -2806,6 +2806,9 @@ SpreadsheetViewer::operationSum()
 //   Brad Whitlock, Wed Apr 23 11:35:09 PDT 2008
 //   Support for internationalization.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Correct use of QString::asprintf to proper form.
+//
 // ****************************************************************************
 
 void

--- a/src/plots/Spreadsheet/SpreadsheetViewer.C
+++ b/src/plots/Spreadsheet/SpreadsheetViewer.C
@@ -85,7 +85,7 @@
 // ****************************************************************************
 // Method: SpreadsheetViewer::SpreadsheetViewer
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the SpreadsheetViewer class.
 //
 // Arguments:
@@ -125,7 +125,7 @@
 // ****************************************************************************
 
 SpreadsheetViewer::SpreadsheetViewer(ViewerPlot *p, QWidget *parent) :
-    QMainWindow(parent), Observer((Subject*)p->GetPlotAtts()), 
+    QMainWindow(parent), Observer((Subject*)p->GetPlotAtts()),
     cachedAtts(), menuPopulator()
 {
     // Initialize the color table button if we've not done that before
@@ -286,7 +286,7 @@ SpreadsheetViewer::SpreadsheetViewer(ViewerPlot *p, QWidget *parent) :
     varLabel = new QLabel(tr("Variable"), top);
     varLayout->addWidget(varLabel, 0, 0);
     // Have to display metadata -- the list of variables.
-    varButton = new QvisVariableButton(false, false, true, 
+    varButton = new QvisVariableButton(false, false, true,
         QvisVariableButton::Scalars, top);
     connect(varButton, SIGNAL(activated(const QString &)),
             this, SLOT(changedVariable(const QString &)));
@@ -351,7 +351,7 @@ SpreadsheetViewer::SpreadsheetViewer(ViewerPlot *p, QWidget *parent) :
 // ****************************************************************************
 // Method: SpreadsheetViewer::~SpreadsheetViewer
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the SpreadsheetViewer class.
 //
 // Programmer: Brad Whitlock
@@ -388,7 +388,7 @@ SpreadsheetViewer::~SpreadsheetViewer()
 // ****************************************************************************
 // Method: SpreadsheetViewer::setAllowRender
 //
-// Purpose: 
+// Purpose:
 //   Sets whether the window will respond to render events from the vis window.
 //
 // Arguments:
@@ -414,7 +414,7 @@ SpreadsheetViewer::setAllowRender(bool val)
 // ****************************************************************************
 // Method: SpreadsheetViewer::render
 //
-// Purpose: 
+// Purpose:
 //   This method tells the window to update itself using the specified
 //   VTK dataset.
 //
@@ -429,7 +429,7 @@ SpreadsheetViewer::setAllowRender(bool val)
 //   Gunther H. Weber, Fri Sep 14 14:04:10 PDT 2007
 //   Select appropriate picks the first time a data set is rendered (i.e.,
 //   input is NULL).
-// 
+//
 //   Brad Whitlock, Wed Apr 23 11:13:35 PDT 2008
 //   Added tr().
 //
@@ -449,8 +449,8 @@ SpreadsheetViewer::render(vtkDataSet *ds)
         raise();
 
         // If input is NULL then there may be picks in the attributes that need
-        // to be highlighted 
-        bool needPickUpdate = !input; 
+        // to be highlighted
+        bool needPickUpdate = !input;
         bool sliceIndexSet = false;
 
         // Set the input pointer
@@ -511,14 +511,14 @@ SpreadsheetViewer::render(vtkDataSet *ds)
 // ****************************************************************************
 // Method: SpreadsheetViewer::updateVariableMenus
 //
-// Purpose: 
+// Purpose:
 //   Updates the menu populator using the plot as input.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Feb 20 18:07:31 PST 2007
 //
 // Modifications:
-//   
+//
 //    Mark C. Miller, Thu Jun 14 10:26:37 PDT 2007
 //    Added support to treat all databases as time varying to
 //    PopulateVariableLists
@@ -549,7 +549,7 @@ SpreadsheetViewer::updateVariableMenus()
 // ****************************************************************************
 // Method: SpreadsheetViewer::enterEvent
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the mouse enters the window.
 //
 // Arguments:
@@ -562,7 +562,7 @@ SpreadsheetViewer::updateVariableMenus()
 // Creation:   Tue Feb 20 18:08:05 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -575,7 +575,7 @@ SpreadsheetViewer::enterEvent(QEvent *e)
 // ****************************************************************************
 // Method: SpreadsheetViewer::closeEvent
 //
-// Purpose: 
+// Purpose:
 //   Minimize the window instead of closing it.
 //
 // Arguments:
@@ -585,7 +585,7 @@ SpreadsheetViewer::enterEvent(QEvent *e)
 // Creation:   Wed Mar 28 18:49:50 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -598,7 +598,7 @@ SpreadsheetViewer::closeEvent(QCloseEvent *e)
 // ****************************************************************************
 // Method: SpreadsheetViewer::setColorTable
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the plot needs to tell the window the name of
 //   the color table to use.
 //
@@ -628,9 +628,9 @@ SpreadsheetViewer::setColorTable(const char *ctName)
     bool colorTableChanged = false;
 
     if (plotAtts->GetColorTableName() == "Default")
-        colorTableChanged = colorLUT->SetColorTable(NULL, namesMatch); 
+        colorTableChanged = colorLUT->SetColorTable(NULL, namesMatch);
     else
-        colorTableChanged = colorLUT->SetColorTable(ctName, namesMatch); 
+        colorTableChanged = colorLUT->SetColorTable(ctName, namesMatch);
 
     if(colorTableChanged)
     {
@@ -645,7 +645,7 @@ SpreadsheetViewer::setColorTable(const char *ctName)
 // ****************************************************************************
 // Method: SpreadsheetViewer::PickPointsChanged()
 //
-// Purpose: 
+// Purpose:
 //    Determine based on current plotAtts and cached attributes if the list
 //    of pick points changed.
 //
@@ -698,7 +698,7 @@ SpreadsheetViewer::PickPointsChanged() const
 // ****************************************************************************
 // Method: SpreadsheetViewer::Update
 //
-// Purpose: 
+// Purpose:
 //   This method implements the Observer interface and allows the window to
 //   display SpreadsheetAttributes.
 //
@@ -708,7 +708,7 @@ SpreadsheetViewer::PickPointsChanged() const
 // Modifications:
 //   Brad Whitlock, Wed Jun 6 17:24:26 PST 2007
 //   Support using a single tab of values.
-//   
+//
 //   Hank Childs, Tue Sep  4 10:53:55 PDT 2007
 //   Highlight and label pick points in spreadsheet. This functionality
 //   required changes to handling other events as well (such as invalidating
@@ -751,7 +751,7 @@ SpreadsheetViewer::Update(Subject *)
             {
                 // Invalidate pointer to data set so that pick information
                 // is not applied to the incorrect subset
-                input = 0; 
+                input = 0;
             }
             break;
         case SpreadsheetAttributes::ID_formatString:
@@ -887,7 +887,7 @@ SpreadsheetViewer::Update(Subject *)
             zTabs->setCurrentIndex(plotAtts->GetSliceIndex());
             zTabs->blockSignals(false);
         }
-   
+
         kSlider->blockSignals(true);
         kSlider->setValue(plotAtts->GetSliceIndex());
         kSlider->blockSignals(false);
@@ -899,7 +899,7 @@ SpreadsheetViewer::Update(Subject *)
 // ****************************************************************************
 // Method: SpreadsheetViewer::updateSpreadsheet
 //
-// Purpose: 
+// Purpose:
 //   This method takes the input VTK dataset and makes sure that the spreadsheet
 //   properly displays the VTK dataset.
 //
@@ -962,7 +962,7 @@ SpreadsheetViewer::updateSpreadsheet()
 // ****************************************************************************
 // Method: SpreadsheetViewer::GetBaseIndexFromMetaData
 //
-// Purpose: 
+// Purpose:
 //   Set the base_index from the plot's metadata.
 //
 // Arguments:
@@ -972,7 +972,7 @@ SpreadsheetViewer::updateSpreadsheet()
 // Creation:   Fri May  8 09:13:33 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1005,7 +1005,7 @@ SpreadsheetViewer::GetBaseIndexFromMetaData(int *base_index) const
 // ****************************************************************************
 // Method: SpreadsheetViewer::displayStructuredGrid
 //
-// Purpose: 
+// Purpose:
 //   This method updates the spreadsheet so it displays the data as a
 //   structured grid.
 //
@@ -1026,7 +1026,7 @@ SpreadsheetViewer::GetBaseIndexFromMetaData(int *base_index) const
 //   I fixed a logic error that produced all zeros in the table.
 //
 //   Brad Whitlock, Fri May  8 09:09:29 PDT 2009
-//   Set the mesh's base index differently if there are no base_index or 
+//   Set the mesh's base index differently if there are no base_index or
 //   realDims field data arrays. We use the mesh's cell and node origins.
 //
 //   Brad Whitlock, Mon Dec  6 14:29:41 PST 2010
@@ -1146,7 +1146,7 @@ SpreadsheetViewer::displayStructuredGrid(int meshDims[3])
         }
 
         // Detect whether we have a 1D curve.
-        bool isCurve = (dims[1] == 1 && dims[2] == 1 && 
+        bool isCurve = (dims[1] == 1 && dims[2] == 1 &&
                         input->IsA("vtkRectilinearGrid"));
 
         // Make sure that each table can access the VTK data.
@@ -1159,13 +1159,13 @@ SpreadsheetViewer::displayStructuredGrid(int meshDims[3])
         {
             tables[t]->blockSignals(true);
 
-            // Tell the table about our data so it can display it 
+            // Tell the table about our data so it can display it
             // appropriately.
             if(isCurve)
                 tables[t]->setCurveData((vtkRectilinearGrid *)input);
             else
             {
-                tables[t]->setDataArray(arr, ghostArray, missingDataArray, dims, 
+                tables[t]->setDataArray(arr, ghostArray, missingDataArray, dims,
                     dMode, offset + t, base_index);
             }
             tables[t]->setFormatString(plotAtts->GetFormatString().c_str());
@@ -1185,7 +1185,7 @@ SpreadsheetViewer::displayStructuredGrid(int meshDims[3])
 // ****************************************************************************
 // Method: SpreadsheetViewer::displayUnstructuredGrid
 //
-// Purpose: 
+// Purpose:
 //   Displays the input data as an unstructured grid.
 //
 // Programmer: Brad Whitlock
@@ -1193,7 +1193,7 @@ SpreadsheetViewer::displayStructuredGrid(int meshDims[3])
 //
 // Modifications:
 //   Brad Whitlock, Fri May  8 09:09:29 PDT 2009
-//   Set the mesh's base index differently if there is no base_index  
+//   Set the mesh's base index differently if there is no base_index
 //   field data array. We use the mesh's cell and node origins.
 //
 //   Brad Whitlock, Thu Jan  5 14:09:44 PST 2012
@@ -1232,11 +1232,11 @@ SpreadsheetViewer::displayUnstructuredGrid()
         // We only need one tab for unstructured data.
         setNumberOfTabs(1, base_index[0], false);
 
-        // Tell the table about our data so it can display it 
+        // Tell the table about our data so it can display it
         // appropriately.
         int dims[] = {1,1,1};
         dims[1] = arr->GetNumberOfTuples();
-        tables[0]->setDataArray(arr, 0, missingDataArray, dims, 
+        tables[0]->setDataArray(arr, 0, missingDataArray, dims,
                 SpreadsheetTable::UCDNode, 0, base_index);
         tables[0]->setFormatString(plotAtts->GetFormatString().c_str());
         tables[0]->setRenderInColor(plotAtts->GetUseColorTable());
@@ -1251,11 +1251,11 @@ SpreadsheetViewer::displayUnstructuredGrid()
         // Make sure that we have the right number of tabs.
         setNumberOfTabs(1, base_index[0], false);
 
-        // Tell the table about our data so it can display it 
+        // Tell the table about our data so it can display it
         // appropriately.
         int dims[] = {1,1,1};
         dims[1] = arr->GetNumberOfTuples();
-        tables[0]->setDataArray(arr, ghostArray, missingDataArray, dims, 
+        tables[0]->setDataArray(arr, ghostArray, missingDataArray, dims,
                 SpreadsheetTable::UCDCell, 0, base_index);
         tables[0]->setFormatString(plotAtts->GetFormatString().c_str());
         tables[0]->setRenderInColor(plotAtts->GetUseColorTable());
@@ -1292,12 +1292,12 @@ SpreadsheetViewer::displayUnstructuredGrid()
 #define END_MINMAX \
         QString fmt, tmp;\
         fmt = tr("Min = ") + QString(plotAtts->GetFormatString().c_str());\
-        tmp.asprintf(fmt.toStdString().c_str(), minValue);\
+        tmp = QString::asprintf(fmt.toStdString().c_str(), minValue);\
         minButton->setText(tmp);\
         minButton->setEnabled(true);\
         debug5 << mName << "min=" << minValue << ", minCell=[" << minCell[0] << "," << minCell[1] << "," << minCell[2] << "]" << endl;\
         fmt = tr("Max = ") + QString(plotAtts->GetFormatString().c_str());\
-        tmp.asprintf(fmt.toStdString().c_str(), maxValue);\
+        tmp = QString::asprintf(fmt.toStdString().c_str(), maxValue);\
         maxButton->setText(tmp);\
         maxButton->setEnabled(true);\
         debug5 << mName << "max=" << maxValue << ", maxCell=[" << maxCell[0] << "," << maxCell[1] << "," << maxCell[2] << "]" << endl;
@@ -1306,7 +1306,7 @@ SpreadsheetViewer::displayUnstructuredGrid()
 // ****************************************************************************
 // Method: SpreadsheetViewer::calculateMinMaxCells
 //
-// Purpose: 
+// Purpose:
 //   Calculates the min,max of the dataset and where they are located within
 //   the spreadsheet.
 //
@@ -1327,7 +1327,7 @@ SpreadsheetViewer::displayUnstructuredGrid()
 // ****************************************************************************
 
 void
-SpreadsheetViewer::calculateMinMaxCells(int meshDims[3], 
+SpreadsheetViewer::calculateMinMaxCells(int meshDims[3],
     bool structured)
 {
     const char *mName = "SpreadsheetViewer::calculateMinMaxCells: ";
@@ -1455,7 +1455,7 @@ SpreadsheetViewer::calculateMinMaxCells(int meshDims[3],
         }
     }
     else if(arr != 0)
-    { 
+    {
         // Unstructured
         vtkIdType index = 0;
         BEGIN_MINMAX
@@ -1482,14 +1482,14 @@ SpreadsheetViewer::calculateMinMaxCells(int meshDims[3],
 // ****************************************************************************
 // Method: SpreadsheetViewer::updateMinMaxButtons
 //
-// Purpose: 
+// Purpose:
 //   Updates the min,max buttons with the min,max values.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Feb 20 14:13:43 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1502,7 +1502,7 @@ SpreadsheetViewer::updateMinMaxButtons()
 // ****************************************************************************
 // Method: SpreadsheetViewer::setNumberOfTabs
 //
-// Purpose: 
+// Purpose:
 //   Makes sure that the window has the correct number of tabs for the
 //   dataset that will be displayed.
 //
@@ -1518,7 +1518,7 @@ SpreadsheetViewer::updateMinMaxButtons()
 // Modifications:
 //   Brad Whitlock, Wed Jun 6 17:24:26 PST 2007
 //   Support using a single tab of values.
-//   
+//
 //   Gunther H. Weber, Thu Sep 27 13:33:36 PDT 2007
 //   Add support for setting spreadsheet font
 //
@@ -1611,11 +1611,11 @@ SpreadsheetViewer::setNumberOfTabs(int nt, int base, bool structured)
         if(!structured)
             name = tr("Unstructured");
         else if(plotAtts->GetNormal() == SpreadsheetAttributes::X)
-            name.asprintf("i=%d", i+base+offset);
+            name = QString("i=%1").arg(i+base+offset);
         else if(plotAtts->GetNormal() == SpreadsheetAttributes::Y)
-            name.asprintf("j=%d", i+base+offset);
+            name = QString("j=%1").arg(i+base+offset);
         else
-            name.asprintf("k=%d", i+base+offset);
+            name = QString("k=%1").arg(i+base+offset);
         zTabs->setTabText(i, name);
     }
     zTabs->blockSignals(false);
@@ -1636,7 +1636,7 @@ SpreadsheetViewer::setNumberOfTabs(int nt, int base, bool structured)
 // ****************************************************************************
 // Method: SpreadsheetViewer::updateSliderLabel
 //
-// Purpose: 
+// Purpose:
 //   Updates the slider label based on the slice index.
 //
 // Programmer: Brad Whitlock
@@ -1684,26 +1684,32 @@ SpreadsheetViewer::updateSliderLabel()
     QString kl;
     if(plotAtts->GetNormal() == SpreadsheetAttributes::X)
     {
-        kl.asprintf("i=%d [%d,%d]", base_index[0] + plotAtts->GetSliceIndex(), 
-            base_index[0], base_index[0] + nTablesForSlider - 1);
+        kl = QString("i=%1 [%2,%3]")
+             .arg(base_index[0] + plotAtts->GetSliceIndex())
+             .arg(base_index[0])
+             .arg(base_index[0] + nTablesForSlider - 1);
     }
     else if(plotAtts->GetNormal() == SpreadsheetAttributes::Y)
     {
-        kl.asprintf("j=%d [%d,%d]", base_index[1] + plotAtts->GetSliceIndex(), 
-            base_index[1], base_index[1] + nTablesForSlider - 1);
+        kl = QString("j=%1 [%2,%3]")
+             .arg(base_index[1] + plotAtts->GetSliceIndex())
+             .arg(base_index[1])
+             .arg(base_index[1] + nTablesForSlider - 1);
     }
     else
     {
-        kl.asprintf("k=%d [%d,%d]", base_index[2] + plotAtts->GetSliceIndex(), 
-            base_index[2], base_index[2] + nTablesForSlider - 1);
-    } 
+        kl = QString("k=%1 [%2,%3]")
+             .arg(base_index[2] + plotAtts->GetSliceIndex())
+             .arg(base_index[2])
+             .arg(base_index[2] + nTablesForSlider - 1);
+    }
     kLabel->setText(kl);
 }
 
 // ****************************************************************************
 // Method: SpreadsheetViewer::clear
 //
-// Purpose: 
+// Purpose:
 //   Disassociates the VTK data from the spreadsheets and redraws the active
 //   spreadsheet so it is cleared.
 //
@@ -1736,7 +1742,7 @@ SpreadsheetViewer::clear()
 // ****************************************************************************
 // Method: SpreadsheetViewer::updateMenuEnabledState
 //
-// Purpose: 
+// Purpose:
 //   Sets the enabled state of the window's menus based on the table's
 //   number of selections.
 //
@@ -1786,21 +1792,21 @@ SpreadsheetViewer::updateMenuEnabledState(int tableIndex)
 // ****************************************************************************
 // Method: SpreadsheetViewer::GetPickIJK
 //
-// Purpose: 
+// Purpose:
 //   Determine the IJK from the pick element.
 //
 // Arguments:
 //   pickId   : The pick element.
 //   pickType : 0 == zone, otherwise, node pick.
 //   ijk      : The return ijk values.
-//   
-// Returns:    
+//
+// Returns:
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue May 26 11:05:30 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -1861,15 +1867,15 @@ SpreadsheetViewer::GetPickIJK(int pickId, int pickType, int *ijk) const
 // ****************************************************************************
 // Method: SpreadSheetViewer::moveSliceToCurrentPick()
 //
-// Purpose: 
+// Purpose:
 //   Moves the displayed slice to the current pick point
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //;   Whether the slice was moved
 //
-// Note:       
+// Note:
 //
 // Programmer: Gunther H. Weber
 // Creation:   Mon Sep 10 15:05:01 PDT 2007
@@ -1937,7 +1943,7 @@ SpreadsheetViewer::moveSliceToCurrentPick()
                     debug1 << mName << "Setting slice index to: " << ijk[sliceAxis] << endl;
                     // Set the slice index that we calculated into the plotAtts.
                     plotAtts->SetSliceIndex(ijk[sliceAxis]);
- 
+
                     // Issue a Notify from the main event loop.
                     QTimer::singleShot(0, this, SLOT(postNotify()));
                     retval = true;
@@ -1951,14 +1957,14 @@ SpreadsheetViewer::moveSliceToCurrentPick()
 // ****************************************************************************
 // Method: SpreadSheetViewer::selectPickPoints
 //
-// Purpose: 
+// Purpose:
 //   Updates pick points in spreadsheet.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Gunther H. Weber
 // Creation:   Mon Sep 10 15:05:01 PDT 2007
@@ -2033,7 +2039,7 @@ SpreadsheetViewer::selectPickPoints()
 #ifndef SINGLE_TAB_WINDOW
             else if (ijk[0] != -1)
 #else
-            // In single slice mode we only need to handle the current 
+            // In single slice mode we only need to handle the current
             // pick if the spreadsheet is visible
             else if (ijk[0] != -1 && ijk[sliceAxis] == plotAtts->GetSliceIndex())
 #endif
@@ -2060,7 +2066,7 @@ SpreadsheetViewer::selectPickPoints()
 
 #ifndef SINGLE_TAB_WINDOW
                 debug1 << mName << "Setting current cell (" << row << ", " << col << ")"
-                       << std::endl; 
+                       << std::endl;
                 QModelIndex id = tables[activeTable]->model()->index(row, col);
                 tables[activeTable]->selectionModel()->setCurrentIndex(id, QItemSelectionModel::ClearAndSelect);
 #else
@@ -2078,7 +2084,7 @@ SpreadsheetViewer::selectPickPoints()
 #endif
             }
 
-            // Now, go through the old picks 
+            // Now, go through the old picks
             const std::vector<double>& pastPicks = plotAtts->GetPastPicks();
             const std::vector<std::string>& pastPickLetters = plotAtts->GetPastPickLetters();
             size_t numOldPicks = pastPicks.size() / 2;
@@ -2143,7 +2149,7 @@ SpreadsheetViewer::selectPickPoints()
 // ****************************************************************************
 // Method: SpreadsheetViewer::formatChanged
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when the format is changed and causes the spreadsheets
 //   to update using the new format.
 //
@@ -2151,7 +2157,7 @@ SpreadsheetViewer::selectPickPoints()
 // Creation:   Tue Feb 20 14:16:07 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2166,7 +2172,7 @@ SpreadsheetViewer::formatChanged()
 // ****************************************************************************
 // Method: SpreadsheetViewer::sliderChanged
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when the slider changes. We use it to set the active
 //   slice index in the plot attributes and also make sure that the right
 //   spreadshset page is visible.
@@ -2211,14 +2217,14 @@ SpreadsheetViewer::sliderChanged(int slice)
 // ****************************************************************************
 // Method: SpreadsheetViewer::sliderPressed
 //
-// Purpose: 
+// Purpose:
 //   Sets a flag that tells us to ignore updates while the slider is moving.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Feb 22 13:43:02 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2234,7 +2240,7 @@ SpreadsheetViewer::sliderPressed()
 // ****************************************************************************
 // Method: SpreadsheetViewer::sliderReleased
 //
-// Purpose: 
+// Purpose:
 //   Sets a flag that tells us not to ignore updates.
 //
 // Programmer: Brad Whitlock
@@ -2260,9 +2266,9 @@ SpreadsheetViewer::sliderReleased()
 // ****************************************************************************
 // Method: SpreadsheetViewer::tabChanged
 //
-// Purpose: 
-//   This slot is called when the active tab changes. We use it to set the 
-//   active slice index in the plot attributes and also make sure that the 
+// Purpose:
+//   This slot is called when the active tab changes. We use it to set the
+//   active slice index in the plot attributes and also make sure that the
 //   right spreadshset page is visible.
 //
 // Arguments:
@@ -2298,7 +2304,7 @@ SpreadsheetViewer::tabChanged(int index)
 // ****************************************************************************
 // Method: SpreadsheetViewer::normalChanged
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when we want to change how the data are sliced.
 //
 // Arguments:
@@ -2308,7 +2314,7 @@ SpreadsheetViewer::tabChanged(int index)
 // Creation:   Tue Feb 20 14:18:06 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2325,7 +2331,7 @@ SpreadsheetViewer::normalChanged(int val)
 // ****************************************************************************
 // Method: SpreadsheetViewer::colorTableCheckBoxToggled
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when we want to change whether colors are used in
 //   the spreadsheet.
 //
@@ -2336,7 +2342,7 @@ SpreadsheetViewer::normalChanged(int val)
 // Creation:   Tue Feb 20 14:18:34 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2349,7 +2355,7 @@ SpreadsheetViewer::colorTableCheckBoxToggled(bool val)
 // ****************************************************************************
 // Method: SpreadsheetViewer::tracerCheckBoxToggled
 //
-// Purpose: 
+// Purpose:
 //   This slot turns the highlight plane on/off.
 //
 // Arguments:
@@ -2359,7 +2365,7 @@ SpreadsheetViewer::colorTableCheckBoxToggled(bool val)
 // Creation:   Tue Feb 20 14:19:17 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2372,7 +2378,7 @@ SpreadsheetViewer::tracerCheckBoxToggled(bool val)
 // ****************************************************************************
 // Method: SpreadsheetViewer::outlineCheckBoxToggled
 //
-// Purpose: 
+// Purpose:
 //   This slot turns the patch outline on/off.
 //
 // Arguments:
@@ -2382,7 +2388,7 @@ SpreadsheetViewer::tracerCheckBoxToggled(bool val)
 // Creation:   Tue Oct 16 20:40:50 PDT 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2395,7 +2401,7 @@ SpreadsheetViewer::outlineCheckBoxToggled(bool val)
 // ****************************************************************************
 // Method: SpreadsheetViewer::showCurrentCellOutlineCheckBoxToggled
 //
-// Purpose: 
+// Purpose:
 //   This slot turns the current cell on/off.
 //
 // Arguments:
@@ -2405,7 +2411,7 @@ SpreadsheetViewer::outlineCheckBoxToggled(bool val)
 // Creation:   Wed Nov 28 15:27:10 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2418,7 +2424,7 @@ SpreadsheetViewer::showCurrentCellOutlineCheckBoxToggled(bool val)
 // ****************************************************************************
 // Method: SpreadsheetViewer::minClicked
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when the min button is clicked and we make the
 //   window highlight the min value in the spreadsheet.
 //
@@ -2475,7 +2481,7 @@ SpreadsheetViewer::minClicked()
 // ****************************************************************************
 // Method: SpreadsheetViewer::maxClicked
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when the max button is clicked and we make the
 //   window highlight the max value in the spreadsheet.
 //
@@ -2532,14 +2538,14 @@ SpreadsheetViewer::maxClicked()
 // ****************************************************************************
 // Method: SpreadsheetViewer::postNotify
 //
-// Purpose: 
+// Purpose:
 //   This slot is used to force a plot attributes notify from the main event loop.
 //
 // Programmer: Brad Whitlock
 // Creation:   Tue Feb 20 14:20:42 PST 2007
 //
 // Modifications:
-//   
+//
 //    Hank Childs, Thu Sep 20 11:18:18 PDT 2007
 //    Make sure the active plots stay the same.
 //
@@ -2578,7 +2584,7 @@ SpreadsheetViewer::postNotify()
 // ****************************************************************************
 // Method: SpreadsheetViewer::selectedColorTable
 //
-// Purpose: 
+// Purpose:
 //   This slot is called when we change the color table name.
 //
 // Arguments:
@@ -2588,7 +2594,7 @@ SpreadsheetViewer::postNotify()
 // Creation:   Tue Feb 20 14:21:14 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2602,7 +2608,7 @@ SpreadsheetViewer::selectedColorTable(bool, const QString &ctName)
 // ****************************************************************************
 // Method: SpreadsheetViewer::changedVariable
 //
-// Purpose: 
+// Purpose:
 //   This slot if called when we select a new variable from the variable button.
 //
 // Arguments:
@@ -2612,7 +2618,7 @@ SpreadsheetViewer::selectedColorTable(bool, const QString &ctName)
 // Creation:   Thu Feb 22 13:23:45 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2630,7 +2636,7 @@ SpreadsheetViewer::changedVariable(const QString &newVar)
 // ****************************************************************************
 // Method: SpreadsheetViewer::saveAsText
 //
-// Purpose: 
+// Purpose:
 //   This slot saves the selected cells to a text file.
 //
 // Programmer: Brad Whitlock
@@ -2654,7 +2660,7 @@ SpreadsheetViewer::saveAsText()
     if(nTables > 0)
     {
         // Get the name of the file that the user wants to save
-        QString fileName = QFileDialog::getSaveFileName(this, tr("Save as"), 
+        QString fileName = QFileDialog::getSaveFileName(this, tr("Save as"),
             tr("selection.txt"), tr("Text (*.txt)"));
 
         // If the user chose to save a file, write it out.
@@ -2686,7 +2692,7 @@ SpreadsheetViewer::saveAsText()
 // ****************************************************************************
 // Method: SpreadsheetViewer::copySelectionToClipboard
 //
-// Purpose: 
+// Purpose:
 //   This slot saves the selected cells to the clipboard so they can be
 //   pasted into other applications.
 //
@@ -2694,7 +2700,7 @@ SpreadsheetViewer::saveAsText()
 // Creation:   Thu Feb 22 13:24:45 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2713,14 +2719,14 @@ SpreadsheetViewer::copySelectionToClipboard()
 // ****************************************************************************
 // Method: SpreadsheetViewer::selectAll
 //
-// Purpose: 
+// Purpose:
 //   This slot selects all cells in the active table.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Feb 22 13:25:30 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2736,14 +2742,14 @@ SpreadsheetViewer::selectAll()
 // ****************************************************************************
 // Method: SpreadsheetViewer::selectNone
 //
-// Purpose: 
+// Purpose:
 //   This slot clears the selection from the active table.
 //
 // Programmer: Brad Whitlock
 // Creation:   Thu Feb 22 13:25:48 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2759,7 +2765,7 @@ SpreadsheetViewer::selectNone()
 // ****************************************************************************
 // Method: SpreadsheetViewer::operationSum
 //
-// Purpose: 
+// Purpose:
 //   This slot calculates the sum of the selected cells and displays the sum
 //   in a message box.
 //
@@ -2779,8 +2785,8 @@ SpreadsheetViewer::operationSum()
     {
         SpreadsheetTable *t = (SpreadsheetTable *)zTabs->currentWidget();
         double sum = t->selectedCellsSum();
-        QString sumStr;
-        sumStr.asprintf(plotAtts->GetFormatString().c_str(), sum);
+        QString sumStr =
+            QString::asprintf(plotAtts->GetFormatString().c_str(), sum);
         QString msg(tr("The sum of the selected cells is: %1.").arg(sumStr));
         QMessageBox::information(this, tr("Sum results"), msg, QMessageBox::Ok);
     }
@@ -2789,8 +2795,8 @@ SpreadsheetViewer::operationSum()
 // ****************************************************************************
 // Method: SpreadsheetViewer::operationAverage
 //
-// Purpose: 
-//   This slot calculates the average of the selected cells and displays the 
+// Purpose:
+//   This slot calculates the average of the selected cells and displays the
 //   average in a message box.
 //
 // Programmer: Brad Whitlock
@@ -2799,7 +2805,7 @@ SpreadsheetViewer::operationSum()
 // Modifications:
 //   Brad Whitlock, Wed Apr 23 11:35:09 PDT 2008
 //   Support for internationalization.
-//   
+//
 // ****************************************************************************
 
 void
@@ -2809,8 +2815,8 @@ SpreadsheetViewer::operationAverage()
     {
         SpreadsheetTable *t = (SpreadsheetTable *)zTabs->currentWidget();
         double avg = t->selectedCellsAverage();
-        QString avgStr;
-        avgStr.asprintf(plotAtts->GetFormatString().c_str(), avg);
+        QString avgStr =
+            QString::asprintf(plotAtts->GetFormatString().c_str(), avg);
         QString msg(tr("The average value of the selected cells is: %1.").arg(avgStr));
         QMessageBox::information(this, "Average results", msg, QMessageBox::Ok);
     }
@@ -2819,24 +2825,24 @@ SpreadsheetViewer::operationAverage()
 // ****************************************************************************
 // Method: SpreadsheetViewer::GetDataVsCoordinate
 //
-// Purpose: 
+// Purpose:
 //   Extract data and make a curve.
 //
 // Arguments:
 //
-// Returns:    
+// Returns:
 //
-// Note:       
+// Note:
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri May  8 16:53:13 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
-SpreadsheetViewer::GetDataVsCoordinate(double *curve, const vtkIdType *indices, 
+SpreadsheetViewer::GetDataVsCoordinate(double *curve, const vtkIdType *indices,
     int nvals, int coord) const
 {
     const char *mName = "SpreadsheetViewer::GetDataVsCoordinate: ";
@@ -2929,7 +2935,7 @@ SpreadsheetViewer::GetDataVsCoordinate(double *curve, const vtkIdType *indices,
                 vtkIdType nodeId = K*dims[1]*dims[0] + J*dims[0] + I;
 
                 curve[i*2  ] = sgrid->GetPoint(nodeId)[comp];
-                curve[i*2+1] = arr->GetTuple1(indices[i]); 
+                curve[i*2+1] = arr->GetTuple1(indices[i]);
             }
         }
         else
@@ -2949,7 +2955,7 @@ SpreadsheetViewer::GetDataVsCoordinate(double *curve, const vtkIdType *indices,
 // ****************************************************************************
 // Method: SpreadsheetViewer::DisplayCurve
 //
-// Purpose: 
+// Purpose:
 //   Display curve data in a new window.
 //
 // Arguments:
@@ -2960,7 +2966,7 @@ SpreadsheetViewer::GetDataVsCoordinate(double *curve, const vtkIdType *indices,
 // Creation:   Fri May  8 16:52:44 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -2974,14 +2980,14 @@ SpreadsheetViewer::DisplayCurve(const double *vals, int nvals)
 // ****************************************************************************
 // Method: SpreadsheetViewer::operationCurveX
 //
-// Purpose: 
+// Purpose:
 //   Extract a row of data, match it with the X values and make a curve.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri May  8 16:52:04 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3022,14 +3028,14 @@ SpreadsheetViewer::operationCurveX1()
 // ****************************************************************************
 // Method: SpreadsheetViewer::operationCurveY
 //
-// Purpose: 
+// Purpose:
 //   Extract a column of data, match it with the X values and make a curve.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri May  8 16:52:04 PDT 2009
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -3070,7 +3076,7 @@ SpreadsheetViewer::operationCurveY1()
 // ****************************************************************************
 // Method: SpreadsheetViewer::tableSelectionChanged
 //
-// Purpose: 
+// Purpose:
 //   This slot is called by any table when its selection changes. We use it to
 //   ensure that the menus are updated appropriately for the active table.
 //

--- a/src/tools/dev/xmledit/XMLEditFields.C
+++ b/src/tools/dev/xmledit/XMLEditFields.C
@@ -1135,6 +1135,9 @@ XMLEditFields::valuesChanged()
 //    Cyrus Harrison, Thu May 15 16:00:46 PDT 200
 //    First pass at porting to Qt 4.4.0
 //
+//    Kathleen Biagas, Thu Jan 21, 2021
+//    Replace use of QString.asprint with QString.arg.
+//
 // ****************************************************************************
 void
 XMLEditFields::fieldlistNew()

--- a/src/tools/dev/xmledit/XMLEditFields.C
+++ b/src/tools/dev/xmledit/XMLEditFields.C
@@ -462,7 +462,7 @@ XMLEditFields::UpdateWindowSingleItem()
         if (f->type.right(5) == "Array")
         {
             QString str;
-            str.asprintf("%d",f->length);
+            str.setNum(f->length);
             length->setText(str);
         }
         else
@@ -1146,7 +1146,7 @@ XMLEditFields::fieldlistNew()
     while (!okay)
     {
         okay = true;
-        newname.asprintf("unnamed%d", newid);
+        newname = QString("unnamed%1").arg(newid);
         for (int i=0; i<fieldlist->count() && okay; i++)
         {
             if (fieldlist->item(i)->text() == newname)

--- a/src/tools/dev/xmledit/XMLEditIncludes.C
+++ b/src/tools/dev/xmledit/XMLEditIncludes.C
@@ -417,6 +417,9 @@ XMLEditIncludes::quotedGroupChanged(int qg)
 //    Cyrus Harrison, Thu May 15 16:00:46 PDT 200
 //    First pass at porting to Qt 4.4.0
 //
+//    Kathleen Biagas, Thu Jan 21, 2021
+//    Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 void
 XMLEditIncludes::includelistNew()

--- a/src/tools/dev/xmledit/XMLEditIncludes.C
+++ b/src/tools/dev/xmledit/XMLEditIncludes.C
@@ -428,7 +428,7 @@ XMLEditIncludes::includelistNew()
     while (!okay)
     {
         okay = true;
-        newname.asprintf("unnamed%d", newid);
+        newname = QString("unnamed%1").arg(newid);
         for (int i=0; i<includelist->count() && okay; i++)
         {
             if (includelist->item(i)->text() == newname)

--- a/src/viewer/main/ui/PlotAndOperatorActionsUI.C
+++ b/src/viewer/main/ui/PlotAndOperatorActionsUI.C
@@ -50,7 +50,7 @@
 // ****************************************************************************
 // Method: AddOperatorActionUI::AddOperatorActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the AddOperator action.
 //
 // Arguments:
@@ -91,7 +91,7 @@ AddOperatorActionUI::AddOperatorActionUI(ViewerActionLogic *L) :
         info = pluginMgr->GetViewerPluginInfo(pluginMgr->GetEnabledID(i));
         if(info)
         {
-            if(!GetViewerProperties()->GetNowin() && 
+            if(!GetViewerProperties()->GetNowin() &&
                info->XPMIconData() != 0 &&
                info->GetUserSelectable())
             {
@@ -102,8 +102,8 @@ AddOperatorActionUI::AddOperatorActionUI(ViewerActionLogic *L) :
                 {
                     // Create a pixmap for the operator or get its pixmap from
                     // the pixmap cache.
-                    QString key;
-                    key.asprintf("operator_icon_%s", info->GetName());
+                    QString key =
+                        QString("operator_icon_%1").arg(info->GetName());
                     QPixmap pix;
                     if(!QPixmapCache::find(key, &pix))
                     {
@@ -128,14 +128,14 @@ AddOperatorActionUI::AddOperatorActionUI(ViewerActionLogic *L) :
 // ****************************************************************************
 // Method: AddOperatorActionUI::~AddOperatorActionUI
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the AddOperatorActionUI class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Mon Mar 17 09:20:04 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 AddOperatorActionUI::~AddOperatorActionUI()
@@ -145,7 +145,7 @@ AddOperatorActionUI::~AddOperatorActionUI()
 // ****************************************************************************
 // Method: AddOperatorActionUI::Enabled()
 //
-// Purpose: 
+// Purpose:
 //   This method indicates when the action is enabled.
 //
 // Returns:    A bool indicating when the action is enabled.
@@ -172,7 +172,7 @@ AddOperatorActionUI::Enabled() const
 // ****************************************************************************
 // Method: AddOperatorActionUI::ChoiceEnabled
 //
-// Purpose: 
+// Purpose:
 //   This method indicates when individual choices in the action are enabled.
 //
 // Returns:    true
@@ -181,7 +181,7 @@ AddOperatorActionUI::Enabled() const
 // Creation:   Mon Mar 17 09:22:55 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -193,7 +193,7 @@ AddOperatorActionUI::ChoiceEnabled(int) const
 // ****************************************************************************
 // Method: AddOperatorActionUI::ConstructToolbar
 //
-// Purpose: 
+// Purpose:
 //   Adds the action's operators to the toolbar.
 //
 // Arguments:
@@ -221,7 +221,7 @@ AddOperatorActionUI::ConstructToolbar(QToolBar *toolbar)
 // ****************************************************************************
 // Method: RemoveLastOperatorActionUI::RemoveLastOperatorActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the RemoveLastOperatorActionUI class.
 //
 // Arguments:
@@ -231,7 +231,7 @@ AddOperatorActionUI::ConstructToolbar(QToolBar *toolbar)
 // Creation:   Thu Mar 20 12:41:50 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 RemoveLastOperatorActionUI::RemoveLastOperatorActionUI(ViewerActionLogic *L) : ViewerActionUISingle(L)
@@ -244,7 +244,7 @@ RemoveLastOperatorActionUI::RemoveLastOperatorActionUI(ViewerActionLogic *L) : V
 // ****************************************************************************
 // Method: RemoveLastOperatorActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns when this action is enabled.
 //
 // Returns:    Returns true when the action is enabled; false otherwise.
@@ -255,7 +255,7 @@ RemoveLastOperatorActionUI::RemoveLastOperatorActionUI(ViewerActionLogic *L) : V
 // Modifications:
 //   Eric Brugger, Wed Aug 20 10:53:00 PDT 2003
 //   I removed the disabling of the action in curve windows.
-//   
+//
 // ****************************************************************************
 
 bool
@@ -271,7 +271,7 @@ RemoveLastOperatorActionUI::Enabled() const
 // ****************************************************************************
 // Method: RemoveAllOperatorsActionUI::RemoveAllOperatorsActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the RemoveAllOperatorsActionUI class.
 //
 // Arguments:
@@ -281,10 +281,10 @@ RemoveLastOperatorActionUI::Enabled() const
 // Creation:   Thu Mar 20 12:41:50 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
-RemoveAllOperatorsActionUI::RemoveAllOperatorsActionUI(ViewerActionLogic *L) : 
+RemoveAllOperatorsActionUI::RemoveAllOperatorsActionUI(ViewerActionLogic *L) :
     ViewerActionUISingle(L)
 {
     SetAllText(tr("Remove all operators"));
@@ -295,7 +295,7 @@ RemoveAllOperatorsActionUI::RemoveAllOperatorsActionUI(ViewerActionLogic *L) :
 // ****************************************************************************
 // Method: RemoveAllOperatorsActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns when this action is enabled.
 //
 // Returns:    True if the action is enabled; false otherwise.
@@ -309,7 +309,7 @@ RemoveAllOperatorsActionUI::RemoveAllOperatorsActionUI(ViewerActionLogic *L) :
 //
 //   Eric Brugger, Wed Aug 20 10:53:00 PDT 2003
 //   I removed the disabling of the action in curve windows.
-//   
+//
 // ****************************************************************************
 
 bool
@@ -325,7 +325,7 @@ RemoveAllOperatorsActionUI::Enabled() const
 // ****************************************************************************
 // Method: AddPlotActionUI::AddPlotActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the AddPlotActionUI class.
 //
 // Arguments:
@@ -384,8 +384,8 @@ AddPlotActionUI::AddPlotActionUI(ViewerActionLogic *L) : ViewerActionUIMultiple(
                 // the pixmap cache.
                 if(!GetViewerProperties()->GetNowin())
                 {
-                    QString key;
-                    key.asprintf("plot_icon_%s", info->GetName());
+                    QString key =
+                     QString("plot_icon_%1").arg(info->GetName());
                     QPixmap pix;
                     if(!QPixmapCache::find(key, &pix))
                     {
@@ -418,7 +418,7 @@ AddPlotActionUI::AddPlotActionUI(ViewerActionLogic *L) : ViewerActionUIMultiple(
 // ****************************************************************************
 // Method: AddPlotActionUI::~AddPlotActionUI
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the AddPlotActionUI class.
 //
 // Note:       We manually delete the menus because they have no parent widget.
@@ -427,7 +427,7 @@ AddPlotActionUI::AddPlotActionUI(ViewerActionLogic *L) : ViewerActionUIMultiple(
 // Creation:   Thu Mar 20 12:42:34 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 AddPlotActionUI::~AddPlotActionUI()
@@ -439,7 +439,7 @@ AddPlotActionUI::~AddPlotActionUI()
 // ****************************************************************************
 // Method: AddPlotActionUI::Update
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the action needs to be updated.
 //
 // Programmer: Brad Whitlock
@@ -551,7 +551,7 @@ AddPlotActionUI::Update()
 
                     int varCount = menuPopulator.UpdateSingleVariableMenu(
                         pluginEntries[i].varMenu,
-                        pluginEntries[i].varTypes, this, 
+                        pluginEntries[i].varTypes, this,
                         SLOT(addPlot(int, const QString &)));
                     bool hasEntries = (varCount > 0);
 
@@ -569,7 +569,7 @@ AddPlotActionUI::Update()
 // ****************************************************************************
 // Method: AddPlotActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   This method lets callers know if the action's menu should be enabled.
 //
 // Programmer: Brad Whitlock
@@ -581,7 +581,7 @@ AddPlotActionUI::Update()
 //
 //   Eric Brugger, Wed Aug 20 10:53:00 PDT 2003
 //   I removed the disabling of the action in curve windows.
-//   
+//
 // ****************************************************************************
 
 bool
@@ -595,7 +595,7 @@ AddPlotActionUI::Enabled() const
 // ****************************************************************************
 // Method: AddPlotActionUI::ChoiceEnabled
 //
-// Purpose: 
+// Purpose:
 //   This method lets callers know a choice in the action's menu should
 //   be enabled.
 //
@@ -606,7 +606,7 @@ AddPlotActionUI::Enabled() const
 // Creation:   Thu Mar 20 12:46:09 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -618,7 +618,7 @@ AddPlotActionUI::ChoiceEnabled(int i) const
 // ****************************************************************************
 // Method: AddPlotActionUI::CreatePlotMenu
 //
-// Purpose: 
+// Purpose:
 //   This method creates the i'th plot menu.
 //
 // Arguments:
@@ -628,7 +628,7 @@ AddPlotActionUI::ChoiceEnabled(int i) const
 // Creation:   Fri Nov 19 15:09:34 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -648,7 +648,7 @@ AddPlotActionUI::CreatePlotMenu(int i)
 // ****************************************************************************
 // Method: AddPlotActionUI::DeletePlotMenu
 //
-// Purpose: 
+// Purpose:
 //   This method deletes the i'th plot menu.
 //
 // Arguments:
@@ -658,7 +658,7 @@ AddPlotActionUI::CreatePlotMenu(int i)
 // Creation:   Fri Nov 19 15:09:34 PST 2010
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -674,7 +674,7 @@ AddPlotActionUI::DeletePlotMenu(int i)
 // ****************************************************************************
 // Method: AddPlotActionUI::ConstructMenu
 //
-// Purpose: 
+// Purpose:
 //   This method constructs a menu that contains the plots that are available.
 //
 // Arguments:
@@ -688,7 +688,7 @@ AddPlotActionUI::DeletePlotMenu(int i)
 //   Qt 4.
 //
 //   Mark C. Miller, Thu Jun  8 15:10:46 PDT 2017
-//   Add logic to catch the aboutToShow() signal indicating the menu is 
+//   Add logic to catch the aboutToShow() signal indicating the menu is
 //   about to be shown.
 // ****************************************************************************
 
@@ -720,7 +720,7 @@ AddPlotActionUI::ConstructMenu(QMenu *menu)
 // ****************************************************************************
 // Method: AddPlotActionUI::RemoveFromMenu
 //
-// Purpose: 
+// Purpose:
 //   Removes the action from the menu.
 //
 // Arguments:
@@ -730,7 +730,7 @@ AddPlotActionUI::ConstructMenu(QMenu *menu)
 // Creation:   Thu Mar 20 12:47:43 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 void
@@ -768,7 +768,7 @@ AddPlotActionUI::addPlotAboutToShow()
 // ****************************************************************************
 // Method: AddPlotActionUI::ConstructToolbar
 //
-// Purpose: 
+// Purpose:
 //   Adds the action's plots to the toolbar.
 //
 // Arguments:
@@ -805,7 +805,7 @@ AddPlotActionUI::ConstructToolbar(QToolBar *toolbar)
 // ****************************************************************************
 // Method: AddPlotActionUI::addPlot
 //
-// Purpose: 
+// Purpose:
 //   This is a Qt slot function, which is private to this class, that is called
 //   when the user makes a selection from one of the variable menus.
 //
@@ -841,7 +841,7 @@ AddPlotActionUI::addPlot(int index, const QString &var)
 // ****************************************************************************
 // Method: AddPlotActionUI::changeMenuIconSize
 //
-// Purpose: 
+// Purpose:
 //   This method is called when the vis window changes its icon size.
 //
 // Arguments:
@@ -897,7 +897,7 @@ AddPlotActionUI::changeMenuIconSize(bool large)
 // ****************************************************************************
 // Method: DrawPlotsActionUI::DrawPlotsActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the DrawPlotsActionUI class.
 //
 // Arguments:
@@ -907,7 +907,7 @@ AddPlotActionUI::changeMenuIconSize(bool large)
 // Creation:   Fri Mar 21 15:55:52 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 DrawPlotsActionUI::DrawPlotsActionUI(ViewerActionLogic *L) : ViewerActionUISingle(L)
@@ -918,14 +918,14 @@ DrawPlotsActionUI::DrawPlotsActionUI(ViewerActionLogic *L) : ViewerActionUISingl
 // ****************************************************************************
 // Method: DrawPlotsActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the action is enabled.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Mar 21 15:51:48 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -941,7 +941,7 @@ DrawPlotsActionUI::Enabled() const
 // ****************************************************************************
 // Method: HideActivePlotsActionUI::HideActivePlotsActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the HideActivePlotsActionUI class.
 //
 // Arguments:
@@ -951,7 +951,7 @@ DrawPlotsActionUI::Enabled() const
 // Creation:   Fri Mar 21 15:54:54 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 HideActivePlotsActionUI::HideActivePlotsActionUI(ViewerActionLogic *L) : ViewerActionUISingle(L)
@@ -963,14 +963,14 @@ HideActivePlotsActionUI::HideActivePlotsActionUI(ViewerActionLogic *L) : ViewerA
 // ****************************************************************************
 // Method: HideActivePlotsActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the action is enabled.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Mar 21 15:51:48 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -986,7 +986,7 @@ HideActivePlotsActionUI::Enabled() const
 // ****************************************************************************
 // Method: DeleteActivePlotsActionUI::DeleteActivePlotsActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the DeleteActivePlotsActionUI class.
 //
 // Arguments:
@@ -996,7 +996,7 @@ HideActivePlotsActionUI::Enabled() const
 // Creation:   Fri Mar 21 15:50:38 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 DeleteActivePlotsActionUI::DeleteActivePlotsActionUI(ViewerActionLogic *L) :
@@ -1009,14 +1009,14 @@ DeleteActivePlotsActionUI::DeleteActivePlotsActionUI(ViewerActionLogic *L) :
 // ****************************************************************************
 // Method: DeleteActivePlotsActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the action is enabled.
 //
 // Programmer: Brad Whitlock
 // Creation:   Fri Mar 21 15:51:48 PST 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -1032,7 +1032,7 @@ DeleteActivePlotsActionUI::Enabled() const
 // ****************************************************************************
 // Method: CopyPlotActionUI::CopyPlotActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the CopyPlotActionUI class.
 //
 // Arguments:
@@ -1042,7 +1042,7 @@ DeleteActivePlotsActionUI::Enabled() const
 // Creation:   Fri Sept 28 15:38:54 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 CopyPlotActionUI::CopyPlotActionUI(ViewerActionLogic *L) : ViewerActionUISingle(L)
@@ -1054,14 +1054,14 @@ CopyPlotActionUI::CopyPlotActionUI(ViewerActionLogic *L) : ViewerActionUISingle(
 // ****************************************************************************
 // Method: CopyPlotActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the action is enabled.
 //
 // Programmer: Ellen Tarwater
 // Creation:   Fri Sept 28 15:54:27 PST 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -1077,7 +1077,7 @@ CopyPlotActionUI::Enabled() const
 // ****************************************************************************
 // Method: SetPlotFollowsTimeActionUI::SetPlotFollowsTimeActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the SetPlotFollowsTimeActionUI class.
 //
 // Arguments:
@@ -1102,14 +1102,14 @@ SetPlotFollowsTimeActionUI::SetPlotFollowsTimeActionUI(ViewerActionLogic *L) :
 // ****************************************************************************
 // Method: SetPlotFollowsTimeActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns whether the action is enabled.
 //
 // Programmer: Ellen Tarwater
 // Creation:   Thurs, Dec 6, 2007
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool

--- a/src/viewer/main/ui/PlotAndOperatorActionsUI.C
+++ b/src/viewer/main/ui/PlotAndOperatorActionsUI.C
@@ -71,6 +71,9 @@
 //   Brad Whitlock, Fri Sep 12 12:20:02 PDT 2014
 //   Do the menu name translation here instead of in the plugin.
 //
+//   Kathleen Biagas, Thu Jan 21, 2021
+//   Replace QString.asprintf with QString.arg.
+//
 // ****************************************************************************
 
 AddOperatorActionUI::AddOperatorActionUI(ViewerActionLogic *L) :

--- a/src/viewer/main/ui/ViewActionsUI.C
+++ b/src/viewer/main/ui/ViewActionsUI.C
@@ -103,7 +103,7 @@ UndoViewActionUI::UndoViewActionUI(ViewerActionLogic *L) :
 bool
 UndoViewActionUI::Enabled() const
 {
-    // This ActionUI should only be enabled if the window to which the 
+    // This ActionUI should only be enabled if the window to which the
     // ActionUI belongs has plots in it and there are views to undo.
     return (GetLogic()->GetWindow()->GetPlotList()->GetNumPlots() > 0) &&
             GetLogic()->GetWindow()->UndoViewEnabled();
@@ -121,7 +121,7 @@ RedoViewActionUI::RedoViewActionUI(ViewerActionLogic *L) : ViewerActionUISingle(
 bool
 RedoViewActionUI::Enabled() const
 {
-    // This ActionUI should only be enabled if the window to which the 
+    // This ActionUI should only be enabled if the window to which the
     // ActionUI belongs has plots in it and there are views to Redo.
     return (GetLogic()->GetWindow()->GetPlotList()->GetNumPlots() > 0) &&
             GetLogic()->GetWindow()->RedoViewEnabled();
@@ -129,7 +129,7 @@ RedoViewActionUI::Enabled() const
 
 ///////////////////////////////////////////////////////////////////////////////
 
-ToggleFullFrameActionUI::ToggleFullFrameActionUI(ViewerActionLogic *L) : 
+ToggleFullFrameActionUI::ToggleFullFrameActionUI(ViewerActionLogic *L) :
     ViewerActionUIToggle(L)
 {
     SetAllText(tr("Full frame"));
@@ -139,7 +139,7 @@ ToggleFullFrameActionUI::ToggleFullFrameActionUI(ViewerActionLogic *L) :
 bool
 ToggleFullFrameActionUI::Enabled() const
 {
-    // This ActionUI should only be enabled if the window to which the ActionUI 
+    // This ActionUI should only be enabled if the window to which the ActionUI
     // belongs has plots in it, and is 2D.
     return (GetLogic()->GetWindow()->GetPlotList()->GetNumPlots() > 0) &&
            (GetLogic()->GetWindow()->GetWindowMode() == WINMODE_2D);
@@ -156,7 +156,7 @@ ToggleFullFrameActionUI::Checked() const
 // ****************************************************************************
 // Method: SaveViewActionUI::SaveViewActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the SaveViewActionUI class.
 //
 // Arguments:
@@ -207,14 +207,14 @@ SaveViewActionUI::SaveViewActionUI(ViewerActionLogic *L) : ViewerActionUIMultipl
 // ****************************************************************************
 // Method: SaveViewActionUI::~SaveViewActionUI
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the SaveViewActionUI class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Feb 26 08:53:31 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 SaveViewActionUI::~SaveViewActionUI()
@@ -269,7 +269,7 @@ SaveViewActionUI::Update()
                 QPixmap icon(blankcamera_xpm);
                 QPainter paint(&icon);
                 QString str;
-                str.asprintf("%d", nGUIViews + i + 1);
+                str.setNum(nGUIViews + i + 1);
                 paint.setPen(QColor(0,255,0));
                 QFont f(QApplication::font());
                 f.setBold(true);
@@ -312,14 +312,14 @@ SaveViewActionUI::Update()
 // ****************************************************************************
 // Method: SaveViewActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Tells when this ActionUI is enabled.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Feb 26 08:53:46 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -332,7 +332,7 @@ SaveViewActionUI::Enabled() const
 // ****************************************************************************
 // Method: SaveViewActionUI::ChoiceEnabled
 //
-// Purpose: 
+// Purpose:
 //   Tells when the individual choices in this ActionUI are enabled.
 //
 // Arguments:
@@ -342,7 +342,7 @@ SaveViewActionUI::Enabled() const
 // Creation:   Wed Feb 26 08:53:14 PDT 2003
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -365,7 +365,7 @@ SaveViewActionUI::ChoiceEnabled(int i) const
 // ****************************************************************************
 // Method: ChooseCenterOfRotationActionUI::ChooseCenterOfRotationActionUI
 //
-// Purpose: 
+// Purpose:
 //   Constructor for the ChooseCenterOfRotationActionUI class.
 //
 // Arguments:
@@ -375,7 +375,7 @@ SaveViewActionUI::ChoiceEnabled(int i) const
 // Creation:   Wed Jan 7 10:05:39 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 ChooseCenterOfRotationActionUI::ChooseCenterOfRotationActionUI(ViewerActionLogic *L) :
@@ -390,14 +390,14 @@ ChooseCenterOfRotationActionUI::ChooseCenterOfRotationActionUI(ViewerActionLogic
 // ****************************************************************************
 // Method: ChooseCenterOfRotationActionUI::~ChooseCenterOfRotationActionUI
 //
-// Purpose: 
+// Purpose:
 //   Destructor for the ChooseCenterOfRotationActionUI class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Jan 7 10:06:02 PDT 2004
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 ChooseCenterOfRotationActionUI::~ChooseCenterOfRotationActionUI()
@@ -407,7 +407,7 @@ ChooseCenterOfRotationActionUI::~ChooseCenterOfRotationActionUI()
 // ****************************************************************************
 // Method: ChooseCenterOfRotationActionUI::Enabled
 //
-// Purpose: 
+// Purpose:
 //   Returns when the ActionUI is enabled.
 //
 // Returns:    True if there are realized plots; false otherwise.


### PR DESCRIPTION
### Description

Resolves #5399

This PR replaces QString::asprintf with QString::arg or QString::setNum when possible.
QString.asprintf was being used improperly, and Qt docs suggest not using it at all.

**Note to reviewers:** I did whitespace cleanup on the files I touched, so be sure to turn on the file filtering.

### How Has This Been Tested?

I tested use of SaveMovieWizard which is called out in the bug ticket.
I also tested most of the widgets involved in the change, ensuring correct values were being created.


### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

