### PR TITLE
Allow TP download from visit's thidparty master.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -114,6 +114,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Add new assertion tests to ensure tests are running in mode specified by -m/--mode= command-line argument.</li>
   <li>QT version updated to 5.14.2.</li>
   <li>AssertXXXX() style test checks were replaced with TestValueXX which supports more features.</li>
+  <li>When run from develop, build_visit will now look for tarballs in the github master branch of visit-dav/thirdparty if all other avenues fail.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -74,6 +74,9 @@ export webaddr="${webroot}/trunk/src/tools/dev/scripts/bv_support/"
 export visitroot="https://github.com/visit-dav/visit/releases/download/"
 export thirdpartyroot="https://github.com/visit-dav/third-party/releases/download/"
 
+# for use when running a develop verison of build_visit
+export thirdpartyroot_dev="https://github.com/visit-dav/third-party/raw/master/lib"
+
 #state = "disabled", "enabled", "installed"
 declare -a reqlibs
 declare -a reqlibs_state
@@ -432,6 +435,9 @@ function bv_write_unified_file
     echo "export webaddr=\"\${webroot}/trunk/src/tools/dev/scripts/bv_support/\"" >> $OUTPUT_bv_FILE
     echo "export visitroot=\"https://github.com/visit-dav/visit/releases/download/\"" >> $OUTPUT_bv_FILE
     echo "export thirdpartyroot=\"https://github.com/visit-dav/third-party/releases/download/\"" >> $OUTPUT_bv_FILE
+
+    # for use when running a develop verison of build_visit
+    echo "export thirdpartyroot_dev=\"https://github.com/visit-dav/third-party/raw/master/lib\"" >> $OUTPUT_bv_FILE
 
     echo "declare -a reqlibs" >> $OUTPUT_bv_FILE
     echo "declare -a optlibs" >> $OUTPUT_bv_FILE

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -522,6 +522,16 @@ function download_file
         done
     fi
 
+    # if all else has failed, and running develop version of build_visit,
+    # then also check the master repo.
+    if [[ "$TRUNK_BUILD" == "yes" ]]; then
+        site="${thirdpartyroot_dev}"
+        try_download_file $site/$dfile $dfile
+        if [[ $? == 0 ]] ; then
+            return 0
+        fi
+    fi
+
     return 1
 }
 


### PR DESCRIPTION
When running from develop and all other options fail.

### Description

Resolves #5391

### How Has This Been Tested?

I ran build_visit (with modified bv_llvm and bv_mesa so it would look for the newer versions of these libraries which aren't on the releases, and it downloaded them correctly.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
