### PR TITLE
Fix PyInit_visit_writer export on Windows.

### DIFF
--- a/src/tools/data/writer/py_visit_writer.c
+++ b/src/tools/data/writer/py_visit_writer.c
@@ -26,7 +26,7 @@ enum TokenTypes { endOfList = 0, logicalToken, integerToken };
 typedef struct {
     enum TokenTypes type;
     int value;
-    char *string;
+    char *tok_string;
 } visItWriterIntegerTokens;
 
 static int convertDims( PyObject *dims_py, int pts[3] );
@@ -635,7 +635,7 @@ static int getIntegerToken( PyObject *item, visItWriterIntegerTokens *tokens ) {
         s = PyString_AsString( item );
         for( i = 0; tokens[i].type; i++ )
         {
-            if( strcmp( tokens[i].string, s ) == 0 ) return( tokens[i].value );
+            if( strcmp( tokens[i].tok_string, s ) == 0 ) return( tokens[i].value );
         }
         return( -2 );
         PyString_AsString_Cleanup(s);
@@ -801,6 +801,8 @@ static struct PyModuleDef visit_writer_module_def =
     #if __GNUC__ >= 4
     /* Ensure this function is visible even if -fvisibility=hidden was passed */
     __attribute__ ((visibility("default"))) PyObject * PyInit_visit_writer( void )
+    #elif _WIN32
+    __declspec(dllexport) PyObject * PyInit_visit_writer( void )
     #else
     PyObject * PyInit_visit_writer( void )
     #endif


### PR DESCRIPTION
### Description

This resolves the locus.py regression test crash.

### Type of change

I added __declspec(dllexport).
Also change 'char *string' to 'char *tok_string', which Visual Studio called out during the build.

### How Has This Been Tested?

Compiled and ran the locus.py test on Windows with success.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
