### PR TITLE
Add the date to the release notes.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <center><b><font size="6">VisIt 3.2 Release Notes</font></b></center>
+<center><b><font size="4">February, 2021</font></b></center>
 
 <p>Welcome to VisIt's release notes page. This page describes the important
 enhancements and bug-fixes that were added to this release.</p>


### PR DESCRIPTION
### Description

Resolves #5302 

I added the date (month, year) to the 3.2.0 release notes right under the title. Since I copy the previous release notes to start the new release notes, this will propagate to future releases. Here is what the release notes look like on Linux.

![Release_Notes_3 2 0](https://user-images.githubusercontent.com/1102718/106531788-c5729600-64a3-11eb-86a4-d3b657b9ca93.png)

I didn't update the release notes since this change is trivial.

### Type of change

New feature.

### How Has This Been Tested?

I made the change to an installation and looked at the result, which is shown in the image above.

### Checklist:

~~- [] I have followed the [style guidelines][1] of this project.~~
~~- [ ] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis