### PR TITLE
Modify the LLNL custom launcher for Trinity. (#5438)

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -43,7 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the documentation for the Smooth Operator.</li>
   <li>Enhanced boxlib readers to always serve up to VisIt double precision data.</li>
   <li>The -disable-ghosts-for-t-intersections flag has been reverted back to -enable-ghosts-for-t-intersections, and the creation of ghosts for t-intersections will now be off by default. This will improve performance for the default situation where ghost t-intersections are not needed or desired.</li>
-  <li>Updated the job launching on Trinity so that the VisIt Pyhton CLI could be launched from a batch job without having to load the module of the compiler used to build VisIt.</li>
+  <li>Updated the job launching on Trinity so that the VisIt CLI could be launched from a batch job without having to load the module of the compiler used to build VisIt.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -43,6 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the documentation for the Smooth Operator.</li>
   <li>Enhanced boxlib readers to always serve up to VisIt double precision data.</li>
   <li>The -disable-ghosts-for-t-intersections flag has been reverted back to -enable-ghosts-for-t-intersections, and the creation of ghosts for t-intersections will now be off by default. This will improve performance for the default situation where ghost t-intersections are not needed or desired.</li>
+  <li>Updated the job launching on Trinity so that the VisIt CLI could be launched from a batch job without having to load the module of the compiler used to build VisIt.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -43,7 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the documentation for the Smooth Operator.</li>
   <li>Enhanced boxlib readers to always serve up to VisIt double precision data.</li>
   <li>The -disable-ghosts-for-t-intersections flag has been reverted back to -enable-ghosts-for-t-intersections, and the creation of ghosts for t-intersections will now be off by default. This will improve performance for the default situation where ghost t-intersections are not needed or desired.</li>
-  <li>Updated the job launching on Trinity so that the VisIt CLI could be launched from a batch job without having to load the module of the compiler used to build VisIt.</li>
+  <li>Updated the job launching on Trinity so that the VisIt Pyhton CLI could be launched from a batch job without having to load the module of the compiler used to build VisIt.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -209,6 +209,11 @@ class JobSubmitter_bsub_LLNL(JobSubmitter):
 #   Cyrus Harrison, Fri Dec 11 09:34:38 PST 2020
 #   Python 3 port (avoid using old string methods)
 #
+#   Eric Brugger, Wed Feb  3 16:49:58 PST 2021
+#   Added code to set the LD_LIBRARY_PATH on trinity to include the
+#   directory with the standard C++ library used by the compiler used
+#   to compile visit.
+#
 ###############################################################################
 
 class LLNLLauncher(MainLauncher):
@@ -260,6 +265,16 @@ class LLNLLauncher(MainLauncher):
             self.generalArgs.host = "130.106.204.1"
         elif self.generalArgs.host == "agate5.llnl.gov":
             self.generalArgs.host = "130.106.204.3"
+
+        #
+        # Set the LD_LIBRARY_PATH on trinity to include the directory
+        # with the standard C++ library used by the compiler used to
+        # compile visit.
+        #
+        if self.sectorname() == "tr-fe" or self.sectorname() == "nid":
+            ld_library_path = GETENV("LD_LIBRARY_PATH")
+            new_ld_library_path = self.joinpaths(["/opt/gcc/9.3.0/snos/lib64", ld_library_path])
+            SETENV("LD_LIBRARY_PATH", new_ld_library_path)
 
         #
         # Set the LD_LIBRARY_PATH to include the path to MPI on


### PR DESCRIPTION
### Description

Resolves #5201

Modify the LLNL custom launcher so that the visit cli could be run directly from a batch mode without loading a module for the compiler used to build VisIt.

This is a merge of a change from the 3.1RC to develop.

### Type of change

Bug fix.

### How Has This Been Tested?

I developed the fix on Trinity and verified that I could launch a batch job on trinity that launched the VisIt cli and ran a script that created a png image from curv2d.silo.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
