### PR TITLE
Fix text diff in regression testing for Windows

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -120,6 +120,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>When run from develop, build_visit will now look for tarballs in the github master branch of visit-dav/thirdparty if all other avenues fail.</li>
   <li>LLVM version updated to 6.0.1, added libclang to the build.</li>
   <li>Mesa/OSMesa version updated to 17.3.9.</li>
+  <li>Textual differencing in regression testing has been fixed for Windows OS.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/test/HtmlDiff.py
+++ b/src/test/HtmlDiff.py
@@ -12,9 +12,16 @@
 #    Added exception handling code so it does not crash if baselines are
 #    missing.
 #
+#    Kathleen Biagas, Tue Feb 9 20201 
+#    Removed ParseDiff, which used *nix 'diff -f', in favor of
+#    difflib.SequenceMatcher and it's get_opcodes function.  This allows
+#    text diffs to work on Windows.  While difflib has an HtmlDiff option for
+#    creating html output, the html created here serves our purposes better,
+#    hence the choice of SequenceMatcher and get_opcodes.
+#
 # ----------------------------------------------------------------------------
 
-import os, string, cgi
+import os, string, cgi, difflib
 
 class TextFile:
     def __init__(self, fn, msg):
@@ -110,30 +117,6 @@ class Differencer:
         self.in1.close()
         self.in2.close()
 
-    def ParseDiff(self):
-        self.commands=[]
-        f = os.popen("/usr/bin/diff -f '%s' '%s' 2>/dev/null"%(self.fn1,self.fn2))
-        op = f.read(1)
-        while op != '':
-            arguments = f.readline().split()
-            line = int(arguments[0])
-            arg  = 1
-            if len(arguments) > 1: arg = int(arguments[1]) + 1 - line
-            if (op != 'd'):
-                length = 0;
-                buff = f.readline().strip()
-                while buff == "" or buff[0] != '.':
-                    length = length + 1
-                    buff = f.readline().strip()
-            else:
-                length = arg
-
-            if op != 'a': line=line-1
-
-            self.commands.append((op,line,arg,length))
-            op = f.read(1)
-        f.close()
-
     def GetNextLeft(self):
         astr=cgi.escape(self.nextleft.rstrip())
         self.nextleft = self.in1.readline()
@@ -200,53 +183,65 @@ class Differencer:
         return (self.nextleft == "" or self.nextright == "")
 
     def Difference(self, filename, testname):
-        commands = self.ParseDiff()
 
+        self.nModifications = 0
         self.nModifiedLines = 0
         self.nChanged = 0
         self.nAdded   = 0
         self.nDeleted = 0
-        for (op,line,arg,length) in self.commands:
-            if (op == 'a'): self.nAdded   = self.nAdded   + length
-            if (op == 'd'): self.nDeleted = self.nDeleted + arg
-            if (op == 'c'): self.nChanged = self.nChanged + arg
-        self.nModifications = len(self.commands)
-        self.nModifiedLines = self.nAdded + self.nChanged + self.nDeleted
-
         self.leftline=0
         self.rightline=0
-        curdiff=0
+
+        # open ... as handles the close
+        with open(self.fn1) as bf:
+            blines = bf.readlines()
+        with open(self.fn2) as cf:
+            clines = cf.readlines()
+
+        sm = difflib.SequenceMatcher(None, blines, clines)
+
+        # get mod counts before calling InitIO 
+        for opcode, b1, b2, c1, c2 in sm.get_opcodes():
+            #print("%7s base[%d:%d] cur[%d:%d] "%(opcode, b1, b2, c1, c2))
+            if opcode == 'delete':
+                self.nModifications += 1
+                self.nDeleted += (b2-b1)
+            elif opcode == 'insert':
+                self.nModifications += 1
+                self.nAdded += (c2-c1)
+            elif opcode == 'replace':
+                self.nModifications += 1
+                brange = b2-b1
+                crange = c2-c1
+                for i in range(min(brange,crange)):
+                    self.nChanged += 1
+                self.nChanged += abs(brange-crange) 
+
+        self.nModifiedLines = self.nAdded + self.nChanged + self.nDeleted
 
         self.InitIO(filename, testname)
-        while (not self.EOFReached()):
-            if (curdiff < len(self.commands)):
-                (op,line,arg,length) = self.commands[curdiff]
 
-            if (curdiff < len(self.commands) and line == self.leftline):
-                #print "op=%c line=%d arg=%d len=%d"%(op,line,arg,length)
-                if (op == 'd'):
-                    for i in range(arg):
-                        self.InsertLeft(self.DELETE)
-                elif (op == 'a'):
-                    for i in range(length):
-                        self.InsertRight(self.INSERT)
-                elif (op == 'c'):
-                    for i in range(min(arg,length)):
-                        self.InsertLine(self.CHANGE,self.CHANGE)
-                    if length>arg:
-                        for i in range(arg,length):
-                            self.InsertRight(self.CHANGE)
-                    else:
-                        for i in range(length,arg):
-                            self.InsertLeft(self.CHANGE)
-                curdiff=curdiff+1
-            else:
-                self.InsertLine(self.NOCOLOR, self.NOCOLOR)
-
-        while (self.nextleft != ""):
-            self.InsertLeft(self.DELETE)
-        while (self.nextright != ""):
-            self.InsertRight(self.INSERT)
+        for opcode, b1, b2, c1, c2 in sm.get_opcodes():
+            if opcode == 'delete':
+                for i in range(b2-b1):
+                    self.InsertLeft(self.DELETE)
+            elif opcode == 'insert':
+                for i in range(c2-c1):
+                    self.InsertRight(self.INSERT)
+            elif opcode == 'replace':
+                brange = b2-b1
+                crange = c2-c1
+                for i in range(min(brange,crange)):
+                    self.InsertLine(self.CHANGE, self.CHANGE)
+                if crange>brange:
+                    for i in range(brange,crange):
+                        self.InsertRight(self.CHANGE)
+                else:
+                    for i in range(crange,brange):
+                        self.InsertLeft(self.CHANGE)
+            else: # opcode == 'equal'
+                for i in range(b2-b1):
+                    self.InsertLine(self.NOCOLOR, self.NOCOLOR)
 
         self.FiniIO()
         

--- a/src/test/visit_test_main.py
+++ b/src/test/visit_test_main.py
@@ -11,10 +11,13 @@ notes:   Ported/refactored from 'Testing.py'
 """
 # ----------------------------------------------------------------------------
 #  Modifications:
-#
+#    Kathleen Biagas, Tue Feb 9, 2021
+#    When creating text diff output use difflib.context_diff instead of
+#    *nix 'diff', so content can be generated on Windows.
 # ----------------------------------------------------------------------------
 
 import atexit
+import difflib
 import glob
 import gzip
 import json
@@ -1806,7 +1809,6 @@ def TestText(case_name, inText, baseText=None, numdifftol=None):
 
     # diff the baseline and current text files
     d = HtmlDiff.Differencer(base, cur)
-    # change to use difflib
     (nchanges, nlines) = d.Difference(out_path("html","%s.html"%case_name), case_name)
 
     # Copy the text file itself to "html" dir if there are diffs
@@ -1814,14 +1816,17 @@ def TestText(case_name, inText, baseText=None, numdifftol=None):
     if nchanges > 0:
         shutil.copy(cur, out_path("html", "c_%s.txt"%case_name))
 
-    # save the diff output
-    # TODO_WINDOWS THIS WONT WORK ON WINDOWS
-    # we can use difflib
-    diff_cmd = "diff " + base + " " + cur
-    res = sexe(diff_cmd,ret_output = True)
-    fout = open(diff, 'w')
-    fout.write(res["output"])
-    fout.close()
+    # save the diff output using difflib.context_diff
+
+    # open ... as handles close
+    with open(base) as bfile:
+        blines=bfile.readlines()
+    with open(cur) as cfile:
+        clines=cfile.readlines()
+
+    res = difflib.context_diff(blines, clines, base, cur) 
+    with open(diff, 'w') as fout:
+        fout.writelines(res)
 
     # did the test fail?
     failed = (nchanges > 0)


### PR DESCRIPTION
Use difflib instead of *nix command 'diff'.
Use difflib.SequenceMatcher and get_opcodes when generating html.
Use difflib.context_diff when generating diff text file.

Note:
While difflib has HtmlDiff for generating html output,  there isn't an option for customizing the table or other aspects without reparsing the generated html.  As as result I opted to use difflib.SequenceMatcher and its get_opcodes function to mostly closely duplicate current functionality.

### How Has This Been Tested?

I ran it on Linux with some deliberately faulty text-based tests with successful output.
I ran the full test suite and Windows, and it generated many text-based test failures
(most of which are python3 related : from NONE to None).  These failures were expected, as
textual differencing wasn't previously occuring on Windows.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
