### PR TITLE
Fix issue with not being able to import numpy from th…

### DIFF
--- a/src/resources/help/en_US/relnotes3.1.5.html
+++ b/src/resources/help/en_US/relnotes3.1.5.html
@@ -49,6 +49,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.1.5</font></b></p>
 <ul>
   <li>Created a NotarizeAction in the masonry scripts so that notarization can be executed in the correct order with the rest of the actions.</li>
+  <li>Added a patch to bv_python.sh to fix the issue with not being able to import numpy in the CLI on macOS.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
Resolves #5262. Fix issue with not being able to import numpy from the CLI on macOS.

### How Has This Been Tested?

Ran build_visit on macOS 10.15 and confirmed the fix.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
