### PR TITLE
Add a newline to end of pluginVsInstall test output.

### DIFF
--- a/src/test/tests/plugins/pluginVsInstallHelpers
+++ b/src/test/tests/plugins/pluginVsInstallHelpers
@@ -221,7 +221,7 @@ def do_plugin_type(pluginType, pluginList):
     results = buildPlugin(pluginType, pluginList)
 
     pp = pprint.PrettyPrinter(indent=4)
-    txt = pp.pformat(results)
+    txt = pp.pformat(results) + "\n"
     TestText("%sVsInstall"%pluginType, txt)
 
 


### PR DESCRIPTION
Fixes problem with new text diffing calling out the final line as failure.

### Checklist:

~~- [ ] I have followed the [style guidelines][1] of this project.~~
~~- [ ] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
