### PR TITLE
Update the make manuals target for Python 3.

### DIFF
--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -24,7 +24,7 @@
 #
 #****************************************************************************
 
-if(VISIT_PYTHON_DIR and VISIT_ENABLE_MANUALS)
+if(VISIT_PYTHON_DIR AND VISIT_ENABLE_MANUALS)
     message(STATUS "Configure manuals targets")
     set(errmsgtail "Either install sphinx or set VISIT_ENABLE_MANUALS to false.")
     if(WIN32)

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -19,27 +19,30 @@
 #   same for all platforms, except the sphinx build command which is
 #   different on Windows.  Added logic to ensure sphinx build command exists.
 #
+#   Eric Brugger, Wed Feb 10 15:07:41 PST 2021
+#   Update for switch to Python 3.
+#
 #****************************************************************************
 
-if(VISIT_PYTHON3_DIR AND VISIT_ENABLE_MANUALS)
+if(VISIT_ENABLE_MANUALS)
     message(STATUS "Configure manuals targets")
     set(errmsgtail "Either install sphinx or set VISIT_ENABLE_MANUALS to false.")
     if(WIN32)
         # Need a different sphinx build command for windows
-        if(NOT EXISTS ${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py)
+        if(NOT EXISTS ${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py)
             message(FATAL_ERROR "Manuals are enabled but"
-                   " ${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py"
+                   " ${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py"
                    " does not exist. ${errmsgtail}")
         endif()
-        set(sphinx_build_cmd "${VISIT_PYTHON3_DIR}/python.exe \ "
-              "${VISIT_PYTHON3_DIR}/Scripts/sphinx-build-script.py")
+        set(sphinx_build_cmd "${VISIT_PYTHON_DIR}/python.exe \ "
+              "${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py")
     else()
-        if(NOT EXISTS ${VISIT_PYTHON3_DIR}/bin/sphinx-build)
+        if(NOT EXISTS ${VISIT_PYTHON_DIR}/bin/sphinx-build)
             message(FATAL_ERROR "Manuals are enabled but"
-                    " ${VISIT_PYTHON3_DIR}/bin/sphinx-build"
+                    " ${VISIT_PYTHON_DIR}/bin/sphinx-build"
                     " does not exist. ${errmsgtail}")
         endif()
-        set(sphinx_build_cmd ${VISIT_PYTHON3_DIR}/bin/sphinx-build)
+        set(sphinx_build_cmd ${VISIT_PYTHON_DIR}/bin/sphinx-build)
     endif()
 
     # Add custom target to build the manuals

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -24,7 +24,7 @@
 #
 #****************************************************************************
 
-if(VISIT_ENABLE_MANUALS)
+if(VISIT_PYTHON_DIR and VISIT_ENABLE_MANUALS)
     message(STATUS "Configure manuals targets")
     set(errmsgtail "Either install sphinx or set VISIT_ENABLE_MANUALS to false.")
     if(WIN32)


### PR DESCRIPTION
### Description

Resolves #5448

I updated the make manuals target for Python 3. I didn't update the release notes since this is a fix for the switch to Python 3.

### Type of change

Bug fix.

### How Has This Been Tested?

I did a clean build on quartz using "make -j 36" followed by "cd doc;make manuals". It built the sphinx manuals and I verified that they looked correct by looking at it with firefox.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
