### PR TITLE
Fix problem running unit regression tests on Windows.

### DIFF
--- a/src/test/visit_test_main.py
+++ b/src/test/visit_test_main.py
@@ -2803,6 +2803,7 @@ SILO_MODE = TestEnv.SILO_MODE
 # Run our test script using "Source"
 #
 import visit
-visit.Source(TestEnv.params["script"])
+from pathlib import Path
+visit.Source(Path(TestEnv.params["script"]).as_posix())
 
 


### PR DESCRIPTION
Path-separator escaping is no longer working correctly, getting an error for unit tests like so:
```
File "<string>", line 1
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 45-46: truncated \uXXXX escape
```
Due to path-to-test looking like "C:\visit\src\test\tests\unit\mrucache.py"  (the \u is the problem)
Think its related to python3, but no amount of fiddling with extra path-separator-escaping resolved the issue.
I found references to pathlib:Path, and using it to convert to unix-style path resolved this issue.

### How Has This Been Tested?

I ran the test suite on Windows, and unit tests now run. I also ran the entire suite on pascal with no issues due to the change.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
