### PR TITLE
fix use of mpicom in python filter env

### DIFF
--- a/src/avt/PythonFilters/avtPythonFilterEnvironment.C
+++ b/src/avt/PythonFilters/avtPythonFilterEnvironment.C
@@ -85,6 +85,9 @@ avtPythonFilterEnvironment::~avtPythonFilterEnvironment()
 //    Kathleen Biagas, Fri May 4 14:08:12 PDT 2012 
 //    Call GetVisItLibraryDirectory instead of GetVisItArchitectureDirectory.
 //
+//    Cyrus Harrison, Thu Feb 18 16:06:46 PST 2021
+//    Change the way the import works for parallel case to support Python 3.
+//
 // ****************************************************************************
 
 bool
@@ -111,7 +114,7 @@ avtPythonFilterEnvironment::Initialize()
 
 #ifdef PARALLEL
     // init mpicom w/ visit's communicator
-    if(!pyi->RunScript("import mpicom\n"))
+    if(!pyi->RunScript("import mpicom.mpicom as mpicom\n"))
         return false;
     ostringstream oss;
     oss << (void*)VISIT_MPI_COMM_PTR;

--- a/src/visitpy/mpicom/py_src/__init__.py
+++ b/src/visitpy/mpicom/py_src/__init__.py
@@ -11,16 +11,19 @@
 #
 #
 # Modifications:
-#
+#    Cyrus Harrison, Thu Feb 18 16:06:46 PST 2021
+#    Change the way the compiled lib import works to support Python 3.
 #
 ###############################################################################
 
+# import the serial stub module
 from . import mpistub
+
+# try to import the compiled module
+# (this will only exist if visit with built with mpi support)
 try:
-    from mpicom import *
+    from . import mpicom
 except ImportError:
     pass
-
-
 
 

--- a/src/visitpy/mpicom/py_src/__init__.py
+++ b/src/visitpy/mpicom/py_src/__init__.py
@@ -20,7 +20,7 @@
 from . import mpistub
 
 # try to import the compiled module
-# (this will only exist if visit with built with mpi support)
+# (this will only exist if visit was built with mpi support)
 try:
     from . import mpicom
 except ImportError:


### PR DESCRIPTION
### Description

Resolves #5425 

Fixes how the mpicom module is structured and imported to support Python 3. 


### Type of change

Bugfix

### How Has This Been Tested?

Tested on my mac by running the `py_queries` test with `-m parallel`

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
