### PR TITLE
refactor python thread locking for py3, fix command recording crash

### DIFF
--- a/src/visitpy/common/CallbackManager.C
+++ b/src/visitpy/common/CallbackManager.C
@@ -383,6 +383,9 @@ CallbackManager::StartWork()
 //   Brad Whitlock, Tue Jun 24 14:20:53 PDT 2008
 //   Pass the viewer proxy pointer to the callback.
 //
+//   Cyrus Harrison, Fri Feb 19 13:25:57 PST 2021
+//   Update to use new VisItLockPythonInterpreter signature. 
+//
 // ****************************************************************************
 
 void

--- a/src/visitpy/common/CallbackManager.C
+++ b/src/visitpy/common/CallbackManager.C
@@ -392,7 +392,7 @@ CallbackManager::Work()
     bool keepWorking = working;
 
     // Lock the Python interpreter
-    PyThreadState *threadState = VisItLockPythonInterpreter();
+    VISIT_PY_THREAD_LOCK_STATE threadState = VisItLockPythonInterpreter();
 
     do
     {

--- a/src/visitpy/common/visitmodulehelpers.h
+++ b/src/visitpy/common/visitmodulehelpers.h
@@ -6,6 +6,7 @@
 #define VISIT_MODULE_HELPERS_H
 #include <ViewerProxy.h>
 #include <Python.h>
+#include <Py2and3Support.h>
 
 //
 // Visible Prototypes.
@@ -15,8 +16,36 @@ ViewerProxy   *GetViewerProxy();
 ViewerState   *GetViewerState();
 ViewerMethods *GetViewerMethods();
 
+
+// ---------------------------------------------------------------
+//
+// Our thread locking solution did not work in Python 3.
+// This lead to CLI crashing whenever a lock was requested
+// (the primary case was command line recording, but there
+//  may be others)
+//
+// Prior locking solution worked fine in Python 2, so we keep
+// it when Python 2 is in play, but provide a new Python 3
+// solution using on PyGILState_Ensure() + PyGILState_Release()
+//
+// ---------------------------------------------------------------
+
+#if defined(IS_PY3K)
+// ---------------------------------------------------------------
+// Python 3 lock state
+// ---------------------------------------------------------------
+#define VISIT_PY_THREAD_LOCK_STATE PyGILState_STATE
+// ---------------------------------------------------------------
+#else
+// ---------------------------------------------------------------
+// Python 2 lock state
+// ---------------------------------------------------------------
+#define VISIT_PY_THREAD_LOCK_STATE PyThreadState *
+// ---------------------------------------------------------------
+#endif 
+
 // Functions from visitmodule.C that lock and release the Python interpreter.
-PyThreadState *VisItLockPythonInterpreter();
-void VisItUnlockPythonInterpreter(PyThreadState *);
+VISIT_PY_THREAD_LOCK_STATE  VisItLockPythonInterpreter();
+void VisItUnlockPythonInterpreter(VISIT_PY_THREAD_LOCK_STATE);
 
 #endif


### PR DESCRIPTION
### Description

Resolves #5412 

Refactors the thread locking logic in the visit python module.

Provides new locking logic for python 3, preserves old logic for python 2.


### Type of change
Bug fix

### How Has This Been Tested?

Tested on my mac and it restored my ability to do command recording.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
