### PR TITLE
change mpicom init to use c2f handle, instead of address

### DIFF
--- a/src/visitpy/mpicom/src/mpicom.C
+++ b/src/visitpy/mpicom/src/mpicom.C
@@ -42,7 +42,7 @@ extern "C"
 // use MPI f2c API to keep a mpi handle
 // and avoid MPI_Comm data structure issues.
 /***************************************************************************/
-static int mpi_comm_main_id = 0;
+static int mpi_comm_main_id = -1;
 MPI_Comm
 mpi_comm_main()
 {
@@ -157,6 +157,8 @@ mpicom_init(PyObject *self, PyObject *args,PyObject *kwds)
             mpicom_error("mpicom_init:: Call to MPI_Init failed",err);
             return NULL;
         }
+
+        mpi_comm_main_id = MPI_Comm_c2f(MPI_COMM_WORLD);
     }
     else
     {


### PR DESCRIPTION
### Description

Resolves #5488

Remove logic that passes com address string between VisIt and MPI comm, and replace it with logic that uses 
MPI_Comm_c2f and  MPI_Comm_f2c -- which allow us to pass handles as integers regardless of the mpi implemention. 


### Type of change

Bugfix

### How Has This Been Tested?

Ran py_queries test on my mac in parallel mode.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
