### PR TITLE
install quick_check_... to unified file

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -452,6 +452,7 @@ function bv_write_unified_file
     echo "declare -a defaultLicenses" >> $OUTPUT_bv_FILE
     echo "declare -a args" >> $OUTPUT_bv_FILE
 
+    declare -f quick_check_for_help >> $OUTPUT_bv_FILE
     declare -f check_for_versioning >> $OUTPUT_bv_FILE
     declare -f call_build_visit >> $OUTPUT_bv_FILE
     declare -f configure_support_files >> $OUTPUT_bv_FILE


### PR DESCRIPTION
### Description

Resolves #5498 by ensuring the `quick_check_for_help` func gets installed to unified file.

### Type of change

Bug fix.

### How Has This Been Tested?

Manually, both myself and @biagas who reported original issue

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added any new baselines to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- ~~[ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
