### PR TITLE
Fix QString::arg indexing to remove warnings.

### DIFF
--- a/src/gui/QvisEngineWindow.C
+++ b/src/gui/QvisEngineWindow.C
@@ -490,6 +490,9 @@ QvisEngineWindow::UpdateInformation(int index)
 //    Cyrus Harrison, Tue Jun 24 11:15:28 PDT 2008
 //    Initial Qt4 Port.
 //
+//    Kathleen Biagas, Tue Mar  2 15:49:07 PST 2021
+//    Fix QString arg indexing.
+//
 // ****************************************************************************
 
 void
@@ -528,7 +531,7 @@ QvisEngineWindow::UpdateStatusArea()
         }
         else if (s->GetMessageType() == 2)
         {
-            QString msg = QString("%1/%1").arg(s->GetCurrentStage()).arg(s->GetMaxStage());
+            QString msg = QString("%1/%2").arg(s->GetCurrentStage()).arg(s->GetMaxStage());
             msg = tr("Total Status: Stage ") + msg;
             totalStatusLabel->setText(msg);
             msg = tr("Stage Status: ") + QString(s->GetCurrentStageName().c_str());


### PR DESCRIPTION
Resolves #5494.

I didn't update release notes as the commit that introduced the warning was only on develop.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
