### PR TITLE
Ensure DEBUG_MEMORY_LEAKS is undefined by default.

### DIFF
--- a/src/doc/dev_manual/MemoryLeaks.rst
+++ b/src/doc/dev_manual/MemoryLeaks.rst
@@ -49,7 +49,8 @@ Building VisIt_
 Just like the third party libraries, VisIt_ needs to be built with debug
 support in order for Valgrind to produce useful stack traces. Furthermore,
 VisIt_ contains conditional code that does additional cleanup at exit to
-eliminate spurious memory leaks that is enabled with DEBUG_MEMORY_LEAKS.
+eliminate spurious memory leaks. The additional cleanup is enabled with
+DEBUG_MEMORY_LEAKS.
 The following steps were used to build VisIt_ as described. ::
 
     cd visit3.1.0

--- a/src/doc/dev_manual/MemoryLeaks.rst
+++ b/src/doc/dev_manual/MemoryLeaks.rst
@@ -49,7 +49,7 @@ Building VisIt_
 Just like the third party libraries, VisIt_ needs to be built with debug
 support in order for Valgrind to produce useful stack traces. Furthermore,
 VisIt_ contains conditional code that does additional cleanup at exit to
-eliminate spurious memory leaks that is enabled with VISIT_DEBUG_LEAKS.
+eliminate spurious memory leaks that is enabled with DEBUG_MEMORY_LEAKS.
 The following steps were used to build VisIt_ as described. ::
 
     cd visit3.1.0

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -372,9 +372,16 @@ logic here to cause compilation failure if this logic seems to be failing.
 /* Define a uniform socket buffer size that we can use in various places. */
 #define VISIT_SOCKET_BUFFER_SIZE 1024
 
-/* define control to intentionally leak things or not. my profiling shows it
-   saves on the order of 0.001 sec to undefine this. leaving it undefined
-   for now in case there's some issue with it when using a remote server.
+/* 
+   When DEBUG_MEMORY_LEAKS is defined, then extra object-cleanup occurs.
+   When not defined, VisIt shortciruits some cleanup at exit.
+   Profiling shows it saves on the order of 0.001 sec to NOT have this defined.
+
+   Uncomment this when debugging memory leaks so that there will be no
+   intentional leaks.
+
+   The uncommenting of DEBUG_MEMORY_LEAKS should never be committed. 
+
 #define DEBUG_MEMORY_LEAKS
 */
 

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -375,6 +375,6 @@ logic here to cause compilation failure if this logic seems to be failing.
 /* define control to intentionally leak things or not. my profiling shows it
    saves on the order of 0.001 sec to undefine this. leaving it undefined
    for now in case there's some issue with it when using a remote server.
-*/
 #define DEBUG_MEMORY_LEAKS
+*/
 


### PR DESCRIPTION
Resolves #5529

Also fixed minor typo in MemoryLeaks doc.

The change that enabled DEBUG_MEMORY_LEAKS was only in develop so I didn't update release notes.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X ] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
