### PR TITLE
Fix the building of pyside in build_visit when no system LLVM is present.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -68,8 +68,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Boxlib reader reading double precision data.</li>
   <li>Fixed a bug with the Silo reader that resulted in VisIt crashing whenever negative material numbers were encountered. VisIt will now display an error message noting that negative material numbers are not supported.</li>
   <li>Fixed a bug in the Stimulate Image reader (file extensions spr, sdt), where a negative pixel delta in the metadata resulted in incorrect pick results, incorrect sampled lineouts and potentially other erroneous behavior.</li>
-  <li>The Xolotl Database reader now supports the ability to visulize super clusters.</li>
-  <li>The CGNS reader now supports reading arbitrary polygons and polyhedra.</li>
+  <li>Enhanced the Xolotl reader to support the ability to visualize super clusters.</li>
+  <li>Enhanced the CGNS reader to support reading arbitrary polygons and polyhedra.</li>
 </ul>
 
 <a name="Plot_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_pyside.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pyside.sh
@@ -281,11 +281,21 @@ function build_pyside
         info "Configuring pyside . . ."
 
         # Note:
-        # the pyside build process needs to resolve OpenGL libs several times 
-        # if we are using mesa as gl, we need to provide the proper path 
-        # to gl via LD_LIBRARY_PATH
+        # The pyside build process needs to resolve OpenGL libs several
+        # times. If we are using mesa as gl, we need to provide the proper
+        # path to gl via LD_LIBRARY_PATH
         if [[ "$DO_MESAGL" == "yes" ]] ; then
             export LD_LIBRARY_PATH=${MESAGL_LIB_DIR}:${LD_LIBRARY_PATH}
+        fi
+
+        # If we are using our own llvm, then we need to provide the path
+        # to libLLVM.
+        if [[ "$DO_LLVM" == "yes" ]] ; then
+            if [[ "$OPSYS" == "Darwin" ]]; then
+                export DYLD_LIBRARY_PATH="$VISITDIR/llvm/$BV_LLVM_VERSION/$VISITARCH/lib":$DYLD_LIBRARY_PATH
+            else
+                export LD_LIBRARY_PATH="$VISITDIR/llvm/$BV_LLVM_VERSION/$VISITARCH/lib":$LD_LIBRARY_PATH
+            fi
         fi
 
         echo "\"${CMAKE_BIN}\"" ${pyside_opts} ../${PYSIDE_SRC_DIR} > bv_run_cmake.sh


### PR DESCRIPTION
### Description

I modified bv_pyside.sh to set the LD_LIBRARY_PATH to include the library for libLLVM-6.0.so. I believe that bv_pyside.sh worked on systems where LLVM could be found in the system libraries and not on systems with LLVM installed.

I didn't update the release notes with this fix because this was never released to users. I did improve some existing comments and correct a typo in the release notes.

### Type of change

Bug fix.

### How Has This Been Tested?

I ran into this when running build_visit in a debian 9 container and pyside failed to build. I then ran build_visit with the fix in a debian 9 container and everything built properly including pyside.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
