### PR TITLE
Fix the path to mesa when building icet in build_visit.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -110,6 +110,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>For build_visit, there is now only one way to specify a debug build: --build-mode "Debug". The --debug flag was removed. The default build-mode is "Release". If "Debug" is specified, all third-party libraries are built in debug mode. If the intention is only to build VisIt in debug mode, it should be compiled separately after all the third-party libraries are compiled, passing -DCMAKE_BUILD_TYPE:STRING=Debug to cmake when configuring VisIt.</li>
   <li>Removed FastBit and FastQuery from VisIt.</li>
   <li>Fixed a bug with build_visit building IceT with MPICH.</li>
+  <li>Fixed a bug with build_visit building IceT on a system without OpenGL installed.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_icet.sh
+++ b/src/tools/dev/scripts/bv_support/bv_icet.sh
@@ -134,12 +134,20 @@ function build_icet
         -DCMAKE_C_FLAGS:STRING="${CFLAGS} ${C_OPT_FLAGS}" \
         -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-        -DCMAKE_INSTALL_PREFIX:PATH="$VISITDIR/icet/${ICET_VERSION}/${VISITARCH}"\
-        -DCMAKE_C_FLAGS:STRING="-fPIC ${CFLAGS} ${C_OPT_FLAGS}"\
-        -DMPI_COMPILER:PATH="${PAR_COMPILER}"\
-        -DBUILD_TESTING:BOOL=OFF\
+        -DCMAKE_INSTALL_PREFIX:PATH="$VISITDIR/icet/${ICET_VERSION}/${VISITARCH}" \
+        -DCMAKE_C_FLAGS:STRING="-fPIC ${CFLAGS} ${C_OPT_FLAGS}" \
+        -DMPI_COMPILER:PATH="${PAR_COMPILER}" \
+        -DBUILD_TESTING:BOOL=OFF \
         .
     else
+        mesa_opts=""
+        if [[ "$DO_MESAGL" == "yes" ]] ; then
+            mesa_opts="${mesa_opts} -DOPENGL_INCLUDE_DIR:PATH=$VISITDIR/mesagl/${MESAGL_VERSION}/${VISITARCH}/include"
+            mesa_opts="${mesa_opts} -DOPENGL_gl_LIBRARY:FILEPATH=$VISITDIR/mesagl/${MESAGL_VERSION}/${VISITARCH}/lib/libOSMesa.${LIBEXT}"
+        elif [[ "$DO_OSMESA" == "yes" ]] ; then
+            mesa_opts="${mesa_opts} -DOPENGL_INCLUDE_DIR:PATH=$VISITDIR/osmesa/${OSMESA_VERSION}/${VISITARCH}/include"
+            mesa_opts="${mesa_opts} -DOPENGL_gl_LIBRARY:FILEPATH=$VISITDIR/osmesa/${OSMESA_VERSION}/${VISITARCH}/lib/libOSMesa.${LIBEXT}"
+        fi
         ${CMAKE_BIN} \
         -DCMAKE_C_COMPILER:STRING=${C_COMPILER} \
         -DCMAKE_CXX_COMPILER:STRING=${CXX_COMPILER} \
@@ -148,11 +156,10 @@ function build_icet
         -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
         -DCMAKE_INSTALL_PREFIX:PATH="$VISITDIR/icet/${ICET_VERSION}/${VISITARCH}"\
-        -DOPENGL_INCLUDE_DIR:PATH="$VISITDIR/mesa/${MESAGL_VERSION}/${VISITARCH}/include"\
-        -DOPENGL_gl_LIBRARY:FILEPATH="$VISITDIR/mesa/${MESAGL_VERSION}/${VISITARCH}/lib/libOSMesa.${LIBEXT}"\
-        -DCMAKE_C_FLAGS:STRING="-fPIC ${CFLAGS} ${C_OPT_FLAGS}"\
-        -DMPI_COMPILER:PATH="${PAR_COMPILER}"\
-        -DBUILD_TESTING:BOOL=OFF\
+        -DCMAKE_C_FLAGS:STRING="-fPIC ${CFLAGS} ${C_OPT_FLAGS}" \
+        -DMPI_COMPILER:PATH="${PAR_COMPILER}" \
+        -DBUILD_TESTING:BOOL=OFF \
+        ${mesa_opts} \
         .
     fi
 


### PR DESCRIPTION
### Description

I fixed the path to mesa in bv_icet.sh. The path had "mesa" when it should have been either "mesagl" or "osmesa", depending on whether --mesagl or --osmesa had been specified. This bug will only manifest itself if there is no trace of OpenGL installed on the system.

### Type of change

Bug fix.

### How Has This Been Tested?

I ran build_visit in a Fedora 31 Docker container and everything but pyside built successfully. This is the system where I ran into the issue. I added issue #5559 for the pyside failure.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
