### PR TITLE
Domain decomposed max expression bug-fix DEV

### DIFF
--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
@@ -116,7 +116,7 @@ avtMultipleInputMathExpression::DeriveVariable(vtkDataSet* in_ds, int dummy)
     for (int i = 0; i < nProcessedArgs; ++i)
     {
         avtCentering currentCenter;
-        dataArrays.push_back(ExractCenteredData(&currentCenter, in_ds, varnames[i]));
+        dataArrays.push_back(ExtractCenteredData(&currentCenter, in_ds, varnames[i]));
         centerings.push_back(currentCenter);
     }
 
@@ -129,7 +129,7 @@ avtMultipleInputMathExpression::DeriveVariable(vtkDataSet* in_ds, int dummy)
 }
 
 // ****************************************************************************
-//  Method: avtMultipleInputMathExpression::ExractCenteredData
+//  Method: avtMultipleInputMathExpression::ExtractCenteredData
 //
 //  Purpose:
 //      Determines the centering of an input variable and outputs the
@@ -148,10 +148,10 @@ avtMultipleInputMathExpression::DeriveVariable(vtkDataSet* in_ds, int dummy)
 // ****************************************************************************
 
 vtkDataArray*
-avtMultipleInputMathExpression::ExractCenteredData(avtCentering *centering_out,
+avtMultipleInputMathExpression::ExtractCenteredData(avtCentering *centering_out,
         vtkDataSet *in_ds, const char *varname)
 {
-    debug5 << "Entering avtMultipleInputMathExpression::ExractCenteredData("
+    debug5 << "Entering avtMultipleInputMathExpression::ExtractCenteredData("
             "avtCentering*, vtkDataSet*, const char*)" << std::endl;
     debug5 << "\t For " << varname << std::endl;
     vtkDataArray* out = in_ds->GetCellData()->GetArray(varname);
@@ -168,7 +168,7 @@ avtMultipleInputMathExpression::ExractCenteredData(avtCentering *centering_out,
         {
             *(centering_out) = AVT_NODECENT;
             debug5 << "Exiting  "
-                    "avtMultipleInputMathExpression::ExractCenteredData("
+                    "avtMultipleInputMathExpression::ExtractCenteredData("
                     "avtCentering*, vtkDataSet*, const char*)" << std::endl;
             return out;
         }
@@ -176,7 +176,7 @@ avtMultipleInputMathExpression::ExractCenteredData(avtCentering *centering_out,
     else
     {
         *(centering_out) = AVT_ZONECENT;
-        debug5 << "Exiting  avtMultipleInputMathExpression::ExractCenteredData("
+        debug5 << "Exiting  avtMultipleInputMathExpression::ExtractCenteredData("
                 "avtCentering*, vtkDataSet*, const char*)" << std::endl;
         return out;
     }

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.C
@@ -104,6 +104,11 @@ avtMultipleInputMathExpression::~avtMultipleInputMathExpression()
 //  Programmer: Eddie Rusu
 //  Creation:   Tue Sep 24 09:07:44 PDT 2019
 //
+//  Modifications:
+//
+//      Alister Maguire, Mon Mar 29 11:17:07 PDT 2021
+//      Clear our containers after we've performed our work.
+//
 // ****************************************************************************
 
 vtkDataArray*
@@ -122,6 +127,15 @@ avtMultipleInputMathExpression::DeriveVariable(vtkDataSet* in_ds, int dummy)
 
     RecenterData(in_ds);
     vtkDataArray* output = DoOperation();
+
+    //
+    // Before we leave, we need to clear out our data containers. There are
+    // times when an instantiation of this class will be used more than once
+    // (like with domain decomposed data), and we can't have old information
+    // hanging around.
+    //
+    dataArrays.clear();
+    centerings.clear();
 
     debug3 << "Exiting  avtMultipleInputMathExpression::DeriveVariable("
             "vtkDataSet*, int)" << std::endl;

--- a/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
+++ b/src/avt/Expressions/Abstract/avtMultipleInputMathExpression.h
@@ -78,8 +78,8 @@ class EXPRESSION_API avtMultipleInputMathExpression
 
     protected:
         virtual vtkDataArray *DeriveVariable(vtkDataSet*, int);
-        virtual vtkDataArray *ExractCenteredData(avtCentering*, vtkDataSet*,
-                                                 const char*);
+        virtual vtkDataArray *ExtractCenteredData(avtCentering*, vtkDataSet*,
+                                                  const char*);
         virtual vtkDataArray *CreateOutputVariable();
         virtual vtkDataArray *CreateOutputVariable(int);
         virtual vtkDataArray *DoOperation() = 0;

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -23,8 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.2.1</font></b></p>
 <ul>
-  <li>Bugs Fixed 1</li>
-  <li>Bugs Fixed 2</li>
+  <li>Fixed a bug preventing the Min/Max expressions from working with domain decomposed datasets.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/hybrid/expressions.py
+++ b/src/test/tests/hybrid/expressions.py
@@ -58,7 +58,64 @@
 #
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #    Added ability to swtich between Silo's HDF5 and PDB data.
+#
+#    Moved min/max tests into function and extended to include
+#    multi-domain data.
+#
 # ----------------------------------------------------------------------------
+
+def TestMinMaxExpression():
+    # Test min/max expression
+    OpenDatabase(silo_data_path("rect2d.silo"))
+
+    #
+    # First, let's test a serial dataset.
+    #
+    DefineScalarExpression('min1', 'min(10.0, 5.0, d+p)')
+    AddPlot('Pseudocolor', 'min1')
+    DrawPlots()
+    Test('min1')
+    DeleteAllPlots()
+
+    DefineScalarExpression('min2', 'min(d+p, 5.0, 10.0)')
+    AddPlot('Pseudocolor', 'min2')
+    DrawPlots()
+    Test('min2')
+    DeleteAllPlots()
+
+    DefineScalarExpression('max1', 'max(10.0, 5.0, d+p)')
+    AddPlot('Pseudocolor', 'max1')
+    DrawPlots()
+    Test('max1')
+    DeleteAllPlots()
+
+    DefineScalarExpression('min3', 'min(2.0, d+p, d*p+2*d)')
+    AddPlot('Pseudocolor', 'min3')
+    DrawPlots()
+    Test('min3')
+    DeleteAllPlots()
+
+    CloseDatabase(silo_data_path("rect2d.silo"))
+
+    #
+    # Multi-domain datasets are handled a little differently, so
+    # let's test one here.
+    #
+    OpenDatabase(silo_data_path("multi_ucd3d.silo"))
+
+    DefineScalarExpression('max2', 'max(p*16, 4)')
+    AddPlot('Pseudocolor', 'max2')
+    DrawPlots()
+    Test('max2')
+    DeleteAllPlots()
+
+    DefineScalarExpression('max3', 'max(p*16, d, 4)')
+    AddPlot('Pseudocolor', 'max3')
+    DrawPlots()
+    Test('max3')
+    DeleteAllPlots()
+
+    CloseDatabase(silo_data_path("multi_ucd3d.silo"))
 
 
 OpenDatabase(silo_data_path("bigsil.silo"))
@@ -382,31 +439,6 @@ DrawPlots()
 Test('divide3')
 DeleteAllPlots()
 
-# Test min/max expression
-DefineScalarExpression('min1', 'min(10.0, 5.0, d+p)')
-AddPlot('Pseudocolor', 'min1')
-DrawPlots()
-Test('min1')
-DeleteAllPlots()
-
-DefineScalarExpression('min2', 'min(d+p, 5.0, 10.0)')
-AddPlot('Pseudocolor', 'min2')
-DrawPlots()
-Test('min2')
-DeleteAllPlots()
-
-DefineScalarExpression('max1', 'max(10.0, 5.0, d+p)')
-AddPlot('Pseudocolor', 'max1')
-DrawPlots()
-Test('max1')
-DeleteAllPlots()
-
-DefineScalarExpression('min3', 'min(2.0, d+p, d*p+2*d)')
-AddPlot('Pseudocolor', 'min3')
-DrawPlots()
-Test('min3')
-DeleteAllPlots()
-
 # Test resrad
 DefineScalarExpression("resrad", "resrad(recenter(u), 0.1)")
 AddPlot("Pseudocolor", "resrad")
@@ -426,4 +458,5 @@ AddPlot("Pseudocolor", "ident_mesh")
 DrawPlots()
 Test("ident_mesh")
 
+TestMinMaxExpression()
 Exit()

--- a/src/test/tests/hybrid/expressions.py
+++ b/src/test/tests/hybrid/expressions.py
@@ -59,6 +59,7 @@
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #    Added ability to swtich between Silo's HDF5 and PDB data.
 #
+#    Alister Maguire, Mon Mar 29 12:17:40 PDT 2021
 #    Moved min/max tests into function and extended to include
 #    multi-domain data.
 #

--- a/test/baseline/hybrid/expressions/max2.png
+++ b/test/baseline/hybrid/expressions/max2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db1deaf1e7971fa693adbc1ee02dc48a665f205cad5cb670f5e89433441a7c55
+size 5563

--- a/test/baseline/hybrid/expressions/max3.png
+++ b/test/baseline/hybrid/expressions/max3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deb6a91f052016ebfa054f2a478aeac2b8b37ac5d91d788554ade290bc11de5c
+size 7227


### PR DESCRIPTION
### Description

Resolves #5534 

This PR contains a simple change to fix  an issue preventing the Min/Max expressions from working with domain decomposed data. I also fixed a typo (Exract to Extract).


### Type of change

Bugfix.

### How Has This Been Tested?

I've tested this by hand, run the hybrid/expressions tests on Pascal, and added new tests to hybrid/expressions.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
