### PR TITLE
Fix frontendlauncher.py for Python 3 and running old internallaunchers.

### DIFF
--- a/src/bin/frontendlauncher.py
+++ b/src/bin/frontendlauncher.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
 import os
+import string
 import sys
 import subprocess
 
@@ -82,7 +82,7 @@ def UNSETENV(var):
 
 def exit(msg, value):
     if msg != None:
-        print(msg, file=sys.stderr)
+        sys.stderr.write("%s\n" % msg)
     sys.exit(value)
 
 def ParseVersion(ver):
@@ -195,9 +195,9 @@ while i < len(sys.argv):
         want_version = 1
     elif arg in programs:
         progname = arg[1:]
-        print("NOTE:  Specifying tools as an argument to VisIt is ", file=sys.stderr)
-        print("no longer necessary.\nIn the future, you should ", file=sys.stderr)
-        print("just run '%s' instead.\n" % progname, file=sys.stderr)
+        sys.stderr.write("NOTE:  Specifying tools as an argument to VisIt is \n")
+        sys.stderr.write("no longer necessary.\nIn the future, you should \n")
+        sys.stderr.write("just run '%s' instead.\n\n" % progname)
     elif arg in list(programsWithOtherNames.keys()):
         progname = programsWithOtherNames[arg]
     else:
@@ -301,6 +301,10 @@ else:
         add_forceversion = 1
     if (not (version[0] == 1 and version[1] < 7)) and version[2] == -1 and version[3] == -1:
         add_forceversion = 0
+        # We take the list of all the versions and create an unsorted
+        # list of the versions where the major and minor versions match.
+        # Then we sort that list by patch number and select that one
+        # as the version.
         unsorted_matches = []
         for v in exeversions:
             try:
@@ -309,16 +313,12 @@ else:
                     unsorted_matches.append(v)
             except:
                 continue
-        def by_patch_version(a,b):
-            v1 = a.split(".")
-            v2 = b.split(".")
-            if len(v1) < 3: return -1
-            if len(v2) < 3: return +1
-            if v1[2] < v2[2]: return -1
-            if v1[2] > v2[2]: return +1
-            return 0
+        def get_patch_version(a):
+            v = a.split(".")
+            if len(v) < 3: return -1
+            return int(v[2])
         if len(unsorted_matches) > 0:
-            sorted_matches = sorted(unsorted_matches, cmp=by_patch_version)
+            sorted_matches = sorted(unsorted_matches, key=get_patch_version)
             ver = sorted_matches[-1]
             version = ParseVersion(ver)
 
@@ -330,10 +330,10 @@ else:
 
     # Warn if we mixed public and private development versions.
     if using_dev:
-        print("", file=sys.stderr);
-        print("WARNING: You are launching a public version of VisIt", file=sys.stderr);
-        print("         from within a development version!", file=sys.stderr);
-        print("", file=sys.stderr);
+        sys.stderr.write("\n");
+        sys.stderr.write("WARNING: You are launching a public version of VisIt\n");
+        sys.stderr.write("         from within a development version!\n");
+        sys.stderr.write("\n");
         visitargs = ["-dv"] + visitargs
 
     # The actual visit directory is now version-specific
@@ -405,7 +405,7 @@ else:
             newlauncher = createlauncher()
             launcher = newlauncher
         except:
-            print("Could not create custom launcher", file=sys.stderr)
+            sys.stderr.write("Could not create custom launcher\n")
 
     # Now, call the regular internallauncher function with the launcher
     # object that we created.


### PR DESCRIPTION
### Description

Resolves #5572 

I made 2 different modifications to frontendlauncher.py.

This first was to make it compliant with Python 3. It was doing a sort using "cmp" and that was no longer supported. I changed it to use "key".

The second was to modify it so that it could launch old Python 2 based internal launchers.
- I removed an import of print_function, since that caused old Python 2 based print statements in the old internal launcher scripts to fail.
- I added import string, since some of the old Python 2 based internal launchers made use of it.
- I replaced print using file=sys.stderr with sys.stderr.write, since print with file=sys.stderr is not supported in Python 2

I didn't update the release notes since this wasn't a fix for a released version.

### Type of change

Bug fix.

### How Has This Been Tested?

I created a visit installation with versions 3.1.4 and 3.2.0 installed and then made a bunch of sym links for other versions. I then ran visit with no version, with X.Y.Z versions for many versions and then with X.Y version for 3.1 and 3.2. I also tested 2.13 but that didn't work because all the 2.13 versions were links to 3.2.0 and those would start with the latest patch version but then launch a 3.2.0 viewer, which makes sense since that really version 3.2.0.

Here is the output of the tests.

quartz386{brugger}159: ls -l visit
total 24
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 2.13.0 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 2.13.1 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 2.13.2 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 2.13.3 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.0.0 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.0.1 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.0.2 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.1.0 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.1.1 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.1.2 -> 3.2.0
lrwxrwxrwx 1 brugger brugger    5 Mar 29 19:22 3.1.3 -> 3.2.0
drwxr-sr-x 5 brugger brugger 4096 Mar 30 06:53 3.1.4
drwxr-sr-x 5 brugger brugger 4096 Mar 29 10:46 3.2.0
drwxr-sr-x 2 brugger brugger 8192 Mar 30 06:54 bin
lrwxrwxrwx 1 brugger brugger    5 Mar 30 06:54 current -> 3.1.4
drwxr-sr-x 2 brugger brugger 8192 Mar 30 06:53 data
quartz386{brugger}160: visit/bin/visit
Running: gui3.1.4
Running: viewer3.1.4 -geometry 1508x958+412+56 -borders 26,4,4,4 -shift 0,0 -preshift 4,26 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.4 -host 127.0.0.1 -port 5601
quartz386{brugger}161: visit/bin/visit -v 3.2.0
Running: gui3.2.0 -forceversion 3.2.0
Running: viewer3.2.0 -forceversion 3.2.0 -geometry 1516x958+404+56 -borders 0,0,0,0 -shift 90,92 -preshift -90,-92 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.2.0 -forceversion 3.2.0 -host 127.0.0.1 -port 5601
quartz386{brugger}162: visit/bin/visit -v 3.2
Running: gui3.2.0
Running: viewer3.2.0 -geometry 1508x958+412+56 -borders 26,4,4,4 -shift 90,92 -preshift -86,-66 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.2.0 -host 127.0.0.1 -port 5601
quartz386{brugger}163: visit/bin/visit -v 3.1.0
Running: gui3.1.0 -forceversion 3.1.0
Running: viewer3.1.0 -forceversion 3.1.0 -geometry 1516x958+404+56 -borders 0,0,0,0 -shift 90,92 -preshift -90,-92 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.0 -forceversion 3.1.0 -host 127.0.0.1 -port 5601
quartz386{brugger}164: visit/bin/visit -v 3.1.1
Running: gui3.1.1 -forceversion 3.1.1
Running: viewer3.1.1 -forceversion 3.1.1 -geometry 1508x958+412+56 -borders 26,4,4,4 -shift 90,92 -preshift -86,-66 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.1 -forceversion 3.1.1 -host 127.0.0.1 -port 5601
quartz386{brugger}165: visit/bin/visit -v 3.1.2
Running: gui3.1.2 -forceversion 3.1.2
Running: viewer3.1.2 -forceversion 3.1.2 -geometry 1516x958+404+56 -borders 0,0,0,0 -shift 90,92 -preshift -90,-92 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.2 -forceversion 3.1.2 -host 127.0.0.1 -port 5601
quartz386{brugger}166: visit/bin/visit -v 3.1.3
Running: gui3.1.3 -forceversion 3.1.3
Running: viewer3.1.3 -forceversion 3.1.3 -geometry 1508x958+412+56 -borders 26,4,4,4 -shift 90,92 -preshift -86,-66 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.3 -forceversion 3.1.3 -host 127.0.0.1 -port 5601
quartz386{brugger}167: visit/bin/visit -v 3.1.4
Running: gui3.1.4 -forceversion 3.1.4
Running: viewer3.1.4 -forceversion 3.1.4 -geometry 1516x958+404+56 -borders 0,0,0,0 -shift 90,92 -preshift -90,-92 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.4 -forceversion 3.1.4 -host 127.0.0.1 -port 5601
quartz386{brugger}168: visit/bin/visit -v 3.1
Running: gui3.1.4
Running: viewer3.1.4 -geometry 1516x958+404+56 -borders 0,0,0,0 -shift 90,92 -preshift -90,-92 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.1.4 -host 127.0.0.1 -port 5601
quartz386{brugger}169: visit/bin/visit -v 3.0.1
Running: gui3.0.1 -forceversion 3.0.1
Running: viewer3.0.1 -forceversion 3.0.1 -geometry 1508x958+412+56 -borders 26,4,4,4 -shift 90,92 -preshift -86,-66 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.0.1 -forceversion 3.0.1 -host 127.0.0.1 -port 5601
quartz386{brugger}170: visit/bin/visit -v 2.13.1
Running: gui2.13.1 -forceversion 2.13.1
Running: viewer2.13.1 -forceversion 2.13.1 -geometry 1516x958+404+56 -borders 0,0,0,0 -shift 90,92 -preshift -90,-92 -defer -host 127.0.0.1 -port 5600
Running: mdserver2.13.1 -forceversion 2.13.1 -host 127.0.0.1 -port 5601
quartz386{brugger}171: visit/bin/visit -v 2.13
Running: gui2.13.3
Running: viewer3.2.0 -geometry 1508x958+412+56 -borders 26,4,4,4 -shift 90,92 -preshift -86,-66 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.2.0 -host 127.0.0.1 -port 5601
quartz386{brugger}172:

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
