### PR TITLE
Fix frontendlauncher for Python 3 and running old internallaunchers. (#5580)

### DIFF
--- a/src/bin/frontendlauncher.py
+++ b/src/bin/frontendlauncher.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
 import os
+import string
 import sys
 import subprocess
 
@@ -82,7 +82,7 @@ def UNSETENV(var):
 
 def exit(msg, value):
     if msg != None:
-        print(msg, file=sys.stderr)
+        sys.stderr.write("%s\n" % msg)
     sys.exit(value)
 
 def ParseVersion(ver):
@@ -195,9 +195,9 @@ while i < len(sys.argv):
         want_version = 1
     elif arg in programs:
         progname = arg[1:]
-        print("NOTE:  Specifying tools as an argument to VisIt is ", file=sys.stderr)
-        print("no longer necessary.\nIn the future, you should ", file=sys.stderr)
-        print("just run '%s' instead.\n" % progname, file=sys.stderr)
+        sys.stderr.write("NOTE:  Specifying tools as an argument to VisIt is \n")
+        sys.stderr.write("no longer necessary.\nIn the future, you should \n")
+        sys.stderr.write("just run '%s' instead.\n\n" % progname)
     elif arg in list(programsWithOtherNames.keys()):
         progname = programsWithOtherNames[arg]
     else:
@@ -301,6 +301,10 @@ else:
         add_forceversion = 1
     if (not (version[0] == 1 and version[1] < 7)) and version[2] == -1 and version[3] == -1:
         add_forceversion = 0
+        # We take the list of all the versions and create an unsorted
+        # list of the versions where the major and minor versions match.
+        # Then we sort that list by patch number and select that one
+        # as the version.
         unsorted_matches = []
         for v in exeversions:
             try:
@@ -309,16 +313,12 @@ else:
                     unsorted_matches.append(v)
             except:
                 continue
-        def by_patch_version(a,b):
-            v1 = a.split(".")
-            v2 = b.split(".")
-            if len(v1) < 3: return -1
-            if len(v2) < 3: return +1
-            if v1[2] < v2[2]: return -1
-            if v1[2] > v2[2]: return +1
-            return 0
+        def get_patch_version(a):
+            v = a.split(".")
+            if len(v) < 3: return -1
+            return int(v[2])
         if len(unsorted_matches) > 0:
-            sorted_matches = sorted(unsorted_matches, cmp=by_patch_version)
+            sorted_matches = sorted(unsorted_matches, key=get_patch_version)
             ver = sorted_matches[-1]
             version = ParseVersion(ver)
 
@@ -330,10 +330,10 @@ else:
 
     # Warn if we mixed public and private development versions.
     if using_dev:
-        print("", file=sys.stderr);
-        print("WARNING: You are launching a public version of VisIt", file=sys.stderr);
-        print("         from within a development version!", file=sys.stderr);
-        print("", file=sys.stderr);
+        sys.stderr.write("\n");
+        sys.stderr.write("WARNING: You are launching a public version of VisIt\n");
+        sys.stderr.write("         from within a development version!\n");
+        sys.stderr.write("\n");
         visitargs = ["-dv"] + visitargs
 
     # The actual visit directory is now version-specific
@@ -405,7 +405,7 @@ else:
             newlauncher = createlauncher()
             launcher = newlauncher
         except:
-            print("Could not create custom launcher", file=sys.stderr)
+            sys.stderr.write("Could not create custom launcher\n")
 
     # Now, call the regular internallauncher function with the launcher
     # object that we created.


### PR DESCRIPTION
Resolves #5572 
Merge from the 3.2RC to develop.