### PR TITLE
Fix a frontendlauncher bug and a movie wizard bug.

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -114,6 +114,11 @@ if test "$version" != ""; then
     thispython="$dir/../$version/$platform/bin/python"
     if test -x "$thispython"; then
         visitpython="$thispython"
+    else
+        thispython="$dir/../$version/$platform/bin/python3"
+        if test -x "$thispython"; then
+            visitpython="$thispython"
+        fi
     fi
 fi
 
@@ -127,7 +132,7 @@ if test -n "$visitpython"; then
     # next to the python binary we located already.
     pyver=""
     for ver in 2.4 2.5 2.6 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12; do
-        if test -x "$visitpython$ver"; then
+        if test -x "$visitdir/bin/python$ver"; then
             pyver=$ver
             break
         fi

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -8436,7 +8436,7 @@ QvisGUIApplication::SaveMovieMain()
                     "redblue", "redgreen"};
                 int si = (stereos[i] < 0 || stereos[i] > 3) ? 0 : stereos[i];
                 QString order =
-                    QString("    movie.RequestFormat(\"%1\", %2, %3 \"%4\")\n")
+                    QString("    movie.RequestFormat(\"%1\", %2, %3, \"%4\")\n")
                     .arg(formats[i].c_str())
                     .arg(widths[i])
                     .arg(heights[i])


### PR DESCRIPTION
### Description

This commit fixes 2 distinct bugs.

1) When you have version 3.2.0 installed as well as some older versions of VisIt and the current version is one of the older versions and you run version 3.2.0, it will pick up the Python associated with the current version and not version 3.2.0. This is a problem because 3.2.0 needs Python 3 and the older versions use Python 2. In particular, if you have 3.1.4 and 3.2.0 installed with 3.1.4 being the current version and run "visit -v 3.2.0 -cli", this will fail. The problem is that the 3.2.0 version doesn't have "python" in its bin directory, but "python3". I modified the frontendlauncher to also look for "python3".

2) If you try to generate a movie with the movie creation wizard and specify "Now, use currently allocated processors", you will get an error message associated with the command:

movie.RequestFormat("png", 1024, 768 "off")

If you look at the command, there is a comma missing between 768 and "off". I modified the code that generates the command to add the comma.

### Type of change

Bug fix.

### How Has This Been Tested?

I created an installation of VisIt with 3.1.4 and the new 3.2.0 installed. I then ran "visit/bin/visit -v 3.2.0 -cli" and it worked. I used the same installation to create a movie with "Now, use currently allocated processors" and the cli started fine and there weren't any errors from the script it ran and it successfully generated the movie.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
