### PR TITLE
Change regression suite delay to post results to 10 hours.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -558,6 +558,6 @@ if test "$testHost" = "pascal" ; then
     subTag=`date +%Y-%m-%d-%H:%M`
     ssh pascal "./checkout_pascal $subTag"
     ssh pascal "msub -l nodes=1:ppn=16 -l gres=ignore -l walltime=10:00:00 -o pascal_testit_$subTag.out -q pvis -A wbronze -z ./runit_pascal $subTag"
-    sleep 28800
+    sleep 36000
     ssh pascal "./postit_pascal $subTag"
 fi


### PR DESCRIPTION
### Description

Changed the delay before the results get posted from 8 hours to 10 hours. The regression suite time limit had been raised to 10 hours at some point but the delay before posting never got updated to match.

The test suite is now taking more than 8 hours to run and I believe that posting the results before the tests have completed is preventing the scalable parallel icet results from posting.

### Type of change

Bug fix.

### How Has This Been Tested?

No way to test other than making it live. I'll see tomorrow morning if it worked.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
~~- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
