### PR TITLE
minor fixes for derived variables

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2600,6 +2600,9 @@ avtMiliFileFormat::AddMiliVariableToMetaData(avtDatabaseMetaData *avtMD,
 //      Alister Maguire, Thu Mar 25 13:55:53 PDT 2021
 //      Added support for stress and strain derivations and the sand mesh.
 //
+//      Alister Maguire, Wed Apr  7 11:26:57 PDT 2021
+//      Only add pressure for stress.
+//
 // ****************************************************************************
 
 void
@@ -2727,8 +2730,18 @@ avtMiliFileFormat::AddMiliDerivedVariables(avtDatabaseMetaData *md,
                 derivedPath = meshPath + "Derived/" + varPath;
             }
 
+            bool needPressure = false;
+
+            //
+            // Currently, we only add pressure for stress.
+            //
+            if ((*mdItr)->GetShortName() == "stress")
+            {
+                needPressure = true;
+            }
+
             AddStressStrainDerivations(md, (*mdItr)->GetShortName(),
-                varPath, derivedPath, true);
+                varPath, derivedPath, needPressure);
 
             //
             // If we've added one, we've added them all.
@@ -4247,6 +4260,9 @@ avtMiliFileFormat::ScalarExpressionFromVec(const char *vecPath,
 //
 //  Modifications
 //
+//      Alister Maguire, Wed Apr  7 11:26:57 PDT 2021
+//      Added missing component (1) for the principal tensor expressions.
+//
 // ****************************************************************************
 
 void
@@ -4298,6 +4314,12 @@ avtMiliFileFormat::AddStressStrainDerivations(avtDatabaseMetaData *md,
     maxShear.SetDefinition("tensor_maximum_shear(<" + varPath + ">)");
     maxShear.SetType(Expression::ScalarMeshVar);
     md->AddExpression(&maxShear);
+
+    Expression pTensor1;
+    pTensor1.SetName(derivedPath + "/prin_" + varName.c_str() + "/1");
+    pTensor1.SetDefinition("principal_tensor(<" + varPath + ">)[0]");
+    pTensor1.SetType(Expression::ScalarMeshVar);
+    md->AddExpression(&pTensor1);
 
     Expression pTensor2;
     pTensor2.SetName(derivedPath + "/prin_" + varName.c_str() + "/2");


### PR DESCRIPTION
### Description

Resolves #5601 

This PR contains some minor changes for the derived variables in the Mili plugin. They are:
1. Only add the "pressure" derivation for stress.
2. Add a missing component for the principal tensor derivation.

@durrenberger1

### Type of change

Task/bug fix

### How Has This Been Tested?

I've tested this by hand by opening up Mili datasets in VisIt, and I've re-run the Mili section of our test suite.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
