### PR TITLE
Moved content from the 3.2.1 release notes to the 3.2.0 release notes.

### DIFF
--- a/src/gui/SplashScreen.C
+++ b/src/gui/SplashScreen.C
@@ -244,6 +244,9 @@
 //    Eric Brugger, Mon Mar  1 14:47:30 PST 2021
 //    Changed the date on the splash screen to March 2021.
 //
+//    Eric Brugger, Thu Apr  8 08:51:53 PDT 2021
+//    Changed the date on the splash screen to April 2021.
+//
 // ****************************************************************************
 
 SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
@@ -364,7 +367,7 @@ SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
            << tr("October")
            << tr("November")
            << tr("December");
-    int currentMonth = 3;
+    int currentMonth = 4;
     lLayout->addWidget(new QLabel(versionText, this));
     lLayout->addWidget(new QLabel(months[currentMonth-1] + " 2021", this));
 

--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -70,6 +70,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Stimulate Image reader (file extensions spr, sdt), where a negative pixel delta in the metadata resulted in incorrect pick results, incorrect sampled lineouts and potentially other erroneous behavior.</li>
   <li>Enhanced the Xolotl reader to support the ability to visualize super clusters.</li>
   <li>Enhanced the CGNS reader to support reading arbitrary polygons and polyhedra.</li>
+  <li>Fixed a bug with the BoxLib reader causing VisIt to crash when opening files on OSX.</li>
+  <li>Enhanced the Mili reader to derive variables from stress and strain. If strain does not exist in the dataset, the plugin will derive four different versions of strain from the mesh.</li>
 </ul>
 
 <a name="Plot_changes"></a>
@@ -94,6 +96,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed an issue preventing build_visit from being able to build IceT.</li>
   <li>When using the resample operator in VisIt's python interface, <code>useExtents</code> will now take precedence over setting the resample dimensions explicitly, which matches the behavior in the GUI.</li>
   <li>Fixed a bug with DataBinning (and DDFs) where it did not exclude Ghost Zones when binning.</li>
+  <li>Fixed a bug preventing the Min/Max expressions from working with domain decomposed datasets.</li>
 </ul>
 
 <a name="Configuration_changes"></a>
@@ -102,6 +105,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added host profiles for the Lawrence Livermore National Laboratory's Ruby system. Removed the host profiles for the Lawrence Livermore National Laboratory's Zin system.</li>
   <li>Added a host profile for the pdebug queue for the Lawrence Livermore National Laboratory's Magma system.</li>
   <li>Updated the job launching on Trinity so that the VisIt CLI could be launched from a batch job without having to load the module of the compiler used to build VisIt.</li>
+  <li>Updated the Oak Ridge National Laboratory's host profiles to only include current machines.</li>
 </ul>
 
 <a name="Build_features"></a>

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -23,15 +23,15 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.2.1</font></b></p>
 <ul>
-  <li>Fixed a bug preventing the Min/Max expressions from working with domain decomposed datasets.</li>
-  <li>Fixed a bug causing VisIt to crash when opening BoxLib files on OSX builds.</li>
+  <li>Bug Fix 1</li>
+  <li>Bug Fix 2</li>
 </ul>
 
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.2.1</font></b></p>
 <ul>
-  <li>Enhanced the Mili plugin to derive variables from stress and strain. If strain does not exist in the dataset, the plugin will derive four different versions of strain from the mesh.</li>
-  <li>Updated the ORNL host file list to include only current machines.</li>
+  <li>Enhancement 1</li>
+  <li>Enhancement 2</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Moved content from the 3.2.1 release notes to the 3.2.0 release notes since the 3.2.0 release will be re-tagged and the work that we originally going into 3.2.1 is now going into 3.2.0.

Updated the month on the splash screen to April.

### Type of change

New feature.

### How Has This Been Tested?

I reviewed the changes to the release notes. I inspected the change to the splash screen since it was trivial.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
