### PR TITLE
Improve handling of incorrect structured domain boundary info.

### DIFF
--- a/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
@@ -26,6 +26,7 @@
 #include <avtMaterial.h>
 #include <avtMixedVariable.h>
 #include <avtParallel.h>
+#include <avtParallelContext.h>
 
 #include <BadIndexException.h>
 #include <DebugStream.h>
@@ -213,6 +214,10 @@ BoundaryHelperFunctions<T>::InitializeBoundaryData()
 //    Cyrus Harrison, Tue Dec 22 15:39:48 PST 2015
 //    When match index == -1, find match index instead of using a stored index.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 template <class T>
 void
@@ -246,6 +251,8 @@ BoundaryHelperFunctions<T>::FillBoundaryData(int      d1,
             // find the match index ourselves
             mi = FindMatchIndex(d1,d2);
         }
+        if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
+            EXCEPTION1(VisItException,"Bad Neighbor Index");
 
         Neighbor *n2 = &(sdb->boundary[d2].neighbors[mi]);
         int *n2extents = (isPointData ? n2->nextents : n2->zextents);
@@ -302,6 +309,10 @@ BoundaryHelperFunctions<T>::FillBoundaryData(int      d1,
 //    Cyrus Harrison, Tue Dec 22 15:39:48 PST 2015
 //    When match index == -1, find match index instead of using a stored index.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 template <class T>
 void
@@ -330,10 +341,11 @@ BoundaryHelperFunctions<T>::FillRectilinearBoundaryData(int      d1,
             // find the match index ourselves
             mi = FindMatchIndex(d1,d2);
         }
+        if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
+            EXCEPTION1(VisItException,"Bad Neighbor Index");
 
         // get the other neis list
         Neighbor *n2 = &(sdb->boundary[d2].neighbors[mi]);
-
 
         int *n2extents = n2->nextents;
         int bndindex = 0;
@@ -396,6 +408,10 @@ BoundaryHelperFunctions<T>::FillRectilinearBoundaryData(int      d1,
 //    Skip generating neighbor data for a donor relationship.  It won't
 //    get used anyway.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 template <class T>
 void
@@ -421,6 +437,15 @@ BoundaryHelperFunctions<T>::FillMixedBoundaryData(int          d1,
             continue;
         }
         int mi = n1->match;
+        // local dbi's case doesn't use an explicit match index
+        if(mi == -1)
+        {
+            // find the match index ourselves
+            mi = FindMatchIndex(d1,d2);
+        }
+        if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
+            EXCEPTION1(VisItException,"Bad Neighbor Index");
+
         Neighbor *n2 = &(sdb->boundary[d2].neighbors[mi]);
         int *n2extents = n2->zextents;
 
@@ -1157,6 +1182,10 @@ avtStructuredDomainBoundaries::SetExistence(int      d1,
 //    Cyrus Harrison, Tue Dec 22 15:39:48 PST 2015
 //    When match index == -1, find match index instead of using a stored index.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 template <class T>
 void
@@ -1185,6 +1214,8 @@ BoundaryHelperFunctions<T>::SetNewBoundaryData(int       d1,
             // find the match index ourselves
             mi = FindMatchIndex(d1,d2);
         }
+        if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
+            EXCEPTION1(VisItException,"Bad Neighbor Index");
 
         T *data = bnddata[d2][mi];
         if (!data)
@@ -1240,6 +1271,10 @@ BoundaryHelperFunctions<T>::SetNewBoundaryData(int       d1,
 //    Cyrus Harrison, Tue Dec 22 15:39:48 PST 2015
 //    When match index == -1, find match index instead of using a stored index.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 template <class T>
 void
@@ -1264,6 +1299,8 @@ BoundaryHelperFunctions<T>::SetNewRectilinearBoundaryData(int d1,
             // find the match index ourselves
             mi = FindMatchIndex(d1,d2);
         }
+        if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
+            EXCEPTION1(VisItException,"Bad Neighbor Index");
 
         T *data = coord[d2][mi];
         if (!data)
@@ -1815,6 +1852,10 @@ avtStructuredDomainBoundaries::ExchangeScalar(vector<int>           domainNum,
 //    Jeremy Meredith, Thu Apr 12 18:00:17 EDT 2012
 //    Added timings for each phase of ghost zone communication.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<vtkDataArray*>
 avtStructuredDomainBoundaries::ExchangeFloatScalar(vector<int>     domainNum,
@@ -1836,12 +1877,30 @@ avtStructuredDomainBoundaries::ExchangeFloatScalar(vector<int>     domainNum,
     // Create the matching arrays for the given scalars
     //
     float ***vals = bhf_float->InitializeBoundaryData();
-    for (size_t d = 0; d < scalars.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        float *oldvals = (float*)scalars[d]->GetVoidPointer(0);
-        bhf_float->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        for (size_t d = 0; d < scalars.size(); d++)
+        {
+            float *oldvals = (float*)scalars[d]->GetVoidPointer(0);
+            bhf_float->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in float version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_float->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_float->CommunicateBoundaryData(domain2proc, vals, isPointData);
 
@@ -1893,6 +1952,9 @@ avtStructuredDomainBoundaries::ExchangeFloatScalar(vector<int>     domainNum,
 //  Creation:    Sun Apr 22 08:53:31 PDT 2012
 //
 //  Modifications:
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
 //
 // ****************************************************************************
 
@@ -1916,12 +1978,30 @@ avtStructuredDomainBoundaries::ExchangeDoubleScalar(vector<int>     domainNum,
     // Create the matching arrays for the given scalars
     //
     double ***vals = bhf_double->InitializeBoundaryData();
-    for (size_t d = 0; d < scalars.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        double *oldvals = (double*)scalars[d]->GetVoidPointer(0);
-        bhf_double->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        for (size_t d = 0; d < scalars.size(); d++)
+        {
+            double *oldvals = (double*)scalars[d]->GetVoidPointer(0);
+            bhf_double->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in double version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_double->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_double->CommunicateBoundaryData(domain2proc, vals, isPointData);
 
@@ -1982,6 +2062,10 @@ avtStructuredDomainBoundaries::ExchangeDoubleScalar(vector<int>     domainNum,
 //    Jeremy Meredith, Thu Apr 12 18:00:17 EDT 2012
 //    Added timings for each phase of ghost zone communication.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<vtkDataArray*>
 avtStructuredDomainBoundaries::ExchangeIntScalar(vector<int>       domainNum,
@@ -2003,12 +2087,30 @@ avtStructuredDomainBoundaries::ExchangeIntScalar(vector<int>       domainNum,
     // Create the matching arrays for the given scalars
     //
     int ***vals = bhf_int->InitializeBoundaryData();
-    for (size_t d = 0; d < scalars.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        int *oldvals = (int*)scalars[d]->GetVoidPointer(0);
-        bhf_int->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        for (size_t d = 0; d < scalars.size(); d++)
+        {
+            int *oldvals = (int*)scalars[d]->GetVoidPointer(0);
+            bhf_int->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in int version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_int->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_int->CommunicateBoundaryData(domain2proc, vals, isPointData);
 
@@ -2070,6 +2172,10 @@ avtStructuredDomainBoundaries::ExchangeIntScalar(vector<int>       domainNum,
 //    Jeremy Meredith, Thu Apr 12 18:00:17 EDT 2012
 //    Added timings for each phase of ghost zone communication.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<vtkDataArray*>
 avtStructuredDomainBoundaries::ExchangeUCharScalar(vector<int>     domainNum,
@@ -2091,12 +2197,30 @@ avtStructuredDomainBoundaries::ExchangeUCharScalar(vector<int>     domainNum,
     // Create the matching arrays for the given scalars
     //
     unsigned char ***vals = bhf_uchar->InitializeBoundaryData();
-    for (size_t d = 0; d < scalars.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        unsigned char *oldvals = (unsigned char*)scalars[d]->GetVoidPointer(0);
-        bhf_uchar->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        for (size_t d = 0; d < scalars.size(); d++)
+        {
+            unsigned char *oldvals = (unsigned char*)scalars[d]->GetVoidPointer(0);
+            bhf_uchar->FillBoundaryData(domainNum[d], oldvals, vals, isPointData);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in uchar version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_uchar->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_uchar->CommunicateBoundaryData(domain2proc, vals, isPointData);
 
@@ -2225,6 +2349,10 @@ avtStructuredDomainBoundaries::ExchangeVector(vector<int>           domainNum,
 //    Jeremy Meredith, Thu Apr 12 18:00:17 EDT 2012
 //    Added timings for each phase of ghost zone communication.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<vtkDataArray*>
 avtStructuredDomainBoundaries::ExchangeFloatVector(vector<int>      domainNum,
@@ -2248,12 +2376,30 @@ avtStructuredDomainBoundaries::ExchangeFloatVector(vector<int>      domainNum,
     float ***vals = bhf_float->InitializeBoundaryData();
 
     int nComp = (vectors.size() > 0 ? vectors[0]->GetNumberOfComponents() :-1);
-    for (size_t d = 0; d < vectors.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        float *oldvals = (float*)vectors[d]->GetVoidPointer(0);
-        bhf_float->FillBoundaryData(domainNum[d], oldvals, vals, isPointData, nComp);
+        for (size_t d = 0; d < vectors.size(); d++)
+        {
+            float *oldvals = (float*)vectors[d]->GetVoidPointer(0);
+            bhf_float->FillBoundaryData(domainNum[d], oldvals, vals, isPointData, nComp);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in floatvec version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_float->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_float->CommunicateBoundaryData(domain2proc, vals, isPointData, nComp);
 
@@ -2304,6 +2450,9 @@ avtStructuredDomainBoundaries::ExchangeFloatVector(vector<int>      domainNum,
 //  Creation:    November 21, 2001
 //
 //  Modifications:
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
 //
 // ****************************************************************************
 vector<vtkDataArray*>
@@ -2328,12 +2477,30 @@ avtStructuredDomainBoundaries::ExchangeDoubleVector(vector<int>      domainNum,
     double ***vals = bhf_double->InitializeBoundaryData();
 
     int nComp = (vectors.size() > 0 ? vectors[0]->GetNumberOfComponents() :-1);
-    for (size_t d = 0; d < vectors.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        double *oldvals = (double*)vectors[d]->GetVoidPointer(0);
-        bhf_double->FillBoundaryData(domainNum[d], oldvals, vals, isPointData, nComp);
+        for (size_t d = 0; d < vectors.size(); d++)
+        {
+            double *oldvals = (double*)vectors[d]->GetVoidPointer(0);
+            bhf_double->FillBoundaryData(domainNum[d], oldvals, vals, isPointData, nComp);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in doublevec version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_double->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_double->CommunicateBoundaryData(domain2proc, vals, isPointData, nComp);
 
@@ -2403,6 +2570,10 @@ avtStructuredDomainBoundaries::ExchangeDoubleVector(vector<int>      domainNum,
 //    Jeremy Meredith, Thu Apr 12 18:00:17 EDT 2012
 //    Added timings for each phase of ghost zone communication.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<vtkDataArray*>
 avtStructuredDomainBoundaries::ExchangeIntVector(vector<int>        domainNum,
@@ -2426,12 +2597,30 @@ avtStructuredDomainBoundaries::ExchangeIntVector(vector<int>        domainNum,
     int ***vals = bhf_int->InitializeBoundaryData();
 
     int nComp = (vectors.size() > 0 ? vectors[0]->GetNumberOfComponents(): -1);
-    for (size_t d = 0; d < vectors.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        int *oldvals = (int*)vectors[d]->GetVoidPointer(0);
-        bhf_int->FillBoundaryData(domainNum[d], oldvals, vals, isPointData, nComp);
+        for (size_t d = 0; d < vectors.size(); d++)
+        {
+            int *oldvals = (int*)vectors[d]->GetVoidPointer(0);
+            bhf_int->FillBoundaryData(domainNum[d], oldvals, vals, isPointData, nComp);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in intvec version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_int->FreeBoundaryData(vals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_int->CommunicateBoundaryData(domain2proc, vals, isPointData, nComp);
 
@@ -2504,6 +2693,10 @@ avtStructuredDomainBoundaries::ExchangeIntVector(vector<int>        domainNum,
 //    data.  We can't reliably use any other information (like a change
 //    in zone ID) to determine when a segment of mix data has ended.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<avtMaterial*>
 avtStructuredDomainBoundaries::ExchangeMaterial(vector<int>          domainNum,
@@ -2532,18 +2725,39 @@ avtStructuredDomainBoundaries::ExchangeMaterial(vector<int>          domainNum,
     for (size_t b = 0; b < boundary.size(); b++)
         mixlen[b] = vector<int>(boundary[b].neighbors.size(), 0);
 
-    for (size_t d = 0; d < mats.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        const int *oldmatlist = mats[d]->GetMatlist();
-        bhf_int->FillBoundaryData(domainNum[d], oldmatlist, matlist, false);
-    }
+        for (size_t d = 0; d < mats.size(); d++)
+        {
+            const int *oldmatlist = mats[d]->GetMatlist();
+            bhf_int->FillBoundaryData(domainNum[d], oldmatlist, matlist, false);
+        }
 
-    for (size_t d = 0; d < mats.size(); d++)
-    {
-        bhf_float->FillMixedBoundaryData(domainNum[d], mats[d], mats[d]->GetMixVF(),
-                              mixvf, mixmat, mixzone, mixnext, mixlen[domainNum[d]]);
+        for (size_t d = 0; d < mats.size(); d++)
+        {
+            bhf_float->FillMixedBoundaryData(domainNum[d], mats[d], mats[d]->GetMixVF(),
+                mixvf, mixmat, mixzone, mixnext, mixlen[domainNum[d]]);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in mat version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_int->FreeBoundaryData(matlist);
+        bhf_int->FreeBoundaryData(mixmat);
+        bhf_int->FreeBoundaryData(mixzone);
+        bhf_int->FreeBoundaryData(mixnext);
+        bhf_float->FreeBoundaryData(mixvf);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_int->CommunicateBoundaryData(domain2proc, matlist, false);
     bhf_float->CommunicateMixedBoundaryData(domain2proc, mixvf, mixmat, mixzone, mixnext, mixlen);
@@ -2675,6 +2889,10 @@ avtStructuredDomainBoundaries::ExchangeMaterial(vector<int>          domainNum,
 //    data.  We can't reliably use any other information (like a change
 //    in zone ID) to determine when a segment of mix data has ended.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 vector<avtMixedVariable*>
 avtStructuredDomainBoundaries::ExchangeMixVar(vector<int>            domainNum,
@@ -2742,19 +2960,40 @@ avtStructuredDomainBoundaries::ExchangeMixVar(vector<int>            domainNum,
     for (size_t  b = 0; b < boundary.size(); b++)
         mixlen[b] = vector<int>(boundary[b].neighbors.size(), 0);
 
-    for (size_t d = 0; d < mats.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        const int *oldmatlist = mats[d]->GetMatlist();
-        bhf_int->FillBoundaryData(domainNum[d], oldmatlist, matlist, false);
-    }
+        for (size_t d = 0; d < mats.size(); d++)
+        {
+            const int *oldmatlist = mats[d]->GetMatlist();
+            bhf_int->FillBoundaryData(domainNum[d], oldmatlist, matlist, false);
+        }
 
-    for (size_t d = 0; d < mats.size(); d++)
-    {
-        const float *oldmixvals = (mixvars[d] ? mixvars[d]->GetBuffer() : NULL);
-        bhf_float->FillMixedBoundaryData(domainNum[d], mats[d], oldmixvals,
-                              mixvals, NULL, mixzone, mixnext, mixlen[domainNum[d]]);
+        for (size_t d = 0; d < mats.size(); d++)
+        {
+            const float *oldmixvals = (mixvars[d] ? mixvars[d]->GetBuffer() : NULL);
+            bhf_float->FillMixedBoundaryData(domainNum[d], mats[d], oldmixvals,
+                mixvals, NULL, mixzone, mixnext, mixlen[domainNum[d]]);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in mixvar version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf_int->FreeBoundaryData(matlist);
+        bhf_int->FreeBoundaryData(mixzone);
+        bhf_int->FreeBoundaryData(mixnext);
+        bhf_float->FreeBoundaryData(mixvals);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf_int->CommunicateBoundaryData(domain2proc, matlist, false);
     bhf_float->CommunicateMixedBoundaryData(domain2proc, mixvals, NULL, mixzone, mixnext, mixlen);
@@ -3133,6 +3372,10 @@ avtCurvilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
 //    Brad Whitlock, Sun Apr 22 09:37:32 PDT 2012
 //    I templated this function so we can support double.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 
 template <typename Helper>
@@ -3146,13 +3389,31 @@ avtCurvilinearDomainBoundaries::ExchangeMesh(Helper *bhf, int vtktype,
     // Create the matching arrays for the given meshes
     //
     typename Helper::Storage ***coord = bhf->InitializeBoundaryData();
-    for (size_t d = 0; d < meshes.size(); d++)
+    int exceptionThrown = 0;
+    TRY
     {
-        vtkStructuredGrid *mesh = (vtkStructuredGrid*)(meshes[d]);
-        typename Helper::Storage *oldcoord = (typename Helper::Storage*)mesh->GetPoints()->GetVoidPointer(0);
-        bhf->FillBoundaryData(domainNum[d], oldcoord, coord, true, 3);
+        for (size_t d = 0; d < meshes.size(); d++)
+        {
+            vtkStructuredGrid *mesh = (vtkStructuredGrid*)(meshes[d]);
+            typename Helper::Storage *oldcoord = (typename Helper::Storage*)mesh->GetPoints()->GetVoidPointer(0);
+            bhf->FillBoundaryData(domainNum[d], oldcoord, coord, true, 3);
+        }
     }
+    CATCH2(VisItException, e)
+    {
+        exceptionThrown = 1;
+    }
+    ENDTRY
+
     visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in curvmesh version)");
+
+    avtParallelContext context;
+    exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+    if (exceptionThrown)
+    {
+        bhf->FreeBoundaryData(coord);
+        EXCEPTION1(VisItException, "Bad Neighbor Index");
+    }
 
     bhf->CommunicateBoundaryData(domain2proc, coord, true, 3);
 
@@ -3246,6 +3507,10 @@ avtCurvilinearDomainBoundaries::ExchangeMesh(Helper *bhf, int vtktype,
 //    Brad Whitlock, Sun Apr 22 09:55:30 PDT 2012
 //    Added support for double coordinates.
 //
+//    Eric Brugger, Mon Apr 12 13:49:50 PDT 2021
+//    Add code to detect incorrect domain boundary information, where two
+//    neighbors don't list each other in their neighbor lists.
+//
 // ****************************************************************************
 
 vector<vtkDataSet*>
@@ -3276,12 +3541,31 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
     {
         int timer_PackData = visitTimer->StartTimer();
         ghosts = bhf_uchar->InitializeBoundaryData();
-        for (d = 0 ; d < meshes.size() ; d++)
+        int exceptionThrown = 0;
+        TRY
         {
-            unsigned char *g = (unsigned char*)meshes[d]->GetCellData()->GetArray("avtGhostZones")->GetVoidPointer(0);
-            bhf_uchar->FillBoundaryData(domainNum[d], g, ghosts, false, 1);
+            for (d = 0 ; d < meshes.size() ; d++)
+            {
+                unsigned char *g = (unsigned char*)meshes[d]->GetCellData()->GetArray("avtGhostZones")->GetVoidPointer(0);
+                bhf_uchar->FillBoundaryData(domainNum[d], g, ghosts, false, 1);
+            }
         }
+        CATCH2(VisItException, e)
+        {
+            exceptionThrown = 1;
+        }
+        ENDTRY
+
         visitTimer->StopTimer(timer_PackData, "Ghost Zone Generation phase 2: Pack Data (in rectmesh version)");
+
+        avtParallelContext context;
+        exceptionThrown = context.UnifyMaximumValue(exceptionThrown);
+        if (exceptionThrown)
+        {
+            bhf_uchar->FreeBoundaryData(ghosts);
+            EXCEPTION1(VisItException, "Bad Neighbor Index");
+        }
+
         bhf_uchar->CommunicateBoundaryData(domain2proc, ghosts, false, 1);
     }
 

--- a/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
@@ -252,7 +252,13 @@ BoundaryHelperFunctions<T>::FillBoundaryData(int      d1,
             mi = FindMatchIndex(d1,d2);
         }
         if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
-            EXCEPTION1(VisItException,"Bad Neighbor Index");
+        {
+            char msg[256];
+            snprintf(msg, 256,
+                "Bad Neighbor Index: domain %d missing neighbor for %d.",
+                d2, d1);
+            EXCEPTION1(VisItException, msg);
+        }
 
         Neighbor *n2 = &(sdb->boundary[d2].neighbors[mi]);
         int *n2extents = (isPointData ? n2->nextents : n2->zextents);
@@ -342,7 +348,13 @@ BoundaryHelperFunctions<T>::FillRectilinearBoundaryData(int      d1,
             mi = FindMatchIndex(d1,d2);
         }
         if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
-            EXCEPTION1(VisItException,"Bad Neighbor Index");
+        {
+            char msg[256];
+            snprintf(msg, 256,
+                "Bad Neighbor Index: domain %d missing neighbor for %d.",
+                d2, d1);
+            EXCEPTION1(VisItException, msg);
+        }
 
         // get the other neis list
         Neighbor *n2 = &(sdb->boundary[d2].neighbors[mi]);
@@ -444,7 +456,13 @@ BoundaryHelperFunctions<T>::FillMixedBoundaryData(int          d1,
             mi = FindMatchIndex(d1,d2);
         }
         if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
-            EXCEPTION1(VisItException,"Bad Neighbor Index");
+        {
+            char msg[256];
+            snprintf(msg, 256,
+                "Bad Neighbor Index: domain %d missing neighbor for %d.",
+                d2, d1);
+            EXCEPTION1(VisItException, msg);
+        }
 
         Neighbor *n2 = &(sdb->boundary[d2].neighbors[mi]);
         int *n2extents = n2->zextents;
@@ -543,7 +561,7 @@ BoundaryHelperFunctions<T>::FindMatchIndex(int src_domain,
         }
     }
     if (res_match == -1)
-            EXCEPTION1(VisItException,"Bad Neighbor Index");
+        EXCEPTION1(VisItException,"Bad Neighbor Index");
 
     return res_match;
 }
@@ -1215,7 +1233,13 @@ BoundaryHelperFunctions<T>::SetNewBoundaryData(int       d1,
             mi = FindMatchIndex(d1,d2);
         }
         if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
-            EXCEPTION1(VisItException,"Bad Neighbor Index");
+        {
+            char msg[256];
+            snprintf(msg, 256,
+                "Bad Neighbor Index: domain %d missing neighbor for %d.",
+                d2, d1);
+            EXCEPTION1(VisItException, msg);
+        }
 
         T *data = bnddata[d2][mi];
         if (!data)
@@ -1300,7 +1324,13 @@ BoundaryHelperFunctions<T>::SetNewRectilinearBoundaryData(int d1,
             mi = FindMatchIndex(d1,d2);
         }
         if (mi < 0 || mi >= sdb->boundary[d2].neighbors.size())
-            EXCEPTION1(VisItException,"Bad Neighbor Index");
+        {
+            char msg[256];
+            snprintf(msg, 256,
+                "Bad Neighbor Index: domain %d missing neighbor for %d.",
+                d2, d1);
+            EXCEPTION1(VisItException, msg);
+        }
 
         T *data = coord[d2][mi];
         if (!data)

--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -99,6 +99,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with DataBinning (and DDFs) where it did not exclude Ghost Zones when binning.</li>
   <li>Fixed a bug preventing the Min/Max expressions from working with domain decomposed datasets.</li>
   <li>Fixed a bug that caused some LibSim examples to crash.</li>
+  <li>Fixed a bug where the VisIt compute engine would crash generating ghost zone information when it had incorrect structured domain boundary information. In particular, the compute engine would crash when a pair of neighbors didn't list each other as neighbors. VisIt now generates a "Bad Neighbor Index" exception when it encoutners the situation.</li>
 </ul>
 
 <a name="Configuration_changes"></a>

--- a/src/resources/help/en_US/relnotes3.2.0.html
+++ b/src/resources/help/en_US/relnotes3.2.0.html
@@ -99,7 +99,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with DataBinning (and DDFs) where it did not exclude Ghost Zones when binning.</li>
   <li>Fixed a bug preventing the Min/Max expressions from working with domain decomposed datasets.</li>
   <li>Fixed a bug that caused some LibSim examples to crash.</li>
-  <li>Fixed a bug where the VisIt compute engine would crash generating ghost zone information when it had incorrect structured domain boundary information. In particular, the compute engine would crash when a pair of neighbors didn't list each other as neighbors. VisIt now generates a "Bad Neighbor Index" exception when it encoutners the situation.</li>
+  <li>Fixed a bug where the VisIt compute engine would crash generating ghost zone information when it had incorrect structured domain boundary information. In particular, the compute engine would crash when a pair of neighbors didn't list each other as neighbors. VisIt now generates a "Bad Neighbor Index" exception when it encounters the situation.</li>
 </ul>
 
 <a name="Configuration_changes"></a>


### PR DESCRIPTION
### Description

Resolves #5619

I had a user give me a Silo file that had incorrect structured domain boundary information, where the neighbor information for some of the domains had a bad value causing the neighbor information to be treated as a periodic boundary and subsequently getting removed. This meant that there were pairs of neighbors that didn't reference each other causing the ghost zone creation to crash.

This fix detects the error where there are pairs of neighbors that don't reference each other and throws a "Bad Neighbor Index" exception. Logic was also added so that the engine doesn't hang when running in parallel and not all the processors throw the error. This involved catching the error before the next collective communication that could occur after the exception was thrown, unifying the exception across all the processors, and throwing another exception on all the processors if 1 or more of them threw the exception. I threw another "Bad Neighbor Index" exception since currently that is the only type of exception that could have occured. A better solution would be to also unify the type of exception and then throw that exception. Unfortunately, we don't have any infrastructure to support this and add that seemed out of the scope of this ticket.

### Type of change

Bug fix.

### How Has This Been Tested?

I did the following with the bad Silo file from the user.

1) I opened the file
2) I created a Pseudocolor plot of den
3) I turned off material 2

At this point the engine threw a "Bad Neighbor Index"

4) I turned material 2 on

At this point the plot drew again.

I did this in serial and in parallel with 4, 8, 12 and 17 processors. The file had 36 domains, so this is pretty good coverage. I did check that not all processors were throwing the exception in parallel, so the tests did handle the case where VisIt could hang if not all the processors threw the exception.

I also modified the Silo reader to ignore the bad value, creating valid structured domain boundary information. I ran the above scenario again and it worked properly in all cases, so things still work correctly in that case as well.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
