### PR TITLE
Update Docker files to handle changes to Qt build.

### DIFF
--- a/scripts/docker/Dockerfile-centos8
+++ b/scripts/docker/Dockerfile-centos8
@@ -25,6 +25,7 @@ RUN dnf -y upgrade \
     libxcb-devel \
     libxkbcommon-devel \
     libXext-devel \
+    libXrender-devel \
     libXt-devel \
     freetype-devel \
     fontconfig \

--- a/scripts/docker/Dockerfile-fedora31
+++ b/scripts/docker/Dockerfile-fedora31
@@ -23,6 +23,7 @@ RUN dnf -y upgrade && dnf -y install \
     libxcb-devel \
     libxkbcommon-devel \
     libXext-devel \
+    libXrender-devel \
     libXt-devel \
     freetype-devel \
     fontconfig \


### PR DESCRIPTION
### Description

The build of Qt was changed in build_visit to add "-xcb-native-painting" to the configure line to resolve ticket #5593, where using zoom messed up the toolbar when running remotely over X Windows. This change required installing "libXrender-devel" on Centos8 and Fedora31.

### Type of change

Bug fix.

### How Has This Been Tested?

I used the new Docker files to successfully generate containers on Centos8 and Fedora31.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
