### PR TITLE
Fix ospray regression failure

### DIFF
--- a/src/avt/Plotter/vtk/vtkVisItDataSetMapper.h
+++ b/src/avt/Plotter/vtk/vtkVisItDataSetMapper.h
@@ -21,6 +21,11 @@ class vtkLookupTable;
 //  This route was part of Brad's original Cinema support, so it was
 //  a quick way to re-enable the Cinema composite functionality.
 //
+//  KSB 04-15-2021
+//  Note: in VisWinRendering.C, OSPRAY creates its own override of
+//  vtkDataSetMapper.  The OSPRAY override was modified to override this
+//  class instead.  If this class is ever removed, the OSPRAY override will
+//  need to be changed back to vtkDataSetMapper.
 
 class PLOTTER_API vtkVisItDataSetMapper : public vtkDataSetMapper
 {

--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -137,6 +137,12 @@ bool VisWinRendering::stereoEnabled = false;
 //
 //   Garrett Morrison, Fri May 11 17:57:47 PDT 2018
 //   Added optional OSPRay initialization to constructor
+//
+//   Kathleen Biagas, Thur Apr 15 2021
+//   Since vtkVisItDataSetMapper is a subclass of and used as an override
+//   for vtkDataSetMapper within VisIt, changed pd_maker to be an override of
+//   vtkVisItDataSetMapper.
+//
 // ****************************************************************************
 
 VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
@@ -188,7 +194,10 @@ VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
 
     osprayPass = vtkOSPRayPass::New();
     vtkViewNodeFactory* factory = osprayPass->GetViewNodeFactory();
-    factory->RegisterOverride("vtkDataSetMapper",
+    // Override vtkVisItDataSetMapper instead of vtkDataSetMapper.
+    // If the use of vtkVisItDataSetMapper as a general override of
+    // vtkDataSetMapper is removed this code will need to be changed.
+    factory->RegisterOverride("vtkVisItDataSetMapper",
                               vtkVisItViewNodeFactory::pd_maker);
     factory->RegisterOverride("vtkPointGlyphMapper",
                               vtkVisItViewNodeFactory::pd_maker);


### PR DESCRIPTION
The failure was introduced by my Cinema changes.
Change OSPRAY's override of vtkDataSetMapper to vtkVisItDataSetMapper.
Add comments regarding the need to change this back if vtkVisItDataSetMapper is ever removed.

### How Has This Been Tested?

I ran the ospray test with success.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
