### PR TITLE
Fix OSPRAY regression failure. (#5630)

### DIFF
--- a/src/avt/Plotter/vtk/vtkVisItDataSetMapper.h
+++ b/src/avt/Plotter/vtk/vtkVisItDataSetMapper.h
@@ -21,6 +21,11 @@ class vtkLookupTable;
 //  This route was part of Brad's original Cinema support, so it was
 //  a quick way to re-enable the Cinema composite functionality.
 //
+//  KSB 04-15-2021
+//  Note: in VisWinRendering.C, OSPRAY creates its own override of
+//  vtkDataSetMapper.  The OSPRAY override was modified to override this
+//  class instead.  If this class is ever removed, the OSPRAY override will
+//  need to be changed back to vtkDataSetMapper.
 
 class PLOTTER_API vtkVisItDataSetMapper : public vtkDataSetMapper
 {

--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -137,6 +137,12 @@ bool VisWinRendering::stereoEnabled = false;
 //
 //   Garrett Morrison, Fri May 11 17:57:47 PDT 2018
 //   Added optional OSPRay initialization to constructor
+//
+//   Kathleen Biagas, Thur Apr 15 2021
+//   Since vtkVisItDataSetMapper is a subclass of and used as an override
+//   for vtkDataSetMapper within VisIt, changed pd_maker to be an override of
+//   vtkVisItDataSetMapper.
+//
 // ****************************************************************************
 
 VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
@@ -188,7 +194,10 @@ VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
 
     osprayPass = vtkOSPRayPass::New();
     vtkViewNodeFactory* factory = osprayPass->GetViewNodeFactory();
-    factory->RegisterOverride("vtkDataSetMapper",
+    // Override vtkVisItDataSetMapper instead of vtkDataSetMapper.
+    // If the use of vtkVisItDataSetMapper as a general override of
+    // vtkDataSetMapper is removed this code will need to be changed.
+    factory->RegisterOverride("vtkVisItDataSetMapper",
                               vtkVisItViewNodeFactory::pd_maker);
     factory->RegisterOverride("vtkPointGlyphMapper",
                               vtkVisItViewNodeFactory::pd_maker);


### PR DESCRIPTION
Merge from 3.2RC
Change OSPRAY override of vtkDataSetMapper to vtkVisItDataSetMapper.
Add comments regarding the need to change this back if vtkVisItDataSetMapper is ever removed.
