### PR TITLE
Fix unicode error message related to Macros. (#5642)

### DIFF
--- a/src/gui/QvisCommandWindow.C
+++ b/src/gui/QvisCommandWindow.C
@@ -958,6 +958,10 @@ QvisCommandWindow::macroClearClicked()
 //   On windows, escape the rcFileName's backslashes before adding it as an
 //   arg for the command.
 //
+//   Kathleen Biagas, Tue Apr 20 2021
+//   On windows, convert the rcFileName's backslashes to forward slashes
+//   before adding it as an arg for the command. (Python 3 change).
+//
 // ****************************************************************************
 
 void
@@ -981,15 +985,11 @@ QvisCommandWindow::macroUpdateClicked()
            // the changes that have been put into place.
            QString command("ClearMacros()\nSource(\"%1\")\n");
 #ifdef WIN32
-           // On windows, the string passed to the python commands needs to
-           // have it's back-slash's escaped.
-           QString tmp(rcFileName);
-           tmp.replace("\\", "\\\\");
-           command = command.arg(tmp);
-
-#else
-           command = command.arg(rcFileName);
+           // On windows, the path-string passed to the python commands needs
+           // to have it's back-slash's converted.
+           rcFileName.replace("\\", "/");
 #endif
+           command = command.arg(rcFileName);
            emit runCommand(command);
         }
         else

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -8,6 +8,7 @@
 #if !defined(_WIN32)
 #include <strings.h>
 #else
+#include <algorithm>
 #include <process.h> // for _getpid
 #endif
 #include <map>
@@ -19546,6 +19547,9 @@ cli_initvisit(int debugLevel, bool verbose,
 //   Cyrus Harrison, Wed Sep 30 07:53:17 PDT 2009
 //   Added book keeping to track execution stack of source files.
 //
+//   Kathleen Biagas, Tue Apr 20 2021 
+//   On Windows, convert fileName's backslashes to forward (Python 3 change).
+//
 // ****************************************************************************
 
 void
@@ -19557,9 +19561,13 @@ cli_runscript(const char *fileName)
         FILE *fp = fopen(fileName, "r");
         if(fp)
         {
+            std::string fn(fileName);
+#ifdef WIN32
+            std::replace(fn.begin(), fn.end(), '\\', '/');
+#endif
             // book keeping for source stack
             std::string pycmd  = "__visit_source_file__ = ";
-            pycmd += " os.path.abspath('" + std::string(fileName) + "')\n";
+            pycmd += " os.path.abspath('" + fn + "')\n";
             pycmd += "__visit_source_stack__.append(__visit_source_file__)\n";
             PyRun_SimpleString(pycmd.c_str());
 


### PR DESCRIPTION
Path specs being sent to PyRun_SimpleString needed to have Windows backslashes converted to forward slashes.
Merge from 3.2RC to develop

