### PR TITLE
Indicate dir is on remote host.

### DIFF
--- a/src/gui/QvisExportDBWindow.C
+++ b/src/gui/QvisExportDBWindow.C
@@ -237,6 +237,9 @@ QvisExportDBWindow::SubjectRemoved(Subject *TheRemovedSubject)
 //   Brad Whitlock, Mon Aug 10 17:16:32 PDT 2015
 //   Add support for grouping.
 //
+//   Kathleen Biagas, Mon Apr 26, 2021
+//   Add remote host to 'Directory name' if needed.
+//
 // ****************************************************************************
 
 void
@@ -250,7 +253,21 @@ QvisExportDBWindow::CreateWindowContents()
     fileLayout->setMargin(5);
 
     // Directory
-    directoryNameLabel = new QLabel(tr("Directory name"), fileBox);
+
+    QString caption("Directory name");
+    if(plotList)
+    {
+        int sel = plotList->FirstSelectedIndex();
+        if (sel >=0)
+        {
+            QualifiedFilename dbName(plotList->GetPlots(sel).GetDatabaseName());
+            if (dbName.host != "localhost");
+            {
+                caption += QString(" on %1").arg(dbName.host.c_str());
+            }
+        }
+    }
+    directoryNameLabel = new QLabel(tr(caption.toStdString().c_str()), fileBox);
     
     QHBoxLayout *directoryLayout = new QHBoxLayout();
     directoryNameLineEdit = new QLineEdit(fileBox);

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug that resulted in incorrect plots of mesh_quality/min_side_volume and mesh_quality/max_side_volume.</li>
   <li>Fixed a few issues running build_visit with '--static'.</li>
+  <li>When Export database will happen on a remote machine, the window will now display the host name next to request for Directory.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #3689
If export will happen on remote host, indicate this in the window next to directory name.
![exportDBWindow](https://user-images.githubusercontent.com/17075318/116143402-f40da080-a68f-11eb-8e01-0112d345b294.PNG)


- [X I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
