### PR TITLE
Fix CreateBonds operator window.

### DIFF
--- a/src/operators/CreateBonds/QvisCreateBondsWindow.C
+++ b/src/operators/CreateBonds/QvisCreateBondsWindow.C
@@ -670,7 +670,7 @@ void QvisCreateBondsWindow::maxDistTextChanged(const QString &txt)
         return;
 
     atts->GetMaxDist()[index] = maxDist->displayText().toFloat();
-    item->setText(3, QString("%.1").arg(atts->GetMaxDist()[index],0,'f',4));
+    item->setText(3, QString("%1").arg(atts->GetMaxDist()[index],0,'f',4));
     atts->SelectMaxDist();
 }
 

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug that resulted in incorrect plots of mesh_quality/min_side_volume and mesh_quality/max_side_volume.</li>
   <li>Fixed a few issues running build_visit with '--static'.</li>
   <li>When Export database will happen on a remote machine, the window will now display the host name next to request for Directory.</li>
+  <li>Fixed a bug with the CreateBonds operator window displaying %.1 in Bonds list Max field instead of correct value.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5658 
Use of QString.arg was incorrect, had '%.1' instead of '%1'

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
