### PR TITLE
Silo patch for build_visit

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -271,6 +271,9 @@ configure_support_files
 #import helper functions..
 . $bv_PREFIX/helper_funcs.sh
 
+# Test a key version compare function there
+test_compare_version_strings
+
 #import visit
 . $bv_PREFIX/bv_visit.sh
 

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -459,7 +459,7 @@ function build_silo
     #
     info "Configuring Silo . . ."
     cd $SILO_BUILD_DIR || error "Can't cd to Silo build dir."
-    apply_silo_patch
+    apply_silo_patch || return 1
     info "Invoking command to configure Silo"
     SILO_LINK_OPT=""
     if [[ "$DO_HDF5" == "yes" ]] ; then

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -106,6 +106,322 @@ function bv_silo_dry_run
     fi
 }
 
+function apply_silo_4102_fpzip_patch
+{
+    info "Patching silo for fpzip DOMAIN and RANGE symbols"
+    patch -p0 <<EOF
+Index: src/fpzip/codec.h
+===================================================================
+--- src/fpzip/codec.h	(revision 809)
++++ src/fpzip/codec.h	(working copy)
+@@ -16,13 +16,13 @@
+ // identity map for integer arithmetic
+ template <typename T, unsigned width>
+ struct PCmap<T, width, T> {
+-  typedef T DOMAIN;
+-  typedef T RANGE;
++  typedef T FPZIP_Domain_t;
++  typedef T FPZIP_Range_t;
+   static const unsigned bits = width;
+   static const T        mask = ~T(0) >> (bitsizeof(T) - bits);
+-  RANGE forward(DOMAIN d) const { return d & mask; }
+-  DOMAIN inverse(RANGE r) const { return r & mask; }
+-  DOMAIN identity(DOMAIN d) const { return d & mask; }
++  FPZIP_Range_t forward(FPZIP_Domain_t d) const { return d & mask; }
++  FPZIP_Domain_t inverse(FPZIP_Range_t r) const { return r & mask; }
++  FPZIP_Domain_t identity(FPZIP_Domain_t d) const { return d & mask; }
+ };
+ #endif
+ 
+Index: src/fpzip/pcdecoder.inl
+===================================================================
+--- src/fpzip/pcdecoder.inl	(revision 809)
++++ src/fpzip/pcdecoder.inl	(working copy)
+@@ -19,7 +19,7 @@
+ T PCdecoder<T, M, false>::decode(T pred, unsigned context)
+ {
+   // map type T to unsigned integer type
+-  typedef typename M::RANGE U;
++  typedef typename M::FPZIP_Range_t U;
+   U p = map.forward(pred);
+   // entropy decode d = r - p
+   U r = p + rd->decode(rm[context]) - bias;
+@@ -46,7 +46,7 @@
+ template <typename T, class M>
+ T PCdecoder<T, M, true>::decode(T pred, unsigned context)
+ {
+-  typedef typename M::RANGE U;
++  typedef typename M::FPZIP_Range_t U;
+   unsigned s = rd->decode(rm[context]);
+   if (s > bias) {      // underprediction
+     unsigned k = s - bias - 1;
+Index: src/fpzip/pcencoder.inl
+===================================================================
+--- src/fpzip/pcencoder.inl	(revision 809)
++++ src/fpzip/pcencoder.inl	(working copy)
+@@ -18,7 +18,7 @@
+ T PCencoder<T, M, false>::encode(T real, T pred, unsigned context)
+ {
+   // map type T to unsigned integer type
+-  typedef typename M::RANGE U;
++  typedef typename M::FPZIP_Range_t U;
+   U r = map.forward(real);
+   U p = map.forward(pred);
+   // entropy encode d = r - p
+@@ -47,7 +47,7 @@
+ T PCencoder<T, M, true>::encode(T real, T pred, unsigned context)
+ {
+   // map type T to unsigned integer type
+-  typedef typename M::RANGE U;
++  typedef typename M::FPZIP_Range_t U;
+   U r = map.forward(real);
+   U p = map.forward(pred);
+   // compute (-1)^s (2^k + m) = r - p, entropy code (s, k),
+Index: src/fpzip/pcmap.h
+===================================================================
+--- src/fpzip/pcmap.h	(revision 809)
++++ src/fpzip/pcmap.h	(working copy)
+@@ -14,53 +14,53 @@
+ // specialized for integer-to-integer map
+ template <typename T, unsigned width>
+ struct PCmap<T, width, void> {
+-  typedef T DOMAIN;
+-  typedef T RANGE;
+-  static const unsigned bits = width;                    // RANGE bits
+-  static const unsigned shift = bitsizeof(RANGE) - bits; // DOMAIN\RANGE bits
+-  RANGE forward(DOMAIN d) const { return d >> shift; }
+-  DOMAIN inverse(RANGE r) const { return r << shift; }
+-  DOMAIN identity(DOMAIN d) const { return inverse(forward(d)); }
++  typedef T FPZIP_Domain_t;
++  typedef T FPZIP_Range_t;
++  static const unsigned bits = width;                    // FPZIP_Range_t bits
++  static const unsigned shift = bitsizeof(FPZIP_Range_t) - bits; // FPZIP_Domain_t\FPZIP_Range_t bits
++  FPZIP_Range_t forward(FPZIP_Domain_t d) const { return d >> shift; }
++  FPZIP_Domain_t inverse(FPZIP_Range_t r) const { return r << shift; }
++  FPZIP_Domain_t identity(FPZIP_Domain_t d) const { return inverse(forward(d)); }
+ };
+ 
+ // specialized for float type
+ template <unsigned width>
+ struct PCmap<float, width, void> {
+-  typedef float    DOMAIN;
+-  typedef unsigned RANGE;
++  typedef float    FPZIP_Domain_t;
++  typedef unsigned FPZIP_Range_t;
+   union UNION {
+-    UNION(DOMAIN d) : d(d) {}
+-    UNION(RANGE r) : r(r) {}
+-    DOMAIN d;
+-    RANGE r;
++    UNION(FPZIP_Domain_t d) : d(d) {}
++    UNION(FPZIP_Range_t r) : r(r) {}
++    FPZIP_Domain_t d;
++    FPZIP_Range_t r;
+   };
+-  static const unsigned bits = width;                    // RANGE bits
+-  static const unsigned shift = bitsizeof(RANGE) - bits; // DOMAIN\RANGE bits
+-  RANGE fcast(DOMAIN d) const;
+-  DOMAIN icast(RANGE r) const;
+-  RANGE forward(DOMAIN d) const;
+-  DOMAIN inverse(RANGE r) const;
+-  DOMAIN identity(DOMAIN d) const;
++  static const unsigned bits = width;                    // FPZIP_Range_t bits
++  static const unsigned shift = bitsizeof(FPZIP_Range_t) - bits; // FPZIP_Domain_t\FPZIP_Range_t bits
++  FPZIP_Range_t fcast(FPZIP_Domain_t d) const;
++  FPZIP_Domain_t icast(FPZIP_Range_t r) const;
++  FPZIP_Range_t forward(FPZIP_Domain_t d) const;
++  FPZIP_Domain_t inverse(FPZIP_Range_t r) const;
++  FPZIP_Domain_t identity(FPZIP_Domain_t d) const;
+ };
+ 
+ // specialized for double type
+ template <unsigned width>
+ struct PCmap<double, width, void> {
+-  typedef double             DOMAIN;
+-  typedef unsigned long long RANGE;
++  typedef double             FPZIP_Domain_t;
++  typedef unsigned long long FPZIP_Range_t;
+   union UNION {
+-    UNION(DOMAIN d) : d(d) {}
+-    UNION(RANGE r) : r(r) {}
+-    DOMAIN d;
+-    RANGE r;
++    UNION(FPZIP_Domain_t d) : d(d) {}
++    UNION(FPZIP_Range_t r) : r(r) {}
++    FPZIP_Domain_t d;
++    FPZIP_Range_t r;
+   };
+-  static const unsigned bits = width;                    // RANGE bits
+-  static const unsigned shift = bitsizeof(RANGE) - bits; // DOMAIN\RANGE bits
+-  RANGE fcast(DOMAIN d) const;
+-  DOMAIN icast(RANGE r) const;
+-  RANGE forward(DOMAIN d) const;
+-  DOMAIN inverse(RANGE r) const;
+-  DOMAIN identity(DOMAIN d) const;
++  static const unsigned bits = width;                    // FPZIP_Range_t bits
++  static const unsigned shift = bitsizeof(FPZIP_Range_t) - bits; // FPZIP_Domain_t\FPZIP_Range_t bits
++  FPZIP_Range_t fcast(FPZIP_Domain_t d) const;
++  FPZIP_Domain_t icast(FPZIP_Range_t r) const;
++  FPZIP_Range_t forward(FPZIP_Domain_t d) const;
++  FPZIP_Domain_t inverse(FPZIP_Range_t r) const;
++  FPZIP_Domain_t identity(FPZIP_Domain_t d) const;
+ };
+ 
+ #include "pcmap.inl"
+Index: src/fpzip/pcmap.inl
+===================================================================
+--- src/fpzip/pcmap.inl	(revision 809)
++++ src/fpzip/pcmap.inl	(working copy)
+@@ -3,12 +3,12 @@
+ PCmap<float, width, void>::fcast(float d) const
+ {
+ #ifdef WITH_REINTERPRET_CAST
+-  return reinterpret_cast<const RANGE&>(d);
++  return reinterpret_cast<const FPZIP_Range_t&>(d);
+ #elif defined WITH_UNION
+   UNION shared(d);
+   return shared.r;
+ #else
+-  RANGE r;
++  FPZIP_Range_t r;
+   memcpy(&r, &d, sizeof(r));
+   return r;
+ #endif
+@@ -19,12 +19,12 @@
+ PCmap<float, width, void>::icast(unsigned r) const
+ {
+ #ifdef WITH_REINTERPRET_CAST
+-  return reinterpret_cast<const DOMAIN&>(r);
++  return reinterpret_cast<const FPZIP_Domain_t&>(r);
+ #elif defined WITH_UNION
+   UNION shared(r);
+   return shared.d;
+ #else
+-  DOMAIN d;
++  FPZIP_Domain_t d;
+   memcpy(&d, &r, sizeof(d));
+   return d;
+ #endif
+@@ -37,7 +37,7 @@
+ unsigned
+ PCmap<float, width, void>::forward(float d) const
+ {
+-  RANGE r = fcast(d);
++  FPZIP_Range_t r = fcast(d);
+   r = ~r;
+   r >>= shift;
+   r ^= -(r >> (bits - 1)) >> (shift + 1);
+@@ -61,7 +61,7 @@
+ float
+ PCmap<float, width, void>::identity(float d) const
+ {
+-  RANGE r = fcast(d);
++  FPZIP_Range_t r = fcast(d);
+   r >>= shift;
+   r <<= shift;
+   return icast(r);
+@@ -72,12 +72,12 @@
+ PCmap<double, width, void>::fcast(double d) const
+ {
+ #ifdef WITH_REINTERPRET_CAST
+-  return reinterpret_cast<const RANGE&>(d);
++  return reinterpret_cast<const FPZIP_Range_t&>(d);
+ #elif defined WITH_UNION
+   UNION shared(d);
+   return shared.r;
+ #else
+-  RANGE r;
++  FPZIP_Range_t r;
+   memcpy(&r, &d, sizeof(r));
+   return r;
+ #endif
+@@ -88,12 +88,12 @@
+ PCmap<double, width, void>::icast(unsigned long long r) const
+ {
+ #ifdef WITH_REINTERPRET_CAST
+-  return reinterpret_cast<const DOMAIN&>(r);
++  return reinterpret_cast<const FPZIP_Domain_t&>(r);
+ #elif defined WITH_UNION
+   UNION shared(r);
+   return shared.d;
+ #else
+-  DOMAIN d;
++  FPZIP_Domain_t d;
+   memcpy(&d, &r, sizeof(d));
+   return d;
+ #endif
+@@ -106,7 +106,7 @@
+ unsigned long long
+ PCmap<double, width, void>::forward(double d) const
+ {
+-  RANGE r = fcast(d);
++  FPZIP_Range_t r = fcast(d);
+   r = ~r;
+   r >>= shift;
+   r ^= -(r >> (bits - 1)) >> (shift + 1);
+@@ -130,7 +130,7 @@
+ double
+ PCmap<double, width, void>::identity(double d) const
+ {
+-  RANGE r = fcast(d);
++  FPZIP_Range_t r = fcast(d);
+   r >>= shift;
+   r <<= shift;
+   return icast(r);
+Index: src/fpzip/read.cpp
+===================================================================
+--- src/fpzip/read.cpp	(revision 809)
++++ src/fpzip/read.cpp	(working copy)
+@@ -103,7 +103,7 @@
+ {
+   // initialize decompressor
+   typedef PCmap<T, bits> TMAP;
+-  typedef typename TMAP::RANGE U;
++  typedef typename TMAP::FPZIP_Range_t U;
+   typedef PCmap<U, bits, U> UMAP;
+   RCmodel* rm = new RCqsmodel(false, PCdecoder<U, UMAP>::symbols);
+   PCdecoder<U, UMAP>* fd = new PCdecoder<U, UMAP>(rd, &rm);
+Index: src/fpzip/write.cpp
+===================================================================
+--- src/fpzip/write.cpp	(revision 809)
++++ src/fpzip/write.cpp	(working copy)
+@@ -103,7 +103,7 @@
+ {
+   // initialize compressor
+   typedef PCmap<T, bits> TMAP;
+-  typedef typename TMAP::RANGE U;
++  typedef typename TMAP::FPZIP_Range_t U;
+   typedef PCmap<U, bits, U> UMAP;
+   RCmodel* rm = new RCqsmodel(true, PCencoder<U, UMAP>::symbols);
+   PCencoder<U, UMAP>* fe = new PCencoder<U, UMAP>(re, &rm);
+EOF
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+}
+
+function apply_silo_patch
+{
+    info "Patching silo . . ."
+
+    compare_version_strings $SILO_VERSION 4.10.3 -le
+    if [[ $? -eq 0 ]]; then
+        apply_silo_4102_fpzip_patch
+        if [[ $? != 0 ]] ; then
+            if [[ $untarred_silo == 1 ]] ; then
+                warn "Giving up on Silo build because the patch failed."
+                return 1
+            else
+                warn "Patch failed, but continuing.  I believe that this script\n" \
+                     "tried to apply a patch to an existing directory that had\n" \
+                     "already been patched ... that is, the patch is\n" \
+                     "failing harmlessly on a second application."
+            fi
+        fi
+    fi
+    return 0
+}
+
 # *************************************************************************** #
 #                            Function 8, build_silo
 #
@@ -143,6 +459,7 @@ function build_silo
     #
     info "Configuring Silo . . ."
     cd $SILO_BUILD_DIR || error "Can't cd to Silo build dir."
+    apply_silo_patch
     info "Invoking command to configure Silo"
     SILO_LINK_OPT=""
     if [[ "$DO_HDF5" == "yes" ]] ; then

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -1,6 +1,49 @@
 export LOG_FILE=${LOG_FILE:-"${0##*/}_log"}
 
 # *************************************************************************** #
+# Purpose: Flexible comparison function for version strings                   #
+#                                                                             #
+#   - Converts version string "4.101.3" to bash array (4 101 3)               #
+#   - Appends zeros to operand with fewer array members (4)==>(4 000 0)       #
+#   - Ensures appended zeros have same length as counterparts                 #
+#   - Forms integer values from arrays (4 101 3)==>41013                      #
+#   - Compares integers using specified operator                              #
+#   - Sets status using test operator                                         #
+#                                                                             #
+# *************************************************************************** #
+function compare_version_strings
+{   
+    # default op is -lt and separator char is .
+    op=${3:-'-lt'}
+    sep=${4:-'.'}
+
+    # create array variables of digits from version string
+    vldigitarr=($(echo $1 | tr $sep ' '))
+    vrdigitarr=($(echo $2 | tr $sep ' '))
+
+    # append strings of zeros of equal length for missing digits
+    # "5"==>"0", "10"==>"00", "101"==>"000"
+    i=0
+    while [[ ${#vldigitarr[@]} -lt ${#vrdigitarr[@]} ]]; do
+        zeros=$(echo ${vrdigitarr[$i]} | tr '1234567890' '0000000000')
+        vldigitarr+=($zeros)
+        i=$((i+1))
+    done
+    while [[ ${#vrdigitarr[@]} -lt ${#vldigitarr[@]} ]]; do
+        zeros=$(echo ${vldigitarr[$i]} | tr '1234567890' '0000000000')
+        vrdigitarr+=($zeros)
+        i=$((i+1))
+    done
+
+    # Turn arrays of digit strings into integers
+    # "4 10 3" ==> 4103
+    vlval=$(echo ${vldigitarr[@]} | tr -d ' ')
+    vrval=$(echo ${vrdigitarr[@]} | tr -d ' ')
+
+    test $vlval $op $vrval
+}
+
+# *************************************************************************** #
 # Function: errorFunc                                                         #
 #                                                                             #
 # Purpose: Error messages                                                     #


### PR DESCRIPTION
### Description

* Add patch for silo as required in [this comment](https://github.com/visit-dav/visit/issues/4516#issuecomment-770951855) in #4516.
* Added method `compare_version_strings` to `helper_funcs.sh`. There is something similar in `bv_main.sh` with `vercomp` and `testvercomp` and maybe this new method should replace those? If so, lemme know by a comment here in the PR. The new method is not specific to testing compiler versions and I think is more general and works for many more cases of comparing version strings. A problem with methods in `bv_main.sh` is that I don't think any of the modules can call methods there. So, its better to have utilities like this in `helper_funcs.sh` so other modules can use them.
* Added a testing method `test_compare_version_strings` which calls `compare_version_strings` with a number of inputs to confirm correct behavior. Those tests are run each time `build_visit` is run and will prevent `build_visit` from continuing if there is a logic error there for some reason (think different implementations of bash).
* Finally, you are reviewing this change for merge into the *integration branch*,  `32rel-mcm86-28apr21-bv-fixes-macos` which is targeted for `3.2RC`

### Type of change

Bug fix for macOS 10.14 and 10.15

### How Has This Been Tested?

I've tested manually on my macOS system.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
