### PR TITLE
Patch for isatty for bv_hdf5.sh

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -144,73 +144,10 @@ function bv_hdf5_dry_run
     fi
 }
 
-function apply_hdf5_187_188_patch
-{
-    info "Patching hdf5"
-    patch -p0 << \EOF
-diff -c tools/lib/h5diff.c.orig tools/lib/h5diff.c
-*** tools/lib/h5diff.c.orig     2013-11-13 08:14:48.924716921 -0800
---- tools/lib/h5diff.c  2013-11-13 08:15:28.066716686 -0800
-***************
-*** 635,641 ****
-      char         filenames[2][MAX_FILENAME];
-      hsize_t      nfound = 0;
-      int i;
-!     //int i1, i2;
-      int l_ret;
-      const char * obj1fullname = NULL;
-      const char * obj2fullname = NULL;
---- 635,641 ----
-      char         filenames[2][MAX_FILENAME];
-      hsize_t      nfound = 0;
-      int i;
-!     /* int i1, i2; */
-      int l_ret;
-      const char * obj1fullname = NULL;
-      const char * obj2fullname = NULL;
-EOF
-    if [[ $? != 0 ]] ; then
-        warn "HDF5 patch failed."
-        return 1
-    fi
-
-    return 0
-}
-
-function apply_hdf5_187_thread_patch
-{
-    info "Patching thread hdf5"
-    patch -p0 << \EOF
-diff -c src/H5private.h.orig src/H5private.h
-*** src/H5private.h.orig    2014-07-28 10:46:54.821807839 -0700
---- src/H5private.h 2014-07-08 13:00:12.562002468 -0700
-***************
-*** 30,40 ****
-  
-  /* include the pthread header */
-  #ifdef H5_HAVE_THREADSAFE
-- #ifdef H5_HAVE_PTHREAD_H
-  #include <pthread.h>
-- #else /* H5_HAVE_PTHREAD_H */
-- #define H5_HAVE_WIN_THREADS
-- #endif /* H5_HAVE_PTHREAD_H */
-  #endif /* H5_HAVE_THREADSAFE */
-  
-  /*
---- 30,36 ----
-EOF
-    if [[ $? != 0 ]] ; then
-        warn "HDF5 thread patch failed."
-        return 1
-    fi
-
-    return 0;
-}
-
 function apply_hdf5_1814_static_patch
 {
-    info "Patching hdf5 for static build"
-    patch -p0 << \EOF
+    info "Patching hdf5 1.8.14 for static build"
+    patch -p0 << EOF
 *** src/H5PL.c.orig    2015-10-23 11:51:35.000000000 -0700
 --- src/H5PL.c  2015-10-23 11:56:48.000000000 -0700
 ***************
@@ -529,7 +466,7 @@ function apply_hdf5_1814_static_patch
   #endif /*H5_VMS*/
 EOF
     if [[ $? != 0 ]] ; then
-        warn "HDF5 static patch failed."
+        warn "HDF5 1.8.14 static patch failed."
         return 1
     fi
 
@@ -538,33 +475,11 @@ EOF
 
 function apply_hdf5_patch
 {
-    if [[ "${HDF5_VERSION}" == 1.8.7 ]] ; then
-        apply_hdf5_187_188_patch
+    # Apply a patch for static if we build statically.
+    if [[ "$DO_STATIC_BUILD" == "yes" ]] ; then
+        apply_hdf5_1814_static_patch
         if [[ $? != 0 ]]; then
             return 1
-        fi
-        if [[ "$DO_THREAD_BUILD" == "yes" ]]; then
-            apply_hdf5_187_thread_patch
-            if [[ $? != 0 ]]; then
-                return 1
-            fi
-        fi
-    else
-        if [[ "${HDF5_VERSION}" == 1.8.8 ]] ; then
-            apply_hdf5_187_188_patch
-            if [[ $? != 0 ]]; then
-                return 1
-            fi
-        else
-            # Latest HDF5.
-
-            # Apply a patch for static if we build statically.
-            if [[ "$DO_STATIC_BUILD" == "yes" ]] ; then
-                apply_hdf5_1814_static_patch
-                if [[ $? != 0 ]]; then
-                    return 1
-                fi
-            fi
         fi
     fi
 

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -473,6 +473,29 @@ EOF
     return 0;
 }
 
+
+function apply_hdf5_1814_isatty_patch
+{
+    info "Patching hdf5 1.8.14 for isatty"
+    patch -p0 << EOF
+--- hl/src/H5LTanalyze.c.orig	2014-11-07 04:53:42.000000000 -0800
++++ hl/src/H5LTanalyze.c	2021-02-01 13:40:36.000000000 -0800
+@@ -40,6 +40,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <stdlib.h>
++#include <unistd.h>
+ 
+ /* end standard C headers. */
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "HDF5 1.8.14 isatty patch failed."
+        return 1
+    fi
+
+    return 0;
+}
+
 function apply_hdf5_patch
 {
     # Apply a patch for static if we build statically.
@@ -481,6 +504,11 @@ function apply_hdf5_patch
         if [[ $? != 0 ]]; then
             return 1
         fi
+    fi
+
+    apply_hdf5_1814_isatty_patch
+    if [[ $? != 0 ]]; then
+        return 1
     fi
 
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -569,7 +569,7 @@ function build_hdf5
         sz_dir="${VISITDIR}/szip/${SZIP_VERSION}/${VISITARCH}"
         cf_szip="--with-szlib=${sz_dir}"
     fi
-    cv_zlib=""
+    cf_zlib=""
     if [[ "$DO_ZLIB" == "yes" ]]; then
         info "Configuring HDF5 with ZLib support."
         cf_zlib="--with-zlib=\"${VISITDIR}/zlib/${ZLIB_VERSION}/${VISITARCH}\""

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -30,11 +30,11 @@ function bv_hdf5_depends_on
         local depends_on=""
 
         if [[ "$DO_ZLIB" == "yes" ]] ; then
-            depends_on="$depends_on zlib"    
+            depends_on="$depends_on zlib"
         fi
 
         if [[ "$DO_SZIP" == "yes" ]] ; then
-            depends_on="$depends_on szip"    
+            depends_on="$depends_on szip"
         fi
 
         if [[ -n "$PAR_COMPILER" && "$DO_MOAB" == "yes"  && "$DO_MPICH" == "yes" ]]; then
@@ -570,7 +570,7 @@ function build_hdf5
         cf_szip="--with-szlib=${sz_dir}"
     fi
     cv_zlib=""
-    if [[ "$DO_ZLIB " == "yes" ]]; then
+    if [[ "$DO_ZLIB" == "yes" ]]; then
         info "Configuring HDF5 with ZLib support."
         cf_zlib="--with-zlib=\"${VISITDIR}/zlib/${ZLIB_VERSION}/${VISITARCH}\""
     fi

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -27,7 +27,11 @@ function bv_hdf5_depends_on
     if [[ "$USE_SYSTEM_HDF5" == "yes" ]]; then
         echo ""
     else
-        local depends_on="zlib"
+        local depends_on=""
+
+        if [[ "$DO_ZLIB" == "yes" ]] ; then
+            depends_on="$depends_on zlib"    
+        fi
 
         if [[ "$DO_SZIP" == "yes" ]] ; then
             depends_on="$depends_on szip"    
@@ -100,7 +104,10 @@ function bv_hdf5_host_profile
                     >> $HOSTCONF 
             fi
 
-            ZLIB_LIBDEP="\${VISITHOME}/zlib/\${ZLIB_VERSION}/\${VISITARCH}/lib z"
+            ZLIB_LIBDEP=""
+            if [[ "$DO_ZLIB" == "yes" ]] ; then
+                ZLIB_LIBDEP="\${VISITHOME}/zlib/\${ZLIB_VERSION}/\${VISITARCH}/lib z"
+            fi
             SZIP_LIBDEP=""
             if [[ "$DO_SZIP" == "yes" ]] ; then
                 SZIP_LIBDEP="\${VISITHOME}/szip/$SZIP_VERSION/\${VISITARCH}/lib sz"
@@ -619,9 +626,11 @@ function build_hdf5
         sz_dir="${VISITDIR}/szip/${SZIP_VERSION}/${VISITARCH}"
         cf_szip="--with-szlib=${sz_dir}"
     fi
-    info "Configuring HDF5 with ZLib support."
-    cf_zlib="--with-zlib=${zlib_dir}"
-    zlib_dir="${VISITDIR}/zlib/${ZLIB_VERSION}/${VISITARCH}"
+    cv_zlib=""
+    if [[ "$DO_ZLIB " == "yes" ]]; then
+        info "Configuring HDF5 with ZLib support."
+        cf_zlib="--with-zlib=\"${VISITDIR}/zlib/${ZLIB_VERSION}/${VISITARCH}\""
+    fi
 
     # Disable Fortran on Darwin since it causes HDF5 builds to fail.
     if [[ "$OPSYS" == "Darwin" ]]; then


### PR DESCRIPTION
### Description

Address [step 2 in this issue comment](https://github.com/visit-dav/visit/issues/4516#issuecomment-770951855) which patches `bv_hdf5.sh` to deal with compilation failure for `#include <unistd.h>` missing for `isatty` in one of the HDF5' high-level interface files. Note that although nothing in VisIt actually uses HDF5's high-level interface, we still wind up having to build it because [netcdf insists on passing `-lhdf5_hl`](https://github.com/visit-dav/visit/issues/4516#issuecomment-831578909) when building itself (even though version 4.1.1 doesn't use HDF5's high-level interface either).

This is a merge into my integration branch.

### Type of change

Bug fix

### How Has This Been Tested?

Manually on my macOS system.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
