### PR TITLE
Fix DataBinning operator window dim2Var being disabled for 3D.

### DIFF
--- a/src/operators/DataBinning/QvisDataBinningWindow.C
+++ b/src/operators/DataBinning/QvisDataBinningWindow.C
@@ -382,6 +382,9 @@ QvisDataBinningWindow::CreateWindowContents()
 //   Hank Childs, Fri Jan  4 11:49:36 PST 2013
 //   Remove unused bins for curves.
 //
+//   Kathleen Biagas, Tue May 4 2021
+//   Ensure dim2Var is enabled when NumDimensions is 3.
+//
 // ****************************************************************************
 
 void
@@ -675,7 +678,7 @@ QvisDataBinningWindow::UpdateWindow(bool doAll)
           case DataBinningAttributes::ID_dim2BinBasedOn:
             if (atts->GetDim2BinBasedOn() == DataBinningAttributes::Variable
                 && (atts->GetNumDimensions() == DataBinningAttributes::Two ||
-                    atts->GetNumDimensions() == DataBinningAttributes::Two))
+                    atts->GetNumDimensions() == DataBinningAttributes::Three))
                dim2Var->setEnabled(true);
             else
                dim2Var->setEnabled(false);

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a few issues running build_visit with '--static'.</li>
   <li>When Export database will happen on a remote machine, the window will now display the host name next to request for Directory.</li>
   <li>Fixed a bug with the CreateBonds operator window displaying %.1 in Bonds list Max field instead of correct value.</li>
+  <li>Fixed a bug with DataBinning operator window where the Dimension 2 var would be disabled for 3D.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #2039
There was a typo in a test for NumDimensions == 2 or 3 for enablement of the Dimension 2 var.


### Type of change

Bug fix

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
