### PR TITLE
making cgns build on macOS

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -89,6 +89,7 @@ function bv_cgns_dry_run
 
 function apply_cgns_410_patch
 {
+    info "Patching CGNS 4.1.0"
     patch -p0 << \EOF
 diff -c CGNS-4.1.0/src/configure.orig CGNS-4.1.0/src/configure
 *** CGNS-4.1.0/src/configure.orig	Thu Feb 11 17:51:22 2021
@@ -268,6 +269,24 @@ EOF
         return 1
     fi
 
+    patch -p0 << \EOF
+diff -u CGNS-4.1.0/src/Makefile.in.orig CGNS-4.1.0/src/Makefile.in
+--- CGNS-4.1.0/src/Makefile.in.orig	2021-01-29 09:15:50.000000000 -0800
++++ CGNS-4.1.0/src/Makefile.in	2021-05-05 08:52:32.000000000 -0700
+@@ -53,7 +53,7 @@
+ 
+ $(CGNSLIB) : $(OBJDIR) $(CGNSOBJS) $(FGNSOBJS) $(ADFOBJS) $(F2COBJS)
+ 	-@$(RM) $@
+-	@AR_LIB@ $@ $(CGNSOBJS) $(FGNSOBJS) $(ADFOBJS) $(F2COBJS)
++	@AR_LIB@ $@ $(LDFLAGS) $(CGNSOBJS) $(FGNSOBJS) $(ADFOBJS) $(F2COBJS) $(CLIBS)
+ 	@RAN_LIB@ $@
+ 
+ $(OBJDIR) :
+EOF
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+
     return 0
 }
 
@@ -355,21 +374,35 @@ function build_cgns
     fi
 
     # optionally add HDF5 and szip to the configure.
+    LIBS_ENV=""
+    LDFLAGS_ENV=""
     H5ARGS=""
     if [[ "$DO_HDF5" == "yes" ]] ; then
+        LIBS_ENV="-lhdf5"
+        LDFLAGS_ENV="-L$VISITDIR/hdf5/$HDF5_VERSION/$VISITARCH/lib"
         H5ARGS="--with-hdf5=$VISITDIR/hdf5/$HDF5_VERSION/$VISITARCH"
         if [[ "$DO_SZIP" == "yes" ]] ; then
+            LDFLAGS_ENV="$LDFLAGS_ENV -L$VISITDIR/szip/$SZIP_VERSION/$VISITARCH/lib"
             H5ARGS="$H5ARGS --with-szip=$VISITDIR/szip/$SZIP_VERSION/$VISITARCH"
+            LIBS_ENV="$LIBS_ENV -lsz"
         fi
+        LIBS_ENV="$LIBS_ENV -lz"
+        LDFLAGS_ENV="$LDFLAGS_ENV -L$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH/lib"
         H5ARGS="$H5ARGS --with-zlib=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH"
     fi
+
+    # Disable fortran
+    FORTRANARGS="--with-fortran=no"
+
     info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
         CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-        ./configure --enable-64bit ${cf_build_type} $H5ARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
+        LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\" \
+        ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
 
     env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
         CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
-        ./configure --enable-64bit ${cf_build_type} $H5ARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
+        LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV" \
+        ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
 
     if [[ $? != 0 ]] ; then
         warn "CGNS configure failed.  Giving up"
@@ -381,7 +414,7 @@ function build_cgns
     #
     info "Building CGNS . . . (~2 minutes)"
 
-    $MAKE
+    $MAKE cgns
     if [[ $? != 0 ]] ; then
         warn "CGNS build failed.  Giving up"
         return 1
@@ -392,7 +425,7 @@ function build_cgns
     #
     info "Installing CGNS . . ."
 
-    $MAKE install
+    $MAKE install-cgns
     if [[ $? != 0 ]] ; then
         warn "CGNS install failed.  Giving up"
         return 1


### PR DESCRIPTION
### Description

Resolves #5463 and issues mentioned in #5592

I encountered a number of issues with CGNS autotools build...

- **NOTE:** @brugger1 had to previously [patch `configure`](https://github.com/visit-dav/visit/pull/5465)
- linking the shared lib, `libcgns.so`, never linked to dependent libs such as HDF5, szip or zlib no matter what I tried. I eventually decided to patch `Makefile.in` to include `$(LDFLAGS)` and `$(LIBS)` when linking `libcgns.so`
- CGNS' build *needed* to find header files for third-party dependent libs (szip zlib) even though it itself never calls functions in those libs or include their header files anywhere
- Variables such as `HDF5LIB` and friends (there are many candidates) never get populated with info we'd expect about the associated lib.
- disabling cgnstools (--disable-cgnstools) on the configure command had no effect in preventing it from attempting to build tools

### Type of change

This applies several fixes...

- Adds a patch to `Makefile.in` to ensure `libcgns.so` link command gets `-L` and `-l` flags for dependent libs such as hdf5, szip and zlib
- Explicitly makes target `cgns` for the build and installs target `install-cgns` for the install
- Passes information about dependent libs like hdf5, szip and zlib using `env` configure variables `LDFLAGS` and `LIBS`
- 
### How Has This Been Tested?

Manually on macOS 10.14

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
