### PR TITLE
Add support for TIME_LIST in Xdmf temporal collections.

### DIFF
--- a/src/databases/Xdmf/avtXdmfFileFormat.h
+++ b/src/databases/Xdmf/avtXdmfFileFormat.h
@@ -54,20 +54,6 @@ class avtXdmfFileFormat: public avtMTMDFileFormat
         avtXdmfFileFormat(const char *);
         virtual ~avtXdmfFileFormat();
 
-        //
-        // This is used to return unconvention data -- ranging from material
-        // information to information about block connectivity.
-        //
-        // virtual void      *GetAuxiliaryData(const char *var, int timestep,
-        //                                     int domain, const char *type, void *args,
-        //                                     DestructorFunction &);
-        //
-
-        //
-        // If you know the times and cycle numbers, overload this function.
-        // Otherwise, VisIt will make up some reasonable ones for you.
-        //
-        // virtual void        GetCycles(std::vector<int> &);
         virtual void        GetTimes(std::vector<double> &);
 
         virtual int GetNTimesteps(void);
@@ -76,7 +62,7 @@ class avtXdmfFileFormat: public avtMTMDFileFormat
         {
             return "Xdmf";
         }
-        ;
+
         virtual void FreeUpResources(void);
 
         virtual vtkDataSet *GetMesh(int, int, const char *);

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a few issues running build_visit with '--static'.</li>
   <li>When Export database will happen on a remote machine, the window will now display the host name next to request for Directory.</li>
   <li>Fixed a bug with the CreateBonds operator window displaying %.1 in Bonds list Max field instead of correct value.</li>
+  <li>Fixed a bug with the Xdmf Reader not reading TIME_LIST for temporal data collections.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #2849
Added logic to read TIME_LIST if present in temporal collections


### Type of change

Bug fix
### How Has This Been Tested?

I opened and plotted the data supplied with the ticket and was able to see correct time displayed

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
