### PR TITLE
Fix the git version in the splash screen for builds from a tar file. (#5692)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -481,6 +481,10 @@
 #    'DataManualExamples' is dependent on VISIT_ENABLE_DATA_MANUAL_EXAMPLES
 #    being ON.
 #
+#    Eric Brugger, Wed May  5 08:31:16 PDT 2021
+#    Set VISIT_GIT_VERSION from the file GIT_VERSION if we are not in a
+#    git checkout.
+#
 #****************************************************************************
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.8 FATAL_ERROR)
@@ -1752,12 +1756,15 @@ ENDFUNCTION(MAC_NIB_INSTALL)
 
 #-----------------------------------------------------------------------------
 # Read the GIT version
+# If we are in a git repo, get the version using git, otherwise try the
+# file GIT_VERSION, which will be present in a source code tar file
+# created by visit-dist.
 #-----------------------------------------------------------------------------
 #dummy revision, in case commands fail
-SET(VISIT_GIT_VERSION "Unknown")
-    IF (EXISTS ${VISIT_SOURCE_DIR}/../.git)
-        # Only try and determine the version number if it looks like
-        # we're in a working copy (a .git directory should be present)
+set(VISIT_GIT_VERSION "Unknown")
+if (EXISTS ${VISIT_SOURCE_DIR}/../.git)
+    # Only try and determine the version number if it looks like
+    # we're in a working copy (a .git directory should be present)
     find_package(Git QUIET)
     if(Git_FOUND)
         # if we would prefer the full hash, remove --short in the command
@@ -1769,11 +1776,15 @@ SET(VISIT_GIT_VERSION "Unknown")
             ERROR_QUIET
             OUTPUT_STRIP_TRAILING_WHITESPACE)
         if(${found_it} EQUAL 0)
-            SET(VISIT_GIT_VERSION ${git_rev})
+            set(VISIT_GIT_VERSION ${git_rev})
         endif()
         unset(found_it)
         unset(git_rev)
     endif()
+else (EXISTS ${VISIT_SOURCE_DIR}/../.git)
+    if (EXISTS ${VISIT_SOURCE_DIR}/GIT_VERSION)
+        file(STRINGS ${VISIT_SOURCE_DIR}/GIT_VERSION VISIT_GIT_VERSION)
+    endif (EXISTS ${VISIT_SOURCE_DIR}/GIT_VERSION)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a few issues running build_visit with '--static'.</li>
   <li>When Export database will happen on a remote machine, the window will now display the host name next to request for Directory.</li>
   <li>Fixed a bug with the CreateBonds operator window displaying %.1 in Bonds list Max field instead of correct value.</li>
+  <li>Fixed a bug where the splash screen in some binary distributions would display "Unknown" for the git version instead of the actual git version.</li>
   <li>Fixed a bug with the Xdmf Reader not reading TIME_LIST for temporal data collections.</li>
 </ul>
 

--- a/src/tools/dev/scripts/visit-dist
+++ b/src/tools/dev/scripts/visit-dist
@@ -96,6 +96,10 @@ exec perl -x $0 ${1+"$@"};
 #     Brad Whitlock, Fri Oct 12 16:52:21 PDT 2012
 #     Removed -withhelp option.
 #
+#     Eric Brugger, Wed May  5 16:25:11 PDT 2021
+#     Modified the code that gets the git version to grab 10 characters
+#     instead of 7, to match what "git rev-parse --short HEAD" produces.
+#
 require "newgetopt.pl";
 
 $USAGE = "USAGE: $0 dist_file [-withtest] [-dbioonly]\n";
@@ -107,7 +111,7 @@ if (! -d "src")
     exit(-1);
 }
 
-system("git log -1 | grep \"^commit\" | cut -d' ' -f2 | head -c 7 > ./src/GIT_VERSION");
+system("git log -1 | grep \"^commit\" | cut -d' ' -f2 | head -c 10 > ./src/GIT_VERSION");
 
 # Parse the argument list.
 &NGetOpt("withtest","dbioonly");


### PR DESCRIPTION
Resolves #5683
Merge from the 3.2RC to develop.