### PR TITLE
Modify mili reader to not set material colors when none in file.

### DIFF
--- a/src/databases/Mili/avtMiliMetaData.C
+++ b/src/databases/Mili/avtMiliMetaData.C
@@ -3104,6 +3104,8 @@ avtMiliMetaData::GetMaterialNames(stringVector &matNames)
 //  Creation:   Jan 15, 2019
 //
 //  Modifications:
+//      Eric Brugger, Fri May  7 15:54:32 PDT 2021
+//      Return an empty vector if not a single color is specified.
 //
 // ****************************************************************************
 
@@ -3118,13 +3120,26 @@ avtMiliMetaData::GetMaterialColors(stringVector &matColors)
     matColors.clear();
     matColors.reserve(numMaterials);
 
+    string emptyString;
+    bool colorPresent = false;
     for (int i = 0; i < numMaterials; ++i)
     {
-        if (miliMaterials[i] != NULL)
+        if (miliMaterials[i] != NULL && !miliMaterials[i]->GetColor().empty())
         {
+            colorPresent = true;
             matColors.push_back(miliMaterials[i]->GetColor());
         }
+        else
+        {
+            matColors.push_back(emptyString);
+        }
     }
+
+    //
+    // If no colors are present return an empty vector.
+    //
+    if (!colorPresent)
+        matColors.clear();
 }
 
 

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -29,6 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the CreateBonds operator window displaying %.1 in Bonds list Max field instead of correct value.</li>
   <li>Fixed a bug where the splash screen in some binary distributions would display "Unknown" for the git version instead of the actual git version.</li>
   <li>Fixed a bug with the Xdmf Reader not reading TIME_LIST for temporal data collections.</li>
+  <li>Fixed a bug with the Mili reader where some of the material colors in a filled boundary plot would be black. The Mili reader would assign random colors to materials when no material colors were specified in the file, which resulted in some materials being black. Now the reader doesn't specify any colors in that case so that the material colors are chosen using the filled boundary plot's default color selection algorithm.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/databases/mili.py
+++ b/src/test/tests/databases/mili.py
@@ -187,7 +187,26 @@ def TestSandMesh():
 
 
 def TestMaterials():
+    #
+    # The tests need to be in this order to work around a bug in
+    # the filled boundary plot with getting colors from a database
+    # that causes the colors to be set the same for subsequent
+    # filled boundary plots where the colors are not set in the
+    # database.
+    #
     TestSection("Materials")
+    OpenDatabase(single_domain_path + "/sslide14ball_l.plt.mili")
+    v = GetView3D()
+    v.viewNormal = (0.9, 0.35, -0.88)
+    SetView3D(v)
+    SetTimeSliderState(12)
+
+    AddPlot("FilledBoundary", "materials1")
+    DrawPlots()
+    Test("mili_materials_00")
+
+    DeleteAllPlots()
+
     OpenDatabase(single_domain_path + "/d3samp6.plt.mili")
     v = GetView3D()
     v.viewNormal = (0.9, 0.35, -0.88)
@@ -196,9 +215,9 @@ def TestMaterials():
 
     AddPlot("FilledBoundary", "materials1(mesh1)")
     DrawPlots()
-    Test("mili_materials_00")
-    DeleteAllPlots()
+    Test("mili_materials_01")
 
+    DeleteAllPlots()
 
 def TestMultiDomain():
     TestSection("Multi-domain")
@@ -223,6 +242,7 @@ def TestParticles():
     v = GetView3D()
     v.viewNormal = (0.9, 0.35, -0.88)
     SetView3D(v)
+    SetTimeSliderState(0)
 
     AddPlot("Pseudocolor", "Primal/particle/stress/sxy")
     DrawPlots()

--- a/test/baseline/databases/mili/mili_materials_00.png
+++ b/test/baseline/databases/mili/mili_materials_00.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c636ce680698edf1b21b16ece5b92a79fb6fa4a59278e4465183c1fbcb41222
-size 2616
+oid sha256:e384e91f71983b80d02b398bd170cf044d75c3ec8e90cd3f0bb1e561045ecf35
+size 2495

--- a/test/baseline/databases/mili/mili_materials_01.png
+++ b/test/baseline/databases/mili/mili_materials_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fd987e36ed099fa7690d61bab425a8a459aea2eb891953700a54219888adb34
-size 2793
+oid sha256:8c636ce680698edf1b21b16ece5b92a79fb6fa4a59278e4465183c1fbcb41222
+size 2616


### PR DESCRIPTION
### Description

Resolves #5640

Modified the mili reader to not set any material colors when the mili file doesn't specify and colors instead of assigning random colors. The assignment of random colors resulted in a fair number of the colors being black. When the colors aren't set it uses the default algorithm for assigning colors to materials for the specific plot type.

### Type of change

Bug fix.

### How Has This Been Tested?

I ran the mili tests in the test suite. I also tested the change with the mili file provided by one of the customers that exhibited the bug.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
