### PR TITLE
When changing '.' to actual dir, do so at end of method.

### DIFF
--- a/src/engine/main/NetworkManager.C
+++ b/src/engine/main/NetworkManager.C
@@ -4801,6 +4801,10 @@ NetworkManager::GetDataBinning(const char *name)
 //    Change atts arg from 'const &' to * so that actual dir name can be
 //    returned in them.  If Dirname is '.', GetCWD to store instead.
 //
+//    Kathleen Biagas, Mon May 10 2021
+//    Move re-setting of Dirname when '.' to end of method, so it doesn't
+//    affect dirs stored internally in exported db's (like Silo). 
+//
 // ****************************************************************************
 
 void
@@ -4819,12 +4823,6 @@ NetworkManager::ExportDatabases(const intVector &ids,
     }
     else
         filename = f;
-
-    if (atts->GetDirname() == ".")
-    {
-        // get the real path used for displaying back to user
-        atts->SetDirname(FileFunctions::GetCurrentWorkingDirectory());
-    }
 
     if(ids.size() > 1)
     {
@@ -4874,6 +4872,13 @@ NetworkManager::ExportDatabases(const intVector &ids,
             eAtts.SetFilename(filename + ext);
         ExportSingleDatabase(ids[0], eAtts);
     }
+
+    if (atts->GetDirname() == ".")
+    {
+        // get the real path used for displaying back to user
+        atts->SetDirname(FileFunctions::GetCurrentWorkingDirectory());
+    }
+
 }
 
 // ****************************************************************************


### PR DESCRIPTION
So it won't affect internally stored dirs (eg when exporting Silo).
This came up with the export_db test on Windows.
No change to release notes, as this was a recently introduced bug.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
