### PR TITLE
Update some links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Source code repository for the VisIt Scientific Visualization and Data Analysis 
 
 ##  Documentation
 
-[Users Wiki](https://www.visitusers.org) | [GUI and CLI Users Manuals](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop) [![Documentation Status](https://readthedocs.org/projects/visit-sphinx-github-user-manual/badge/?version=develop)](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/?badge=develop)
+[Users Manuals](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop) [![Documentation Status](https://readthedocs.org/projects/visit-sphinx-github-user-manual/badge/?version=develop)](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/?badge=develop)
 
 ##  Developer Resources
 
-* [Github Development Info](https://visitusers.org/index.php?title=Github)
+* [Github Development Info](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/GitHub.html)
 * [Newly Submitted Issues](https://github.com/visit-dav/visit/issues?utf8=✓&q=is%3Aissue+is%3Aopen+-label%3Areviewed)
 
 


### PR DESCRIPTION
### Description

Resolves #5672

Modified README.md to remove the reference to visitusers.org since we want people going to the users manuals for documentation since visitusers.org has a lot of out-of-date material. Also changed the "GitHub Development Info" link to point to the user manual instead of the outdated material on visitusers.org. Also changed the link to the manuals to "Users Manuals" since they aren't just GUI and CLI manuals.

### Type of change

New documentation.

### How Has This Been Tested?

I proofread the documentation changes.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
