### PR TITLE
html test text: handle leading spaces DEV

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -43,8 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.2.1</font></b></p>
 <ul>
-  <li>Developer Changes 1</li>
-  <li>Developer Changes 2</li>
+  <li>When viewing test results in a web browser, the text tests will now correctly display leading spaces.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/test/HtmlDiff.py
+++ b/src/test/HtmlDiff.py
@@ -22,6 +22,7 @@
 # ----------------------------------------------------------------------------
 
 import os, string, cgi, difflib
+from HtmlPython import LeadingSpaceToHtmlFormat
 
 class TextFile:
     def __init__(self, fn, msg):
@@ -139,10 +140,17 @@ class Differencer:
         self.out.write("    <td align=\"right\"><b><code>%d:&nbsp;</code></b></td>\n"%num)
 
     def WriteLineText(self, color, text):
+
+        #
+        # Before writing the text, replace leading spaces with their
+        # html equivalent.
+        #
+        html_text = LeadingSpaceToHtmlFormat(text)
+
         if color == "":
-            self.out.write("    <td><code>%s</code></td>\n"%text)
+            self.out.write("    <td><code>%s</code></td>\n"%html_text)
         else:
-            self.out.write("    <td bgcolor=\"%s\"><code>%s</code></td>\n"%(color,text))
+            self.out.write("    <td bgcolor=\"%s\"><code>%s</code></td>\n"%(color,html_text))
 
     def WriteLeft(self,cl):
         l = self.GetNextLeft()

--- a/src/test/HtmlPython.py
+++ b/src/test/HtmlPython.py
@@ -116,3 +116,13 @@ class Parser:
 def ColorizePython(test_script ,result_dir,category, filename, filebase):
     source = open(test_script).read()
     Parser(source, open(pjoin(result_dir,"html",'%s_%s_py.html' % (category, filebase)), 'wt')).format(None, None, "%s/%s"%(category,filename))
+
+def LeadingSpaceToHtmlFormat(in_str):
+    """
+        Given an input string, replace all leading spaces with the
+        html equivalent, "&nbsp;".
+    """
+    html_space   = "&nbsp;"
+    lstripped    = in_str.lstrip()
+    num_leading  = len(in_str) - len(lstripped)
+    return html_space * num_leading + lstripped


### PR DESCRIPTION
### Description

Resolves #4877 

This is a simple fix for handling leading spaces in the html text diffs in our test suite. In short, text diffs can show up as having changes when leading spaces exist in one text but not the other, and our html visualizer didn't show these leading spaces. I updated the test suite so that these leading spaces are shown.

NOTE: this does not solve the issue of not seeing differences resulting from _trailing_ spaces. Those are a bit more complicated... 


### Type of change

Task/bug fix.

### How Has This Been Tested?

I altered a baseline text to include leading spaces, and I used this to confirm that the html pages correctly displayed the leading spaces.
I'm currently running the entire test suite on Pascal to make sure nothing funny happens.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added any new baselines to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
