### PR TITLE
 Fix bug with ghost zone generation using local to global ids.

### DIFF
--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7768,6 +7768,9 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundariesFromFile(
 //    Eric Brugger, Fri Mar 13 15:20:08 PDT 2020
 //    Modify to handle NULL meshes.
 //
+//    Eric Brugger, Mon May 24 11:38:21 PDT 2021
+//    Modify to handle meshes with no points or cells.
+//
 // ****************************************************************************
 
 bool
@@ -7881,8 +7884,10 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
     for (int i = 0 ; i < (int)doms.size() ; i++)
     {
         list.push_back(ds.GetDataset(i, 0));
-        if (list[i] != NULL)
-            list[i]->Register(NULL);
+        if (list[i] == NULL ||
+            list[i]->GetNumberOfPoints() == 0 || list[i]->GetNumberOfCells() == 0)
+            continue;
+        list[i]->Register(NULL);
     }
     vector<vtkDataSet *> newList = dbi->ExchangeMesh(doms, list);
 
@@ -7892,7 +7897,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
     //
     for (int i = 0 ; i < (int)doms.size() ; i++)
     {
-        if (list[i] == NULL)
+        if (list[i] == NULL ||
+            list[i]->GetNumberOfPoints() == 0 || list[i]->GetNumberOfCells() == 0)
             continue;
         vtkFieldData *fd = list[i]->GetFieldData();
         for (int k = 0; k < fd->GetNumberOfArrays(); k++)
@@ -7922,7 +7928,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (size_t i = 0 ; i < doms.size() ; i++)
         {
             vtkDataSet *ds1 = list[i];
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
             {
                 scalars.push_back(NULL);
                 continue;
@@ -7943,7 +7950,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (int i = 0 ; i < (int)doms.size() ; i++)
         {
             vtkDataSet *ds1 = ds.GetDataset(i, 0);
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                 continue;
             vtkDataArray *s   = scalarsOut[i];
             if (centering == AVT_NODECENT)
@@ -7969,7 +7977,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (size_t i = 0 ; i < doms.size() ; i++)
         {
             vtkDataSet *ds1 = list[i];
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
             {
                 vectors.push_back(NULL);
                 continue;
@@ -7990,7 +7999,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (int i = 0 ; i < (int)doms.size() ; i++)
         {
             vtkDataSet *ds1 = ds.GetDataset(i, 0);
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                 continue;
             vtkDataArray *s   = vectorsOut[i];
             if (vmd->centering == AVT_NODECENT)
@@ -8026,7 +8036,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 for (size_t j = 0 ; j < doms.size() ; j++)
                 {
                     vtkDataSet *ds1 = list[j];
-                    if (ds1 == NULL)
+                    if (ds1 == NULL ||
+                        ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                     {
                         scalars.push_back(NULL);
                         continue;
@@ -8047,7 +8058,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 for (int j = 0 ; j < (int)doms.size() ; j++)
                 {
                     vtkDataSet *ds1 = ds.GetDataset(j, 0);
-                    if (ds1 == NULL)
+                    if (ds1 == NULL ||
+                        ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                         continue;
                     vtkDataSetAttributes *atts = NULL;
                     if (isPointData)
@@ -8068,7 +8080,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 vector<vtkDataArray *> scalars;
                 for (size_t j = 0 ; j < doms.size() ; j++)
                 {
-                    if (list[j] == NULL)
+                    if (list[j] == NULL ||
+                        list[j]->GetNumberOfPoints() == 0 || list[j]->GetNumberOfCells() == 0)
                     {
                         scalars.push_back(NULL);
                         continue;
@@ -8081,7 +8094,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 for (int j = 0 ; j < (int)doms.size() ; j++)
                 {
                     vtkDataSet *ds1 = ds.GetDataset(j, 0);
-                    if (ds1 == NULL)
+                    if (ds1 == NULL ||
+                        ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                         continue;
                     ds1->GetCellData()->AddArray(scalarsOut[j]);
                     scalarsOut[j]->Delete();
@@ -8097,7 +8111,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 for (size_t j = 0 ; j < doms.size() ; j++)
                 {
                     vtkDataSet *ds1 = list[j];
-                    if (ds1 == NULL)
+                    if (ds1 == NULL ||
+                        ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                     {
                         vectors.push_back(NULL);
                         continue;
@@ -8118,7 +8133,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 for (int j = 0 ; j < (int) doms.size() ; j++)
                 {
                     vtkDataSet *ds1 = ds.GetDataset(j, 0);
-                    if (ds1 == NULL)
+                    if (ds1 == NULL ||
+                        ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                         continue;
                     vtkDataSetAttributes *atts = NULL;
                     if (isPointData)
@@ -8250,7 +8266,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (size_t j = 0 ; j < doms.size() ; j++)
         {
             vtkDataSet *ds1 = list[j];
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
             {
                 nodeNums.push_back(NULL);
                 continue;
@@ -8263,7 +8280,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (int j = 0 ; j < (int)doms.size() ; j++)
         {
             vtkDataSet *ds1 = ds.GetDataset(j, 0);
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                 continue;
             ds1->GetPointData()->AddArray(nodeNumsOut[j]);
             nodeNumsOut[j]->Delete();
@@ -8279,7 +8297,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (size_t j = 0 ; j < doms.size() ; j++)
         {
             vtkDataSet *ds1 = list[j];
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
             {
                 cellNums.push_back(NULL);
                 continue;
@@ -8292,7 +8311,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (int j = 0 ; j < (int)doms.size() ; j++)
         {
             vtkDataSet *ds1 = ds.GetDataset(j, 0);
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                 continue;
             ds1->GetCellData()->AddArray(cellNumsOut[j]);
             cellNumsOut[j]->Delete();
@@ -8308,7 +8328,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (size_t j = 0 ; j < doms.size() ; j++)
         {
             vtkDataSet *ds1 = list[j];
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
             {
                 nodeNums.push_back(NULL);
                 continue;
@@ -8321,7 +8342,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (int j = 0 ; j < (int)doms.size() ; j++)
         {
             vtkDataSet *ds1 = ds.GetDataset(j, 0);
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                 continue;
             ds1->GetPointData()->AddArray(nodeNumsOut[j]);
             nodeNumsOut[j]->Delete();
@@ -8337,7 +8359,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (size_t j = 0 ; j < doms.size() ; j++)
         {
             vtkDataSet *ds1 = list[j];
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
             {
                 cellNums.push_back(NULL);
                 continue;
@@ -8350,7 +8373,8 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         for (int j = 0 ; j < (int)doms.size() ; j++)
         {
             vtkDataSet *ds1 = ds.GetDataset(j, 0);
-            if (ds1 == NULL)
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
                 continue;
             ds1->GetCellData()->AddArray(cellNumsOut[j]);
             cellNumsOut[j]->Delete();
@@ -8501,6 +8525,9 @@ avtGenericDatabase::CommunicateGhostNodesFromDomainBoundariesFromFile(
 //    Kathleen Biagas, Fri May 22 15:41:44 PDT 2020
 //    Test for myMin > myMax.
 //
+//    Eric Brugger, Mon May 24 11:38:21 PDT 2021
+//    Modify to handle meshes with no points or cells.
+//
 // ****************************************************************************
 
 bool
@@ -8546,7 +8573,8 @@ avtGenericDatabase::CommunicateGhostZonesFromGlobalNodeIds(
     for (int i = 0 ; i < (int)doms.size() ; i++)
     {
         vtkUnstructuredGrid *d = (vtkUnstructuredGrid *) ds.GetDataset(i, 0);
-        if (d == NULL)
+        if (d == NULL ||
+            d->GetNumberOfPoints() == 0 || d->GetNumberOfCells() == 0)
         {
             gni.push_back(NULL);
             lni.push_back(NULL);

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -334,6 +334,9 @@ CopyPointer(T *src, T *dest, int components,
 //    Eric Brugger, Fri Mar 13 15:20:08 PDT 2020
 //    Modify to handle NULL meshes.
 //
+//    Eric Brugger, Mon May 24 11:38:21 PDT 2021
+//    Modify to handle meshes with no points or cells.
+//
 // ****************************************************************************
 
 vector<vtkDataSet*>
@@ -394,7 +397,8 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
     {
         int recvDom = domainNum[d];
         vtkUnstructuredGrid *mesh = (vtkUnstructuredGrid*)(meshes[d]);
-        if (mesh == NULL)
+        if (mesh == NULL ||
+            mesh->GetNumberOfPoints() == 0 || mesh->GetNumberOfCells() == 0)
             continue;
         int nOldPoints = mesh->GetNumberOfPoints();
 

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Xdmf Reader not reading TIME_LIST for temporal data collections.</li>
   <li>Fixed a bug with the Mili reader where some of the material colors in a filled boundary plot would be black. The Mili reader would assign random colors to materials when no material colors were specified in the file, which resulted in some materials being black. Now the reader doesn't specify any colors in that case so that the material colors are chosen using the filled boundary plot's default color selection algorithm.</li>
   <li>Fixed a bug with DataBinning operator window where the Dimension 2 var would be disabled for 3D.</li>
+  <li>Fixed a bug where VisIt print an error message and not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -31,7 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Xdmf Reader not reading TIME_LIST for temporal data collections.</li>
   <li>Fixed a bug with the Mili reader where some of the material colors in a filled boundary plot would be black. The Mili reader would assign random colors to materials when no material colors were specified in the file, which resulted in some materials being black. Now the reader doesn't specify any colors in that case so that the material colors are chosen using the filled boundary plot's default color selection algorithm.</li>
   <li>Fixed a bug with DataBinning operator window where the Dimension 2 var would be disabled for 3D.</li>
-  <li>Fixed a bug where VisIt print an error message and not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
+  <li>Fixed a bug with ghost zone generation that caused VisIt to not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5720

Corrected a bug with the ghost zone generation for unstructured meshes with global ids present. The logic skipped blocks that were null, but didn't skip blocks with either no cells or points. This particular Exodus file had blocks with zero cells and points. I put in logic in the ghost zone generation to skip datasets with zero cells or points wherever it was skipping datasets that were null.

### Type of change

Bug fix.

### How Has This Been Tested?

I tested it on the dataset provided by the user. I tested with a pseudocolor plot, a vector plot and a subset plot. I tested this in serial and parallel with 4 processors.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
