### PR TITLE
Modify frontendlauncher to handle a 2 digit version number for cli.

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -64,12 +64,12 @@ fi
 # Come up with a list of versions, starting with current
 versions="current"
 for minor in 9 8 7 6 5 4 3 2 1 0; do
-    for patch in 4 3 2 1 0; do
+    for patch in 9 8 7 6 5 4 3 2 1 0; do
         versions="$versions 3.$minor.$patch"
     done
 done
 for minor in 15 14 13 12 11 10 9 8 7 6; do
-    for patch in 4 3 2 1 0; do
+    for patch in 9 8 7 6 5 4 3 2 1 0; do
         versions="$versions 2.$minor.$patch"
     done
 done
@@ -118,7 +118,7 @@ done
 # If we have a two digit version number, find the latest patch associated
 # with that two digit version. 
 if [[ $version =~ ^[0-9]+.[0-9]+$ ]]; then
-    for patch in 6 5 4 3 2 1 0; do
+    for patch in 9 8 7 6 5 4 3 2 1 0; do
         version_dir="$dir/../$version.$patch"
         if test -x "$version_dir"; then
             version="$version.$patch"

--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -25,6 +25,10 @@
 #   Modified the script to use the the python that goes with the version of
 #   visit specified rather than the python that goes with the newest visit.
 #
+#   Eric Brugger, Tue May 25 15:18:03 PDT 2021
+#   Modified the logic that determines the python version to work with a
+#   two digit version when launching the cli.
+#
 ###############################################################################
 
 # Determine VisIt architecture
@@ -110,6 +114,20 @@ do
         have_version=yes
     fi
 done
+
+# If we have a two digit version number, find the latest patch associated
+# with that two digit version. 
+if [[ $version =~ ^[0-9]+.[0-9]+$ ]]; then
+    for patch in 6 5 4 3 2 1 0; do
+        version_dir="$dir/../$version.$patch"
+        if test -x "$version_dir"; then
+            version="$version.$patch"
+            break
+        fi
+    done
+fi
+
+# Find the python associated with the version.
 if test "$version" != ""; then
     thispython="$dir/../$version/$platform/bin/python"
     if test -x "$thispython"; then

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with DataBinning operator window where the Dimension 2 var would be disabled for 3D.</li>
   <li>Fixed a bug with ghost zone generation that caused VisIt to not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
   <li>Fixed a bug with full frame mode that resulted in the labels from the label plot not being drawn correctly.</li>
+  <li>Fixed a bug launching the CLI when specifying "-v 3.2" when the default version in that installation was still an older version of VisIt (e.g. 3.1.4).</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5670 

I modified the frontendlauncher to handle a 2 digit version number when launching the cli for a non default version. The problem arose when 3.1.4 and 3.2.0 were both installed and 3.1.4 was the default. When -v 3.2 was specified it would pick up the Python associated with the default version, which was 3.1.4, which didn't work with 3.2.0.

The script now detects a 2 digit version number and picks the Python with the latest version in that minor version series.

### Type of change

Bug fix.

### How Has This Been Tested?

I installed both 3.1.4 and 3.2.0 in the same installation. I then tried:

visit
visit -cli
visit -v 3.2.0
visit -v 3.2
visit -v 3.2.0 -cli
visit -v 3.2 -cli

and they all worked properly.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
