### PR TITLE
Modify frontendlauncher to handle a 2 digit version number for cli. (#5736)

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -25,6 +25,10 @@
 #   Modified the script to use the the python that goes with the version of
 #   visit specified rather than the python that goes with the newest visit.
 #
+#   Eric Brugger, Tue May 25 15:18:03 PDT 2021
+#   Modified the logic that determines the python version to work with a
+#   two digit version when launching the cli.
+#
 ###############################################################################
 
 # Determine VisIt architecture
@@ -60,12 +64,12 @@ fi
 # Come up with a list of versions, starting with current
 versions="current"
 for minor in 9 8 7 6 5 4 3 2 1 0; do
-    for patch in 4 3 2 1 0; do
+    for patch in 9 8 7 6 5 4 3 2 1 0; do
         versions="$versions 3.$minor.$patch"
     done
 done
 for minor in 15 14 13 12 11 10 9 8 7 6; do
-    for patch in 4 3 2 1 0; do
+    for patch in 9 8 7 6 5 4 3 2 1 0; do
         versions="$versions 2.$minor.$patch"
     done
 done
@@ -110,6 +114,20 @@ do
         have_version=yes
     fi
 done
+
+# If we have a two digit version number, find the latest patch associated
+# with that two digit version. 
+if [[ $version =~ ^[0-9]+.[0-9]+$ ]]; then
+    for patch in 9 8 7 6 5 4 3 2 1 0; do
+        version_dir="$dir/../$version.$patch"
+        if test -x "$version_dir"; then
+            version="$version.$patch"
+            break
+        fi
+    done
+fi
+
+# Find the python associated with the version.
 if test "$version" != ""; then
     thispython="$dir/../$version/$platform/bin/python"
     if test -x "$thispython"; then

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with DataBinning operator window where the Dimension 2 var would be disabled for 3D.</li>
   <li>Fixed a bug with ghost zone generation that caused VisIt to not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
   <li>Fixed a bug with full frame mode that resulted in the labels from the label plot not being drawn correctly.</li>
+  <li>Fixed a bug launching the CLI when specifying "-v 3.2" when the default version in that installation was still an older version of VisIt (e.g. 3.1.4).</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #5670
Merge from the 3.2RC to develop.