### PR TITLE
Update Label plot's xml file so CMakeLists.txt regenerates correctly.

### DIFF
--- a/src/plots/Label/CMakeLists.txt
+++ b/src/plots/Label/CMakeLists.txt
@@ -69,7 +69,6 @@ ${VISIT_INCLUDE_DIR}/avt/Pipeline/Pipeline
 ${VISIT_INCLUDE_DIR}/avt/Pipeline/Sinks
 ${VISIT_INCLUDE_DIR}/avt/Pipeline/Sources
 ${VISIT_INCLUDE_DIR}/avt/Plotter
-${VISIT_INCLUDE_DIR}/avt/Plotter/vtk
 ${VISIT_INCLUDE_DIR}/avt/QtVisWindow
 ${VISIT_INCLUDE_DIR}/avt/View
 ${VISIT_INCLUDE_DIR}/avt/VisWindow/Colleagues
@@ -88,6 +87,7 @@ ${VISIT_INCLUDE_DIR}/visit_vtk/full
 ${VISIT_INCLUDE_DIR}/visit_vtk/lightweight
 ${VTK_INCLUDE_DIRS}
 ${PYINCLUDES}
+${VISIT_INCLUDE_DIR}/avt/Plotter/vtk
 )
 
 LINK_DIRECTORIES(${VISIT_LIBRARY_DIR} )

--- a/src/plots/Label/Label.xml
+++ b/src/plots/Label/Label.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
   <Plugin name="Label" type="plot" label="Label" version="1.0" enabled="true" mdspecificcode="false" engspecificcode="false" onlyengine="false" noengine="false" vartype="mesh,scalar,vector,material,subset,tensor,symmetrictensor,label,array" iconFile="Label.xpm">
+    <CXXFLAGS>
+      ${VISIT_INCLUDE_DIR}/avt/Plotter/vtk
+    </CXXFLAGS>
     <Files components="V">
       avtLabelFilter.C
       avtLabelSubsetsFilter.C


### PR DESCRIPTION
### Description

This fixes the regression suite error with plotsVsInstall test.

### How Has This Been Tested?

I ran the plotsVsInstall test successfully.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added any new baselines to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
