### PR TITLE
fix libsim crash dbexport with options

### DIFF
--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -1300,7 +1300,13 @@ DBOptionsAttributes::SetInt(const std::string &name, int defaultValue)
         optInts.push_back(defaultValue);
     }
     else
-        optInts[bIndex] = defaultValue;
+    {
+        OptionType ot = GetType(name);    
+        if (ot == Int)
+            optInts[bIndex] = defaultValue;
+        else if (ot == Enum)
+            optEnums[bIndex] = defaultValue;
+    }
 }
 
 // ****************************************************************************
@@ -1324,7 +1330,11 @@ DBOptionsAttributes::GetInt(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    return optInts[bIndex];
+    OptionType ot = GetType(name);    
+    if (ot == Int)
+        return optInts[bIndex]; 
+    else if (ot == Enum)
+        return optEnums[bIndex]; 
 }
 
 // ****************************************************************************
@@ -1349,7 +1359,25 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
         optStrings.push_back(defaultValue);
     }
     else
-        optStrings[bIndex] = defaultValue;
+    {
+        OptionType ot = GetType(name);    
+        if (ot == String)
+        {
+            optStrings[bIndex] = defaultValue;
+        }
+        else if (ot == Enum)
+        {
+            stringVector es = GetEnumStrings(name);
+            for (size_t i = 0; i < es.size(); ++i)
+            {
+                if(es[i] == defaultValue)
+                {
+                    optEnums[bIndex] = i;
+                    break;
+                }
+            }
+        }
+    }
 }
 
 // ****************************************************************************
@@ -1373,7 +1401,16 @@ DBOptionsAttributes::GetString(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    return optStrings[bIndex];
+    OptionType ot = GetType(name);    
+    if (ot == Int)
+    {
+        return optStrings[bIndex]; 
+    }
+    else if (ot == Enum)
+    {
+        stringVector es = GetEnumStrings(name);
+        return es[optEnums[bIndex]]; 
+    }
 }
 
 // ****************************************************************************
@@ -1484,6 +1521,16 @@ DBOptionsAttributes::GetType(int index) const
         EXCEPTION0(BadDeclareFormatString);
 
     return (DBOptionsAttributes::OptionType) types[index];
+}
+
+DBOptionsAttributes::OptionType
+DBOptionsAttributes::GetType(const std::string &name) const
+{
+    for (size_t i = 0 ; i < names.size() ; i++)
+        if (names[i] == name)
+            return (DBOptionsAttributes::OptionType) types[i];
+
+    EXCEPTION0(BadDeclareFormatString);
 }
 
 // ****************************************************************************

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -1287,6 +1287,10 @@ DBOptionsAttributes::GetDouble(const std::string &name) const
 //  Programmer: Hank Childs
 //  Creation:   May 23, 2005
 //
+//  Modifications:
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type when name already exists.
+//
 // ****************************************************************************
 
 void
@@ -1301,11 +1305,10 @@ DBOptionsAttributes::SetInt(const std::string &name, int defaultValue)
     }
     else
     {
-        OptionType ot = GetType(name);    
-        if (ot == Int)
-            optInts[bIndex] = defaultValue;
-        else if (ot == Enum)
+        if (GetType(name) == Enum)
             optEnums[bIndex] = defaultValue;
+         else
+            optInts[bIndex] = defaultValue;
     }
 }
 
@@ -1321,6 +1324,9 @@ DBOptionsAttributes::SetInt(const std::string &name, int defaultValue)
 //  Modifications:
 //    Mark C. Miller, Tue Apr 29 17:39:39 PDT 2008
 //    Made it a const method
+//
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type. 
 //
 // ****************************************************************************
 
@@ -1346,6 +1352,10 @@ DBOptionsAttributes::GetInt(const std::string &name) const
 //  Programmer: Hank Childs
 //  Creation:   May 23, 2005
 //
+//  Modifications:
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type when name already exists.
+//
 // ****************************************************************************
 
 void
@@ -1360,12 +1370,7 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
     }
     else
     {
-        OptionType ot = GetType(name);    
-        if (ot == String)
-        {
-            optStrings[bIndex] = defaultValue;
-        }
-        else if (ot == Enum)
+        if (GetType(name) == Enum)
         {
             stringVector es = GetEnumStrings(name);
             for (size_t i = 0; i < es.size(); ++i)
@@ -1376,6 +1381,10 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
                     break;
                 }
             }
+        }
+        else
+        {
+            optStrings[bIndex] = defaultValue;
         }
     }
 }
@@ -1392,6 +1401,9 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
 //  Modifications:
 //    Mark C. Miller, Tue Apr 29 17:39:39 PDT 2008
 //    Made it a const method
+//
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type. 
 //
 // ****************************************************************************
 

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -1330,11 +1330,11 @@ DBOptionsAttributes::GetInt(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    OptionType ot = GetType(name);    
-    if (ot == Int)
-        return optInts[bIndex]; 
-    else if (ot == Enum)
+
+    if (GetType(name) == Enum)
         return optEnums[bIndex]; 
+
+    return optInts[bIndex]; 
 }
 
 // ****************************************************************************
@@ -1401,16 +1401,14 @@ DBOptionsAttributes::GetString(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    OptionType ot = GetType(name);    
-    if (ot == Int)
-    {
-        return optStrings[bIndex]; 
-    }
-    else if (ot == Enum)
+
+    if (GetType(name) == Enum)
     {
         stringVector es = GetEnumStrings(name);
         return es[optEnums[bIndex]]; 
     }
+
+    return optStrings[bIndex]; 
 }
 
 // ****************************************************************************

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -222,7 +222,13 @@ DBOptionsAttributes::SetInt(const std::string &name, int defaultValue)
         optInts.push_back(defaultValue);
     }
     else
-        optInts[bIndex] = defaultValue;
+    {
+        OptionType ot = GetType(name);    
+        if (ot == Int)
+            optInts[bIndex] = defaultValue;
+        else if (ot == Enum)
+            optEnums[bIndex] = defaultValue;
+    }
 }
 
 Function: GetInt
@@ -249,7 +255,11 @@ DBOptionsAttributes::GetInt(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    return optInts[bIndex];
+    OptionType ot = GetType(name);    
+    if (ot == Int)
+        return optInts[bIndex]; 
+    else if (ot == Enum)
+        return optEnums[bIndex]; 
 }
 
 Function: SetString
@@ -277,7 +287,25 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
         optStrings.push_back(defaultValue);
     }
     else
-        optStrings[bIndex] = defaultValue;
+    {
+        OptionType ot = GetType(name);    
+        if (ot == String)
+        {
+            optStrings[bIndex] = defaultValue;
+        }
+        else if (ot == Enum)
+        {
+            stringVector es = GetEnumStrings(name);
+            for (size_t i = 0; i < es.size(); ++i)
+            {
+                if(es[i] == defaultValue)
+                {
+                    optEnums[bIndex] = i;
+                    break;
+                }
+            }
+        }
+    }
 }
 
 Function: GetString
@@ -304,7 +332,16 @@ DBOptionsAttributes::GetString(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    return optStrings[bIndex];
+    OptionType ot = GetType(name);    
+    if (ot == Int)
+    {
+        return optStrings[bIndex]; 
+    }
+    else if (ot == Enum)
+    {
+        stringVector es = GetEnumStrings(name);
+        return es[optEnums[bIndex]]; 
+    }
 }
 
 Function: SetEnum
@@ -431,6 +468,20 @@ DBOptionsAttributes::GetType(int index) const
 
     return (DBOptionsAttributes::OptionType) types[index];
 }
+
+Function: GetType2
+Declaration: DBOptionsAttributes::OptionType GetType(const std::string &) const;
+Definition:
+DBOptionsAttributes::OptionType
+DBOptionsAttributes::GetType(const std::string &name) const
+{
+    for (size_t i = 0 ; i < names.size() ; i++)
+        if (names[i] == name)
+            return (DBOptionsAttributes::OptionType) types[i];
+
+    EXCEPTION0(BadDeclareFormatString);
+}
+
 
 Function: GetEnumStrings
 Declaration: std::vector<std::string> GetEnumStrings(const std::string &name) const;

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -209,6 +209,10 @@ Definition:
 //  Programmer: Hank Childs
 //  Creation:   May 23, 2005
 //
+//  Modifications:
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type when name already exists.
+//
 // ****************************************************************************
 
 void
@@ -223,11 +227,10 @@ DBOptionsAttributes::SetInt(const std::string &name, int defaultValue)
     }
     else
     {
-        OptionType ot = GetType(name);    
-        if (ot == Int)
-            optInts[bIndex] = defaultValue;
-        else if (ot == Enum)
+        if (GetType(name) == Enum)
             optEnums[bIndex] = defaultValue;
+         else
+            optInts[bIndex] = defaultValue;
     }
 }
 
@@ -246,6 +249,9 @@ Definition:
 //  Modifications:
 //    Mark C. Miller, Tue Apr 29 17:39:39 PDT 2008
 //    Made it a const method
+//
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type. 
 //
 // ****************************************************************************
 
@@ -274,6 +280,10 @@ Definition:
 //  Programmer: Hank Childs
 //  Creation:   May 23, 2005
 //
+//  Modifications:
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type when name already exists.
+//
 // ****************************************************************************
 
 void
@@ -288,12 +298,7 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
     }
     else
     {
-        OptionType ot = GetType(name);    
-        if (ot == String)
-        {
-            optStrings[bIndex] = defaultValue;
-        }
-        else if (ot == Enum)
+        if (GetType(name) == Enum)
         {
             stringVector es = GetEnumStrings(name);
             for (size_t i = 0; i < es.size(); ++i)
@@ -304,6 +309,10 @@ DBOptionsAttributes::SetString(const std::string &name, const std::string &defau
                     break;
                 }
             }
+        }
+        else
+        {
+            optStrings[bIndex] = defaultValue;
         }
     }
 }
@@ -323,6 +332,9 @@ Definition:
 //  Modifications:
 //    Mark C. Miller, Tue Apr 29 17:39:39 PDT 2008
 //    Made it a const method
+//
+//    Kathleen Biagas, Thu May 27, 2021
+//    Allow enum type. 
 //
 // ****************************************************************************
 

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -255,11 +255,11 @@ DBOptionsAttributes::GetInt(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    OptionType ot = GetType(name);    
-    if (ot == Int)
-        return optInts[bIndex]; 
-    else if (ot == Enum)
+
+    if (GetType(name) == Enum)
         return optEnums[bIndex]; 
+
+    return optInts[bIndex]; 
 }
 
 Function: SetString
@@ -332,16 +332,14 @@ DBOptionsAttributes::GetString(const std::string &name) const
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
-    OptionType ot = GetType(name);    
-    if (ot == Int)
-    {
-        return optStrings[bIndex]; 
-    }
-    else if (ot == Enum)
+
+    if (GetType(name) == Enum)
     {
         stringVector es = GetEnumStrings(name);
         return es[optEnums[bIndex]]; 
     }
+
+    return optStrings[bIndex]; 
 }
 
 Function: SetEnum

--- a/src/common/state/DBOptionsAttributes.h
+++ b/src/common/state/DBOptionsAttributes.h
@@ -149,6 +149,7 @@ public:
     void SetEnumStrings(const std::string &name, const std::vector<std::string> &values);
     int GetNumberOfOptions(void) const;
     DBOptionsAttributes::OptionType GetType(int) const;
+    DBOptionsAttributes::OptionType GetType(const std::string &) const;
     std::vector<std::string> GetEnumStrings(const std::string &name) const;
     std::string GetName(int) const;
     void SetObsolete(const std::string &name);

--- a/src/common/state/DBOptionsAttributes.xml
+++ b/src/common/state/DBOptionsAttributes.xml
@@ -64,6 +64,8 @@
     </Function>
     <Function name="GetType" user="true" member="true">
     </Function>
+    <Function name="GetType2" user="true" member="true">
+    </Function>
     <Function name="GetEnumStrings" user="true" member="true">
     </Function>
     <Function name="GetName" user="true" member="true">

--- a/src/test/tests/simulation/updateplots.py
+++ b/src/test/tests/simulation/updateplots.py
@@ -29,6 +29,19 @@ def step(sim):
         if "Command 'step'" in buf:
             keepGoing = False
 
+def testExportVTK(sim):
+    # default export FileFormat for VTK is Legacy ascii (.vtk extension),
+    # Test an export that sets the FileFormat to XML Binary (.vtr extension)
+    sim.consolecommand("exportVTK")
+    # Read from stderr to look for the echoed command. Sync.
+    keepGoing = True
+    while keepGoing:
+        buf = sim.p.stderr.readline()
+        print(buf)
+        if "Command 'exportVTK'" in buf:
+            keepGoing = False
+    step(sim)
+    TestValueEQ("updateplots_export0000.vtr exists", os.path.isfile("updateplots_export0000.vtr"))
 
 # Perform our tests.
 if connected:
@@ -60,7 +73,9 @@ if connected:
         i = i+1
 
     TestText("updateplots%02d"%i, times)
-             
+
+    testExportVTK(sim)
+
 # Close down the simulation.
 if started:        
     sim.endsim()


### PR DESCRIPTION
### Description
Would like some feedback on this fix for #5735

I modified DBOptionsAttributes Set/GetInt and Set/GetString to support enum.

I modified updateplots.c simulation example to allow export-to-vtk with options.

When I run the updateplots simulation, and connect with VisIt compiled with the DBOptionsAttributes changes, exporting works, and there are no crashes.

I also modified updateplots.py simulation test, adding a test for having the sim export to vtk.
The test actually creates the exported file, but crashes the simulation.  Since the crash doesn't happen outside the testing harness,
I'm wondering if something inside the testing is causing the crash, rather than the simulation.

### Type of change

Please choose one of the following: Bug fix, new feature, new documentation, or other (please explain).

### How Has This Been Tested?

Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on.

### Checklist:

- [ ] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added any new baselines to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
