### PR TITLE
fix problems retrieving environment strings necessary to import into python on Windows

### DIFF
--- a/src/bin/visit.c
+++ b/src/bin/visit.c
@@ -145,7 +145,6 @@ string GetVisItEnvironment(stringVector &, bool, bool &, bool &);
 void   SetVisItEnvironment(const stringVector &);
 string AddPath(char *, const char *, const char*);
 bool   ReadKey(const char *key, char **keyval);
-void   PrintEnvironment(void);
 string WinGetEnv(const char * name);
 string GetUsageTextDir(void);
 
@@ -336,6 +335,12 @@ static bool EndsWith(const char *s, const char *suffix)
  *   operation of VisIt when Mesa3D (17.3.0) is used as a drop-in replacment
  *   for system OpenGL.
  *
+ *   Kathleen Biagas, Thur Jun 8, 2021
+ *   Added -nodialog option, to be used with -env when importing VisIt into
+ *   python. It won't be advertised. It allows the environment string to be
+ *   passed via stderr without a dialog box popping up.
+ *   Removed PrintEnvironment as it wasn't printing all environment strings.
+ *
  *****************************************************************************/
 
 int
@@ -350,6 +355,7 @@ VisItLauncherMain(int argc, char *argv[])
     bool parallel = false;
     bool hostset = 0;
     bool envOnly = false;
+    bool noDialog = false;
     bool debugLaunch = false;
     bool apitrace = false;
 
@@ -594,6 +600,10 @@ VisItLauncherMain(int argc, char *argv[])
         {
             envOnly = true;
         }
+        else if(ARG("-nodialog"))
+        {
+            noDialog = true;
+        }
         else if(ARG("-debuglaunch"))
         {
             debugLaunch = true;
@@ -749,23 +759,38 @@ VisItLauncherMain(int argc, char *argv[])
         visitEnv.push_back("MESA_GL_VERSION_OVERRIDE=3.3");
     }
     SetVisItEnvironment(visitEnv);
-#ifdef VISIT_WINDOWS_APPLICATION
-    if(debugLaunch)
+    if(debugLaunch || envOnly)
     {
         // Show the path and the environment we've created.
         string envStr;
         for(size_t i = 0; i < visitEnv.size(); ++i)
             envStr = envStr + visitEnv[i] + "\n";
         string msgStr((visitpath + "\n\n") + envStr);
-        MessageBox(NULL, msgStr.c_str(), component.c_str(), MB_OK);
-    }
-#endif
+#ifdef VISIT_WINDOWS_APPLICATION
+        if(envOnly && noDialog)
+        {
+            // We want the environment string to be readable when
+            // importing VisIt into python, so don't use the dialog
+            cerr << msgStr << endl;
+        }
+        else
+        {
+            MessageBox(NULL, msgStr.c_str(), component.c_str(), MB_OK);
+        }
 
-    if (envOnly)
-    {
-        PrintEnvironment();
-        componentArgs.clear();
-        return 0;
+        if(envOnly)
+        {
+            componentArgs.clear();
+            return 0;
+        }
+#else
+        cerr << msgStr << endl;
+        if (envOnly)
+        {
+            componentArgs.clear();
+            return 0;
+        }
+#endif
     }
 
     stringVector command;
@@ -1134,8 +1159,11 @@ ReadKey(const char *key, char **keyval)
  *   Display message box if VISITSSH set, but does not point
  *   to valid executable.
  *
- *    Kathleen Biagas, Thu Aug 1 13:41:32 MST 2019
- *    Removed useShorFileName argument.
+ *   Kathleen Biagas, Thu Aug 1 13:41:32 MST 2019
+ *   Removed useShorFileName argument.
+ *
+ *   Kathleen Biagas, Thu Jun 8, 2021
+ *   Add LIBPATH for non-dev, needed when importing VisIt into python.
  *
  *****************************************************************************/
 
@@ -1358,13 +1386,15 @@ GetVisItEnvironment(stringVector &env, bool addPluginVars, bool &usingdev,
     }
 
     /*
-     * Set PYTHONPATH
+     * Set PYTHONPATH, PYTHONHOME, LIBPATH (non-dev only)
      */
     if (!usingdev)
     {
         sprintf(tmp, "PYTHONPATH=%s\\lib", visitpath);
         env.push_back(tmp);
         sprintf(tmp, "PYTHONHOME=%s\\lib\\python",visitpath);
+        env.push_back(tmp);
+        sprintf(tmp, "LIBPATH=%s\\lib", visitpath);
         env.push_back(tmp);
     }
     else
@@ -1569,56 +1599,6 @@ AddPath(char *tmp, const char *visitpath, const char *visitdev)
 
     return string(tmp);
 }
-
-/******************************************************************************
- *
- * Purpose: Prints the VisIt environment variables.
- *
- * Modifications:
- *   Kathleen Biagas, Wednesday Sept 30, 2020
- *   Modified to fill a string and to print to mesage box if WinApp.
- *****************************************************************************/
-void
-PrintEnvironment()
-{
-    char *tmp;
-    string envStr;
-    if((tmp = getenv("VISITHOME")) != NULL)
-    {
-        envStr = envStr + string("LIBPATH=") + string(tmp) + string("\\lib\n");
-        envStr = envStr + "VISITHOME=" + string(tmp) + "\n";
-    }
-    if((tmp = getenv("VISITARCHHOME")) != NULL)
-    {
-        envStr = envStr + "VISITARCHHOME=" + string(tmp) + "\n";
-    }
-    if((tmp = getenv("VISITULTRAHOME")) != NULL)
-    {
-        envStr = envStr + "VISITULTRAHOME=" + string(tmp) + "\n";
-    }
-    if((tmp = getenv("VISITPLUGINDIR")) != NULL)
-    {
-        envStr = envStr + "VISITPLUGINDIR=" + string(tmp) + "\n";
-    }
-    if((tmp = getenv("VISITSSH")) != NULL)
-    {
-        envStr = envStr + "VISITSSH=" + string(tmp) + "\n";
-    }
-    if((tmp = getenv("VISITSSHARGS")) != NULL)
-    {
-        envStr = envStr + "VISITSSHARGS=" + string(tmp) + "\n";
-    }
-
-#ifdef VISIT_WINDOWS_APPLICATION
-    MessageBox(NULL,
-               LPCSTR(envStr.c_str()),
-               LPCSTR("VisIt environment variables:"),
-               MB_ICONINFORMATION | MB_OK);
-#else
-    cerr << envStr << endl;
-#endif
-}
-
 
 string
 WinGetEnv(const char * name)

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with ghost zone generation that caused VisIt to not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
   <li>Fixed a bug with full frame mode that resulted in the labels from the label plot not being drawn correctly.</li>
   <li>Fixed a bug launching the CLI when specifying "-v 3.2" when the default version in that installation was still an older version of VisIt (e.g. 3.1.4).</li>
+  <li>Fixed a bug for Windows where importing VisIt into python failed due to inability to retrieve necessary enviroment variable information.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5748 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Add -nodialog option (unadvertised) for use with 'visit -env' on Windows to ensure that environment string is retrievable and that no dialog message box is created.

Add LIBPATH to environment.

For frontend.py, if 'vdir' isn't set in a LaunchCommand, see if 'VISITLOC' is set in environment, and use it for vdir.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
