### PR TITLE
Fix molecule plot created bond coloring issues.

### DIFF
--- a/src/plots/Molecule/vtkVisItMoleculeMapper.cxx
+++ b/src/plots/Molecule/vtkVisItMoleculeMapper.cxx
@@ -11,7 +11,7 @@
 
 // LLNL
 #include <AtomicProperties.h> // common/utility
-#include <avtColorTables.h> 
+#include <avtColorTables.h>
 // a VisIt class
 #include <vtkPointMapper.h>
 
@@ -161,7 +161,7 @@ MoleculeMapperHelper::CreateRectangleBetweenTwoPoints(double *p0, double *p1,
   if (v_len == 0)
     return 0;
 
-  vtkNew<vtkIdList> ids;    
+  vtkNew<vtkIdList> ids;
   ids->InsertNextId(pts->InsertNextPoint(p0[0] + r*v[0], p0[1] + r*v[1], 0.));
   ids->InsertNextId(pts->InsertNextPoint(p1[0] + r*v[0], p1[1] + r*v[1], 0.));
   ids->InsertNextId(pts->InsertNextPoint(p1[0] - r*v[0], p1[1] - r*v[1], 0.));
@@ -198,7 +198,7 @@ MoleculeMapperHelper::CreateCylinderBetweenTwoPoints(double *p0, double *p1,
   this->CalculateCylPts();
 
   int ncells = 0;
-  float vc[3] = {static_cast<float>(p1[0]-p0[0]), 
+  float vc[3] = {static_cast<float>(p1[0]-p0[0]),
                  static_cast<float>(p1[1]-p0[1]),
                  static_cast<float>(p1[2]-p0[2])
                 };
@@ -264,6 +264,8 @@ MoleculeMapperHelper::CreateCylinderBetweenTwoPoints(double *p0, double *p1,
 //  Creation:    January 25, 2010
 //
 //  Modifications:
+//    Kathleen Biagas, June 16, 2021
+//    Add normals for all inserted ids.
 //
 // ****************************************************************************
 
@@ -318,27 +320,29 @@ MoleculeMapperHelper::CreateCylinderCap(double *p0, double *p1, int half,
     if (half==0)
       {
       ids->InsertNextId(pts->InsertNextPoint(p1[0] + r*v0[0], p1[1] + r*v0[1], p1[2] + r*v0[2]));
+      normals->InsertNextTypedTuple(vc);
       }
     else
       {
       ids->InsertNextId(pts->InsertNextPoint(p0[0] + r*v0[0], p0[1] + r*v0[1], p0[2] + r*v0[2]));
+      normals->InsertNextTypedTuple(vc);
       }
     }
 
   for (int i = 1; i < ids->GetNumberOfIds()-1; ++i)
     {
     vtkNew<vtkTriangle> tri;
-    tri->GetPointIds()->SetId(0, ids->GetId(0));   
-    tri->GetPointIds()->SetId(0, ids->GetId(i));   
-    tri->GetPointIds()->SetId(0, ids->GetId(i+1));   
+    tri->GetPointIds()->SetId(0, ids->GetId(0));
+    tri->GetPointIds()->SetId(0, ids->GetId(i));
+    tri->GetPointIds()->SetId(0, ids->GetId(i+1));
     cells->InsertNextCell(tri.GetPointer());
     ncells++;
     }
     // close the fan
     vtkNew<vtkTriangle> tri;
-    tri->GetPointIds()->SetId(0, ids->GetId(0));   
-    tri->GetPointIds()->SetId(0, ids->GetId(ids->GetNumberOfIds()-1));   
-    tri->GetPointIds()->SetId(0, ids->GetId(1));   
+    tri->GetPointIds()->SetId(0, ids->GetId(0));
+    tri->GetPointIds()->SetId(0, ids->GetId(ids->GetNumberOfIds()-1));
+    tri->GetPointIds()->SetId(0, ids->GetId(1));
     cells->InsertNextCell(tri.GetPointer());
     ncells++;
     return ncells;
@@ -520,7 +524,7 @@ vtkVisItMoleculeMapper::SetColors()
   else if (varName == "resseq" ||
           (varName.length()>7 && varName.substr(varName.length()-7)=="/resseq"))
     {
-    new_colortablename = this->ResSeqCTName; 
+    new_colortablename = this->ResSeqCTName;
     if (new_colortablename == "Default")
       new_colortablename = string(ct->GetDefaultDiscreteColorTable());
 
@@ -550,14 +554,14 @@ vtkVisItMoleculeMapper::SetColors()
       new_colortablename == this->ColorTableName)
     {
     return;
-    } 
+    }
 
   this->NumColors      = new_numcolors;
   this->ColorTableName = new_colortablename;
 
   if (this->MolColors)
     delete[] this->MolColors;
-    
+
   this->MolColors = new unsigned char[this->NumColors * 4];
   unsigned char *cptr = this->MolColors;
   //
@@ -724,7 +728,7 @@ void vtkVisItMoleculeMapper::UpdateAtomPolyData()
                   (primaryname.length() > 8 &&
                    primaryname.substr(primaryname.length()-8) == "/restype"));
 
-  vtkDataArray *element = primary_is_element ? primary : 
+  vtkDataArray *element = primary_is_element ? primary :
                                  input->GetPointData()->GetArray("element");
 
   if (element && !element->IsA("vtkFloatArray"))
@@ -821,7 +825,7 @@ void vtkVisItMoleculeMapper::UpdateAtomPolyData()
     double *pt = points->GetPoint(atom);
     vtkIdType id = pts->InsertNextPoint(pt);
     cells->InsertNextCell(1, &id);
-    scaleFactors->InsertNextValue(radius); 
+    scaleFactors->InsertNextValue(radius);
     // Determine color
     if (color_by_element)
       {
@@ -834,7 +838,7 @@ void vtkVisItMoleculeMapper::UpdateAtomPolyData()
       int level = int(scalar[atom]) - (primary_is_resseq ? 1 : 0);
       if(levelsLUT != 0)
         {
-        const unsigned char *rgb = 
+        const unsigned char *rgb =
               levelsLUT->MapValue(level);
         for (int i = 0; i < npts; ++i)
           scol->InsertNextTypedTuple(rgb);
@@ -853,7 +857,7 @@ void vtkVisItMoleculeMapper::UpdateAtomPolyData()
         alpha = 0.5;
       else
         alpha = (scalar[atom] - this->VarMin) / (this->VarMax - this->VarMin);
-            
+
       int color = int((float(this->NumColors)-.01) * alpha);
       if (color < 0)
         color = 0;
@@ -869,7 +873,7 @@ void vtkVisItMoleculeMapper::UpdateAtomPolyData()
   this->AtomPolyData->SetPoints(pts);
   this->AtomPolyData->GetPointData()->SetScalars(scol.GetPointer());
 
-  this->AtomPolyData->SetVerts(cells.GetPointer()); 
+  this->AtomPolyData->SetVerts(cells.GetPointer());
   this->AtomPolyData->GetPointData()->AddArray(scaleFactors.GetPointer());
   this->AtomMapper->SetScaleArray("ScaleFactors");
   this->ImposterMapper->SetImposterScaleArray("ScaleFactors");
@@ -877,6 +881,12 @@ void vtkVisItMoleculeMapper::UpdateAtomPolyData()
 
 //----------------------------------------------------------------------------
 // Generate position, scale, and orientation vectors for each bond cylinder
+//
+//  Modifications:
+//    Kathleen Biagas, June 16, 2021
+//    Use separate color arrays for lines and cylinders as they have different
+//    number of cells.
+//
 void vtkVisItMoleculeMapper::UpdateBondPolyData()
 {
   this->BondLinesPolyData->Initialize();
@@ -896,10 +906,13 @@ void vtkVisItMoleculeMapper::UpdateBondPolyData()
   vtkNew<vtkCellArray> cylPolys;
   vtkNew<vtkFloatArray> cylNorms;
   cylNorms->SetNumberOfComponents(3);
-  vtkNew<vtkUnsignedCharArray> bondColors;
-  bondColors->SetName("Colors");
-  bondColors->SetNumberOfComponents(3);
-  
+  vtkNew<vtkUnsignedCharArray> cylinderBondColors;
+  cylinderBondColors->SetName("Colors");
+  cylinderBondColors->SetNumberOfComponents(3);
+  vtkNew<vtkUnsignedCharArray> lineBondColors;
+  lineBondColors->SetName("Colors");
+  lineBondColors->SetNumberOfComponents(3);
+
   bool primary_is_cell_centered = false;
   vtkDataArray *primary = input->GetPointData()->GetScalars();
   if (!primary)
@@ -937,7 +950,7 @@ void vtkVisItMoleculeMapper::UpdateBondPolyData()
                   (primaryname.length() > 8 &&
                    primaryname.substr(primaryname.length()-8) == "/restype"));
 
-  vtkDataArray *element = primary_is_element ? primary : 
+  vtkDataArray *element = primary_is_element ? primary :
                                  input->GetPointData()->GetArray("element");
   if (element && !element->IsA("vtkFloatArray"))
     {
@@ -1091,7 +1104,8 @@ void vtkVisItMoleculeMapper::UpdateBondPolyData()
           {
           unsigned char bc[3] = {255,0, 0};
           for (int i = 0;i < ncells; ++i)
-            bondColors->InsertNextTypedTuple(this->BondColor);
+            cylinderBondColors->InsertNextTypedTuple(this->BondColor);
+          lineBondColors->InsertNextTypedTuple(this->BondColor);
           }
         else // (this->BondColorMode == ColorByAtom)
           {
@@ -1105,23 +1119,26 @@ void vtkVisItMoleculeMapper::UpdateBondPolyData()
             {
             int level = element_number % this->NumColors;
             for (int i = 0;i < ncells; ++i)
-              bondColors->InsertNextTypedTuple(&this->MolColors[4*level]);
+              cylinderBondColors->InsertNextTypedTuple(&this->MolColors[4*level]);
+            lineBondColors->InsertNextTypedTuple(&this->MolColors[4*level]);
             }
           else if (color_by_levels)
             {
             int level = int(scalarval) - (primary_is_resseq ? 1 : 0);
             if(levelsLUT != 0)
               {
-              const unsigned char *rgb = 
+              const unsigned char *rgb =
               levelsLUT->MapValue(level);
               for (int i = 0;i < ncells; ++i)
-                bondColors->InsertNextTypedTuple(rgb);
+                cylinderBondColors->InsertNextTypedTuple(rgb);
+              lineBondColors->InsertNextTypedTuple(rgb);
               }
             else
               {
               level = level % this->NumColors;
               for (int i = 0;i < ncells; ++i)
-                bondColors->InsertNextTypedTuple(&this->MolColors[4*level]);
+                cylinderBondColors->InsertNextTypedTuple(&this->MolColors[4*level]);
+              lineBondColors->InsertNextTypedTuple(&this->MolColors[4*level]);
               }
             }
           else
@@ -1131,14 +1148,15 @@ void vtkVisItMoleculeMapper::UpdateBondPolyData()
               alpha = 0.5;
             else
               alpha = (scalarval - this->VarMin) / (this->VarMax - this->VarMin);
-          
+
             int color = int((float(this->NumColors)-.01) * alpha);
             if (color < 0)
               color = 0;
             if (color > this->NumColors-1)
               color = this->NumColors-1;
             for (int i = 0;i < ncells; ++i)
-              bondColors->InsertNextTypedTuple(&this->MolColors[4*color]);
+              cylinderBondColors->InsertNextTypedTuple(&this->MolColors[4*color]);
+            lineBondColors->InsertNextTypedTuple(&this->MolColors[4*color]);
             }
           } // color by atom
         } // for half
@@ -1147,10 +1165,10 @@ void vtkVisItMoleculeMapper::UpdateBondPolyData()
     } // for number of lines
   this->BondLinesPolyData->SetPoints(linePoints);
   this->BondLinesPolyData->SetLines(lineLines.GetPointer());
-  this->BondLinesPolyData->GetCellData()->SetScalars(bondColors.GetPointer());
+  this->BondLinesPolyData->GetCellData()->SetScalars(lineBondColors.GetPointer());
   this->BondCylsPolyData->SetPoints(cylPoints);
   this->BondCylsPolyData->SetPolys(cylPolys.GetPointer());
-  this->BondCylsPolyData->GetCellData()->SetScalars(bondColors.GetPointer());
+  this->BondCylsPolyData->GetCellData()->SetScalars(cylinderBondColors.GetPointer());
   this->BondCylsPolyData->GetPointData()->SetNormals(cylNorms.GetPointer());
 }
 
@@ -1175,7 +1193,7 @@ void vtkVisItMoleculeMapper::SetDrawBondsAs(int type)
   DrawBondsAs = type;
   if (DrawBondsAs == vtkVisItMoleculeMapper::Lines)
     this->BondOutput->SetOutput(this->BondLinesPolyData.GetPointer());
-  else 
+  else
     this->BondOutput->SetOutput(this->BondCylsPolyData.GetPointer());
   this->BondMapper->Modified();
 }

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with ghost zone generation that caused VisIt to not display any data when displaying data from a parallel Exodus file when subsetting based on ElementBlock.</li>
   <li>Fixed a bug with full frame mode that resulted in the labels from the label plot not being drawn correctly.</li>
   <li>Fixed a bug launching the CLI when specifying "-v 3.2" when the default version in that installation was still an older version of VisIt (e.g. 3.1.4).</li>
+  <li>Fixed a bug in Molecule plot where created bonds colored by atom were being colored incorrectly.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5780
Polydata for lines was receiving the same colors arrays as polydata for cylinders even though there were far fewer cells in the lines. Now they both receive their own color arrays.

When cylinder bonds were capped, the caps didn't have enough normals associated with them, causing problems with coloring.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the test script in the ticket, and now all bonds are colored correctly.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
