### PR TITLE
Fix molecule plot created bond coloring issues. (#5786)

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with full frame mode that resulted in the labels from the label plot not being drawn correctly.</li>
   <li>Fixed a bug launching the CLI when specifying "-v 3.2" when the default version in that installation was still an older version of VisIt (e.g. 3.1.4).</li>
   <li>Fixed crash with Molecule plot when drawn with Sphere Imposters for atoms and 'scaleRadiusBy' option is changed.</li> 
+  <li>Fixed a bug in Molecule plot where created bonds colored by atom were being colored incorrectly.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Polydata for lines was receiving the same colors arrays as polydata for cylinders even though there were far fewer cells in the lines. Now they both receive their own color arrays.

When cylinder bonds were capped, the caps didn't have enough normals associated with them, causing problems with coloring.

Resolves #5780

This is  merge from 3.2RC

