### PR TITLE
Add some Qt VTK examples.

### DIFF
--- a/src/tools/examples/avtexamples/CMakeLists.txt
+++ b/src/tools/examples/avtexamples/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 #****************************************************************************
 # Modifications:
+#   Eric Brugger, Mon Jun 21 14:21:35 PDT 2021
+#   Added qvtkopenglExample and qtvtkExample.
 #
 #****************************************************************************
 
@@ -44,6 +46,7 @@ ${VISIT_SOURCE_DIR}/avt/VisWindow/Proxies
 ${VISIT_SOURCE_DIR}/avt/VisWindow/Tools
 ${VISIT_SOURCE_DIR}/avt/VisWindow/VisWindow
 ${VISIT_SOURCE_DIR}/engine/main
+${VISIT_SOURCE_DIR}/vtkqt
 ${VTK_INCLUDE_DIRS}
 )
 
@@ -192,5 +195,59 @@ ${ALL_THIRDPARTY_IO_LIB}
 ${VTK_EXTRA_LIBS}
 ${OPENGL_LIBRARIES}
 ${CMAKE_THREAD_LIBS}
+${ZLIB_LIBRARY}
+)
+
+SET(QVTKOPENGLEXAMPLE_SOURCES
+qvtkopenglExample.C
+GUIWindow.C
+)
+
+SET(QVTKOPENGLEXAMPLE_MOC_SOURCES
+GUIWindow.h
+)
+QT_WRAP_CPP(qvtkopenglExample QVTKOPENGLEXAMPLE_SOURCES ${QVTKOPENGLEXAMPLE_MOC_SOURCES})
+
+ADD_EXECUTABLE(qvtkopenglExample ${QVTKOPENGLEXAMPLE_SOURCES})
+VISIT_INSTALL_TARGETS(qvtkopenglExample)
+VISIT_EXAMPLES_ADD_FOLDER(qvtkopenglExample qvtkopenglExample)
+
+TARGET_LINK_LIBRARIES(qvtkopenglExample
+vtkqt
+${QT_QTGUI_LIBRARY}
+${QT_QTOPENGL_LIBRARY}
+${QT_QTNETWORK_LIBRARY}
+${QT_QTCORE_LIBRARY}
+${VTK_EXTRA_LIBS}
+vtkCommonColor
+vtkFiltersSources
+${OPENGL_LIBRARIES}
+${ZLIB_LIBRARY}
+)
+
+SET(QTVTKEXAMPLE_SOURCES
+qtvtkExample.C
+GUIWindow2.C
+)
+
+SET(QTVTKEXAMPLE_MOC_SOURCES
+GUIWindow2.h
+)
+QT_WRAP_CPP(qtvtkExample QTVTKEXAMPLE_SOURCES ${QTVTKEXAMPLE_MOC_SOURCES})
+
+ADD_EXECUTABLE(qtvtkExample ${QTVTKEXAMPLE_SOURCES})
+VISIT_INSTALL_TARGETS(qtvtkExample)
+VISIT_EXAMPLES_ADD_FOLDER(qtvtkExample qtvtkExample)
+
+TARGET_LINK_LIBRARIES(qtvtkExample
+vtkqt
+${QT_QTGUI_LIBRARY}
+${QT_QTOPENGL_LIBRARY}
+${QT_QTNETWORK_LIBRARY}
+${QT_QTCORE_LIBRARY}
+${VTK_EXTRA_LIBS}
+vtkCommonColor
+vtkFiltersSources
+${OPENGL_LIBRARIES}
 ${ZLIB_LIBRARY}
 )

--- a/src/tools/examples/avtexamples/GUIWindow.C
+++ b/src/tools/examples/avtexamples/GUIWindow.C
@@ -1,0 +1,179 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#include <GUIWindow.h>
+
+#include <QApplication>
+#include <QLabel>
+#include <QMainWindow>
+#include <QMenuBar>
+#include <QSpinBox>
+#include <QTabWidget>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <QVTKOpenGLWidget.h>
+
+#include <vtkActor.h>
+#include <vtkCamera.h>
+#include <vtkCylinderSource.h>
+#include <vtkGenericOpenGLRenderWindow.h> 
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+
+#include <iostream>
+
+GUIWindow::GUIWindow() : QMainWindow()
+{
+    CreateWindow();
+}
+
+GUIWindow::~GUIWindow()
+{
+}
+
+void
+GUIWindow::spinBoxChanged(int val)
+{
+    std::cerr << "New spin box value = " << val << std::endl;
+}
+
+void
+GUIWindow::DrawCylinder(vtkRenderWindow *renderWindow)
+{
+    vtkNew<vtkNamedColors> colors;
+
+    //
+    // Set the background color.
+    //
+    std::array<unsigned char, 4> bkg{{26, 51, 102, 255}};
+    colors->SetColor("BkgColor", bkg.data());
+
+    //
+    // Create a polygonal cylinder with eight circumferential facets.
+    //
+    vtkNew<vtkCylinderSource> cylinder;
+    cylinder->SetResolution(8);
+
+    //
+    // Map the cylinder.
+    //
+    vtkNew<vtkPolyDataMapper> cylinderMapper;
+    cylinderMapper->SetInputConnection(cylinder->GetOutputPort());
+
+    //
+    // Create the actor, setting the collor and rotating it.
+    //
+    vtkNew<vtkActor> cylinderActor;
+    cylinderActor->SetMapper(cylinderMapper);
+    cylinderActor->GetProperty()->SetColor(
+    colors->GetColor4d("Tomato").GetData());
+    cylinderActor->RotateX(30.0);
+    cylinderActor->RotateY(-45.0);
+
+    //
+    // Create the renderer.
+    //
+    vtkNew<vtkRenderer> renderer;
+    renderer->AddActor(cylinderActor);
+    renderer->SetBackground(colors->GetColor3d("BkgColor").GetData());
+    // Zoom in a little by accessing the camera and invoking its "Zoom" method.
+    renderer->ResetCamera();
+    renderer->GetActiveCamera()->Zoom(1.5);
+
+    //
+    // Attach the renderer to the render window.
+    //
+    renderWindow->AddRenderer(renderer);
+
+    //
+    // Render the image.
+    //
+    renderWindow->Render();
+}
+
+void
+GUIWindow::CreateWindow()
+{
+    QWidget *central = new QWidget(this);
+    this->setCentralWidget(central);
+
+    //
+    // Create a horizontal split, with controls on the left
+    // and the visualization window on the right.
+    //
+    QHBoxLayout *hLayout = new QHBoxLayout(central);
+    hLayout->setMargin(10);
+    hLayout->setSpacing(10);
+    QVBoxLayout *leftLayout = new QVBoxLayout(0);
+    leftLayout->setSpacing(10);
+    hLayout->addLayout(leftLayout);
+
+    //
+    // Create tabs on the left side of the window.
+    //
+    QTabWidget *tabs = new QTabWidget(central);
+    leftLayout->addWidget(tabs);
+
+    //
+    // Create the general tab.
+    //
+    QWidget *pageGeneral = new QWidget(central);
+    tabs->addTab(pageGeneral, "General");
+
+    QWidget *generalWidget = new QWidget(pageGeneral);
+
+    QVBoxLayout *gLayout = new QVBoxLayout(generalWidget);
+    gLayout->setMargin(5);
+    gLayout->setSpacing(10);
+
+    //
+    // Create a layout for the remaining widgets.
+    //
+    QGridLayout *mainLayout = new QGridLayout(0);
+    gLayout->addLayout(mainLayout);
+
+    //
+    // Add the spin box widgets.
+    //
+    QLabel *spinBoxLabel = new QLabel("SpinBox", generalWidget);
+    mainLayout->addWidget(spinBoxLabel, 0,0);
+
+    QSpinBox *spinBox = new QSpinBox(generalWidget);
+    spinBox->setRange(0, 10);
+    spinBox->setSingleStep(1);
+    this->connect(spinBox, SIGNAL(valueChanged(int)),
+            this, SLOT(spinBoxChanged(int)));
+    mainLayout->addWidget(spinBox, 0,1);
+
+    //
+    // Create the visualization window.
+    //
+    QVTKOpenGLWidget *gl = new QVTKOpenGLWidget(central);;
+    if (!gl->GetRenderWindow())
+    {
+        vtkGenericOpenGLRenderWindow *renWin = vtkGenericOpenGLRenderWindow::New();
+        gl->SetRenderWindow(renWin);
+        renWin->Delete();
+    }
+    gl->GetRenderWindow()->AlphaBitPlanesOn();
+    gl->GetRenderWindow()->SetStereoRender(false);
+    gl->setMinimumSize(QSize(500,500));
+    hLayout->addWidget(gl, 100);
+
+    //
+    // Draw a cylinder in the render window.
+    //
+    DrawCylinder(gl->GetRenderWindow());
+
+    //
+    // Create the menus.
+    //
+    QMenu *fileMenu = this->menuBar()->addMenu("File");
+    fileMenu->addAction("Quit", qApp, SLOT(quit()));
+}

--- a/src/tools/examples/avtexamples/GUIWindow.h
+++ b/src/tools/examples/avtexamples/GUIWindow.h
@@ -1,0 +1,27 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#ifndef GUI_WINDOW_H
+#define GUI_WINDOW_H
+
+#include <QMainWindow>
+
+class vtkRenderWindow;
+
+class GUIWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    GUIWindow();
+    virtual ~GUIWindow();
+
+private slots:
+    void spinBoxChanged(int val);
+
+private:
+    void DrawCylinder(vtkRenderWindow *renderWindow);
+    void CreateWindow();
+};
+
+#endif

--- a/src/tools/examples/avtexamples/GUIWindow2.C
+++ b/src/tools/examples/avtexamples/GUIWindow2.C
@@ -1,0 +1,170 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#include <GUIWindow2.h>
+
+#include <QApplication>
+#include <QLabel>
+#include <QMainWindow>
+#include <QMenuBar>
+#include <QSpinBox>
+#include <QTabWidget>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <vtkActor.h>
+#include <vtkCamera.h>
+#include <vtkCylinderSource.h>
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+
+#include <vtkQtRenderWindow.h>
+
+#include <iostream>
+
+GUIWindow2::GUIWindow2() : QMainWindow()
+{
+    CreateWindow();
+}
+
+GUIWindow2::~GUIWindow2()
+{
+}
+
+void
+GUIWindow2::spinBoxChanged(int val)
+{
+    std::cerr << "New spin box value = " << val << std::endl;
+}
+
+void
+GUIWindow2::DrawCylinder(vtkRenderWindow *renderWindow)
+{
+    vtkNew<vtkNamedColors> colors;
+
+    //
+    // Set the background color.
+    //
+    std::array<unsigned char, 4> bkg{{26, 51, 102, 255}};
+    colors->SetColor("BkgColor", bkg.data());
+
+    //
+    // Create a polygonal cylinder with eight circumferential facets.
+    //
+    vtkNew<vtkCylinderSource> cylinder;
+    cylinder->SetResolution(8);
+
+    //
+    // Map the cylinder.
+    //
+    vtkNew<vtkPolyDataMapper> cylinderMapper;
+    cylinderMapper->SetInputConnection(cylinder->GetOutputPort());
+
+    //
+    // Create the actor, setting the collor and rotating it.
+    //
+    vtkNew<vtkActor> cylinderActor;
+    cylinderActor->SetMapper(cylinderMapper);
+    cylinderActor->GetProperty()->SetColor(
+    colors->GetColor4d("Tomato").GetData());
+    cylinderActor->RotateX(30.0);
+    cylinderActor->RotateY(-45.0);
+
+    //
+    // Create the renderer.
+    //
+    vtkNew<vtkRenderer> renderer;
+    renderer->AddActor(cylinderActor);
+    renderer->SetBackground(colors->GetColor3d("BkgColor").GetData());
+    // Zoom in a little by accessing the camera and invoking its "Zoom" method.
+    renderer->ResetCamera();
+    renderer->GetActiveCamera()->Zoom(1.5);
+
+    //
+    // Attach the renderer to the render window.
+    //
+    renderWindow->AddRenderer(renderer);
+
+    //
+    // Render the image.
+    //
+    renderWindow->Render();
+}
+
+void
+GUIWindow2::CreateWindow()
+{
+    QWidget *central = new QWidget(this);
+    this->setCentralWidget(central);
+
+    //
+    // Create a horizontal split, with controls on the left
+    // and the visualization window on the right.
+    //
+    QHBoxLayout *hLayout = new QHBoxLayout(central);
+    hLayout->setMargin(10);
+    hLayout->setSpacing(10);
+    QVBoxLayout *leftLayout = new QVBoxLayout(0);
+    leftLayout->setSpacing(10);
+    hLayout->addLayout(leftLayout);
+
+    //
+    // Create tabs on the left side of the window.
+    //
+    QTabWidget *tabs = new QTabWidget(central);
+    leftLayout->addWidget(tabs);
+
+    //
+    // Create the general tab.
+    //
+    QWidget *pageGeneral = new QWidget(central);
+    tabs->addTab(pageGeneral, "General");
+
+    QWidget *generalWidget = new QWidget(pageGeneral);
+
+    QVBoxLayout *gLayout = new QVBoxLayout(generalWidget);
+    gLayout->setMargin(5);
+    gLayout->setSpacing(10);
+
+    //
+    // Create a layout for the remaining widgets.
+    //
+    QGridLayout *mainLayout = new QGridLayout(0);
+    gLayout->addLayout(mainLayout);
+
+    //
+    // Add the spin box widgets.
+    //
+    QLabel *spinBoxLabel = new QLabel("SpinBox", generalWidget);
+    mainLayout->addWidget(spinBoxLabel, 0,0);
+
+    QSpinBox *spinBox = new QSpinBox(generalWidget);
+    spinBox->setRange(0, 10);
+    spinBox->setSingleStep(1);
+    this->connect(spinBox, SIGNAL(valueChanged(int)),
+            this, SLOT(spinBoxChanged(int)));
+    mainLayout->addWidget(spinBox, 0,1);
+
+    //
+    // Create the visualization window.
+    //
+    vtkQtRenderWindow *viswin = vtkQtRenderWindow::New(false);
+    viswin->setMinimumSize(QSize(500,500));
+    hLayout->addWidget(viswin, 100);
+
+    //
+    // Draw a cylinder in the render window.
+    //
+    DrawCylinder(viswin->GetRenderWindow());
+
+    //
+    // Create the menus.
+    //
+    QMenu *fileMenu = this->menuBar()->addMenu("File");
+    fileMenu->addAction("Quit", qApp, SLOT(quit()));
+}

--- a/src/tools/examples/avtexamples/GUIWindow2.h
+++ b/src/tools/examples/avtexamples/GUIWindow2.h
@@ -1,0 +1,27 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#ifndef GUI_WINDOW_H
+#define GUI_WINDOW_H
+
+#include <QMainWindow>
+
+class vtkRenderWindow;
+
+class GUIWindow2 : public QMainWindow
+{
+    Q_OBJECT
+public:
+    GUIWindow2();
+    virtual ~GUIWindow2();
+
+private slots:
+    void spinBoxChanged(int val);
+
+private:
+    void DrawCylinder(vtkRenderWindow *renderWindow);
+    void CreateWindow();
+};
+
+#endif

--- a/src/tools/examples/avtexamples/README
+++ b/src/tools/examples/avtexamples/README
@@ -1,6 +1,9 @@
 You must set the following environment variables when running the
-examples in a development build.
+avt examples in a development build.
 
 setenv VISITARCHHOME path_to_visit/src/
 setenv VISITHOME path_to_visit/src
 setenv VISITPLUGINDIR path_to_visit/src/plugins
+
+The qvtkopenglExample and qtvtkExample examples do not require setting
+any environment variables.

--- a/src/tools/examples/avtexamples/qtvtkExample.C
+++ b/src/tools/examples/avtexamples/qtvtkExample.C
@@ -11,7 +11,7 @@
 #include <iostream>
 
 int
-MCVMain(int argc, char *argv[])
+main(int argc, char **argv)
 {
     int retval = 0;
 
@@ -37,10 +37,4 @@ MCVMain(int argc, char *argv[])
     retval = mainApp->exec();
 
     return retval;
-}
-
-int
-main(int argc, char **argv)
-{
-    return MCVMain(argc, argv);
 }

--- a/src/tools/examples/avtexamples/qtvtkExample.C
+++ b/src/tools/examples/avtexamples/qtvtkExample.C
@@ -1,0 +1,46 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#include <GUIWindow2.h>
+
+#include <QApplication>
+
+#include <QVTKOpenGLWidget.h>
+
+#include <iostream>
+
+int
+MCVMain(int argc, char *argv[])
+{
+    int retval = 0;
+
+    //
+    // Setting the default QSurfaceFormat required with QVTKOpenGLwidget.
+    // This causes Qt to create an OpenGL 3.2 context.
+    //
+    auto surfaceFormat = QVTKOpenGLWidget::defaultFormat();
+    surfaceFormat.setSamples(0);
+    surfaceFormat.setAlphaBufferSize(0);
+    QSurfaceFormat::setDefaultFormat(surfaceFormat);
+
+    //
+    // Create the QApplication. This sets the qApp pointer.
+    //
+    QApplication *mainApp = new QApplication(argc, argv, true);
+
+    GUIWindow2 *guiWin = new GUIWindow2();
+
+    guiWin->show();
+    guiWin->raise();
+
+    retval = mainApp->exec();
+
+    return retval;
+}
+
+int
+main(int argc, char **argv)
+{
+    return MCVMain(argc, argv);
+}

--- a/src/tools/examples/avtexamples/qvtkopenglExample.C
+++ b/src/tools/examples/avtexamples/qvtkopenglExample.C
@@ -1,0 +1,46 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+#include <GUIWindow.h>
+
+#include <QApplication>
+
+#include <QVTKOpenGLWidget.h>
+
+#include <iostream>
+
+int
+MCVMain(int argc, char *argv[])
+{
+    int retval = 0;
+
+    //
+    // Setting the default QSurfaceFormat required with QVTKOpenGLwidget.
+    // This causes Qt to create an OpenGL 3.2 context.
+    //
+    auto surfaceFormat = QVTKOpenGLWidget::defaultFormat();
+    surfaceFormat.setSamples(0);
+    surfaceFormat.setAlphaBufferSize(0);
+    QSurfaceFormat::setDefaultFormat(surfaceFormat);
+
+    //
+    // Create the QApplication. This sets the qApp pointer.
+    //
+    QApplication *mainApp = new QApplication(argc, argv, true);
+
+    GUIWindow *guiWin = new GUIWindow();
+
+    guiWin->show();
+    guiWin->raise();
+
+    retval = mainApp->exec();
+
+    return retval;
+}
+
+int
+main(int argc, char **argv)
+{
+    return MCVMain(argc, argv);
+}

--- a/src/tools/examples/avtexamples/qvtkopenglExample.C
+++ b/src/tools/examples/avtexamples/qvtkopenglExample.C
@@ -11,7 +11,7 @@
 #include <iostream>
 
 int
-MCVMain(int argc, char *argv[])
+main(int argc, char **argv)
 {
     int retval = 0;
 
@@ -37,10 +37,4 @@ MCVMain(int argc, char *argv[])
     retval = mainApp->exec();
 
     return retval;
-}
-
-int
-main(int argc, char **argv)
-{
-    return MCVMain(argc, argv);
 }


### PR DESCRIPTION
### Description

I added a couple of Qt VTK examples to the tools/examples/avtexamples. The first is with using the QVTKOpenGLWidget and the second is with using vtkQtRenderWindow. There is a lot of duplicated code between the 2, but I wanted 2 fully stand alone examples with no extraneous code to test VTK OpenGL usage with Qt.

I plan to add more examples using higher level VisIt abstractions.

### Type of change

* [ ] Bug fix
* [X] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran both of these examples on quartz and kickit and the worked properly.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
