### PR TITLE
Fix build_visit with setting the architecture directory with gcc 10.2. (#5847)

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -40,6 +40,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Legend annotation object window where the <i>Values</i> column in the <i>Values/Labels</i> table in the <i>Tick marks</i> tab wasn't being prefilled.</li>
   <li>Fixed a bug for Windows where importing VisIt into python failed due to inability to retrieve necessary enviroment variable information.</li>
   <li>Fixed a bug that resulted in the rubber band zoom box being rendered incorrectly on Mac retina displays.</li>
+  <li>Fixed a bug in build_visit that caused it to improperly set the architecture directory name when using gcc 10.2. For example, on a linux system with an x86_64 processor, it previously set it to <i>linux-x86_64_gcc</i> instead of the correct <i>linux-x86_64_gcc-10.2</i>.</li>
   <li>Fixed a bug for Windows where exporting a multi-block Silo file into a non-default directory would make the file unreadable by VisIt.</li>
 </ul>
 

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -531,9 +531,7 @@ function initialize_build_visit()
         export VISITARCHTMP=${ARCH}_${C_COMPILER}
         if [[ "$CXX_COMPILER" == "g++" ]] ; then
             VERSION=$(g++ -v 2>&1 | grep "gcc version" | cut -d' ' -f3 | cut -d'.' -f1-2)
-            if [[ ${#VERSION} == 3 ]] ; then
-                VISITARCHTMP=${VISITARCHTMP}-${VERSION}
-            fi
+            VISITARCHTMP=${VISITARCHTMP}-${VERSION}
         fi
     else
         # use environment variable value
@@ -1422,9 +1420,7 @@ function run_build_visit()
         export VISITARCH=${ARCH}_${C_COMPILER_BASENAME}
         if [[ "$CXX_COMPILER_BASENAME" == "g++" ]] ; then
             VERSION=$(${CXX_COMPILER} -v 2>&1 | grep "gcc version" | cut -d' ' -f3 | cut -d'.' -f1-2)
-            if [[ ${#VERSION} == 3 ]] ; then
-                VISITARCH=${VISITARCH}-${VERSION}
-            fi
+            VISITARCH=${VISITARCH}-${VERSION}
         elif [[ "$CXX_COMPILER_BASENAME" == "icpc" ]] ; then
             VERSION=$(${CXX_COMPILER} --version | cut -d' ' -f3 | head -n1)
             VISITARCH=${VISITARCH}-${VERSION}


### PR DESCRIPTION
Resolves #5831 
Merge from the 3.2RC to develop.