### PR TITLE
Fix issues building mesa and vtk with gcc-10.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -56,6 +56,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>When viewing test results in a web browser, the text tests will now correctly display leading spaces.</li>
   <li>The build_visit python module was changed so that when  --system-python or --alt-python3-dir is specified, python3 is searched for first.</li>
   <li>Removed tcmalloc from VisIt.</li>
+  <li>Fixed problems building Mesa and VTK (with python wrappers) with gcc 10.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -177,8 +177,7 @@ EOF
     fi
 
     #
-    # Patch so that displaying graphics to the XWin-32 2018 X server
-    # works properly.
+    # Patch so that building with gcc-10 will work.
     #
     patch -p0 << \EOF
 diff -u src/gallium/drivers/swr/rasterizer/common/os.h.orig src/gallium/drivers/swr/rasterizer/common/os.h


### PR DESCRIPTION
### Description

Resolves #5832
Resolves #5830 

Added Mesa patch for building with gcc-10.
Added '-fcommon' to cflags for Mesa when building with gcc-10.

Add VTK patch allowing 2-digits in gcc major version number when performing a version check. Fixes visibility issues.

Updated release notes.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran build_visit using gcc-10 to comile the normal Third party libraries and VisIt itself. Visit ran fine with the few tests I performed.
I then did the same with gcc-6 to ensure I didn't introduce any problems.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
