### PR TITLE
Fix build_visit with --no-sphinx.

### DIFF
--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -25,25 +25,30 @@
 #   Kathleen Biagas, Thu Apr 22, 2021
 #   Don't build manuals for VISIT_STATIC, as sphinx won't be built.
 #
+#   Kathleen Biagas, Thu July 1, 2021
+#   Change FATAL_ERROR to WARNING with early return.
+#
 #****************************************************************************
 
 if(VISIT_PYTHON_DIR AND VISIT_ENABLE_MANUALS AND NOT VISIT_STATIC)
     message(STATUS "Configure manuals targets")
-    set(errmsgtail "Either install sphinx or set VISIT_ENABLE_MANUALS to false.")
+    set(errmsgtail "To remove this warning, either install sphinx or set VISIT_ENABLE_MANUALS to false.")
     if(WIN32)
         # Need a different sphinx build command for windows
         if(NOT EXISTS ${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py)
-            message(FATAL_ERROR "Manuals are enabled but"
+            message(WARNING "Manuals are enabled but"
                    " ${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py"
-                   " does not exist. ${errmsgtail}")
+                   " does not exist so manuals will not be built. ${errmsgtail}")
+            return()
         endif()
         set(sphinx_build_cmd "${VISIT_PYTHON_DIR}/python.exe \ "
               "${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py")
     else()
         if(NOT EXISTS ${VISIT_PYTHON_DIR}/bin/sphinx-build)
-            message(FATAL_ERROR "Manuals are enabled but"
+            message(WARNING "Manuals are enabled but"
                     " ${VISIT_PYTHON_DIR}/bin/sphinx-build"
-                    " does not exist. ${errmsgtail}")
+                    " does not exist so manuals will not be built. ${errmsgtail}")
+            return()
         endif()
         set(sphinx_build_cmd ${VISIT_PYTHON_DIR}/bin/sphinx-build)
     endif()

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -58,6 +58,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The build_visit python module was changed so that when  --system-python or --alt-python3-dir is specified, python3 is searched for first.</li>
   <li>Removed tcmalloc from VisIt.</li>
   <li>Fixed problems building Mesa and VTK (with python wrappers) with gcc 10.</li>
+  <li>Fixed build_visit with --no-sphinx failure to build VisIt.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description
Change FATAL_ERROR to WARNING with early return when VISIT_ENABLE_MANUALS is on but sphinx not found.

Resolves #5767

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran build_visit with --no-sphinx to build TP libs and visit itself. VisIt build successfully and packaged was created successfully.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
