### PR TITLE
Fix build_visit with --no-sphinx. (#5853)

### DIFF
--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -25,25 +25,30 @@
 #   Kathleen Biagas, Thu Apr 22, 2021
 #   Don't build manuals for VISIT_STATIC, as sphinx won't be built.
 #
+#   Kathleen Biagas, Thu July 1, 2021
+#   Change FATAL_ERROR to WARNING with early return.
+#
 #****************************************************************************
 
 if(VISIT_PYTHON_DIR AND VISIT_ENABLE_MANUALS AND NOT VISIT_STATIC)
     message(STATUS "Configure manuals targets")
-    set(errmsgtail "Either install sphinx or set VISIT_ENABLE_MANUALS to false.")
+    set(errmsgtail "To remove this warning, either install sphinx or set VISIT_ENABLE_MANUALS to false.")
     if(WIN32)
         # Need a different sphinx build command for windows
         if(NOT EXISTS ${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py)
-            message(FATAL_ERROR "Manuals are enabled but"
+            message(WARNING "Manuals are enabled but"
                    " ${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py"
-                   " does not exist. ${errmsgtail}")
+                   " does not exist so manuals will not be built. ${errmsgtail}")
+            return()
         endif()
         set(sphinx_build_cmd "${VISIT_PYTHON_DIR}/python.exe \ "
               "${VISIT_PYTHON_DIR}/Scripts/sphinx-build-script.py")
     else()
         if(NOT EXISTS ${VISIT_PYTHON_DIR}/bin/sphinx-build)
-            message(FATAL_ERROR "Manuals are enabled but"
+            message(WARNING "Manuals are enabled but"
                     " ${VISIT_PYTHON_DIR}/bin/sphinx-build"
-                    " does not exist. ${errmsgtail}")
+                    " does not exist so manuals will not be built. ${errmsgtail}")
+            return()
         endif()
         set(sphinx_build_cmd ${VISIT_PYTHON_DIR}/bin/sphinx-build)
     endif()

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -59,6 +59,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The build_visit python module was changed so that when  --system-python or --alt-python3-dir is specified, python3 is searched for first.</li>
   <li>Removed tcmalloc from VisIt.</li>
   <li>Fixed problems building Mesa and VTK (with python wrappers) with gcc 10.</li>
+  <li>Fixed build_visit with --no-sphinx failure to build VisIt.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description
This is a merge from 3.2RC
Change FATAL_ERROR to WARNING with early return when VISIT_ENABLE_MANUALS is on but sphinx not found.

Resolves #5767.



