### PR TITLE
Added support for reading rind data to the CGNS reader.

### DIFF
--- a/src/databases/CGNS/avtCGNSFileReader.C
+++ b/src/databases/CGNS/avtCGNSFileReader.C
@@ -12,14 +12,18 @@
 #include <algorithm>
 #include <string>
 
+#include <vtkCellData.h>
 #include <vtkCellTypes.h>
 #include <vtkCharArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkInformation.h>
 #include <vtkIntArray.h>
 #include <vtkLongArray.h>
 #include <vtkRectilinearGrid.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkStructuredGrid.h>
+#include <vtkUnsignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
 
 #include <avtCallback.h>
@@ -1626,6 +1630,151 @@ avtCGNSFileReader::GetCoords(int timestate, int base, int zone, const cgsize_t *
 }
 
 // ****************************************************************************
+// Method: avtCGNSFileReader::GetQuadGhostZones
+//
+// Purpose:
+//   Add the ghost zone information to the specified data set.
+//
+// Arguments:
+//   base       : The base to use
+//   zone       : The zone (mesh) that whose rind data we want.
+//   zsize      : The zone size information.
+//   cell_dim   : The cell dimension.
+//   ds         : The data set to add the ghost data to.
+//
+// Programmer: Eric Brugger
+// Creation:   Tue Jul  6 10:27:03 PDT 2021
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+avtCGNSFileReader::GetQuadGhostZones(int base, int zone,
+    const cgsize_t *zsize, int cell_dim, vtkDataSet *ds)
+{
+    const char *mName = "avtCGNSFileReader::GetQuadGhostZones: ";
+
+    // Read the rind data.
+    debug4 << "Reading rind node." << endl;
+    int rind[6];
+    if(cg_goto(GetFileHandle(), base, "Zone_t", zone, "FlowSolution_t", 1, "end") == CG_OK)
+    {
+        if (cg_rind_read(rind) == CG_OK)
+        {
+            debug4 << "rind=" << rind[0] << "," << rind[1] << ","
+                              << rind[2] << "," << rind[3] << ","
+                              << rind[4] << "," << rind[5] << endl;
+        }
+        else
+        {
+            debug4 << "No rind data." << endl;
+            return;
+        }
+    }
+    else
+    {
+        debug4 << "Error going to FlowSolution." << endl;
+        return;
+    }
+
+    // Determine the size of the mesh.
+    unsigned int ncells = 0;
+    cgsize_t cdims[3] = {1,1,1};
+    if(cell_dim == 1)
+    {
+        cdims[0] = zsize[0]-1;
+    }
+    else if(cell_dim == 2)
+    {
+        cdims[0] = zsize[0]-1;
+        cdims[1] = zsize[1]-1;
+    }
+    else
+    {
+        cdims[0] = zsize[0]-1;
+        cdims[1] = zsize[1]-1;
+        cdims[2] = zsize[2]-1;
+    }
+    ncells = cdims[0] * cdims[1] * cdims[2];
+
+    // Determine if the rind information is valid.
+    cgsize_t first[3];
+    cgsize_t last[3];
+    bool ghostPresent = false;
+    bool badIndex = false;
+    for (int i = 0; i < cell_dim; i++)
+    {
+        first[i] = rind[i*2];
+        last[i]  = cdims[i] - rind[i*2+1] - 1;
+
+        if (first[i] < 0 || first[i] >= cdims[i])
+        {
+            debug1 << "bad Index on first[" << i << "] dims is: "
+                   << zsize[i] << endl;
+            badIndex = true;
+        }
+
+        if (last[i] < 0 || last[i] >= cdims[i])
+        {
+            debug1 << "bad Index on last[" << i << "] dims is: "
+                   << zsize[i] << endl;
+            badIndex = true;
+        }
+
+        if (first[i] != 0 || last[i] != cdims[i] - 1)
+        {
+            ghostPresent = true;
+        }
+    }
+
+    //  Create the ghost zones array if necessary
+    if (ghostPresent && !badIndex)
+    {
+        vtkUnsignedCharArray *ghostCells = vtkUnsignedCharArray::New();
+        ghostCells->SetName("avtGhostZones");
+        ghostCells->Allocate(ncells);
+
+        unsigned char realVal = 0;
+        unsigned char ghostVal = 0;
+        avtGhostData::AddGhostZoneType(ghostVal,
+                                       DUPLICATED_ZONE_INTERNAL_TO_PROBLEM);
+        for (int i = 0; i < ncells; i++)
+            ghostCells->InsertNextValue(ghostVal);
+
+        unsigned char *gv = ghostCells->GetPointer(0);
+        for (int k = first[2]; k <= last[2]; k++) {
+            for (int j = first[1]; j <= last[1]; j++) {
+                for (int i = first[0]; i <= last[0]; i++)
+                {
+                    int index = k*cdims[1]*cdims[0] + j*cdims[0] + i;
+                    gv[index] = realVal;
+                }
+            }
+        }
+
+        ds->GetCellData()->AddArray(ghostCells);
+        ghostCells->Delete();
+
+        vtkIntArray *realDims = vtkIntArray::New();
+        realDims->SetName("avtRealDims");
+        realDims->SetNumberOfValues(6);
+        realDims->SetValue(0, first[0]);
+        realDims->SetValue(1, last[0]+1);
+        realDims->SetValue(2, first[1]);
+        realDims->SetValue(3, last[1]+1);
+        realDims->SetValue(4, first[2]);
+        realDims->SetValue(5, last[2]+1);
+        ds->GetFieldData()->AddArray(realDims);
+        ds->GetFieldData()->CopyFieldOn("avtRealDims");
+        realDims->Delete();
+    }
+
+    ds->GetInformation()->Set(
+        vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0);
+}
+
+// ****************************************************************************
 // Method: avtCGNSFileReader::GetCurvilinearMesh
 //
 // Purpose:
@@ -1726,6 +1875,8 @@ avtCGNSFileReader::GetCurvilinearMesh(int timestate, int base, int zone, const c
     {
         EXCEPTION1(InvalidVariableException, meshname);
     }
+
+    GetQuadGhostZones(base, zone, zsize, cell_dim, retval);
 
     return retval;
 }

--- a/src/databases/CGNS/avtCGNSFileReader.C
+++ b/src/databases/CGNS/avtCGNSFileReader.C
@@ -1710,15 +1710,15 @@ avtCGNSFileReader::GetQuadGhostZones(int base, int zone,
 
         if (first[i] < 0 || first[i] >= cdims[i])
         {
-            debug1 << "bad Index on first[" << i << "] dims is: "
-                   << zsize[i] << endl;
+            debug1 << "bad rind value: rind[" << i*2 << "]=" << rind[i*2]
+                   << endl;
             badIndex = true;
         }
 
         if (last[i] < 0 || last[i] >= cdims[i])
         {
-            debug1 << "bad Index on last[" << i << "] dims is: "
-                   << zsize[i] << endl;
+            debug1 << "bad rind value: rind[" << i*2+1 << "]=" << rind[i*2+1]
+                   << endl;
             badIndex = true;
         }
 

--- a/src/databases/CGNS/avtCGNSFileReader.h
+++ b/src/databases/CGNS/avtCGNSFileReader.h
@@ -56,6 +56,9 @@ using namespace std;
 //    Added ReadMixedAndNamedElementSections, ReadNGonSections,
 //    ReadNGonAndNFaceSections.
 //
+//    Eric Brugger, Tue Jul  6 10:27:03 PDT 2021
+//    Added support for reading rind data.
+//
 // ****************************************************************************
 
 class avtCGNSFileReader
@@ -109,15 +112,16 @@ protected:
 
     int                    GetFileHandle();
     void                   ReadTimes();
-    bool                   GetCoords(int timestate, int base, int zone, const cgsize_t *zsize,
-                                     int cell_dim, int phys_dim,
-                                     bool structured, float **coords);
+    bool                   GetCoords(int timestate, int base, int zone,
+                               const cgsize_t *zsize, int cell_dim,
+                               int phys_dim, bool structured, float **coords);
     void                   AddReferenceStateExpressions(avtDatabaseMetaData *md,
-                                     int base, int nBases, const std::string &baseName,
-                                     const std::string &meshName);
+                               int base, int nBases,
+                               const std::string &baseName,
+                               const std::string &meshName);
     void                   AddVectorExpressions(avtDatabaseMetaData *md,
-                               bool *haveVelocity, bool *haveMomentum, int nBases,
-                               const std::string &baseName);
+                               bool *haveVelocity, bool *haveMomentum,
+                               int nBases, const std::string &baseName);
     void                   AddVectorExpression(avtDatabaseMetaData *md,
                                bool *haveComponent, int nBases,
                                const std::string &baseName,
@@ -126,6 +130,9 @@ protected:
     bool                   BaseContainsUnits(int base);
     void                   InitializeMaps(int timeState);
 
+    void                   GetQuadGhostZones(int base, int zone,
+                               const cgsize_t *zsize, int cell_dim,
+                               vtkDataSet *ds);
     vtkDataSet *           GetCurvilinearMesh(int, int, int, const char *,
                                               const cgsize_t *, int, int);
     vtkDataSet *           GetUnstructuredMesh(int, int, int, const char *,

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -49,6 +49,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Added a section on developing at GitHub to the developers manual.</li>
   <li>Datasets that contain AMR meshes are now treated as time varying by default. This will guard against issues that arise with time varying AMR meshes that aren't explicitly tagged as time varying within the datasets.</li>
+  <li>Added support for reading Rind values for structured grids from CGNS files to provide ghost zone information.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #5863 

I added support for reading rind data to provide ghost zones for structured grids to the CGNS reader. This doesn't provide support for rind data for unstructured grids.

### Type of change

* [ ] Bug fix
* [X] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I got a CGNS file with rind data and was able to successfully plot the data and it was properly ghosted.

Here is an image from the data. It is 32 zones in each block moving left to right.

![image](https://user-images.githubusercontent.com/1102718/124824272-02492a00-df27-11eb-8813-c649013e0b9b.png)

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [X] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
