### PR TITLE
Fix a bug in build_visit building CGNS on Linux.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -42,6 +42,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug that resulted in the rubber band zoom box being rendered incorrectly on Mac retina displays.</li>
   <li>Fixed a bug in build_visit that caused it to improperly set the architecture directory name when using gcc 10.2. For example, on a linux system with an x86_64 processor, it previously set it to <i>linux-x86_64_gcc</i> instead of the correct <i>linux-x86_64_gcc-10.2</i>.</li>
   <li>Fixed a bug for Windows where exporting a multi-block Silo file into a non-default directory would make the file unreadable by VisIt.</li>
+  <li>Fixed a bug in build_visit that prevented CGNS from building on Linux systems.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -390,26 +390,29 @@ function build_cgns
         LDFLAGS_ENV="$LDFLAGS_ENV -L$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH/lib"
         H5ARGS="$H5ARGS --with-zlib=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH"
     fi
-    if [[ "$OPSYS" == "Darwin" ]] ; then
-        LDFLAGS_DARWIN_INFO='LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV"'
-        LDFLAGS_DARWIN_ENV='LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\"'
-    else
-        LDFLAGS_DARWIN_INFO=""
-        LDFLAGS_DARWIN_ENV=""
-    fi
 
     # Disable fortran
     FORTRANARGS="--with-fortran=no"
 
-    info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-        CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-        $LDFLAGS_DARWIN_INFO \
-        ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
+    if [[ "$OPSYS" == "Darwin" ]] ; then
+        info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
+            CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
+            LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\" \
+            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
 
-    env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
-        CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
-        $LDFLAGS_DARWIN_ENV \
-        ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
+        env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
+            CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
+            LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV" \
+            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
+    else
+        info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
+            CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
+            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
+
+        env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
+            CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
+            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
+    fi
 
     if [[ $? != 0 ]] ; then
         warn "CGNS configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -382,13 +382,18 @@ function build_cgns
         LDFLAGS_ENV="-L$VISITDIR/hdf5/$HDF5_VERSION/$VISITARCH/lib"
         H5ARGS="--with-hdf5=$VISITDIR/hdf5/$HDF5_VERSION/$VISITARCH"
         if [[ "$DO_SZIP" == "yes" ]] ; then
+            LIBS_ENV="$LIBS_ENV -lsz"
             LDFLAGS_ENV="$LDFLAGS_ENV -L$VISITDIR/szip/$SZIP_VERSION/$VISITARCH/lib"
             H5ARGS="$H5ARGS --with-szip=$VISITDIR/szip/$SZIP_VERSION/$VISITARCH"
-            LIBS_ENV="$LIBS_ENV -lsz"
         fi
         LIBS_ENV="$LIBS_ENV -lz"
         LDFLAGS_ENV="$LDFLAGS_ENV -L$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH/lib"
         H5ARGS="$H5ARGS --with-zlib=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH"
+    fi
+    if [[ "$OPSYS" == "Darwin" ]] ; then
+        LDFLAGS_DARWIN="LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\""
+    else
+        LDFLAGS_DARWIN=""
     fi
 
     # Disable fortran
@@ -396,12 +401,12 @@ function build_cgns
 
     info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
         CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-        LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\" \
+        $LDFLAGS_DARWIN \
         ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
 
     env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
         CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
-        LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV" \
+        $LDFLAGS_DARWIN \
         ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
 
     if [[ $? != 0 ]] ; then

--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -391,9 +391,11 @@ function build_cgns
         H5ARGS="$H5ARGS --with-zlib=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH"
     fi
     if [[ "$OPSYS" == "Darwin" ]] ; then
-        LDFLAGS_DARWIN="LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\""
+        LDFLAGS_DARWIN_INFO='LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV"'
+        LDFLAGS_DARWIN_ENV='LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\"'
     else
-        LDFLAGS_DARWIN=""
+        LDFLAGS_DARWIN_INFO=""
+        LDFLAGS_DARWIN_ENV=""
     fi
 
     # Disable fortran
@@ -401,12 +403,12 @@ function build_cgns
 
     info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
         CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-        $LDFLAGS_DARWIN \
+        $LDFLAGS_DARWIN_INFO \
         ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
 
     env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
         CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
-        $LDFLAGS_DARWIN \
+        $LDFLAGS_DARWIN_ENV \
         ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
 
     if [[ $? != 0 ]] ; then


### PR DESCRIPTION
### Description

Resolves #5846

I fixed build_visit so that it builds CGNS properly on Linux. Kathleen discovered that removing the setting of LDFLAGS and LIBS for hdf5 solved the problem. Since these were added specifically for OSX, I made the setting of them dependent on being on OSX. This doesn't impact building on OSX and solves building on Linux. The reviewer may want to specifically test on OSX, just to make sure.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the following on quartz and it built CGNS properly.
```
./build_visit3_2_1 \
    --no-thirdparty --no-visit \
    --cgns --hdf5 --szip --zlib \
    --makeflags -j4
```

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
