### PR TITLE
Fix regression with molecule plot test.

### DIFF
--- a/src/test/tests/plots/molecule.py
+++ b/src/test/tests/plots/molecule.py
@@ -237,7 +237,7 @@ def ReplicateAddBonds():
     CloseDatabase(data_path("vasp_test_data", "GaO40W12", "OUTCAR"))
 
 MoleculeOnly()
-#ReplicateAddBonds()
+ReplicateAddBonds()
 Exit()
 
 

--- a/src/test/tests/plots/molecule.py
+++ b/src/test/tests/plots/molecule.py
@@ -12,6 +12,12 @@
 #
 #  Modifications:
 #
+#    Kathleen Biagas, Tue Jul 13 09:51:58 PDT 2021
+#    Changed retrieval of renAtts from 'RenderingAttributes' to
+#    'GetRenderingAttributes' when turning off specular highlighting. This
+#    fixes a bug in scalable,parallel,icet mode where molecule_04 test would
+#    fail to plot.
+#
 # ----------------------------------------------------------------------------
 
 def SetGradientBackground():
@@ -117,7 +123,7 @@ def MoleculeOnly():
 
     DrawPlots()
     # turn off specular highlighting
-    renAtts = RenderingAttributes()
+    renAtts = GetRenderingAttributes()
     renAtts.specularFlag = 0
     SetRenderingAttributes(renAtts)
     Test500x500("molecule_04")
@@ -231,7 +237,7 @@ def ReplicateAddBonds():
     CloseDatabase(data_path("vasp_test_data", "GaO40W12", "OUTCAR"))
 
 MoleculeOnly()
-ReplicateAddBonds()
+#ReplicateAddBonds()
 Exit()
 
 


### PR DESCRIPTION
When turning off specular highlighting, RenderingAttributes weren't retrieved correctly, in effect turning off other Rendering settings which prevented plot from drawing when run in mode scalable,parallel,icet.



### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the molecule plot test in all nightly modes with success.


### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
