### PR TITLE
Only read CGNS rind values if environment variable CGNS_USE_RIND set.

### DIFF
--- a/src/databases/CGNS/avtCGNSFileReader.C
+++ b/src/databases/CGNS/avtCGNSFileReader.C
@@ -1646,6 +1646,9 @@ avtCGNSFileReader::GetCoords(int timestate, int base, int zone, const cgsize_t *
 // Creation:   Tue Jul  6 10:27:03 PDT 2021
 //
 // Modifications:
+//   Eric Brugger, Wed Jul 14 13:32:10 PDT 2021
+//   Added a temporary hack to only generate ghost zones if the
+//   environment variable CGNS_USE_RIND is set.
 //
 // ****************************************************************************
 
@@ -1726,6 +1729,18 @@ avtCGNSFileReader::GetQuadGhostZones(int base, int zone,
         {
             ghostPresent = true;
         }
+    }
+
+    // Temporary hack to only generate ghost zones if the environment
+    // variable CGNS_USE_RIND is set. This is because there exist some
+    // CGNS files that are single block with rind zones all around the
+    // exterior. Adding ghost zones in this case generates a blank image.
+    // The particular file is delta.cgns.
+    if (getenv("CGNS_USE_RIND") == NULL)
+    {
+        ghostPresent = false;
+        debug4 << "Disabling use of rind values." << endl;
+        debug4 << "To enable setenv CGNS_USE_RIND." << endl;
     }
 
     //  Create the ghost zones array if necessary

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -50,7 +50,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Added a section on developing at GitHub to the developers manual.</li>
   <li>Datasets that contain AMR meshes are now treated as time varying by default. This will guard against issues that arise with time varying AMR meshes that aren't explicitly tagged as time varying within the datasets.</li>
-  <li>Added support for reading Rind values for structured grids from CGNS files to provide ghost zone information.</li>
+  <li>Added support for reading Rind values for structured grids from CGNS files to provide ghost zone information. To enable the reading of Rind values you must set the environment variable CGNS_USE_RIND (i.e. "setenv CGNS_USE_RIND").</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

After I added support for reading Rind values from CGNS files and using that to add ghost zones, some of the CGNS tests using delta.cgns started failing. It turns out it has a single block and there are ghost zones on the entire exterior of the structured grid. When ghost zones are added, all the external faces get removed, resulting in a blank image for plots like mesh and pseudocolor. I don't have a good solution for this, so rather than back out the change since there are users that are waiting for this, I added logic to only use the Rind values if the environment variable CGNS_USE_RIND is set. This should preserve the existing behavior and still allow those that need the new behavior to also get what they need by setting that environment variable.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the CGNS.py test from the test suite on quartz and it passed. For completeness, I set the environment variable CGNS_USE_RIND and it failed like it did previously.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
