### PR TITLE
Fix Contour plot's legend number format for tick labels.

### DIFF
--- a/src/avt/Filters/avtContourFilter.C
+++ b/src/avt/Filters/avtContourFilter.C
@@ -65,7 +65,7 @@ using std::string;
 //    Made the avtContourFilter initialize from the raw levels and
 //    create its own vtkContourFilter.
 //
-//    Kathleen Bonnell, Wed Feb 28 17:06:54 PST 2001 
+//    Kathleen Bonnell, Wed Feb 28 17:06:54 PST 2001
 //    Removed creation and filling of vtkContourFilter cf as it is now
 //    not needed until ExecuteDomainTree method.
 //
@@ -116,7 +116,7 @@ avtContourFilter::avtContourFilter(const ContourOpAttributes &a)
         isoValues = atts.GetContourPercent();
         nLevels = (int)isoValues.size();
     }
- 
+
     // We need to specify that we want a secondary variable as soon as
     // possible.
     if (strcmp(atts.GetVariable().c_str(), "default") != 0)
@@ -137,9 +137,9 @@ avtContourFilter::avtContourFilter(const ContourOpAttributes &a)
 //    Hank Childs, Fri Aug 18 15:53:57 PDT 2000
 //    Added deletion of cd2pd.
 //
-//    Kathleen Bonnell, Fri Feb 16 13:28:57 PST 2001 
-//    Added test for cf equal NULL, as cf only created now in Execute method, 
-//    and this object may be destructed before Execute method is called. 
+//    Kathleen Bonnell, Fri Feb 16 13:28:57 PST 2001
+//    Added test for cf equal NULL, as cf only created now in Execute method,
+//    and this object may be destructed before Execute method is called.
 //
 //    Hank Childs, Mon Apr 23 15:49:59 PDT 2001
 //    Destruct contour grid.
@@ -183,8 +183,8 @@ avtContourFilter::~avtContourFilter()
 //    Hank Childs, Mon Mar  1 07:56:53 PST 2004
 //    Give a better hint about what variable we are working on.
 //
-//    Kathleen Bonnell, Thu Mar 11 11:10:07 PST 2004 
-//    DataExtents now always have only 2 components. 
+//    Kathleen Bonnell, Thu Mar 11 11:10:07 PST 2004
+//    DataExtents now always have only 2 components.
 //
 //    Hank Childs, Wed Aug 11 08:53:57 PDT 2004
 //    Make sure that we request ghost zones.
@@ -236,7 +236,7 @@ avtContourFilter::ModifyContract(avtContract_p in_contract)
     const char *varname = NULL;
     if (atts.GetVariable() != "default")
         varname = atts.GetVariable().c_str();
-    else 
+    else
         varname = contract->GetDataRequest()->GetVariable();
 
     timeslice_index = contract->GetDataRequest()->GetTimestep();
@@ -250,7 +250,7 @@ avtContourFilter::ModifyContract(avtContract_p in_contract)
     //
     avtDataAttributes &in_atts = GetInput()->GetInfo().GetAttributes();
     bool skipGhost = false;
-    if (in_atts.ValidVariable(varname) && 
+    if (in_atts.ValidVariable(varname) &&
         in_atts.GetCentering(varname) == AVT_NODECENT)
         skipGhost = true;
     if (!skipGhost)
@@ -277,7 +277,7 @@ avtContourFilter::ModifyContract(avtContract_p in_contract)
         // must do static load balancing if we don't know what those extents
         // are.
         //
-        double extents[2] = { 0., 0. }; 
+        double extents[2] = { 0., 0. };
         stillNeedExtents = true;
         if (atts.GetMinFlag() && atts.GetMaxFlag())
             stillNeedExtents = false;  // wouldn't use them anyway
@@ -393,8 +393,8 @@ avtContourFilter::ModifyContract(avtContract_p in_contract)
 //    Hank Childs, Tue Sep  4 16:12:00 PDT 2001
 //    Reflect changes in interface for avtDataAttributes.
 //
-//    Kathleen Bonnell, Wed Sep 19 12:55:57 PDT 2001 
-//    Added calls to CreateLabels and SetLabels. 
+//    Kathleen Bonnell, Wed Sep 19 12:55:57 PDT 2001
+//    Added calls to CreateLabels and SetLabels.
 //
 //    Hank Childs, Wed Apr 17 09:01:33 PDT 2002
 //    Added call to base class' PreExecute.
@@ -406,8 +406,8 @@ avtContourFilter::ModifyContract(avtContract_p in_contract)
 //    Fix a bug from last night.  If the variable was not 'default' the test
 //    was incorrect.
 //
-//    Kathleen Bonnell, Thu Mar 11 11:10:07 PST 2004 
-//    DataExtents now always have only 2 components. 
+//    Kathleen Bonnell, Thu Mar 11 11:10:07 PST 2004
+//    DataExtents now always have only 2 components.
 //
 //    Hank Childs, Mon Aug 30 08:42:48 PDT 2004
 //    Initialize current_node and nnodes for better progress indicators.
@@ -422,7 +422,7 @@ avtContourFilter::PreExecute(void)
 {
     avtDatasetToDatasetFilter::PreExecute();
 
-    if (atts.GetVariable() == "default" && 
+    if (atts.GetVariable() == "default" &&
         GetInput()->GetInfo().GetAttributes().GetVariableName() == "<unknown>")
     {
         //
@@ -436,14 +436,14 @@ avtContourFilter::PreExecute(void)
 
     if (stillNeedExtents)
     {
-        double extents[2]; 
+        double extents[2];
         const char *varname = NULL;
         if (atts.GetVariable() != "default")
         {
             varname = atts.GetVariable().c_str();
         }
         GetDataExtents(extents, varname);
- 
+
         //
         // If we are dealing with the default variable, set the values for our
         // output.
@@ -504,7 +504,7 @@ avtContourFilter::PreExecute(void)
 avtDataTree_p
 avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 {
-    if (!in_dr) 
+    if (!in_dr)
     {
         return NULL;
     }
@@ -599,7 +599,7 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
     }
     else
     {
-        outDT = this->ExecuteDataTree_VTK(in_dr); 
+        outDT = this->ExecuteDataTree_VTK(in_dr);
     }
 
     return outDT;
@@ -632,7 +632,7 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 //    Hank Childs, Fri Oct 27 10:23:52 PDT 2000
 //    Added argument for domain number to match inherited interface.
 //
-//    Kathleen Bonnell, Fri Feb 16 13:28:57 PST 2001 
+//    Kathleen Bonnell, Fri Feb 16 13:28:57 PST 2001
 //    Renamed this method ExecuteDomainTree and made it return an
 //    avtDomainTree_p to reflect new inheritance.  Feed levels to
 //    the vtk filter one-by-one.
@@ -647,8 +647,8 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 //    Hank Childs, Sun Mar 25 12:24:17 PST 2001
 //    Account for new data object information interface.
 //
-//    Kathleen Bonnell, Tue Apr 10 11:35:39 PDT 2001 
-//    Renamed method ExecuteDataTree. 
+//    Kathleen Bonnell, Tue Apr 10 11:35:39 PDT 2001
+//    Renamed method ExecuteDataTree.
 //
 //    Hank Childs, Thu Apr 12 16:59:54 PDT 2001
 //    Made use of scalar tree if there was more than one isolevel.  Also use
@@ -656,16 +656,16 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 //
 //    Kathleen Bonnell, Tue Jun 12 14:34:02 PDT 2001
 //    Added preservation of ghost-cell data, if present.  Forced toBeContoured
-//    to be created from New() if cd2pd filter used. 
+//    to be created from New() if cd2pd filter used.
 //
-//    Kathleen Bonnell, Wed Sep 19 12:55:57 PDT 2001 
+//    Kathleen Bonnell, Wed Sep 19 12:55:57 PDT 2001
 //    Added string argument to match new interface, but this filter
 //    does not need the arg as it will set the labels itself.
 //
 //    Hank Childs, Wed Apr 17 15:11:27 PDT 2002
 //    Re-worked routine to account for multiple variables.  Also removed some
 //    hacks to get around VTK bugs.
-//    
+//
 //    Jeremy Meredith, Thu Jul 11 13:36:31 PDT 2002
 //    Added code to not interpolate avtOriginalCellNumbers to the nodes.
 //
@@ -673,8 +673,8 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 //    Better handling of cell variables -- only interpolate the cell variable
 //    we are going to contour by and no others.
 //
-//    Kathleen Bonnell, Fri Dec 13 14:07:15 PST 2002 
-//    Use NewInstance instead of MakeObject to match new vtk api. 
+//    Kathleen Bonnell, Fri Dec 13 14:07:15 PST 2002
+//    Use NewInstance instead of MakeObject to match new vtk api.
 //
 //    Hank Childs, Mon May 12 20:01:50 PDT 2003
 //    Make sure an iso-level can actually contribute triangles before
@@ -693,9 +693,9 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 //    Instantiate cd2pd here inside this routine rather than using a data
 //    member.
 //
-//    Kathleen Bonnell, Tue May 16 09:57:29 PDT 2006 
+//    Kathleen Bonnell, Tue May 16 09:57:29 PDT 2006
 //    VTK pipeline changes: no more SetOutput method for filters, instead
-//    SetOutputData for the filter's Executive. 
+//    SetOutputData for the filter's Executive.
 //
 //    Gunther H. Weber, Wed May 30 16:41:15 PDT 2007
 //    Copy field data when generating isosurfaces. There are still problems
@@ -726,7 +726,7 @@ avtContourFilter::ExecuteDataTree(avtDataRepresentation *in_dr)
 //
 // ****************************************************************************
 
-avtDataTree_p 
+avtDataTree_p
 avtContourFilter::ExecuteDataTree_VTK(avtDataRepresentation *in_dr)
 {
     //
@@ -738,7 +738,7 @@ avtContourFilter::ExecuteDataTree_VTK(avtDataRepresentation *in_dr)
 
     int tt1 = visitTimer->StartTimer();
 
-    char *contourVar = (activeVariable != NULL ? activeVariable 
+    char *contourVar = (activeVariable != NULL ? activeVariable
                                                : pipelineVariable);
     if (isoValues.empty())
     {
@@ -751,9 +751,9 @@ avtContourFilter::ExecuteDataTree_VTK(avtDataRepresentation *in_dr)
     //
     //  Creating these from ::New to pass through the cd2pd filter
     //  is a HACK - WORK-AROUND for a vtk Update/Whole-Extents error
-    //  message encountered when cd2pd->Update() is called.  Occurs 
+    //  message encountered when cd2pd->Update() is called.  Occurs
     //  only when Contour is used on multi-block data.
-    // 
+    //
     vtkDataSet *toBeContoured = (vtkDataSet *)in_ds->NewInstance();
 
     //
@@ -895,11 +895,11 @@ avtContourFilter::ExecuteDataTree_VTK(avtDataRepresentation *in_dr)
     //
     avtDataTree_p outDT = NULL;
     if (shouldCreateLabels)
-    {   
+    {
         outDT = new avtDataTree((int)isoValues.size(), out_ds, domain, isoLabels);
     }
     else
-    {   
+    {
         outDT = new avtDataTree((int)isoValues.size(), out_ds, domain, label);
     }
 
@@ -908,7 +908,7 @@ avtContourFilter::ExecuteDataTree_VTK(avtDataRepresentation *in_dr)
     //
     for (size_t i = 0; i < isoValues.size(); i++)
     {
-        if (out_ds[i] != NULL) 
+        if (out_ds[i] != NULL)
         {
             out_ds[i]->Delete();
         }
@@ -924,7 +924,7 @@ avtContourFilter::ExecuteDataTree_VTK(avtDataRepresentation *in_dr)
 
     #ifndef VISIT_THREADS
     // TODO race to inc. This is part of the progress update.
-    // We can do an atomic incr, but I don't want the time hit 
+    // We can do an atomic incr, but I don't want the time hit
     // just for the progress update. Maybe a better way to do this.
     current_node++;
     #endif // VISIT_THREADS
@@ -1027,12 +1027,12 @@ avtContourFilter::ExecuteDataTree_VTKM(avtDataRepresentation *in_dr)
         // Add the result to the output.
         //
         if (shouldCreateLabels)
-        {   
+        {
             output[i] = new avtDataRepresentation(isoOut,
                 domain, isoLabels[i]);
         }
         else
-        {   
+        {
             output[i] = new avtDataRepresentation(isoOut,
                 domain, label);
         }
@@ -1065,7 +1065,7 @@ avtContourFilter::ExecuteDataTree_VTKM(avtDataRepresentation *in_dr)
 //    Hank Childs, Tue Sep  4 16:12:00 PDT 2001
 //    Reflect changes in interface for avtDataAttributes.
 //
-//    Hank Childs, Thu Oct 10 13:05:49 PDT 2002 
+//    Hank Childs, Thu Oct 10 13:05:49 PDT 2002
 //    Do not assume that output is node-centered.
 //
 //    Hank Childs, Thu Feb 26 09:05:34 PST 2004
@@ -1081,7 +1081,7 @@ avtContourFilter::UpdateDataObjectInfo(void)
 {
     avtDataAttributes &outAtts = GetOutput()->GetInfo().GetAttributes();
     avtDataAttributes &inAtts  = GetInput()->GetInfo().GetAttributes();
-   
+
     outAtts.SetTopologicalDimension(inAtts.GetTopologicalDimension()-1);
 
     const char *var_to_modify = NULL;
@@ -1117,15 +1117,15 @@ avtContourFilter::UpdateDataObjectInfo(void)
 //    min      The variable's minimum value.
 //    max      The variable's maximum value.
 //
-//  Programmer:   Kathleen Bonnell 
-//  Creation:     March 1, 2001 
+//  Programmer:   Kathleen Bonnell
+//  Creation:     March 1, 2001
 //
 //  Modifications:
 //    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001
-//    Added arguments, and passed them to CreateNIsoValues and 
+//    Added arguments, and passed them to CreateNIsoValues and
 //    CreatePercentValues.
 //
-//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001 
+//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001
 //    Revised check for invalid min/max to test artificial limits
 //    set by user if applicable.
 //
@@ -1184,7 +1184,7 @@ avtContourFilter::SetIsoValues(double min, double max)
 //  Method: avtContourFilter::CreatePercentValues
 //
 //  Purpose:
-//    Creates N isoValues between min & max. 
+//    Creates N isoValues between min & max.
 //
 //  Arguments
 //    mn     The variables minimum value.
@@ -1197,14 +1197,14 @@ avtContourFilter::SetIsoValues(double min, double max)
 //    Kathleen Bonnell, Fri Mar  2 11:34:46 PST 2001
 //    Moved test for min equal max to SetIsoValues method.
 //
-//    Kathleen Bonnell, Tue Mar 27 15:27:50 PST 2001 
-//    Added arguments, and test for valid min/max before using log scale.  
+//    Kathleen Bonnell, Tue Mar 27 15:27:50 PST 2001
+//    Added arguments, and test for valid min/max before using log scale.
 //
-//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001 
-//    Revised to use artificial limits if user specified. 
+//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001
+//    Revised to use artificial limits if user specified.
 //
-//    Kathleen Bonnell, Wed Apr 25 14:28:22 PDT 2001 
-//    Reflect change in InvalidLimitsException signature. 
+//    Kathleen Bonnell, Wed Apr 25 14:28:22 PDT 2001
+//    Reflect change in InvalidLimitsException signature.
 //
 //    Hank Childs, Sun Jun 17 18:42:00 PDT 2001
 //    Moved function from avtContourPlot.
@@ -1215,9 +1215,9 @@ void
 avtContourFilter::CreatePercentValues(double mn, double mx)
 {
     double min, max;
-    // 
+    //
     // should we be using user-defined limits?
-    // 
+    //
     min = atts.GetMinFlag() ? atts.GetMin() : mn;
     max = atts.GetMaxFlag() ? atts.GetMax() : mx;
 
@@ -1225,7 +1225,7 @@ avtContourFilter::CreatePercentValues(double mn, double mx)
     {
        if (min <= 0. || max <= 0.)
        {
-           // if mn, mx from the var extents, user needs to specify 
+           // if mn, mx from the var extents, user needs to specify
            // limits > 0 in order to use log scaling.
            EXCEPTION1(InvalidLimitsException, true);
        }
@@ -1240,7 +1240,7 @@ avtContourFilter::CreatePercentValues(double mn, double mx)
        for (int i = 0; i < nLevels; i++)
            isoValues[i] = min + (isoValues[i] * delta) ;
     }
-    else 
+    else
     {
         for (int i = 0; i < nLevels; i++)
            isoValues[i] = pow( 10., min + (isoValues[i] * delta)) ;
@@ -1253,7 +1253,7 @@ avtContourFilter::CreatePercentValues(double mn, double mx)
 //  Method: avtContourFilter::CreateNIsoValues
 //
 //  Purpose:
-//    Creates N isoValues between min & max. 
+//    Creates N isoValues between min & max.
 //
 //  Arguments:
 //    min      The variables minimum value.
@@ -1266,24 +1266,24 @@ avtContourFilter::CreatePercentValues(double mn, double mx)
 //    Kathleen Bonnell, Fri Mar  2 11:34:46 PST 2001
 //    Moved test for min equal max to SetIsoValues method.
 //
-//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001 
-//    Added arguments and test for positive min & max values before using log. 
+//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001
+//    Added arguments and test for positive min & max values before using log.
 //
-//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001 
+//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001
 //    Overhauled this method so that it more closely mimics the MeshTV method
 //    of creating isoValues, including using artificial limits as hi/lo value
-//    if user has requested them. 
+//    if user has requested them.
 //
 //    Hank Childs, Tue Apr 10 10:20:00 PDT 2001
 //    More graceful handling of nLevels == 1.
 //
-//    Kathleen Bonnell, Wed Apr 25 14:28:22 PDT 2001 
-//    Reflect change in InvalidLimitsException signature. 
+//    Kathleen Bonnell, Wed Apr 25 14:28:22 PDT 2001
+//    Reflect change in InvalidLimitsException signature.
 //
 //    Hank Childs, Sun Jun 17 18:42:00 PDT 2001
 //    Moved function from avtContourPlot.
 //
-//    Kathleen Bonnell, Tue Jan 20 17:38:37 PST 2004 
+//    Kathleen Bonnell, Tue Jan 20 17:38:37 PST 2004
 //    Fix problem with delta when lo > hi.
 //
 //    Eric Brugger, Mon Apr  5 15:35:27 PDT 2004
@@ -1291,7 +1291,7 @@ avtContourFilter::CreatePercentValues(double mn, double mx)
 //    of levels and the minimum and maximum.
 //
 //    Brad Whitlock, Mon Dec 19 17:17:05 PST 2005
-//    I changed the code so it conditionally applies the extrema offset 
+//    I changed the code so it conditionally applies the extrema offset
 //    because applying it when min/max were set made it impossible to get
 //    contours that go through the min/max values.
 //
@@ -1303,22 +1303,22 @@ avtContourFilter::CreateNIsoValues(double min, double max)
     double lo, hi, delta, extremaOffset;
     if (atts.GetMinFlag())
         lo = atts.GetMin();
-    else 
+    else
         lo = min;
     if (atts.GetMaxFlag())
         hi = atts.GetMax();
-    else 
+    else
         hi = max;
 
     if (logFlag)
     {
-        if (min <= 0.) 
+        if (min <= 0.)
         {
             if (!atts.GetMinFlag() || atts.GetMin() <= 0.)
             {
                 EXCEPTION1(InvalidLimitsException, true);
             }
-            else 
+            else
             {
                 lo = atts.GetMin();
             }
@@ -1350,7 +1350,7 @@ avtContourFilter::CreateNIsoValues(double min, double max)
     {
         if (lo < hi)
             delta = (hi - lo) / (nLevels - 1.);
-        else 
+        else
             delta = (lo - hi) / (nLevels - 1.);
     }
 
@@ -1359,7 +1359,7 @@ avtContourFilter::CreateNIsoValues(double min, double max)
         for (int i = 0; i < nLevels; ++i)
             isoValues.push_back(pow(10., lo + i * delta));
     }
-    else 
+    else
     {
         for (int i = 0; i < nLevels; ++i)
             isoValues.push_back(lo + i * delta);
@@ -1430,7 +1430,7 @@ avtContourFilter::CreateLabels()
 //    Fix additional memory bloat problems.
 //
 //    Hank Childs, Fri Mar  4 08:12:25 PST 2005
-//    Do not set outputs of filters to NULL, since this will prevent them 
+//    Do not set outputs of filters to NULL, since this will prevent them
 //    from re-executing correctly in DLB-mode.
 //
 //    Hank Childs, Sun Mar  6 08:18:53 PST 2005
@@ -1450,3 +1450,33 @@ avtContourFilter::ReleaseData(void)
     avtSIMODataTreeIterator::ReleaseData();
 }
 
+
+// ****************************************************************************
+//  Method: avtContourFilter::GetIsoValues
+//
+//  Purpose: Retrieve the actual iso values used for contouring.
+//
+//  Arguments:
+//    v      Storage for the isoValues being retrieved.
+//
+//  Programmer: Kathleen Biagas
+//  Creation:   July 14, 2021
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+void
+avtContourFilter::GetIsoValues(std::vector<double> &v)
+{
+    if (!v.empty())
+    {
+        v.clear();
+    }
+
+    v.reserve(isoValues.size());
+    for (size_t i = 0; i < isoValues.size(); i++)
+    {
+        v.push_back(isoValues[i]);
+    }
+}

--- a/src/avt/Filters/avtContourFilter.h
+++ b/src/avt/Filters/avtContourFilter.h
@@ -40,14 +40,14 @@
 //    Jeremy Meredith, Thu Sep 28 12:50:55 PDT 2000
 //    Removed CreateOutputDatasets.  Changed interface to ExecuteDomain.
 //
-//    Kathleen Bonnell, Fri Feb 16 13:28:57 PST 2001 
+//    Kathleen Bonnell, Fri Feb 16 13:28:57 PST 2001
 //    Made inherit from avtDomainTreeDataTreeIterator.  Added default constructor,
 //    SetLevels method.
 //
-//    Kathleen Bonnell, Tue Apr 10 11:35:39 PDT 2001 
-//    Made inherit from avtSIMODataTreeIterator.  
+//    Kathleen Bonnell, Tue Apr 10 11:35:39 PDT 2001
+//    Made inherit from avtSIMODataTreeIterator.
 //
-//    Kathleen Bonnell, Wed Sep 19 12:55:57 PDT 2001 
+//    Kathleen Bonnell, Wed Sep 19 12:55:57 PDT 2001
 //    Added string argument to Execute method. Added member isoLabels, to
 //    hold string representation of computed isoValues.  Added method
 //    CreateLabels.
@@ -71,6 +71,9 @@
 //    Kathleen Biagas, Wed Jan 30 10:41:17 PST 2019
 //    Removed EAVL support.
 //
+//    Kathleen Biagas, Wed July 14, 2021
+//    Added ability to retrieve the actual iso values used for contouring.
+//
 // ****************************************************************************
 
 class AVTFILTERS_API avtContourFilter : public avtSIMODataTreeIterator
@@ -81,18 +84,20 @@ class AVTFILTERS_API avtContourFilter : public avtSIMODataTreeIterator
     virtual                   ~avtContourFilter();
 
     void                       ShouldCreateLabels(bool b)
-                                    { shouldCreateLabels = b; };
-    virtual const char        *GetType(void)  { return "avtContourFilter"; };
-    virtual const char        *GetDescription(void) { return "Contouring"; };
+                                    { shouldCreateLabels = b; }
+    virtual const char        *GetType(void)  { return "avtContourFilter"; }
+    virtual const char        *GetDescription(void) { return "Contouring"; }
     virtual void               ReleaseData(void);
+
+    void                       GetIsoValues(std::vector<double> &v);
 
   protected:
     bool                       stillNeedExtents;
     bool                       shouldCreateLabels;
 
     ContourOpAttributes        atts;
-    bool                       logFlag; 
-    bool                       percentFlag; 
+    bool                       logFlag;
+    bool                       percentFlag;
     int                        nLevels;
     std::vector<double>        isoValues;
     std::vector<std::string>   isoLabels;

--- a/src/plots/Contour/avtContourPlot.C
+++ b/src/plots/Contour/avtContourPlot.C
@@ -36,9 +36,9 @@
 //
 //  Modifications:
 //    Kathleen Bonnell, Fri Mar  2 11:34:46 PST 2001
-//    Removed data members varMin & varMax, and added legend. 
+//    Removed data members varMin & varMax, and added legend.
 //
-//    Kathleen Bonnell, Fri Aug 31 08:50:30 PDT 2001 
+//    Kathleen Bonnell, Fri Aug 31 08:50:30 PDT 2001
 //    Added avtLUT.
 //
 //    Hank Childs, Fri Feb 15 15:42:08 PST 2008
@@ -56,7 +56,7 @@ avtContourPlot::avtContourPlot()
     levelsLegend->SetTitle("Contour");
     avtLUT        = new avtLookupTable;
     numLevels     = 0;
-    contourFilter = NULL; 
+    contourFilter = NULL;
     edgeFilter    = NULL;
     lineFilter    = NULL;
 
@@ -155,50 +155,50 @@ avtContourPlot::Create()
 //      atts    The attributes for this isocontour plot.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   February 15, 2001 
+//  Creation:   February 15, 2001
 //
 //  Modifications:
 //    Kathleen Bonnell, Fri Mar  2 11:34:46 PST 2001
-//    Revised logic, added call to SetIsoValues if var extents are valid. 
+//    Revised logic, added call to SetIsoValues if var extents are valid.
 //
 //  Modifications:
 //    Jeremy Meredith, Fri Mar  2 13:10:02 PST 2001
 //    Made this method take a generic AttributeGroup since it is now virtual.
 //    Also made some variables const.
 //
-//    Kathleen Bonnell, Tue Mar 13 11:35:45 PST 2001 
-//    Added call to SetLegend. 
+//    Kathleen Bonnell, Tue Mar 13 11:35:45 PST 2001
+//    Added call to SetLegend.
 //
-//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001 
+//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001
 //    Removed references to ContourAttributes::VarMin/Max as they are no
-//    longer members. Added min/max arguments to SetIsoValues. 
+//    longer members. Added min/max arguments to SetIsoValues.
 //
-//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001 
+//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001
 //    Made atts a member so it can be accesses from other methods.
 //    Removed call to SetIsoValues as it is called from ApplyOperators and
-//    CustomizeBehavior. 
-//    
+//    CustomizeBehavior.
+//
 //    Jeremy Meredith, Tue Jun  5 20:33:13 PDT 2001
 //    Added code to set a flag if the plot needs recalculation.
 //
 //    Hank Childs, Sun Jun 17 18:47:57 PDT 2001
 //    Pushed code into avtContourFilter.
 //
-//    Kathleen Bonnell, Mon Jun 25 14:33:59 PDT 2001 
+//    Kathleen Bonnell, Mon Jun 25 14:33:59 PDT 2001
 //    Set numLevels based on atts. Set colors in avtLUT and use it
 //    to set mapper's. lut.
 //
 //    Kathleen Bonnell, Mon Sep 24 15:46:23 PDT 2001
 //    avtLevelsMapper no longer uses a vtkLookupTable.  Set its colors
-//    with ColorAttributeList instead. 
+//    with ColorAttributeList instead.
 //
 //    Brad Whitlock, Fri Nov 22 14:33:50 PST 2002
 //    I moved the color code to SetColors.
 //
-//    Kathleen Bonnell, Mon Sep 29 13:13:32 PDT 2003 
+//    Kathleen Bonnell, Mon Sep 29 13:13:32 PDT 2003
 //    Set AntialiasedRenderOrder dependent upon Wireframe mode.
 //
-//    Kathleen Bonnell, Thu Sep  2 11:44:09 PDT 2004 
+//    Kathleen Bonnell, Thu Sep  2 11:44:09 PDT 2004
 //    Ensure that specular properties aren't used in wireframe mode.
 //
 // ****************************************************************************
@@ -218,7 +218,7 @@ avtContourPlot::SetAtts(const AttributeGroup *a)
     {
         numLevels = (int)atts.GetContourValue().size();
     }
-    else 
+    else
     {
         numLevels = (int)atts.GetContourPercent().size();
     }
@@ -231,7 +231,7 @@ avtContourPlot::SetAtts(const AttributeGroup *a)
         behavior->SetAntialiasedRenderOrder(ABSOLUTELY_LAST);
         levelsMapper->SetSpecularIsInappropriate(true);
     }
-    else 
+    else
     {
         behavior->SetAntialiasedRenderOrder(DOES_NOT_MATTER);
         levelsMapper->SetSpecularIsInappropriate(false);
@@ -248,7 +248,7 @@ avtContourPlot::SetAtts(const AttributeGroup *a)
 //      extents The extents used by the plot.
 //
 //  Programmer: Eric Brugger
-//  Creation:   March 25, 2004 
+//  Creation:   March 25, 2004
 //
 // ****************************************************************************
 
@@ -283,7 +283,7 @@ avtContourPlot::GetDataExtents(std::vector<double> &extents)
 // ****************************************************************************
 // Method: avtContourPlot::SetColorTable
 //
-// Purpose: 
+// Purpose:
 //   Sets the plot's color table if the color table is the same as that of
 //   the plot or we are using the default color table for the plot.
 //
@@ -296,7 +296,7 @@ avtContourPlot::GetDataExtents(std::vector<double> &extents)
 // Creation:   Tue Dec 3 09:33:47 PDT 2002
 //
 // Modifications:
-//   
+//
 // ****************************************************************************
 
 bool
@@ -347,7 +347,7 @@ avtContourPlot::NeedZBufferToCompositeEvenIn2D(void)
 // ****************************************************************************
 // Method: avtContourPlot::SetColors
 //
-// Purpose: 
+// Purpose:
 //   Sets the plot's colors.
 //
 // Programmer: Kathleen Bonnell
@@ -375,7 +375,7 @@ avtContourPlot::SetColors()
     if (atts.GetColorType() == ContourAttributes::ColorBySingleColor)
     {
         const ColorAttribute ca = atts.GetSingleColor();
-        ColorAttributeList cal; 
+        ColorAttributeList cal;
         cal.AddColors(atts.GetSingleColor());
         avtLUT->SetLUTColorsWithOpacity(ca.GetColor(), 1);
         levelsMapper->SetColors(cal, needsRecalculation);
@@ -420,7 +420,7 @@ avtContourPlot::SetColors()
         }
 
         bool invert = atts.GetInvertColorTable();
-        // 
+        //
         // Add a color for each subset name.
         //
         if(ct->IsDiscrete(ctName.c_str()))
@@ -474,8 +474,8 @@ avtContourPlot::SetColors()
 //  Arguments:
 //      legendOn     true if the legend should be turned on, false otherwise.
 //
-//  Programmer: Kathleen Bonnell 
-//  Creation:   March 13, 2001 
+//  Programmer: Kathleen Bonnell
+//  Creation:   March 13, 2001
 //
 // ****************************************************************************
 
@@ -542,7 +542,7 @@ avtContourPlot::GetMapper(void)
 //
 //  Purpose:
 //      Performs the implied operators for an isocontour plot, namely,
-//      an avtContourFilter. 
+//      an avtContourFilter.
 //
 //  Arguments:
 //      input   The input data object.
@@ -564,12 +564,12 @@ avtContourPlot::GetMapper(void)
 //    Hank Childs, Sun Mar 25 12:28:25 PST 2001
 //    Fixed spot where data attributes were being used incorrectly.
 //
-//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001 
-//    Added arguments in call to SetIsoValues.  
+//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001
+//    Added arguments in call to SetIsoValues.
 //
-//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001 
+//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001
 //    Removed check for empty isoValues before call to SetIsoValues,
-//    as the logic is part of the SetIsoValues method itself. 
+//    as the logic is part of the SetIsoValues method itself.
 //
 //    Hank Childs, Fri Jun 15 09:14:24 PDT 2001
 //    Changed signature for more general data objects.
@@ -577,12 +577,12 @@ avtContourPlot::GetMapper(void)
 //    Jeremy Meredith, Wed Mar 13 11:16:25 PST 2002
 //    Added a wireframe mode.
 //
-//    Kathleen Bonnell, Mon Jun 24 15:09:37 PDT 2002  
-//    Fix potential memory leak with contourFilter. 
+//    Kathleen Bonnell, Mon Jun 24 15:09:37 PDT 2002
+//    Fix potential memory leak with contourFilter.
 //
-//    Kathleen Bonnell, Tue Oct 22 08:33:26 PDT 2002 
+//    Kathleen Bonnell, Tue Oct 22 08:33:26 PDT 2002
 //    Moved feature edges filter to ApplyRenderingTransformation, so that
-//    output of this method would be a queryable object. 
+//    output of this method would be a queryable object.
 //
 //    Eric Brugger, Thu Mar 25 16:42:45 PST 2004
 //    I added code to use the data extents from the base class if set.
@@ -633,7 +633,7 @@ avtContourPlot::ApplyOperators(avtDataObject_p input)
 //
 //  Purpose:
 //      Performs the rendering transformation for an isocontour plot, namely,
-//      an avtFeatureEdgesFilter. 
+//      an avtFeatureEdgesFilter.
 //
 //  Arguments:
 //      input   The input data object.
@@ -641,7 +641,7 @@ avtContourPlot::ApplyOperators(avtDataObject_p input)
 //  Returns:    The data object after the feature edges is applied.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   October 22, 2002 
+//  Creation:   October 22, 2002
 //
 //  Modifications:
 //    Hank Childs, Fri Feb 15 15:43:37 PST 2008
@@ -669,7 +669,7 @@ avtContourPlot::ApplyRenderingTransformation(avtDataObject_p input)
 // ****************************************************************************
 // Method: avtContourPlot::SetActualExtents
 //
-// Purpose: 
+// Purpose:
 //   Apply the actual extents filter.
 //
 // Arguments:
@@ -686,7 +686,7 @@ avtContourPlot::ApplyRenderingTransformation(avtDataObject_p input)
 // Creation:   Wed Sep  9 16:47:10 PDT 2009
 //
 // Modifications:
-//   
+//
 //    Hank Childs, Thu Aug 26 13:47:30 PDT 2010
 //    Renamed current->actual
 //
@@ -718,7 +718,7 @@ avtContourPlot::SetActualExtents(avtDataObject_p input)
 //  Method: avtContourPlot::CustomizeBehavior
 //
 //  Purpose:
-//      Customizes the behavior of the output.  
+//      Customizes the behavior of the output.
 //
 //  Programmer: Kathleen Bonnell
 //  Creation:   February  15, 2001
@@ -731,25 +731,25 @@ avtContourPlot::SetActualExtents(avtDataObject_p input)
 //    Hank Childs, Mon Mar 12 16:59:34 PST 2001
 //    Added shift factor.
 //
-//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001 
+//    Kathleen Bonnell, Wed Mar 28 17:18:05 PST 2001
 //    Added arguments in call to SetIsoValues. Changed Call to levelsMapper
 //    Get DataRange method to reflect new name.
 //
-//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001 
+//    Kathleen Bonnell, Tue Apr  3 08:56:47 PDT 2001
 //    Change call to retrieve data range.  The correct behavior is to retrieve
 //    the original data extents, as reflected in the new method call.  Added
 //    call to set the legend's VarRange so that limit text will reflect real
 //    var extents, even when artificial limits are set.
-//    
-//    Kathleen Bonnell, Fri Aug 31 08:50:30 PDT 2001 
+//
+//    Kathleen Bonnell, Fri Aug 31 08:50:30 PDT 2001
 //    Use avtLUT to set legend's lut.  Use better test for whether or
 //    not to display the legend.  Use information in atts to set
 //    more reasonable legend labels.  Still needs work!
 //
-//    Kathleen Bonnell, Sat Sep 22 12:13:57 PDT 2001 
-//    Removed logic for setting legend's labels.  Now contained in 
-//    CustomizeMapper. 
-//    
+//    Kathleen Bonnell, Sat Sep 22 12:13:57 PDT 2001
+//    Removed logic for setting legend's labels.  Now contained in
+//    CustomizeMapper.
+//
 //    Eric Brugger, Wed Jul 16 10:27:29 PDT 2003
 //    Modified to work with the new way legends are managed.
 //
@@ -758,15 +758,15 @@ avtContourPlot::SetActualExtents(avtDataObject_p input)
 void
 avtContourPlot::CustomizeBehavior(void)
 {
-    // 
-    //  Need to get the data range from mapper, and 
+    //
+    //  Need to get the data range from mapper, and
     //  recreate the isoValues so they can be sent to the legend.
     //
     double min, max;
     levelsMapper->GetOriginalDataRange(min, max);
 
     //
-    // Legend limits text should be the original data extents. 
+    // Legend limits text should be the original data extents.
     //
     levelsLegend->SetVarRange(min, max);
 
@@ -778,7 +778,7 @@ avtContourPlot::CustomizeBehavior(void)
         levelsLegend->SetMessage("Constant, no levels");
     }
     else
-    { 
+    {
         levelsLegend->SetColorBarVisibility(1);
         levelsLegend->SetMessage(NULL);
     }
@@ -792,22 +792,29 @@ avtContourPlot::CustomizeBehavior(void)
 //  Method: avtContourPlot::CustomizeMapper
 //
 //  Purpose:
-//    Use the info to set the isolevels in the legend.  
+//    Use the info to set the isolevels in the legend.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   September 22, 2001 
+//  Creation:   September 22, 2001
 //
 //  Modifications:
 //    Eric Brugger, Wed Jul 16 10:27:29 PDT 2003
 //    Modified to work with the new way legends are managed.
+//
+//    Kathleen Biagas, Wed July 14, 2021
+//    Prefer use of isoValues from contourFilter rather than labels.
 //
 // ****************************************************************************
 
 void
 avtContourPlot::CustomizeMapper(avtDataObjectInformation &info)
 {
-    std::vector<std::string> isoValues;
-    info.GetAttributes().GetLabels(isoValues);
+    std::vector<double> isoValues;
+    if(contourFilter)
+    {
+        contourFilter->GetIsoValues(isoValues);
+    }
+
 
     if (!isoValues.empty())
     {
@@ -816,9 +823,20 @@ avtContourPlot::CustomizeMapper(avtDataObjectInformation &info)
         levelsLegend->SetMessage(NULL);
     }
     else
-    { 
-        levelsLegend->SetColorBarVisibility(0);
-        levelsLegend->SetMessage("Unable to compute levels");
+    {
+        std::vector<std::string> isoLabels;
+        info.GetAttributes().GetLabels(isoLabels);
+        if (!isoLabels.empty())
+        {
+            levelsLegend->SetLevels(isoLabels);
+            levelsLegend->SetColorBarVisibility(1);
+            levelsLegend->SetMessage(NULL);
+        }
+        else
+        {
+            levelsLegend->SetColorBarVisibility(0);
+            levelsLegend->SetMessage("Unable to compute levels");
+        }
     }
 }
 

--- a/src/resources/help/en_US/relnotes3.3.0.html
+++ b/src/resources/help/en_US/relnotes3.3.0.html
@@ -93,7 +93,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Other bugs fixed in version 3.3</font></b></p>
 <ul>
-  <li>Bug Fix 1</li>
+  <li>Fixed bug where changing the 'Number format' for a Contour plot's legend would have no affect on the labels next to the tick marks.</li>
   <li>Bug Fix 2</li>
 </ul>
 


### PR DESCRIPTION
### Description
Have the plot retrieve the actual isovalue numbers used for contouring.
Use the isovalue numbers (when available) as labels for the legend.
Resolves #111.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I created a contour plot and modified the legend's number format. The tick-labels for the legend now use the number format.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
