### PR TITLE
bp yaml bugfix

### DIFF
--- a/src/databases/Blueprint/avtBlueprintFileFormat.C
+++ b/src/databases/Blueprint/avtBlueprintFileFormat.C
@@ -1224,7 +1224,8 @@ avtBlueprintFileFormat::ReadRootFile()
 //  Creation:   Mon Mar  9 12:24:16 PDT 2020
 //
 //  Modifications:
-//
+//   Cyrus Harrison, Fri Jul 16 15:39:57 PDT 2021
+//   Bugfix: When using relay::io::IOHandle, always open in read only mode
 //
 // ****************************************************************************
 void
@@ -1243,10 +1244,6 @@ avtBlueprintFileFormat::ReadRootIndexItems(const std::string &root_fname,
 
     if(root_protocol == "hdf5")
     {
-        // we can't use relay::io::IOHandle here b/c it currently
-        // lacks an option to open the file in read only mode, and
-        // by default opens in R/W.
-        //
         // For the case where the data is also included in the root file,
         // VisIt may have a read only hdf5 file handle open, trying
         // to open with R/W will throw an error.
@@ -1277,7 +1274,9 @@ avtBlueprintFileFormat::ReadRootIndexItems(const std::string &root_fname,
         // broadcasted to all ranks and is also printed in debug 5 logs
         // so we still filter what is pulled out here
         relay::io::IOHandle root_hnd;
-        root_hnd.open(root_fname,root_protocol);
+        Node open_opts;
+        open_opts["mode"] = "r";
+        root_hnd.open(root_fname, root_protocol, open_opts);
 
         // loop over all names and copy them to the output node
         NodeConstIterator itr = index_names.children();

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -42,7 +42,6 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug for Windows where exporting a multi-block Silo file into a non-default directory would make the file unreadable by VisIt.</li>
   <li>Fixed a bug in build_visit that prevented CGNS from building on Linux systems.</li>
   <li>Fixed a bug causing Pick queries on expression variables to fail.</li>
-  <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.2.1.html
+++ b/src/resources/help/en_US/relnotes3.2.1.html
@@ -42,6 +42,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug for Windows where exporting a multi-block Silo file into a non-default directory would make the file unreadable by VisIt.</li>
   <li>Fixed a bug in build_visit that prevented CGNS from building on Linux systems.</li>
   <li>Fixed a bug causing Pick queries on expression variables to fail.</li>
+  <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -1,0 +1,42 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Language" content="en-us">
+  <title>VisIt 3.2.2 Release Notes</title>
+</head>
+<body>
+<center><b><font size="6">VisIt 3.2.2 Release Notes</font></b></center>
+
+<p>Welcome to VisIt's release notes page. This page describes the important
+enhancements and bug-fixes that were added to this release.</p>
+
+<p><b>Sections</b></p>
+<ul>
+  <li><a href="#Bugs_fixed">Bug Fixes</a></li>
+  <li><a href="#Enhancements">Enhancements</a></li>
+  <li><a href="#Dev_changes">Changes for VisIt developers</a></li>
+</ul>
+
+<a name="Bugs_fixed"></a>
+<p><b><font size="4">Bugs fixed in version 3.2.2</font></b></p>
+<ul>
+  <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
+</ul>
+
+<a name="Enhancements"></a>
+<p><b><font size="4">Enhancements in version 3.2.2</font></b></p>
+<ul>
+  <li> </li>
+</ul>
+
+<a name="Dev_changes"></a>
+<p><b><font size="4">Changes for VisIt developers in version 3.2.2</font></b></p>
+<ul>
+   <li> </li>
+</ul>
+
+<p>Click the following link to view the release notes for the previous version
+of VisIt: <a href=relnotes3.2.1.html>3.2.1</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
### Description

Resolves #5919

Change for Blueprint plugin  -- when using Conduit relay I/OHandle, use read only mode when opening root file.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

Tested by verifying that a file YAML file comments were preserved after open.  (Before comments were stripped after open)

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
