### PR TITLE
Fix a compile issue building on Fedora 31 w/o OpenGL headers installed.

### DIFF
--- a/src/engine/main/CMakeLists.txt
+++ b/src/engine/main/CMakeLists.txt
@@ -36,6 +36,10 @@
 #    I added the ProgrammableCompositer, a helper class
 #    used by the NetworkManager.
 #
+#    Eric Brugger, Tue Jul 20 11:55:04 PDT 2021
+#    Added OPEN_INCLUDE_DIR to the include directories if building IceT
+#    with MesaGL.
+#
 #****************************************************************************
 
 set(LIBENGINE_SOURCES
@@ -197,6 +201,9 @@ if(VISIT_PARALLEL)
         set(ICET_SOURCES IceTNetworkManager.C)
         include_directories(${ICET_INCLUDE_DIR})
         link_directories(${ICET_LIBRARY_DIR})
+        if(VISIT_MESAGL_DIR)
+            include_directories(${OPENGL_INCLUDE_DIR})
+        endif()
     endif()
 
     ADD_PARALLEL_LIBRARY(engine_par ${LIBENGINE_SOURCES} ${ENGINE_PAR_SOURCES} ${ICET_SOURCES})

--- a/src/engine/main/CMakeLists.txt
+++ b/src/engine/main/CMakeLists.txt
@@ -37,7 +37,7 @@
 #    used by the NetworkManager.
 #
 #    Eric Brugger, Tue Jul 20 11:55:04 PDT 2021
-#    Added OPEN_INCLUDE_DIR to the include directories if building IceT
+#    Added OPENGL_INCLUDE_DIR to the include directories if building IceT
 #    with MesaGL.
 #
 #****************************************************************************

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -33,7 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.2.2</font></b></p>
 <ul>
-   <li> </li>
+   <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Resolves #5922

Fixed a compile issue building on Fedora 31 w/o OpenGL headers installed. The compile failure occured because IceT includes an OpenGL header file and since there were no OpenGL header files installed on the system the compile failed. The solution was to modify engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I created a distribution tar file and moved it to my Fedora 31 Docker container and successfully built VisIt.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
