### PR TITLE
Fix rendering of a black image in opengl version of VisIt.

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -2993,7 +2993,7 @@ class MainLauncher(object):
             SETENV("LD_LIBRARY_PATH", self.joinpaths([mesa_gl_dir, GETENV("LD_LIBRARY_PATH")]))
 
         # Enable the native renderer when using mesagl. Enabling it with
-        # opengl results in a black screen. This resolves the toolbar
+        # opengl results in a black image. This resolves the toolbar
         # rendering issue when doing an initial zoom while doing X forwarding.
         if os.path.isfile(mesa_gl_lib):
             SETENV("QT_XCB_NATIVE_PAINTING", "1")

--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -2880,6 +2880,9 @@ class MainLauncher(object):
     #   custom launcher since doing it here interfered with other sites that
     #   were setting LD_PRELOAD to get VisIt to work.
     #
+    #   Eric Brugger, Tue Jul 20 12:41:04 PDT 2021
+    #   Modified to only setenv QT_XCB_NATIVE_PAINTING if using mesagl.
+    #
     ############################################################################
 
     def SetupEnvironment(self):
@@ -2965,11 +2968,6 @@ class MainLauncher(object):
         # the GUI and Viewer.
         SETENV("MESA_GLX_FX", "disable")
 
-        # Enabled the native renderer.
-        # This resolves the toolbar rendering issue when doing an initial zoom
-        # while doing X forwarding.
-        SETENV("QT_XCB_NATIVE_PAINTING", "1")
-
         # The -viewerdisplay argument allows the user to specify an argument
         # that the viewer should use, no matter what the GUI was using.  This
         # can be useful for wall-type displays with a separate console, e.g.
@@ -2993,6 +2991,12 @@ class MainLauncher(object):
               (self.generalArgs.exe_name == "viewer" and
                self.generalArgs.nowin == 0))):
             SETENV("LD_LIBRARY_PATH", self.joinpaths([mesa_gl_dir, GETENV("LD_LIBRARY_PATH")]))
+
+        # Enable the native renderer when using mesagl. Enabling it with
+        # opengl results in a black screen. This resolves the toolbar
+        # rendering issue when doing an initial zoom while doing X forwarding.
+        if os.path.isfile(mesa_gl_lib):
+            SETENV("QT_XCB_NATIVE_PAINTING", "1")
 
         #
         # OSMesa GL Settings

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -22,6 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.2.2</font></b></p>
 <ul>
   <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
+  <li>Fixed a bug where versions of VisIt that supported hardware accelerated rendering would display a black image in the visualization window.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #5664 

Fixes a bug with the hardware accelerated versions of VisIt that use OpenGL rendering a black image in the visualization window. This is caused by setting the environment variable QT_XCB_NATIVE_PAINTING (and enabling qt-xcb-native-painting when building Qt). I modified the internallauncher to only set QT_XCB_NATIVE_PAINTING when using MesaGL.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I built a version VisIt with MesaGL and one with OpenGL and tested that both versions worked properly with the new internallauncher. The QT_XCB_NATIVE_PAINTING was added to fix a problem with the toolbar getting messed up after doing a zoom for the first time. This isn't a problem with the OpenGL version.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
