### PR TITLE
Fix a compile issue building on Fedora 31 w/o OpenGL headers installed. (#5926)

### DIFF
--- a/src/engine/main/CMakeLists.txt
+++ b/src/engine/main/CMakeLists.txt
@@ -36,6 +36,10 @@
 #    I added the ProgrammableCompositer, a helper class
 #    used by the NetworkManager.
 #
+#    Eric Brugger, Tue Jul 20 11:55:04 PDT 2021
+#    Added OPENGL_INCLUDE_DIR to the include directories if building IceT
+#    with MesaGL.
+#
 #****************************************************************************
 
 set(LIBENGINE_SOURCES
@@ -197,6 +201,9 @@ if(VISIT_PARALLEL)
         set(ICET_SOURCES IceTNetworkManager.C)
         include_directories(${ICET_INCLUDE_DIR})
         link_directories(${ICET_LIBRARY_DIR})
+        if(VISIT_MESAGL_DIR)
+            include_directories(${OPENGL_INCLUDE_DIR})
+        endif()
     endif()
 
     ADD_PARALLEL_LIBRARY(engine_par ${LIBENGINE_SOURCES} ${ENGINE_PAR_SOURCES} ${ICET_SOURCES})

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -33,7 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.2.2</font></b></p>
 <ul>
-   <li> </li>
+   <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
Resolves #5922 
Merge from the 3.2RC to develop.