### PR TITLE
Remove vtkVisItStructuredGrid and vtkVisItRectilinearGrid overrides from InitVTKRendering

### DIFF
--- a/src/avt/Plotter/vtk/InitVTKRendering.C
+++ b/src/avt/Plotter/vtk/InitVTKRendering.C
@@ -6,8 +6,6 @@
 
 #include <vtkToolkits.h>
 #include <vtkVisItDataSetMapper.h>
-#include <vtkVisItRectilinearGrid.h>
-#include <vtkVisItStructuredGrid.h>
 #include <vtkOpenGLPointMapper.h>
 
 #include <vtkObjectFactory.h>
@@ -54,8 +52,6 @@ vtkStandardNewMacro(vtkVisItGraphicsFactory)
 // Necessary for each object that will override a vtkObject.
 //
 VTK_CREATE_CREATE_FUNCTION(vtkVisItDataSetMapper);
-VTK_CREATE_CREATE_FUNCTION(vtkVisItRectilinearGrid);
-VTK_CREATE_CREATE_FUNCTION(vtkVisItStructuredGrid);
 VTK_CREATE_CREATE_FUNCTION(vtkOpenGLPointMapper);
 
 const char*
@@ -112,6 +108,10 @@ vtkVisItGraphicsFactory::GetVTKSourceVersion()
 //    Kathleen Biagas, Tue Apr 13 2021
 //    Add vtkVisItDataSetMapper.
 //
+//    Kathleen Biagas, Thu July 22, 2021
+//    Remove vtkVisItRectilinearGrid and vtkStructuredGrid overrides for
+//    they are defined in visit_vtk/full/InitVTK
+//
 
 vtkVisItGraphicsFactory::vtkVisItGraphicsFactory()
 {
@@ -119,14 +119,6 @@ vtkVisItGraphicsFactory::vtkVisItGraphicsFactory()
                          "vtkVisItDataSetMapper override vtkDataSetMapper",
                          1,
                          vtkObjectFactoryCreatevtkVisItDataSetMapper);
-  this->RegisterOverride("vtkRectilinearGrid", "vtkVisItRectilinearGrid",
-                         "vtkVisItRectilinearGrid override vtkRectilinearGrid",
-                         1,
-                         vtkObjectFactoryCreatevtkVisItRectilinearGrid);
-  this->RegisterOverride("vtkStructuredGrid", "vtkVisItStructuredGrid",
-                         "vtkVisItStructuredGrid override vtkStructuredGrid",
-                         1,
-                         vtkObjectFactoryCreatevtkVisItStructuredGrid);
   this->RegisterOverride("vtkPointMapper",
     "vtkOpenGLPointMapper",
     "vtkOpenGLPointMapper override vtkPointMapper",


### PR DESCRIPTION
They are defined in visit_vtk/full/InitVTK.
Resolves #5912.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I compiled and ran the test suite on pascal.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
