### PR TITLE
Remove vtkVisItStructuredGrid and vtkVisItRectilinearGrid overrides from InitVTKRendering (#5943)

### DIFF
--- a/src/avt/Plotter/vtk/InitVTKRendering.C
+++ b/src/avt/Plotter/vtk/InitVTKRendering.C
@@ -6,8 +6,6 @@
 
 #include <vtkToolkits.h>
 #include <vtkVisItDataSetMapper.h>
-#include <vtkVisItRectilinearGrid.h>
-#include <vtkVisItStructuredGrid.h>
 #include <vtkOpenGLPointMapper.h>
 
 #include <vtkObjectFactory.h>
@@ -54,8 +52,6 @@ vtkStandardNewMacro(vtkVisItGraphicsFactory)
 // Necessary for each object that will override a vtkObject.
 //
 VTK_CREATE_CREATE_FUNCTION(vtkVisItDataSetMapper);
-VTK_CREATE_CREATE_FUNCTION(vtkVisItRectilinearGrid);
-VTK_CREATE_CREATE_FUNCTION(vtkVisItStructuredGrid);
 VTK_CREATE_CREATE_FUNCTION(vtkOpenGLPointMapper);
 
 const char*
@@ -112,6 +108,10 @@ vtkVisItGraphicsFactory::GetVTKSourceVersion()
 //    Kathleen Biagas, Tue Apr 13 2021
 //    Add vtkVisItDataSetMapper.
 //
+//    Kathleen Biagas, Thu July 22, 2021
+//    Remove vtkVisItRectilinearGrid and vtkStructuredGrid overrides for
+//    they are defined in visit_vtk/full/InitVTK
+//
 
 vtkVisItGraphicsFactory::vtkVisItGraphicsFactory()
 {
@@ -119,14 +119,6 @@ vtkVisItGraphicsFactory::vtkVisItGraphicsFactory()
                          "vtkVisItDataSetMapper override vtkDataSetMapper",
                          1,
                          vtkObjectFactoryCreatevtkVisItDataSetMapper);
-  this->RegisterOverride("vtkRectilinearGrid", "vtkVisItRectilinearGrid",
-                         "vtkVisItRectilinearGrid override vtkRectilinearGrid",
-                         1,
-                         vtkObjectFactoryCreatevtkVisItRectilinearGrid);
-  this->RegisterOverride("vtkStructuredGrid", "vtkVisItStructuredGrid",
-                         "vtkVisItStructuredGrid override vtkStructuredGrid",
-                         1,
-                         vtkObjectFactoryCreatevtkVisItStructuredGrid);
   this->RegisterOverride("vtkPointMapper",
     "vtkOpenGLPointMapper",
     "vtkOpenGLPointMapper override vtkPointMapper",


### PR DESCRIPTION
They are defined in visit_vtk/full/InitVTK.

Resolves #5912

merge from 3.2RC