### PR TITLE
Add patch to build_visit for building VTK with gcc 10.3.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -34,7 +34,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.2.2</font></b></p>
 <ul>
-   <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
+  <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
+  <li>Enhanced build_visit to apply a patch to fix a compile issue with VTK with gcc 10.3 on Ubuntu 21.04.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -947,7 +947,7 @@ EOF
 
 function apply_vtkospray_patches
 {
-	count_patches=3
+	count_patches=4
     # patch vtkOSPRay files:
 
     # 1) expose vtkViewNodeFactory via vtkOSPRayPass
@@ -1177,6 +1177,7 @@ EOF
         return 1
     fi
 
+	# 3) fix vtkOSPRayVolumeMapper
 	((current_patch++))
     patch -p0 << \EOF
 *** Rendering/OSPRay/vtkOSPRayVolumeMapper.cxx.original	2018-04-23 15:32:58.538749914 -0400
@@ -1195,6 +1196,28 @@ EOF
 EOF
     if [[ $? != 0 ]] ; then
         warn "vtk patch $current_patch/$count_patches for vtkOSPRayVolumeMapper failed."
+        return 1
+    fi
+
+	# 4) Add include string to vtkOSPRayMaterialHelpers.h for gcc 10.
+	((current_patch++))
+    patch -p0 << \EOF
+diff -c Rendering/OSPRay/vtkOSPRayMaterialHelpers.h.original Rendering/OSPRay/vtkOSPRayMaterialHelpers.h
+*** Rendering/OSPRay/vtkOSPRayMaterialHelpers.h.original	Mon Jul 26 16:14:55 2021
+--- Rendering/OSPRay/vtkOSPRayMaterialHelpers.h	Mon Jul 26 16:15:11 2021
+***************
+*** 33,38 ****
+--- 33,39 ----
+  
+  #include "ospray/ospray.h"
+  #include <map>
++ #include <string>
+  
+  class vtkImageData;
+  class vtkOSPRayRendererNode;
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk patch $current_patch/$count_patches for vtkOSPRayMaterialHelpers."
         return 1
     fi
 }

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1199,7 +1199,7 @@ EOF
         return 1
     fi
 
-	# 4) Add include string to vtkOSPRayMaterialHelpers.h for gcc 10.
+	# 4) Add include string to vtkOSPRayMaterialHelpers.h for gcc 10.3.
 	((current_patch++))
     patch -p0 << \EOF
 diff -c Rendering/OSPRay/vtkOSPRayMaterialHelpers.h.original Rendering/OSPRay/vtkOSPRayMaterialHelpers.h


### PR DESCRIPTION
### Description

Resolves #5946 

Modified build_visit to add a patch to VTK to add a missing include statement.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I used the new build_visit to create a Docker image for Ubuntu 21.04, which uses gcc 10.3.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
