### PR TITLE
Add patch to build_visit for building VTK with gcc 10.3. (#5947)

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -34,7 +34,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.2.2</font></b></p>
 <ul>
-   <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
+  <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
+  <li>Enhanced build_visit to apply a patch to fix a compile issue with VTK with gcc 10.3 on Ubuntu 21.04.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -947,7 +947,7 @@ EOF
 
 function apply_vtkospray_patches
 {
-	count_patches=3
+	count_patches=4
     # patch vtkOSPRay files:
 
     # 1) expose vtkViewNodeFactory via vtkOSPRayPass
@@ -1177,6 +1177,7 @@ EOF
         return 1
     fi
 
+	# 3) fix vtkOSPRayVolumeMapper
 	((current_patch++))
     patch -p0 << \EOF
 *** Rendering/OSPRay/vtkOSPRayVolumeMapper.cxx.original	2018-04-23 15:32:58.538749914 -0400
@@ -1195,6 +1196,28 @@ EOF
 EOF
     if [[ $? != 0 ]] ; then
         warn "vtk patch $current_patch/$count_patches for vtkOSPRayVolumeMapper failed."
+        return 1
+    fi
+
+	# 4) Add include string to vtkOSPRayMaterialHelpers.h for gcc 10.3.
+	((current_patch++))
+    patch -p0 << \EOF
+diff -c Rendering/OSPRay/vtkOSPRayMaterialHelpers.h.original Rendering/OSPRay/vtkOSPRayMaterialHelpers.h
+*** Rendering/OSPRay/vtkOSPRayMaterialHelpers.h.original	Mon Jul 26 16:14:55 2021
+--- Rendering/OSPRay/vtkOSPRayMaterialHelpers.h	Mon Jul 26 16:15:11 2021
+***************
+*** 33,38 ****
+--- 33,39 ----
+  
+  #include "ospray/ospray.h"
+  #include <map>
++ #include <string>
+  
+  class vtkImageData;
+  class vtkOSPRayRendererNode;
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk patch $current_patch/$count_patches for vtkOSPRayMaterialHelpers."
         return 1
     fi
 }


### PR DESCRIPTION
Resolves #5946
Merge from the 3.2RC to develop.
