### PR TITLE
Fix atts_assign results for Windows

### DIFF
--- a/src/test/tests/unit/atts_assign.py
+++ b/src/test/tests/unit/atts_assign.py
@@ -11,6 +11,11 @@
 #
 #  Mark C. Miller, Tue Jun  8 15:51:59 PDT 2021
 #
+#  Modifications:
+#    Kathleen Biagas, Tue July 27, 2021
+#    Assigning Max32BitInt+1 to int on Windows causes TypeError, not
+#    ValueError, so change expected results in those cases.
+#
 # ----------------------------------------------------------------------------
 import copy, io, sys
 
@@ -198,7 +203,10 @@ def TestAssignmentToInt():
         pass
 
     fails =  [    '123',      1+2j,      None,         X, Max32BitInt1]
-    excpts = [TypeError, TypeError, TypeError, TypeError, ValueError]
+    if sys.platform.startswith("win"):
+        excpts = [TypeError, TypeError, TypeError, TypeError, TypeError]
+    else:
+        excpts = [TypeError, TypeError, TypeError, TypeError, ValueError]
     for i in range(len(fails)):
         try:
             va.samplesPerRay = fails[i]
@@ -566,8 +574,12 @@ def TestAssignmentToIntVector():
 
     fails =  [(Max32BitInt1,), (1+2j,), ('b',), (None,), (1,Max32BitInt1,3),
               (1,1+2j,3), (1,X,3), (1,'b',3), (1,None,3)]
-    excpts = [ValueError, TypeError, TypeError, TypeError, ValueError,
-              TypeError, TypeError, TypeError, TypeError]
+    if sys.platform.startswith("win"):
+        excpts = [TypeError, TypeError, TypeError, TypeError, TypeError,
+                  TypeError, TypeError, TypeError, TypeError]
+    else:
+        excpts = [ValueError, TypeError, TypeError, TypeError, ValueError,
+                  TypeError, TypeError, TypeError, TypeError]
     for i in range(len(fails)):
         try:
             opa.index = fails[i]
@@ -797,9 +809,13 @@ def TestAssignmentToIntArray():
         TestFOA('ra.reflections=0,1,0,1,0,1,0,1', LINE())
         pass
 
-    fails =  [(0,1,None,1,0,1,0,1), (0,1,1+2j,1,0,1,0,1), (0,1,X,1,0,1,0,1), (0,1,Max32BitInt1,1,0,1,0,1),
-              (0,1,'123',1,0,1,0,1), (0,1,0,1,0,1,0,1,1), (0,1,0,1,0,1,0)]
-    excpts = [TypeError, TypeError, TypeError, ValueError, TypeError, TypeError, TypeError]
+    fails =  [(0,1,None,1,0,1,0,1), (0,1,1+2j,1,0,1,0,1), (0,1,X,1,0,1,0,1),
+              (0,1,Max32BitInt1,1,0,1,0,1), (0,1,'123',1,0,1,0,1),
+              (0,1,0,1,0,1,0,1,1), (0,1,0,1,0,1,0)]
+    if sys.platform.startswith("win"):
+        excpts = [TypeError, TypeError, TypeError, TypeError, TypeError, TypeError, TypeError]
+    else: 
+        excpts = [TypeError, TypeError, TypeError, ValueError, TypeError, TypeError, TypeError]
     for i in range(len(fails)):
         try:
             ra.reflections = fails[i]


### PR DESCRIPTION
Assigning Max32BitInt+1 to an int on Windows causes TypeError not ValueError.
Change expected results for Windows in those cases.


### How Has This Been Tested?

Ran the test on Windows with success.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
