### PR TITLE
Fix bug saving images beyond 8192 x 8192 on Linux.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -23,6 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
   <li>Fixed a bug where versions of VisIt that supported hardware accelerated rendering would display a black image in the visualization window.</li>
+  <li>Fixed a crash when saving images greater than approximately 8,000 x 8,000. Now images can be saved up to 16,384 x 16,384.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/rendering/offscreensave.py
+++ b/src/test/tests/rendering/offscreensave.py
@@ -21,7 +21,13 @@
 #
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #    Added ability to swtich between Silo's HDF5 and PDB data.
+#
+#    Eric Brugger, Mon Aug  2 09:42:50 PDT 2021
+#    Added test of 16384 x 16384 image save.
+#
 # ----------------------------------------------------------------------------
+
+import hashlib
 
 TurnOnAllAnnotations()
 OpenDatabase(silo_data_path("multi_ucd3d.silo"))
@@ -122,5 +128,36 @@ slider.position = (0.5, 0.5)
 swa.width=300
 swa.height=300
 Test("offscreen_11",swa)
+
+# Test saving a 16384 x 16384 image
+slider.Delete()
+DeleteAllPlots()
+
+OpenDatabase(silo_data_path("curv2d.silo"))
+
+AddPlot("Pseudocolor", "d")
+DrawPlots()
+
+view2=GetView2D()
+view2.fullFrameActivationMode=view2.Off
+SetView2D(view2)
+
+swa.width = 16384
+swa.height = 16384
+swa.fileName = "image_16384x16384"
+swa.family = 0
+SetSaveWindowAttributes(swa)
+try:
+    SaveWindow()
+except:
+    TestValueEQ("md5 hash for 16384x16384 image", "Save failed", "9196b516c25ecbeac1fab4cd54ee0c59")
+
+# Comparing md5 sum instead of image, since the image is large.
+md5_hash = hashlib.md5()
+with open("image_16384x16384.png","rb") as f:
+    # Read and update hash in chunks of 4K
+    for byte_block in iter(lambda: f.read(4096),b""):
+        md5_hash.update(byte_block)
+TestValueEQ("md5 hash for 16384x16384 image", "Save failed", "9196b516c25ecbeac1fab4cd54ee0c59")
 
 Exit()

--- a/src/test/tests/rendering/offscreensave.py
+++ b/src/test/tests/rendering/offscreensave.py
@@ -147,10 +147,7 @@ swa.height = 16384
 swa.fileName = "image_16384x16384"
 swa.family = 0
 SetSaveWindowAttributes(swa)
-try:
-    SaveWindow()
-except:
-    TestValueEQ("md5 hash for 16384x16384 image", "Save failed", "9196b516c25ecbeac1fab4cd54ee0c59")
+SaveWindow()
 
 # Comparing md5 sum instead of image, since the image is large.
 md5_hash = hashlib.md5()
@@ -158,6 +155,6 @@ with open("image_16384x16384.png","rb") as f:
     # Read and update hash in chunks of 4K
     for byte_block in iter(lambda: f.read(4096),b""):
         md5_hash.update(byte_block)
-TestValueEQ("md5 hash for 16384x16384 image", "Save failed", "9196b516c25ecbeac1fab4cd54ee0c59")
+TestValueEQ("md5 hash for 16384x16384 image", md5_hash.hexdigest(), "9196b516c25ecbeac1fab4cd54ee0c59")
 
 Exit()

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -207,6 +207,68 @@ EOF
         return 1
     fi
 
+    #
+    # Patch to increase the maximum image size in the llvmpipe
+    # driver to 16K x 16K.
+    #
+    patch -p0 << \EOF
+diff -c src/gallium/drivers/llvmpipe/lp_limits.h.orig src/gallium/drivers/llvmpipe/lp_limits.h
+*** src/gallium/drivers/llvmpipe/lp_limits.h.orig       Fri Jul 30 10:03:06 2021
+--- src/gallium/drivers/llvmpipe/lp_limits.h    Fri Jul 30 10:04:41 2021
+***************
+*** 44,50 ****
+   * Max texture sizes
+   */
+  #define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
+! #define LP_MAX_TEXTURE_2D_LEVELS 14  /* 8K x 8K for now */
+  #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
+  #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
+  #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
+--- 44,50 ----
+   * Max texture sizes
+   */
+  #define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
+! #define LP_MAX_TEXTURE_2D_LEVELS 15  /* 16K x 16K for now */
+  #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
+  #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
+  #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "MesaGL patch 4 failed."
+        return 1
+    fi
+
+    #
+    # Patch to increase the maximum scene temporary storage in the llvmpipe
+    # driver. This is required for large image sizes.
+    #
+    patch -p0 << \EOF
+diff -c src/gallium/drivers/llvmpipe/lp_scene.h.orig src/gallium/drivers/llvmpipe/lp_scene.h
+*** src/gallium/drivers/llvmpipe/lp_scene.h.orig        Fri Jul 30 12:11:39 2021
+--- src/gallium/drivers/llvmpipe/lp_scene.h     Fri Jul 30 12:11:49 2021
+***************
+*** 60,66 ****
+  
+  /* Scene temporary storage is clamped to this size:
+   */
+! #define LP_SCENE_MAX_SIZE (9*1024*1024)
+  
+  /* The maximum amount of texture storage referenced by a scene is
+   * clamped to this size:
+--- 60,66 ----
+  
+  /* Scene temporary storage is clamped to this size:
+   */
+! #define LP_SCENE_MAX_SIZE (64*1024*1024)
+  
+  /* The maximum amount of texture storage referenced by a scene is
+   * clamped to this size:
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "MesaGL patch 5 failed."
+        return 1
+    fi
+
     return 0;
 }
 

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -133,7 +133,142 @@ diff -c configure.ac.orig configure.ac
 EOF
 
     if [[ $? != 0 ]] ; then
-        warn "OSMesa patch failed."
+        warn "OSMesa patch 1 failed."
+        return 1
+    fi
+
+    #
+    # Patch so that displaying graphics to the XWin-32 2018 X server
+    # works properly.
+    #
+    patch -p0 << \EOF
+diff -c src/gallium/winsys/sw/xlib/xlib_sw_winsys.c.orig src/gallium/winsys/sw/xlib/xlib_sw_winsys.c
+*** src/gallium/winsys/sw/xlib/xlib_sw_winsys.c.orig    Thu Mar  4 13:12:20 2021
+--- src/gallium/winsys/sw/xlib/xlib_sw_winsys.c Thu Mar  4 13:14:11 2021
+***************
+*** 396,401 ****
+--- 396,402 ----
+  {
+     struct xlib_displaytarget *xlib_dt;
+     unsigned nblocksy, size;
++    int ignore;
+  
+     xlib_dt = CALLOC_STRUCT(xlib_displaytarget);
+     if (!xlib_dt)
+***************
+*** 410,416 ****
+     xlib_dt->stride = align(util_format_get_stride(format, width), alignment);
+     size = xlib_dt->stride * nblocksy;
+  
+!    if (!debug_get_option_xlib_no_shm()) {
+        xlib_dt->data = alloc_shm(xlib_dt, size);
+        if (xlib_dt->data) {
+           xlib_dt->shm = True;
+--- 411,418 ----
+     xlib_dt->stride = align(util_format_get_stride(format, width), alignment);
+     size = xlib_dt->stride * nblocksy;
+  
+!    if (!debug_get_option_xlib_no_shm() &&
+!        XQueryExtension(xlib_dt->display, "MIT-SHM", &ignore, &ignore, &ignore)) {
+        xlib_dt->data = alloc_shm(xlib_dt, size);
+        if (xlib_dt->data) {
+           xlib_dt->shm = True;
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "OSMesa patch 2 failed."
+        return 1
+    fi
+
+    #
+    # Patch so that building with gcc-10 will work.
+    #
+    patch -p0 << \EOF
+diff -u src/gallium/drivers/swr/rasterizer/common/os.h.orig src/gallium/drivers/swr/rasterizer/common/os.h
+--- src/gallium/drivers/swr/rasterizer/common/os.h.orig 2021-06-28 08:51:12.252643000 -0700
++++ src/gallium/drivers/swr/rasterizer/common/os.h      2021-06-28 08:55:32.676722000 -0700
+@@ -166,14 +166,15 @@
+ #endif
+ 
+ #if !defined( __clang__) && !defined(__INTEL_COMPILER)
+-// Intrinsic not defined in gcc
++// Intrinsic not defined in gcc < 10
++#if (__GNUC__) && (GCC_VERSION < 100000)
+ static INLINE
+ void _mm256_storeu2_m128i(__m128i *hi, __m128i *lo, __m256i a)
+ {
+     _mm_storeu_si128((__m128i*)lo, _mm256_castsi256_si128(a));
+     _mm_storeu_si128((__m128i*)hi, _mm256_extractf128_si256(a, 0x1));
+ }
+-
++#endif
+ // gcc prior to 4.9 doesn't have _mm*_undefined_*
+ #if (__GNUC__) && (GCC_VERSION < 409000)
+ #define _mm_undefined_si128 _mm_setzero_si128
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "OSMesa patch 3 failed."
+        return 1
+    fi
+
+    #
+    # Patch to increase the maximum image size in the llvmpipe
+    # driver to 16K x 16K.
+    #
+    patch -p0 << \EOF
+diff -c src/gallium/drivers/llvmpipe/lp_limits.h.orig src/gallium/drivers/llvmpipe/lp_limits.h
+*** src/gallium/drivers/llvmpipe/lp_limits.h.orig       Fri Jul 30 10:03:06 2021
+--- src/gallium/drivers/llvmpipe/lp_limits.h    Fri Jul 30 10:04:41 2021
+***************
+*** 44,50 ****
+   * Max texture sizes
+   */
+  #define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
+! #define LP_MAX_TEXTURE_2D_LEVELS 14  /* 8K x 8K for now */
+  #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
+  #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
+  #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
+--- 44,50 ----
+   * Max texture sizes
+   */
+  #define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
+! #define LP_MAX_TEXTURE_2D_LEVELS 15  /* 16K x 16K for now */
+  #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
+  #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
+  #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "OSMesa patch 4 failed."
+        return 1
+    fi
+
+    #
+    # Patch to increase the maximum scene temporary storage in the llvmpipe
+    # driver. This is required for large image sizes.
+    #
+    patch -p0 << \EOF
+diff -c src/gallium/drivers/llvmpipe/lp_scene.h.orig src/gallium/drivers/llvmpipe/lp_scene.h
+*** src/gallium/drivers/llvmpipe/lp_scene.h.orig        Fri Jul 30 12:11:39 2021
+--- src/gallium/drivers/llvmpipe/lp_scene.h     Fri Jul 30 12:11:49 2021
+***************
+*** 60,66 ****
+  
+  /* Scene temporary storage is clamped to this size:
+   */
+! #define LP_SCENE_MAX_SIZE (9*1024*1024)
+  
+  /* The maximum amount of texture storage referenced by a scene is
+   * clamped to this size:
+--- 60,66 ----
+  
+  /* Scene temporary storage is clamped to this size:
+   */
+! #define LP_SCENE_MAX_SIZE (64*1024*1024)
+  
+  /* The maximum amount of texture storage referenced by a scene is
+   * clamped to this size:
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "OSMesa patch 5 failed."
         return 1
     fi
 


### PR DESCRIPTION
### Description

Resolves #5966

There were some buffer sizes in the llvmpipe renderer in Mesa that only supported saving images up to 8192 x 8192. I patched Mesa to increase the sizes of those buffers to support saving images up to 16384 x 16384. I added the patches to both bv_mesagl.sh and bv_osmesa.sh. I also noticed that some patches were missing form bv_osmesa.sh that were in bv_mesagl.sh, so I added those to bv_osmesa.sh. I rebuilt Mesa on quartz with the patched Mesa.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I rebuilt mesagl on quartz using the new build_visit. I then tested image saving up to 16384 x 16384 on quartz and added a test to the regression suite for saving an image at 16384 x 16384. Saving images at that size with VisIt 3.2.1 crashed the viewer on quartz.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
