### PR TITLE
Fix a bug in the "Chombo Users" configuration.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -24,6 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
   <li>Fixed a bug where versions of VisIt that supported hardware accelerated rendering would display a black image in the visualization window.</li>
   <li>Fixed a crash when saving images greater than approximately 8,000 x 8,000. Now images can be saved up to 16,384 x 16,384.</li>
+  <li>Fixed a bug in the <i>Chombo Users</i> configuration that prevented the macros from being loaded and appearing in the "Macros" window.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/hosts/chombo/visitrc
+++ b/src/resources/hosts/chombo/visitrc
@@ -265,7 +265,7 @@ def SetupBoundary():
             BoundaryAtts.boundaryType = BoundaryAtts.Material  # Domain, Group, Material, Unknown
             SetPlotOptions(BoundaryAtts)
     else:
-        print "Error: File contains no EB information."
+        print("Error: File contains no EB information.")
 
 def GetActivePlots():
     apl = []


### PR DESCRIPTION
### Description

Resolves #12710

When the "Chombo Users" configuration is installed and then VisIt restarted, there is an error and the macros do not load and appear in the "Macros" window. The problem was due to a print statement that didn't work with Python 3 (it wasn't a function).

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran VisIt 3.2.1 on quartz and went and installed the "Chombo Users" configuration. I then restarted VisIt for the changes to be seen. The following error was displayed in the "CLI" window.

```
Running: cli3.2.1 -forceversion 3.2.1 -reverse_launch -host 127.0.0.1 -port 5600
VisIt: Message - Added a new client to the viewer.
  File "/g/g17/brugger/.visit/visitrc", line 268
    print "Error: File contains no EB information."
                                                  ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Error: File contains no EB information.")?
```

I then created a source code distribution with my changes. I then built a package from it and installed it. I then installed the "Chombo Users" configuration. I then restarted VisIt and there weren't any errors in the CLI window and the macros showed up in the "Macros" window.

![image](https://user-images.githubusercontent.com/1102718/128084068-23289b32-5c42-445b-8819-b92d89c84a6b.png)

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [~~ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
