### PR TITLE
Fix the display of the test suite files in the dashboard.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -38,6 +38,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
   <li>Enhanced build_visit to apply a patch to fix a compile issue with VTK with gcc 10.3 on Ubuntu 21.04.</li>
+  <li>Fixed a bug where the pages for test files were blank in the dashboard produced by the nightly regression test suite run.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -38,7 +38,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a compile issue on a Fedora 31 Docker container that didn't have any OpenGL header files installed. This involved modifying engine/main/CMakeLists.txt to add OPENGL_INCLUDE_DIR to the include directories if building with IceT and MesaGL.</li>
   <li>Enhanced build_visit to apply a patch to fix a compile issue with VTK with gcc 10.3 on Ubuntu 21.04.</li>
-  <li>Fixed a bug where the pages for test files were blank in the dashboard produced by the nightly regression test suite run.</li>
+  <li>Fixed a bug where the test suite files displayed in the dashboard produced by the regression test suite were blank.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/test/HtmlPython.py
+++ b/src/test/HtmlPython.py
@@ -59,7 +59,9 @@ class Parser:
         self.out.write('<html><body bgcolor="#e0e0e0"><head><title>%s</title></head><pre><font face="Lucida,Courier New">'%title)
         try:
             if (sys.version_info > (3, 0)):
-                tokenize.generate_tokens(text.readline)
+                tokens = tokenize.generate_tokens(text.readline)
+                for toktype,toktext,tok_start,tok_end,line in tokens:
+                    self.__call__(toktype,toktext,tok_start,tok_end,line)
             else:
                 tokenize.tokenize(text.readline,self)
         except tokenize.TokenError as ex:


### PR DESCRIPTION
### Description

Resolves #5486 

The test suite files displayed in the dashboard produced by the regression test suite were blank. The code in HtmlPython.py had been converted to run with Python 3, but during the tokenizing the tokens were never processed, so the pages were blank. I added code to loop of the lines of tokens.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I built VisIt and then ran the test suite file on ANALYZE.py and verified with a web browser that the page was present. I ran the following command.
```
python ../../src/test/visit_test_suite.py --parallel-launch "srun" -b ../../test/baseline -d ../../build/testdata -e ../../build/bin/visit tests/databases/ANALYZE.py
```

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
