### PR TITLE
Fix a bug connecting to a remote server from Linux or macOS.

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -29,6 +29,10 @@
 #   Modified the logic that determines the python version to work with a
 #   two digit version when launching the cli.
 #
+#   Eric Brugger, Wed Aug 11 14:31:38 PDT 2021
+#   Added "-u" to the command line when launching python to disable buffering
+#   on output streams.
+#
 ###############################################################################
 
 # Determine VisIt architecture
@@ -173,9 +177,9 @@ if test -n "$visitpython"; then
 
     #echo "VisIt Python: $visitpython $frontendlauncherpy $0 ${1+"$@"}"
 
-    exec "$visitpython" $frontendlauncherpy $0 ${1+"$@"}
+    exec "$visitpython" -u $frontendlauncherpy $0 ${1+"$@"}
 else
     #echo "System python $frontendlauncherpy $0 ${1+"$@"}"
-    exec python $frontendlauncherpy $0 ${1+"$@"}
+    exec python -u $frontendlauncherpy $0 ${1+"$@"}
 fi
 $0 = shift @ARGV;

--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -177,9 +177,12 @@ if test -n "$visitpython"; then
 
     #echo "VisIt Python: $visitpython $frontendlauncherpy $0 ${1+"$@"}"
 
+    # Pass "-u" to python to turn off buffering
     exec "$visitpython" -u $frontendlauncherpy $0 ${1+"$@"}
 else
     #echo "System python $frontendlauncherpy $0 ${1+"$@"}"
+
+    # Pass "-u" to python to turn off buffering
     exec python -u $frontendlauncherpy $0 ${1+"$@"}
 fi
 $0 = shift @ARGV;

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where versions of VisIt that supported hardware accelerated rendering would display a black image in the visualization window.</li>
   <li>Fixed a crash when saving images greater than approximately 8,000 x 8,000. Now images can be saved up to 16,384 x 16,384.</li>
   <li>Fixed a bug in the <i>Chombo Users</i> configuration that prevented the macros from being loaded and appearing in the "Macros" window.</li>
+  <li>Fixed a bug where VisIt would hang when connecting to a remote system running Linux when connecting from a Linux or macOS system.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #13246

VisIt hung when connecting to a remote system from Linux and macOS. It turns out that during the connection process the viewer is waiting for a message from the vcl that starts with "Running: " to start connecting to the sockets and the output from the python frontendlauncher.py wasn't getting back to the viewer. It turns out that python 3 buffers things differently than python 2 and the messages it was sending weren't getting sent back to the viewer. I added "-u" to the python command line to turn off buffering and then things worked.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

The hang could be reproduced connecting from my linux desktop system to pascal. I copied the updated frontendlauncher to the LC CZ and ran VisIt 3.1.4, 3.2.0 and 3.2.1 locally on pascal and VisIt 3.1.3, 3.2.0 and 3.2.1 remotely from kickit to pascal. They all worked fine. Anyone should be able to test the fix by connecting to pascal from a linux or macOS system. It might be good if someone tested the fix from a macOS system for completeness.
### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
