### PR TITLE
Fix a link in the Getting Data Into VisIt Chapter.

### DIFF
--- a/src/doc/data_into_visit/BlueprintFormat.rst
+++ b/src/doc/data_into_visit/BlueprintFormat.rst
@@ -30,4 +30,4 @@ Here is the output.
 
 .. literalinclude:: data_examples/blueprint_example.out
 
-The complete documentation for Blueprint can be found  `here <https:llnl-conduit.readthedocs.io/en/latest/blueprint.html>`_.
+The complete documentation for Blueprint can be found  `here <https://llnl-conduit.readthedocs.io/en/latest/blueprint.html>`_.


### PR DESCRIPTION
### Description

I fixed a link to the Conduit/Blueprint documentation in the Getting Data Into VisIt chapter of the Users Manual.

### Type of change

* [ ] Bug fix
* [ ] New feature
* [X] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I generated the html on quartz and tested the link.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- ~~[ ] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
