### PR TITLE
Rework missing-7z logic.

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -121,8 +121,7 @@ IF("${ARCHIVER_EXE}" STREQUAL "ARCHIVER_EXE-NOTFOUND")
     MESSAGE(WARNING "Archiver \"${VISIT_DATA_ARCHIVER_NAME}\" not found, data files cannot be extracted. Try setting VISIT_SEVEN_ZIP_DIR to location of 7-zip package, and VISIT_DATA_ARCHIVER_NAME to correct 7-zip executable name (eg, 7za, p7zip, 7z).")
     #--------------------------------------------------------------------------
     # CMake target to handle make-time requests to build targets that require
-    # 7z archiver yet none was provided. The test "" forces make-time failure
-    # whereas test " " (note the space) silently succeeds.
+    # 7z archiver yet none was provided. The test "" forces make-time failure.
     #--------------------------------------------------------------------------
     ADD_CUSTOM_TARGET(missing-7z-archiver ALL
         COMMAND ${CMAKE_COMMAND} -E echo ""

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -119,6 +119,16 @@ ENDIF(WIN32)
 #-----------------------------------------------------------------------------
 IF("${ARCHIVER_EXE}" STREQUAL "ARCHIVER_EXE-NOTFOUND")
     MESSAGE(WARNING "Archiver \"${VISIT_DATA_ARCHIVER_NAME}\" not found, data files cannot be extracted. Try setting VISIT_SEVEN_ZIP_DIR to location of 7-zip package, and VISIT_DATA_ARCHIVER_NAME to correct 7-zip executable name (eg, 7za, p7zip, 7z).")
+    #--------------------------------------------------------------------------
+    # CMake target to handle make-time requests to build targets that require
+    # 7z archiver yet none was provided. The test "" forces make-time failure
+    # whereas test " " (note the space) silently succeeds.
+    #--------------------------------------------------------------------------
+    ADD_CUSTOM_TARGET(missing-7z-archiver ALL
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND ${CMAKE_COMMAND} -E echo "No 7z archiver"
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND test "")
 ELSE("${ARCHIVER_EXE}" STREQUAL "ARCHIVER_EXE-NOTFOUND")
     SET(ARCHIVER_CMD ${ARCHIVER_EXE})
     SET(ARCHIVER_XARGS x -y)                 # Expand archive args
@@ -165,10 +175,14 @@ FOREACH(DATASET_TARGET_FILE ${ARCHIVED_TARGETS})
     SET(DATA_TARGET_DEPENDS ${DATA_TARGET_DEPENDS} ${CMAKE_CURRENT_BINARY_DIR}/${DATASET_TARGET})
 ENDFOREACH()
 
+IF(NOT DEFINED ARCHIVER_CMD)
+   set(DATA_TARGET_DEPENDS ${DATA_TARGET_DEPENDS} missing-7z-archiver)
+endif()
+
 #-----------------------------------------------------------------------------
 # Add custom targets: "data" & "testdata"
 #-----------------------------------------------------------------------------
-ADD_CUSTOM_TARGET(data DEPENDS missing-7z-archiver ${DATA_TARGET_DEPENDS})
+ADD_CUSTOM_TARGET(data DEPENDS ${DATA_TARGET_DEPENDS})
 ADD_CUSTOM_TARGET(testdata)
 ADD_DEPENDENCIES(testdata data)
 
@@ -179,21 +193,6 @@ ADD_DEPENDENCIES(testdata data)
 #-----------------------------------------------------------------------------
 SET(ARCHIVE_NAME {ANAME})
 SET(ARCHIVE_FILES {AFILES})
-
-#-----------------------------------------------------------------------------
-# CMake target to handle make-time requests to build targets that require
-# 7z archiver yet none was provided. The test "" forces make-time failure
-# whereas test " " (note the space) silently succeeds.
-#-----------------------------------------------------------------------------
-IF(NOT DEFINED ARCHIVER_CMD)
-    ADD_CUSTOM_TARGET(missing-7z-archiver ALL
-        COMMAND ${CMAKE_COMMAND} -E echo ""
-        COMMAND ${CMAKE_COMMAND} -E echo "No 7z archiver"
-        COMMAND ${CMAKE_COMMAND} -E echo ""
-        COMMAND test "")
-ELSE(NOT DEFINED ARCHIVER_CMD)
-    ADD_CUSTOM_TARGET(missing-7z-archiver COMMAND test " ")
-ENDIF(NOT DEFINED ARCHIVER_CMD)
 
 #-----------------------------------------------------------------------------
 # Define convenience command/target to create an archive


### PR DESCRIPTION
The empty missing-7z-archiver target (when archiver found) was causing build failure on Windows, preventing the testdata archives from being extracted

Modified to only create missing-7z-archiver target when the archiver not found.
Updated the DATA_TARGET_DEPENDS to include missing-7z-archiver when ARCHIVER_CMD not defined.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

Test on Windows.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
