### PR TITLE
Bracket calls to configure with 'set -x'/'set +x' instead of using info calls.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_adios.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios.sh
@@ -313,14 +313,7 @@ function build_adios
         #HDF5_DYLIB=""
     fi
 
-    info   ./configure ${OPTIONAL} CXX="$CXX_COMPILER" CC="$C_COMPILER" \
-           CFLAGS=\"$CFLAGS $C_OPT_FLAGS $WITH_MPI_INC\" \
-           CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS $WITH_MPI_INC\" \
-           $WITH_MPI_ARGS $WITH_HDF5_ARGS \
-           --disable-fortran \
-           --without-netcdf --without-nc4par --without-phdf5 --without-mxml \
-           --prefix="$VISITDIR/adios/$ADIOS_VERSION/$VISITARCH"
-
+    set -x
     sh -c "./configure ${OPTIONAL} CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
            CFLAGS=\"$CFLAGS $C_OPT_FLAGS $WITH_MPI_INC\" \
            CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS $WITH_MPI_INC\" \
@@ -329,6 +322,7 @@ function build_adios
            --without-netcdf --without-nc4par --without-phdf5 --without-mxml \
            --prefix=\"$VISITDIR/adios/$ADIOS_VERSION/$VISITARCH\""
 
+    set +x
     if [[ $? != 0 ]] ; then
         warn "ADIOS configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_advio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_advio.sh
@@ -201,9 +201,11 @@ function build_advio
     if [[ "$VISIT_BUILD_MODE" == "Debug" ]]; then
         ADVIO_DEBUG="--enable-debug"
     fi
+    set -x
     env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
         CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
         ./configure --prefix="$VISITDIR/AdvIO/$ADVIO_VERSION/$VISITARCH" --disable-gtktest $ADVIO_DARWIN $ADVIO_DEBUG
+    set +x
     if [[ $? != 0 ]] ; then
         warn "AdvIO configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_boost.sh
+++ b/src/tools/dev/scripts/bv_support/bv_boost.sh
@@ -239,12 +239,12 @@ function build_boost
         # In order to ensure $FORTRANARGS is expanded to build the arguments to
         # configure, we wrap the invokation in 'sh -c "..."' syntax
         info "Invoking command to configure BOOST"
-        #        info  "./bootstrap.sh $build_libs \
-        #            --prefix=\"$VISITDIR/boost/$BOOST_VERSION/$VISITARCH\" "
 
+        set -x
         sh -c "./bootstrap.sh $build_libs \
             --prefix=\"$VISITDIR/boost/$BOOST_VERSION/$VISITARCH\" "
 
+        set +x
         if [[ $? != 0 ]] ; then
             warn "BOOST configure failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_boxlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_boxlib.sh
@@ -199,6 +199,7 @@ function build_boxlib
     #
     info "Building Boxlib. . . (~4 minutes)"
 
+    set -x
     if [[ "$OPSYS" == "AIX" ]]; then
         $MAKE -f GNUmakefile CXX="$CXX_COMPILER" CC="$C_COMPILER" \
               CCFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
@@ -230,7 +231,7 @@ function build_boxlib
               DEBUG="FALSE" DIM=2 USE_MPI="FALSE" \
               BL_NO_FORT="TRUE" || error "Boxlib build failed. Giving up"
     fi
-
+    set +x
     #
     # Create dynamic library for Darwin
     #

--- a/src/tools/dev/scripts/bv_support/bv_cfitsio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cfitsio.sh
@@ -92,10 +92,12 @@ function build_cfitsio
     info "Configuring CFITSIO . . ."
     cd $CFITSIO_BUILD_DIR || error "Can't cd to cfits IO build dir."
 
+    set -x
     env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
         CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
         ./configure \
         --prefix="$VISITDIR/cfitsio/$CFITSIO_VERSION/$VISITARCH"
+    set +x
     if [[ $? != 0 ]] ; then
         warn "CFITSIO configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -394,25 +394,18 @@ function build_cgns
     # Disable fortran
     FORTRANARGS="--with-fortran=no"
 
+    set -x
     if [[ "$OPSYS" == "Darwin" ]] ; then
-        info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-            CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-            LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\" \
-            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
-
         env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
             CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
             LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV" \
             ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
     else
-        info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-            CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
-
         env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
             CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
             ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
     fi
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "CGNS configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_gdal.sh
+++ b/src/tools/dev/scripts/bv_support/bv_gdal.sh
@@ -172,7 +172,7 @@ function build_gdal
             apply_gdal_linux_x86_64_patch
         fi
     fi
-
+    set -x
     ./configure CXX="$CXX_COMPILER" CC="$C_COMPILER" $EXTRA_FLAGS \
                 CFLAGS="$CFLAGS $C_OPT_FLAGS -DH5_USE_16_API" \
                 CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS -DH5_USE_16_API" \
@@ -183,6 +183,7 @@ function build_gdal
                 --with-hdf5=no --with-pg=no --with-curl=no \
                 --without-jasper --without-python \
                 --without-sqlite3 --without-xml2 --with-geos=no
+    set +x
     if [[ $? != 0 ]] ; then
         warn "GDAL configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_glu.sh
+++ b/src/tools/dev/scripts/bv_support/bv_glu.sh
@@ -199,10 +199,12 @@ function build_glu
 
     # NOTE: we install the library into the MesaGL directories.
     if [[ "$DO_MESAGL" == "yes" ]] ; then
+        set -x
         issue_command env GL_LIBS="-L${MESAGL_INSTALL_DIR}/lib" GL_CFLAGS="-I${MESAGL_INSTALL_DIR}/include" \
             CC=${C_COMPILER} CFLAGS="${C_OPT_FLAGS}" \
             CXX=${CXX_COMPILER} CXXFLAGS="${CXX_OPT_FLAGS}" \
            ./configure --prefix=${MESAGL_INSTALL_DIR} ${GLU_STATIC_DYNAMIC}
+        set +x
         if [[ $? != 0 ]] ; then
             warn "GLU: 'configure' failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_h5part.sh
+++ b/src/tools/dev/scripts/bv_support/bv_h5part.sh
@@ -562,10 +562,12 @@ function build_h5part
     info "Invoking command to configure H5Part"
     # In order to ensure $FORTRANARGS is expanded to build the arguments to
     # configure, we wrap the invokation in 'sh -c "..."' syntax
+    set -x
     sh -c "./configure ${WITHHDF5ARG} ${OPTIONAL} CXX=\"$CXX_COMPILER\" \
        CC=\"$C_COMPILER\" CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
        $FORTRANARGS $EXTRAARGS \
        --prefix=\"$VISITDIR/h5part/$H5PART_VERSION/$VISITARCH\""
+    set +x
     if [[ $? != 0 ]] ; then
         warn "H5Part configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_hdf4.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf4.sh
@@ -1340,6 +1340,7 @@ function build_hdf4
     cd $HDF4_BUILD_DIR || error "Can't cd to hdf4 build dir."
     info "Invoking command to configure HDF4"
     MAKEOPS=""
+    set -x
     if [[ "$OPSYS" == "Darwin" || "$OPSYS" == "AIX" ]]; then
         export DYLD_LIBRARY_PATH="$VISITDIR/szip/$SZIP_VERSION/$VISITARCH/lib":$DYLD_LIBRARY_PATH
         # In order to ensure $FORTRANARGS is expanded to build the arguments to
@@ -1379,6 +1380,7 @@ function build_hdf4
             return 1
         fi
     fi
+    set +x
 
     #
     # Build HDF4

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -630,16 +630,13 @@ function build_hdf5
         # In order to ensure $cf_fortranargs is expanded to build the arguments to
         # configure, we wrap the invokation in 'sh -c "..."' syntax
         info "Invoking command to configure $bt HDF5"
-        info "../configure CC=\"$cf_c_compiler\" \
-            CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" $cf_fortranargs \
-            --prefix=\"$VISITDIR/hdf5${cf_par_suffix}/$HDF5_VERSION/$VISITARCH\" \
-            ${cf_szip} ${cf_zlib} ${cf_build_type} ${cf_build_thread} \
-            ${cf_build_parallel} ${extra_ac_flags} $build_mode"
+        set -x
         sh -c "../configure CC=\"$cf_c_compiler\" \
             CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" $cf_fortranargs \
             --prefix=\"$VISITDIR/hdf5${cf_par_suffix}/$HDF5_VERSION/$VISITARCH\" \
             ${cf_szip} ${cf_zlib} ${cf_build_type} ${cf_build_thread} \
             ${cf_build_parallel} ${extra_ac_flags} $build_mode"
+        set +x
         if [[ $? != 0 ]] ; then
             warn "$bt HDF5 configure failed.  Giving up"
             return 1
@@ -649,8 +646,9 @@ function build_hdf5
         # Build HDF5
         #
         info "Making $bt HDF5 . . ."
-        info "$MAKE $MAKE_OPT_FLAGS" lib
+        set -x
         $MAKE $MAKE_OPT_FLAGS lib
+        set +x
         if [[ $? != 0 ]] ; then
             warn "$bt HDF5 build failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_mdsplus.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mdsplus.sh
@@ -105,9 +105,11 @@ function build_mdsplus
     info "Configuring MDSplus . . ."
     cd $MDSPLUS_BUILD_DIR || error "Can't cd to mdsplus build dir."
     info "Invoking command to configure MDSplus"
+    set -x
     ./configure ${OPTIONAL} --disable-java CXX="$CXX_COMPILER" \
                 CC="$C_COMPILER" CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
                 --prefix="$VISITDIR/mdsplus/$MDSPLUS_VERSION/$VISITARCH"
+    set +x
     if [[ $? != 0 ]] ; then
         warn "MDSplus configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -332,28 +332,7 @@ function build_mesagl
         fi
     fi
 
-    echo CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
-        CXX=${CXX_COMPILER} \
-        CFLAGS="${CFLAGS} ${C_OPT_FLAGS} ${mesa_c_opt_flags}" \
-        CC=${C_COMPILER} \
-        ./autogen.sh \
-        --prefix=${VISITDIR}/mesagl/${MESAGL_VERSION}/${VISITARCH} \
-        --with-platforms=x11 \
-        --disable-dri \
-        --disable-dri3 \
-        --disable-egl \
-        --disable-gbm \
-        --disable-gles1 \
-        --disable-gles2 \
-        --disable-xvmc \
-        --disable-vdpau \
-        --disable-va \
-        --enable-glx \
-        --enable-llvm \
-        --with-gallium-drivers=${MESAGL_GALLIUM_DRIVERS} \
-        --enable-gallium-osmesa $MESAGL_STATIC_DYNAMIC $MESAGL_DEBUG_BUILD \
-        --disable-llvm-shared-libs \
-        --with-llvm-prefix=${VISIT_LLVM_DIR}
+    set -x
     env CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
         CXX=${CXX_COMPILER} \
         CFLAGS="${CFLAGS} ${C_OPT_FLAGS} ${mesa_c_opt_flags}" \
@@ -376,6 +355,7 @@ function build_mesagl
         --enable-gallium-osmesa $MESAGL_STATIC_DYNAMIC $MESAGL_DEBUG_BUILD \
         --disable-llvm-shared-libs \
         --with-llvm-prefix=${VISIT_LLVM_DIR}
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "MesaGL configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -291,10 +291,12 @@ function build_mili
     fi
 
     info "Invoking command to configure Mili"
+    set -x
     ./${config_script} CXX="$CXX_COMPILER" CC="$C_COMPILER" \
                 CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
                 ac_cv_prog_FOUND_GMAKE=make $extra_ac_flags \
                 --prefix="$VISITDIR/mili/$MILI_VERSION/$VISITARCH"
+    set +x
     if [[ $? != 0 ]] ; then
         warn "Mili configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_moab.sh
+++ b/src/tools/dev/scripts/bv_support/bv_moab.sh
@@ -159,19 +159,14 @@ function build_moab
         fi
 
         info "Configuring $bt moab . . ."
-        info ../configure CXX=\"$cf_cxx_compiler\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
-            CC=\"$cf_c_compiler\" CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" \
-            ${cf_prefix_arg} ${cf_mpi_arg} ${cf_common_args} ${cf_static_args} \
-            ${cf_hdf5_arg} ${cf_hdf5_ldflags_arg} \
-            ${cf_szip_arg} ${cf_zlib_arg}
-
+        set -x
         sh -c "../configure \
             CXX=\"$cf_cxx_compiler\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
             CC=\"$cf_c_compiler\" CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" \
             ${cf_prefix_arg} ${cf_mpi_arg} ${cf_common_args} ${cf_static_args} \
             ${cf_hdf5_arg} ${cf_hdf5_ldflags_arg} \
             ${cf_szip_arg} ${cf_zlib_arg}"
-
+        set +x
         if [[ $? != 0 ]] ; then
             warn "$bt MOAB configure failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_mpich.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mpich.sh
@@ -135,6 +135,7 @@ function build_mpich
         mpich_opts="${mpich_opts} --enable-fortran=all"	
     fi
 
+    set -x
     issue_command env CXX="$CXX_COMPILER" \
                   CC="$C_COMPILER" \
                   CFLAGS="$MPICH_CFLAGS $MPICH_C_OPT_FLAGS" \
@@ -142,7 +143,7 @@ function build_mpich
                   FFLAGS="$MPICH_FCFLAGS"\
                   ./configure ${mpich_opts} \
                   --prefix="$VISITDIR/mpich/$MPICH_VERSION/$VISITARCH"
-
+    set +x
     if [[ $? != 0 ]] ; then
         warn "MPICH configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_netcdf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_netcdf.sh
@@ -372,17 +372,13 @@ function build_netcdf
     fi
     ZLIBARGS="--with-zlib=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH"
 
-    info "./configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-        CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
-        FC=\"\" $EXTRA_AC_FLAGS $EXTRA_FLAGS --enable-cxx-4 $H5ARGS $ZLIBARGS\
-        --disable-dap \
-        --prefix=\"$VISITDIR/netcdf/$NETCDF_VERSION/$VISITARCH\""
-
+    set -x
     ./configure CXX="$CXX_COMPILER" CC="$C_COMPILER" \
                 CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
                 FC="" $EXTRA_AC_FLAGS $EXTRA_FLAGS --enable-cxx-4 $H5ARGS $ZLIBARGS\
                 --disable-dap \
                 --prefix="$VISITDIR/netcdf/$NETCDF_VERSION/$VISITARCH"
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "NetCDF configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_openexr.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openexr.sh
@@ -123,9 +123,11 @@ function build_ilmbase
         DISABLE_BUILDTYPE="--disable-static"
     fi
     info "Configuring ILMBase . . ."
+    set -x
     ./configure ${OPTIONAL} CXX="$CXX_COMPILER" \
                 CC="$C_COMPILER" CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
                 --prefix="$VISITDIR/openexr/$ILMBASE_VERSION/$VISITARCH" $DISABLE_BUILDTYPE
+    set +x
     if [[ $? != 0 ]] ; then
         warn "ILMBase configure failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_openssl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openssl.sh
@@ -98,14 +98,12 @@ function build_openssl
     WITH_ZLIB_LIB="--with-zlib-lib=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH/lib"
     WITH_ZLIB_INCLUDE="--with-zlib-include=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH/include"
 
-    info env CC="$C_COMPILER $CFLAGS $C_OPT_FLAGS" KERNEL_BITS=64 ./config \
-            $WITH_ZLIB_LIB $WITH_ZLIB_INCLUDE \
-            --prefix="$VISITDIR/openssl/$OPENSSL_VERSION/$VISITARCH/" \
-            --openssldir="$VISITDIR/openssl/$OPENSSL_VERSION/$VISITARCH/etc/openssl" 
+    set -x
     env CC="$C_COMPILER $CFLAGS $C_OPT_FLAGS" KERNEL_BITS=64 ./config \
             $WITH_ZLIB_LIB $WITH_ZLIB_INCLUDE \
             --prefix="$VISITDIR/openssl/$OPENSSL_VERSION/$VISITARCH/" \
             --openssldir="$VISITDIR/openssl/$OPENSSL_VERSION/$VISITARCH/etc/openssl" 
+    set +x
 
     #
     # Build openssl

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -317,28 +317,7 @@ function build_osmesa
     fi
 
     info "Configuring OSMesa . . ."
-    echo CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
-        CXX=${CXX_COMPILER} \
-        CFLAGS="${CFLAGS} ${C_OPT_FLAGS}" \
-        CC=${C_COMPILER} \
-        ./autogen.sh \
-        --prefix=${VISITDIR}/osmesa/${OSMESA_VERSION}/${VISITARCH} \
-        --disable-gles1 \
-        --disable-gles2 \
-        --disable-dri \
-        --disable-dri3 \
-        --disable-glx \
-        --disable-glx-tls \
-        --disable-egl \
-        --disable-gbm \
-        --disable-xvmc \
-        --disable-vdpau \
-        --disable-va \
-        --with-platforms= \
-        --with-gallium-drivers=swrast,swr \
-        --enable-gallium-osmesa $OSMESA_STATIC_DYNAMIC  $OSMESA_DEBUG_BUILD \
-        --disable-llvm-shared-libs \
-        --with-llvm-prefix=${VISIT_LLVM_DIR}
+    set -x
     env CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}" \
         CXX=${CXX_COMPILER} \
         CFLAGS="${CFLAGS} ${C_OPT_FLAGS}" \
@@ -361,6 +340,7 @@ function build_osmesa
         --enable-gallium-osmesa $OSMESA_STATIC_DYNAMIC $OSMESA_DEBUG_BUILD \
         --disable-llvm-shared-libs \
         --with-llvm-prefix=${VISIT_LLVM_DIR}
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "OSMesa configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -748,14 +748,14 @@ function build_python
     PYTHON_LDFLAGS="${PYTHON_LDFLAGS} -L${PY_ZLIB_LIB}"
     PYTHON_CPPFLAGS="${PYTHON_CPPFLAGS} -I${PY_ZLIB_INCLUDE}"
 
-    info "Configuring Python : ./configure OPT=\"$PYTHON_OPT\" CXX=\"$cxxCompiler\" CC=\"$cCompiler\"" \
-         "LDFLAGS=\"$PYTHON_LDFLAGS\" CPPFLAGS=\"$PYTHON_CPPFLAGS\""\
-         "${PYTHON_SHARED} --prefix=\"$PYTHON_PREFIX_DIR\" --disable-ipv6"
+    info "Configuring Python"
+    set -x
     ./configure OPT="$PYTHON_OPT" CXX="$cxxCompiler" CC="$cCompiler" \
                 LDFLAGS="$PYTHON_LDFLAGS" \
                 CPPFLAGS="$PYTHON_CPPFLAGS" \
                 ${PYTHON_SHARED} \
                 --prefix="$PYTHON_PREFIX_DIR" --disable-ipv6
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "Python configure failed.  Giving up"
@@ -841,15 +841,13 @@ function build_pillow
         fi
     fi
 
-    info "Building Pillow ...\n" \
-     "CC=${C_COMPILER} CXX=${CXX_COMPILER} " \
-     "  CFLAGS=${PYEXT_CFLAGS} CXXFLAGS=${PYEXT_CXXFLAGS} LDFLAGS=${PYEXT_LDFLAGS} " \
-     "  ${PYTHON_COMMAND} ./setup.py build_ext --disable-jpeg install --prefix=${PYHOME}"
-
+    info "Building Pillow ...\n" 
+    set -x
     CC=${C_COMPILER} CXX=${CXX_COMPILER} CFLAGS="${PYEXT_CFLAGS}" \
      CXXFLAGS="${PYEXT_CXXFLAGS}" \
      LDFLAGS="${PYEXT_LDFLAGS}" \
      ${PYTHON_COMMAND} ./setup.py build_ext --disable-jpeg install --prefix="${PYHOME}"
+    set +x
 
     if test $? -ne 0 ; then
         popd > /dev/null

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -595,18 +595,14 @@ function build_qt
         qt_flags="${qt_flags} -debug"
     fi
 
-    info "Configuring ${QT_VER_MSG}: " \
-         "CFLAGS=${QT_CFLAGS} CXXFLAGS=${QT_CXXFLAGS}" \
-         "./configure -prefix ${QT_INSTALL_DIR}" \
-         "-platform ${QT_PLATFORM}" \
-         "-make libs -make tools -no-separate-debug-info" \
-         "${qt_flags}" 
-
+    info "Configuring ${QT_VER_MSG}: " 
+    set -x
     (echo "o"; echo "yes") | CFLAGS="${QT_CFLAGS}" CXXFLAGS="${QT_CXXFLAGS}"  \
                                    ./configure -prefix ${QT_INSTALL_DIR} \
                                    -platform ${QT_PLATFORM} \
                                    -make libs -make tools -no-separate-debug-info \
                                    ${qt_flags} | tee qt.config.out
+    set +x
     if [[ $? != 0 ]] ; then
         warn "${QT_VER_MSG} configure failed. Giving up."
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -501,14 +501,7 @@ function build_silo
          extra_ac_flags="ac_cv_build=powerpc64le-unknown-linux-gnu"
     fi 
 
-    info "./configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
-        $FORTRANARGS \
-        --prefix=\"$VISITDIR/silo/$SILO_VERSION/$VISITARCH\" \
-        $WITHHDF5ARG $WITHSZIPARG $WITHSILOQTARG $WITHSHAREDARG $WITH_HZIP_AND_FPZIP\
-        --enable-install-lite-headers --without-readline \
-        $ZLIBARGS $SILO_EXTRA_OPTIONS ${extra_ac_flags}"
-
+    set -x
     # In order to ensure $FORTRANARGS is expanded to build the arguments to
     # configure, we wrap the invokation in 'sh -c "..."' syntax
     sh -c "./configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
@@ -518,6 +511,7 @@ function build_silo
         $WITHHDF5ARG $WITHSZIPARG $WITHSILOQTARG $WITHSHAREDARG $WITH_HZIP_AND_FPZIP\
         --enable-install-lite-headers --without-readline \
         $ZLIBARGS $SILO_EXTRA_OPTIONS ${extra_ac_flags}"
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "Silo configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_szip.sh
+++ b/src/tools/dev/scripts/bv_support/bv_szip.sh
@@ -107,15 +107,12 @@ function build_szip
          extra_ac_flags="ac_cv_build=powerpc64le-unknown-linux-gnu"
     fi
 
-    info "./configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" LIBS=\"-lm\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
-        --prefix=\"$VISITDIR/szip/$SZIP_VERSION/$VISITARCH\" ${cf_szip} \
-        ${extra_ac_flags}"
-
+    set -x
     ./configure CXX="$CXX_COMPILER" CC="$C_COMPILER" LIBS="-lm" \
                 CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
                 --prefix="$VISITDIR/szip/$SZIP_VERSION/$VISITARCH" ${cf_szip} \
                 ${extra_ac_flags}
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "SZIP configure failed.  Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -255,22 +255,7 @@ function build_uintah
         sdk_root=`xcrun --show-sdk-path`
 
         info "Invoking command to configure UINTAH"
-        info "../src/configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -headerpad_max_install_names\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
-        MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
-        --with-zlib=\"$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH\" \
-        --prefix=\"$VISITDIR/uintah/$UINTAH_VERSION/$VISITARCH\" \
-        ${cf_darwin} \
-        ${cf_build_type} \
-	--enable-minimal --enable-optimize \
-	--with-fortran=no --with-petsc=no --with-hypre=no \
-	--with-lapack=no --with-blas=no \
-        --with-mpi=\"$PAR_INCLUDE_DIR/..\" \ 
-        --with-libxml2=\"$sdk_root/usr\" "
-
-        #        --with-mpi-include="${PAR_INCLUDE_DIR}/" \
-        #        --with-mpi-lib="${PAR_INCLUDE_DIR}/../lib" "
-
+        set -x
         sh -c "../src/configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
         CFLAGS=\"$CFLAGS $C_OPT_FLAGS -headerpad_max_install_names\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
         MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
@@ -286,21 +271,12 @@ function build_uintah
 
         #        --with-mpi-include="${PAR_INCLUDE_DIR}/" \
         #        --with-mpi-lib="${PAR_INCLUDE_DIR}/../lib" "
+        set +x
 
     else
 
         info "Invoking command to configure UINTAH"
-        info "../src/configure CXX=\"$PAR_COMPILER_CXX\" CC=\"$PAR_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
-        MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
-        --with-zlib=\"$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH\" \
-        --prefix=\"$VISITDIR/uintah/$UINTAH_VERSION/$VISITARCH\" \
-        ${cf_build_type} \
-        --enable-minimal --enable-optimize \
-	--with-fortran=no --with-petsc=no --with-hypre=no \
-	--with-lapack=no --with-blas=no \
-        --with-mpi=built-in"
-
+        set -x
         sh -c "../src/configure CXX=\"$PAR_COMPILER_CXX\" CC=\"$PAR_COMPILER\" \
         CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
         MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
@@ -311,6 +287,7 @@ function build_uintah
         --with-fortran=no --with-petsc=no --with-hypre=no \
 	--with-lapack=no --with-blas=no \
         --with-mpi=built-in"
+        set +x
     fi
 
 

--- a/src/tools/dev/scripts/bv_support/bv_xercesc.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xercesc.sh
@@ -93,15 +93,12 @@ function build_xercesc
     info "Configuring Xerces-C . . ."
     cd $XERCESC_BUILD_DIR || error "Can't cd to Xerces-C build dir."
 
-    info "env CXX=$CXX_COMPILER CC=$C_COMPILER ./configure \
-    --prefix=$VISITDIR/xerces-c/$XERCESC_VERSION/$VISITARCH \
-    --disable-threads --disable-network --disable-shared \
-    --enable-transcoder-iconv"
-    
+    set -x 
     env CXX=$CXX_COMPILER CC=$C_COMPILER ./configure \
         --prefix=$VISITDIR/xerces-c/$XERCESC_VERSION/$VISITARCH \
         --disable-threads --disable-network --disable-shared \
         --enable-transcoder-iconv
+    set +x 
 
     if [[ $? != 0 ]] ; then
         warn "Xerces-C configuration failed. Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_zlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_zlib.sh
@@ -109,18 +109,14 @@ function build_zlib
         STATICARGS=""
     fi
 
-    info "env CXX=$CXX_COMPILER CC=$C_COMPILER \
-         CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" \
-         CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
-         ./configure \
-        --prefix=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH $STATIC_ARGS"
-
     # Call configure
+    set -x
     env CXX=$CXX_COMPILER CC=$C_COMPILER \
         CFLAGS="$CFLAGS $C_OPT_FLAGS" \
         CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
         ./configure \
         --prefix=$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH $STATIC_ARGS
+    set +x
 
     if [[ $? != 0 ]] ; then
         warn "ZLIB configure failed.  Giving up"


### PR DESCRIPTION
### Description

Resolves #5887



### How Has This Been Tested?

I ran build_visit. Log file showed exact configure commands being used.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
