### PR TITLE
fix pick output filename windows

### DIFF
--- a/src/common/state/PickAttributes.C
+++ b/src/common/state/PickAttributes.C
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <cstring>
+#include <FileFunctions.h>
 #include <PickVarInfo.h>
 
 //
@@ -3846,7 +3847,12 @@ PickAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
+
 void
 PickAttributes::PrintSelf(ostream &os)
 {
@@ -3854,13 +3860,8 @@ PickAttributes::PrintSelf(ostream &os)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
     if (pickLetter.size() != 0)
         os << "\n" << pickLetter.c_str() << ":  ";
     else
@@ -4118,6 +4119,10 @@ PickAttributes::PrintSelf(ostream &os)
 //   Kathleen Biagas, Wed Mar 08 17:12:07 PST 2012
 //   Use plot overrides of showXXX settings if set in plotRequested MapNode.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -4140,13 +4145,8 @@ PickAttributes::CreateOutputString(std::string &os, bool withLetter)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -4641,6 +4641,10 @@ PickAttributes::PrepareForNewPick()
 //   Kathleen Biagas, Wed Mar 08 17:12:07 PST 2012
 //   Use plot overrides of showXXX settings if set in plotRequested MapNode.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -4648,13 +4652,8 @@ PickAttributes::CreateConciseOutputString(std::string &os, bool withLetter)
 {
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -5082,6 +5081,10 @@ PickAttributes::ClearLines()
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for showing global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -5147,14 +5150,8 @@ PickAttributes::CreateOutputMapNode(MapNode &m, bool withLetter)
 #endif
     }
 
-    std::string fileName;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
-    m["filename"] = fileName;
+    m["filename"] = FileFunctions::Basename(databaseName);
 
     if (withLetter)
     {

--- a/src/common/state/PickAttributes.code
+++ b/src/common/state/PickAttributes.code
@@ -55,7 +55,12 @@ Definition:
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
+
 void
 PickAttributes::PrintSelf(ostream &os)
 {
@@ -63,13 +68,8 @@ PickAttributes::PrintSelf(ostream &os)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
     if (pickLetter.size() != 0)
         os << "\n" << pickLetter.c_str() << ":  ";
     else
@@ -330,6 +330,10 @@ Definition:
 //   Kathleen Biagas, Wed Mar 08 17:12:07 PST 2012
 //   Use plot overrides of showXXX settings if set in plotRequested MapNode.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -352,13 +356,8 @@ PickAttributes::CreateOutputString(std::string &os, bool withLetter)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -859,6 +858,10 @@ Definition:
 //   Kathleen Biagas, Wed Mar 08 17:12:07 PST 2012
 //   Use plot overrides of showXXX settings if set in plotRequested MapNode.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -866,13 +869,8 @@ PickAttributes::CreateConciseOutputString(std::string &os, bool withLetter)
 {
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -1318,6 +1316,10 @@ Definition:
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for showing global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -1383,14 +1385,8 @@ PickAttributes::CreateOutputMapNode(MapNode &m, bool withLetter)
 #endif
     }
 
-    std::string fileName;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
-    m["filename"] = fileName;
+    m["filename"] = FileFunctions::Basename(databaseName);
 
     if (withLetter)
     {

--- a/src/common/state/PickAttributes.xml
+++ b/src/common/state/PickAttributes.xml
@@ -291,4 +291,7 @@
     <Include file="source" quoted="false">
       cstring
     </Include>
+    <Include file="source" quoted="false">
+      FileFunctions.h
+    </Include>
   </Attribute>

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a crash when saving images greater than approximately 8,000 x 8,000. Now images can be saved up to 16,384 x 16,384.</li>
   <li>Fixed a bug in the <i>Chombo Users</i> configuration that prevented the macros from being loaded and appearing in the "Macros" window.</li>
   <li>Fixed a bug where VisIt would hang when connecting to a remote system running Linux when connecting from a Linux or macOS system.</li>
+  <li>Pick output of filename on Windows has been made consistent with output for linux: path is stripped off.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #17005
Use FileFunctions::Basename so that path is stripped off correctly.

### Type of change
* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->



### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
