### PR TITLE
fix pick output filename windows (#17006)

### DIFF
--- a/src/common/state/PickAttributes.C
+++ b/src/common/state/PickAttributes.C
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <cstring>
+#include <FileFunctions.h>
 #include <PickVarInfo.h>
 
 //
@@ -3941,7 +3942,12 @@ PickAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
+
 void
 PickAttributes::PrintSelf(ostream &os)
 {
@@ -3949,13 +3955,8 @@ PickAttributes::PrintSelf(ostream &os)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
     if (pickLetter.size() != 0)
         os << "\n" << pickLetter.c_str() << ":  ";
     else
@@ -4216,6 +4217,10 @@ PickAttributes::PrintSelf(ostream &os)
 //   Alister Maguire, Mon Jul 19 11:06:57 PDT 2021
 //   Include the distance to a previous pick if enabled.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 #include <DebugStream.h>
@@ -4241,13 +4246,8 @@ PickAttributes::CreateOutputString(std::string &os, bool withLetter)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -4783,6 +4783,10 @@ PickAttributes::PrepareForNewPick()
 //   Alister Maguire, Mon Jul 19 11:06:57 PDT 2021
 //   Include the distance to a previous pick if enabled.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 #include <DebugStream.h>
@@ -4793,13 +4797,8 @@ PickAttributes::CreateConciseOutputString(std::string &os, bool withLetter)
 {
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -5265,6 +5264,10 @@ PickAttributes::ClearLines()
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for showing global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -5330,14 +5333,8 @@ PickAttributes::CreateOutputMapNode(MapNode &m, bool withLetter)
 #endif
     }
 
-    std::string fileName;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
-    m["filename"] = fileName;
+    m["filename"] = FileFunctions::Basename(databaseName);
 
     if (withLetter)
     {

--- a/src/common/state/PickAttributes.code
+++ b/src/common/state/PickAttributes.code
@@ -55,7 +55,12 @@ Definition:
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
+
 void
 PickAttributes::PrintSelf(ostream &os)
 {
@@ -63,13 +68,8 @@ PickAttributes::PrintSelf(ostream &os)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
     if (pickLetter.size() != 0)
         os << "\n" << pickLetter.c_str() << ":  ";
     else
@@ -333,6 +333,10 @@ Definition:
 //   Alister Maguire, Mon Jul 19 11:06:57 PDT 2021
 //   Include the distance to a previous pick if enabled.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 #include <DebugStream.h>
@@ -358,13 +362,8 @@ PickAttributes::CreateOutputString(std::string &os, bool withLetter)
 
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -906,6 +905,10 @@ Definition:
 //   Alister Maguire, Mon Jul 19 11:06:57 PDT 2021
 //   Include the distance to a previous pick if enabled.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 #include <DebugStream.h>
@@ -916,13 +919,8 @@ PickAttributes::CreateConciseOutputString(std::string &os, bool withLetter)
 {
     char buff[512];
 
-    std::string fileName;
+    std::string fileName(FileFunctions::Basename(databaseName));
     std::string format;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
     if (withLetter)
     {
@@ -1406,6 +1404,10 @@ Definition:
 //   Kathleen Biagas, Tue Jul 22 11:35:33 MST 2014
 //   Account for showing global ids.
 //
+//   Kathleen Biagas, Wed Sept 8 2021
+//   Use FileFunctions::Basename to strip off path, for consistency on all
+//   platforms.
+//
 // ****************************************************************************
 
 void
@@ -1471,14 +1473,8 @@ PickAttributes::CreateOutputMapNode(MapNode &m, bool withLetter)
 #endif
     }
 
-    std::string fileName;
-    size_t pos = databaseName.find_last_of('/');
-    if (pos >= databaseName.size())
-        fileName = databaseName;
-    else
-        fileName = databaseName.substr(pos+1) ;
 
-    m["filename"] = fileName;
+    m["filename"] = FileFunctions::Basename(databaseName);
 
     if (withLetter)
     {

--- a/src/common/state/PickAttributes.xml
+++ b/src/common/state/PickAttributes.xml
@@ -299,4 +299,7 @@
     <Include file="source" quoted="false">
       cstring
     </Include>
+    <Include file="source" quoted="false">
+      FileFunctions.h
+    </Include>
   </Attribute>

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a crash when saving images greater than approximately 8,000 x 8,000. Now images can be saved up to 16,384 x 16,384.</li>
   <li>Fixed a bug in the <i>Chombo Users</i> configuration that prevented the macros from being loaded and appearing in the "Macros" window.</li>
   <li>Fixed a bug where VisIt would hang when connecting to a remote system running Linux when connecting from a Linux or macOS system.</li>
+  <li>Pick output of filename on Windows has been made consistent with output for linux: path is stripped off.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
* Make pick output for filename be consistent across platforms.

Use FileFunctions::Basename so that path is stripped off correctly.

* Update release notes.

Resolves #17005
Merge from 3.2RC.




