### PR TITLE
Add setValueE method for libsim's OptionList.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.0.html
+++ b/src/resources/help/en_US/relnotes3.3.0.html
@@ -101,6 +101,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed bug where changing the 'Number format' for a Contour plot's legend would have no affect on the labels next to the tick marks.</li>
   <li>Fixed a bug that prevented users from comparing particular VisIt Python objects in the CLI with non-VisIt types.</li>
+  <li>Fixed a crash with libsim when attempting to Export databases.</li>
 </ul>
 
 <a name="Configuration_changes"></a>

--- a/src/resources/help/en_US/relnotes3.3.0.html
+++ b/src/resources/help/en_US/relnotes3.3.0.html
@@ -101,7 +101,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed bug where changing the 'Number format' for a Contour plot's legend would have no affect on the labels next to the tick marks.</li>
   <li>Fixed a bug that prevented users from comparing particular VisIt Python objects in the CLI with non-VisIt types.</li>
-  <li>Fixed a crash with libsim when attempting to Export databases.</li>
+  <li>Fixed a crash with libsim when attempting to Export databases that have export options specified as enums.</li>
 </ul>
 
 <a name="Configuration_changes"></a>

--- a/src/sim/V2/lib/VisItInterfaceTypes_V2.h
+++ b/src/sim/V2/lib/VisItInterfaceTypes_V2.h
@@ -79,6 +79,7 @@ typedef enum
 #define VISIT_DATATYPE_DOUBLE             3
 #define VISIT_DATATYPE_LONG               4
 #define VISIT_DATATYPE_STRING             10
+#define VISIT_DATATYPE_ENUM               11
 
 /* Array Owner */
 #define VISIT_OWNER_SIM                   0

--- a/src/sim/V2/lib/VisIt_OptionList.c
+++ b/src/sim/V2/lib/VisIt_OptionList.c
@@ -18,7 +18,7 @@ int
 VisIt_OptionList_free(visit_handle obj)
 {
     VISIT_DYNAMIC_EXECUTE(OptionList_free,
-                    int, (visit_handle), 
+                    int, (visit_handle),
                     (obj));
 }
 
@@ -56,6 +56,13 @@ int VisIt_OptionList_setValueS(visit_handle h, const char *name, const char *val
     VISIT_DYNAMIC_EXECUTE(OptionList_setValue,
         int, (visit_handle, const char *, int, void *),
         (h, name, VISIT_DATATYPE_STRING, (void*)value));
+}
+
+int VisIt_OptionList_setValueE(visit_handle h, const char *name, int value)
+{
+    VISIT_DYNAMIC_EXECUTE(OptionList_setValue,
+        int, (visit_handle, const char *, int, void *),
+        (h, name, VISIT_DATATYPE_ENUM, &value));
 }
 
 int VisIt_OptionList_getNumValues(visit_handle h, int *nvalues)
@@ -113,17 +120,17 @@ static int VisIt_OptionList_getValue(visit_handle h, int index, void **pvalue)
 
 int VisIt_OptionList_getValueI(visit_handle h, const char *name, int *value)
 {
-    GETVALUE_BODY(VISIT_DATATYPE_INT, int) 
+    GETVALUE_BODY(VISIT_DATATYPE_INT, int)
 }
 
 int VisIt_OptionList_getValueF(visit_handle h, const char *name, float *value)
 {
-    GETVALUE_BODY(VISIT_DATATYPE_FLOAT, float) 
+    GETVALUE_BODY(VISIT_DATATYPE_FLOAT, float)
 }
 
 int VisIt_OptionList_getValueD(visit_handle h, const char *name, double *value)
 {
-    GETVALUE_BODY(VISIT_DATATYPE_DOUBLE, double) 
+    GETVALUE_BODY(VISIT_DATATYPE_DOUBLE, double)
 }
 
 int VisIt_OptionList_getValueS(visit_handle h, const char *name, char **value)
@@ -143,6 +150,11 @@ int VisIt_OptionList_getValueS(visit_handle h, const char *name, char **value)
         }
     }
     return retval;
+}
+
+int VisIt_OptionList_getValueE(visit_handle h, const char *name, int *value)
+{
+    GETVALUE_BODY(VISIT_DATATYPE_ENUM, int)
 }
 
 /************************** Fortran callable routines *************************/

--- a/src/sim/V2/lib/VisIt_OptionList.h
+++ b/src/sim/V2/lib/VisIt_OptionList.h
@@ -16,6 +16,7 @@ int VisIt_OptionList_setValueI(visit_handle h, const char *, int);
 int VisIt_OptionList_setValueF(visit_handle h, const char *, float);
 int VisIt_OptionList_setValueD(visit_handle h, const char *, double);
 int VisIt_OptionList_setValueS(visit_handle h, const char *, const char *);
+int VisIt_OptionList_setValueE(visit_handle h, const char *, int);
 
 int VisIt_OptionList_getNumValues(visit_handle h, int *);
 int VisIt_OptionList_getName(visit_handle h, int, char **);
@@ -25,6 +26,7 @@ int VisIt_OptionList_getValueI(visit_handle h, const char *, int *);
 int VisIt_OptionList_getValueF(visit_handle h, const char *, float *);
 int VisIt_OptionList_getValueD(visit_handle h, const char *, double *);
 int VisIt_OptionList_getValueS(visit_handle h, const char *, char **);
+int VisIt_OptionList_getValueE(visit_handle h, const char *, int *);
 
 #ifdef __cplusplus
 }

--- a/src/sim/V2/runtime/VisItControlInterfaceRuntime.C
+++ b/src/sim/V2/runtime/VisItControlInterfaceRuntime.C
@@ -877,6 +877,8 @@ simv2_set_operator_options(void *e,
 // Creation:   Thu Sep 18 10:53:32 PDT 2014
 //
 // Modifications:
+//    Kathleen Biagas, Fri Sep 10 09:14:56 PDT 2021
+//    Add support for VISIT_DATATYPE_ENUM.
 //
 // ****************************************************************************
 
@@ -943,6 +945,9 @@ simv2_exportdatabase_with_options(void *e, const char *filename, const char *for
                             break;
                         case VISIT_DATATYPE_STRING:
                             opt.SetString(name, std::string((const char *)pvalue));
+                            break;
+                        case VISIT_DATATYPE_ENUM:
+                            opt.SetEnum(name, *((int *)pvalue));
                             break;
                         }
                     }

--- a/src/sim/V2/runtime/simv2_OptionList.C
+++ b/src/sim/V2/runtime/simv2_OptionList.C
@@ -19,6 +19,7 @@ struct SimV2Variant
         long    valueL;
         float   valueF;
         double  valueD;
+        int     valueE;
     } storage;
     std::string valueS;
 };
@@ -47,6 +48,9 @@ SimV2Variant_setValue(SimV2Variant &var, int type, void *value)
     case VISIT_DATATYPE_STRING:
         var.valueS = std::string((const char *)value);
         break;
+    case VISIT_DATATYPE_ENUM:
+        var.storage.valueE = *((int *)value);
+        break;
     }
 }
 
@@ -73,6 +77,9 @@ SimV2Variant_getValue(SimV2Variant &var)
         break;
     case VISIT_DATATYPE_STRING:
         ptr = (void*)var.valueS.c_str();
+        break;
+    case VISIT_DATATYPE_ENUM:
+        ptr = (void*)&var.storage.valueE;
         break;
     }
     return ptr;

--- a/src/sim/V2/swig/python/simV2.py
+++ b/src/sim/V2/swig/python/simV2.py
@@ -4,32 +4,8 @@
 # Do not make changes to this file unless you know what you are doing--modify
 # the SWIG interface file instead.
 
+import _simV2
 
-
-
-
-from sys import version_info
-if version_info >= (2, 6, 0):
-    def swig_import_helper():
-        from os.path import dirname
-        import imp
-        fp = None
-        try:
-            fp, pathname, description = imp.find_module('_simV2', [dirname(__file__)])
-        except ImportError:
-            import _simV2
-            return _simV2
-        if fp is not None:
-            try:
-                _mod = imp.load_module('_simV2', fp, pathname, description)
-            finally:
-                fp.close()
-            return _mod
-    _simV2 = swig_import_helper()
-    del swig_import_helper
-else:
-    import _simV2
-del version_info
 try:
     _swig_property = property
 except NameError:
@@ -708,6 +684,9 @@ VISIT_DATATYPE_LONG = _simV2.VISIT_DATATYPE_LONG
 
 _simV2.VISIT_DATATYPE_STRING_swigconstant(_simV2)
 VISIT_DATATYPE_STRING = _simV2.VISIT_DATATYPE_STRING
+
+_simV2.VISIT_DATATYPE_ENUM_swigconstant(_simV2)
+VISIT_DATATYPE_ENUM = _simV2.VISIT_DATATYPE_ENUM
 
 _simV2.VISIT_OWNER_SIM_swigconstant(_simV2)
 VISIT_OWNER_SIM = _simV2.VISIT_OWNER_SIM
@@ -1420,6 +1399,10 @@ VisIt_OptionList_setValueD = _simV2.VisIt_OptionList_setValueD
 def VisIt_OptionList_setValueS(h, arg2, arg3):
     return _simV2.VisIt_OptionList_setValueS(h, arg2, arg3)
 VisIt_OptionList_setValueS = _simV2.VisIt_OptionList_setValueS
+
+def VisIt_OptionList_setValueE(h, arg2, arg3):
+    return _simV2.VisIt_OptionList_setValueE(h, arg2, arg3)
+VisIt_OptionList_setValueE = _simV2.VisIt_OptionList_setValueE
 
 def VisIt_PointMesh_alloc(*args):
     return _simV2.VisIt_PointMesh_alloc(*args)

--- a/src/sim/V2/swig/python/simV2_wrap.cxx
+++ b/src/sim/V2/swig/python/simV2_wrap.cxx
@@ -9097,6 +9097,17 @@ SWIGINTERN PyObject *VISIT_DATATYPE_STRING_swigconstant(PyObject *SWIGUNUSEDPARM
 }
 
 
+SWIGINTERN PyObject *VISIT_DATATYPE_ENUM_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "VISIT_DATATYPE_ENUM",SWIG_From_int(static_cast< int >(1)));
+  return SWIG_Py_Void();
+}
+
+
 SWIGINTERN PyObject *VISIT_OWNER_SIM_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *module;
   PyObject *d;
@@ -14308,6 +14319,50 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VisIt_OptionList_setValueE(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  visit_handle arg1 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  int result;
+
+  if (!PyArg_ParseTuple(args,(char *)"OOO:VisIt_OptionList_setValueE",&obj0,&obj1,&obj2)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "VisIt_OptionList_setValueE" "', argument " "1"" of type '" "visit_handle""'");
+  }
+  arg1 = static_cast< visit_handle >(val1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VisIt_OptionList_setValueE" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  ecode3 = SWIG_AsVal_int(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VisIt_OptionList_setValueE" "', argument " "3"" of type '" "int""'");
+  }
+  arg3 = static_cast< int >(val3);
+  result = (int)VisIt_OptionList_setValueE(arg1,(char const *)arg2,arg3);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+
 SWIGINTERN PyObject *_wrap_VisIt_PointMesh_alloc__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   visit_handle *arg1 = (visit_handle *) 0 ;
@@ -18187,6 +18242,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VISIT_DATATYPE_DOUBLE_swigconstant", VISIT_DATATYPE_DOUBLE_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"VISIT_DATATYPE_LONG_swigconstant", VISIT_DATATYPE_LONG_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"VISIT_DATATYPE_STRING_swigconstant", VISIT_DATATYPE_STRING_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"VISIT_DATATYPE_ENUM_swigconstant", VISIT_DATATYPE_ENUM_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"VISIT_OWNER_SIM_swigconstant", VISIT_OWNER_SIM_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"VISIT_OWNER_VISIT_swigconstant", VISIT_OWNER_VISIT_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"VISIT_OWNER_COPY_swigconstant", VISIT_OWNER_COPY_swigconstant, METH_VARARGS, NULL},
@@ -18390,6 +18446,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VisIt_OptionList_setValueF", _wrap_VisIt_OptionList_setValueF, METH_VARARGS, NULL},
 	 { (char *)"VisIt_OptionList_setValueD", _wrap_VisIt_OptionList_setValueD, METH_VARARGS, NULL},
 	 { (char *)"VisIt_OptionList_setValueS", _wrap_VisIt_OptionList_setValueS, METH_VARARGS, NULL},
+	 { (char *)"VisIt_OptionList_setValueE", _wrap_VisIt_OptionList_setValueE, METH_VARARGS, NULL},
 	 { (char *)"VisIt_PointMesh_alloc", _wrap_VisIt_PointMesh_alloc, METH_VARARGS, NULL},
 	 { (char *)"VisIt_PointMesh_free", _wrap_VisIt_PointMesh_free, METH_VARARGS, NULL},
 	 { (char *)"VisIt_PointMesh_setCoordsXY", _wrap_VisIt_PointMesh_setCoordsXY, METH_VARARGS, NULL},

--- a/src/sim/V2/swig/simV2_data_objects.i
+++ b/src/sim/V2/swig/simV2_data_objects.i
@@ -364,6 +364,7 @@ int VisIt_OptionList_setValueI(visit_handle h, const char *, int);
 int VisIt_OptionList_setValueF(visit_handle h, const char *, float);
 int VisIt_OptionList_setValueD(visit_handle h, const char *, double);
 int VisIt_OptionList_setValueS(visit_handle h, const char *, const char *);
+int VisIt_OptionList_setValueE(visit_handle h, const char *, int);
 
 
 #ifdef __cplusplus

--- a/src/test/tests/simulation/updateplots.py
+++ b/src/test/tests/simulation/updateplots.py
@@ -9,6 +9,8 @@
 #  Date:       June 18, 2014 
 #
 #  Modifications:
+#   Kathleen Biagas, Fri Sep 10 09:37:11 PDT 2021
+#   Added test for exporting vtk.
 #
 # ----------------------------------------------------------------------------
 
@@ -29,6 +31,21 @@ def step(sim):
         if "Command 'step'" in buf:
             keepGoing = False
 
+def testExportVTK(sim):
+    # default export FileFormat for VTK is Legacy ascii (.vtk extension),
+    # Test an export that sets the FileFormat to XML Binary (.vtr extension)
+    sim.consolecommand("exportVTK")
+    # Read from stderr to look for the echoed command. Sync.
+    keepGoing = True
+    while keepGoing:
+        buf = sim.p.stderr.readline()
+        print(buf)
+        if "Command 'exportVTK'" in buf:
+            keepGoing = False
+    TestValueEQ("updateplots_export0000.vtr exists", 
+         os.path.isfile(os.path.join(TestEnv.params["run_dir"], "updateplots_export0000.vtr")),
+         True)
+
 
 # Perform our tests.
 if connected:
@@ -41,7 +58,7 @@ if connected:
     AddPlot("Vector", "zvec")
     VectorAtts = VectorAttributes()
     VectorAtts.scale = 0.5
-    VectorAtts.colorByMag = 0
+    VectorAtts.colorByMagnitude = 0
     VectorAtts.vectorColor = (255, 255, 255, 255)
     SetPlotOptions(VectorAtts)
     DrawPlots()
@@ -60,7 +77,10 @@ if connected:
         i = i+1
 
     TestText("updateplots%02d"%i, times)
-             
+
+    # Uncomment this when #17008 is fixed (crash when Logging ExportDBRPC)
+    #testExportVTK(sim)
+
 # Close down the simulation.
 if started:        
     sim.endsim()

--- a/src/tools/data/DataManualExamples/Simulations/updateplots.py
+++ b/src/tools/data/DataManualExamples/Simulations/updateplots.py
@@ -132,7 +132,7 @@ class Simulation:
             VisItExecuteCommand('AddPlot("Pseudocolor", "zonal")\n')
             VisItExecuteCommand('DrawPlots()\n')
         elif cmd == "exportVTK":
-            self.export_vtvty()
+            self.export_vtk()
 
     def GetInputFromConsole(self):
         return VisItReadConsole()

--- a/src/tools/data/DataManualExamples/Simulations/updateplots.py
+++ b/src/tools/data/DataManualExamples/Simulations/updateplots.py
@@ -29,6 +29,9 @@ from simV2 import *
 #  Added call to 'VisItFinalize' at completion of MainLoop to prevent crash
 #  on exit when running in parallel.
 #
+#  Kathleen Biagas, Fri Sep 10 10:27:23 PDT 2021
+#  Added exportVTK option. Set runMode to STOPPED.
+#
 #*****************************************************************************
 
 class Simulation:
@@ -36,14 +39,14 @@ class Simulation:
         self.done = 0
         self.cycle = 0
         self.time = 0.
-        self.runMode = VISIT_SIMMODE_RUNNING #STOPPED
+        self.runMode = VISIT_SIMMODE_STOPPED #RUNNING
         self.par_size = 1
         self.par_rank = 0
         self.savingFiles = 0
         self.saveCounter = 0
         self.rmesh_dims = [50,50,1]
         self.rmesh_ndims = 2
-        self.commands = ("halt", "step", "run", "addplot")
+        self.commands = ("halt", "step", "run", "addplot", "saveon", "saveoff", "exportVTK")
 
     def Initialize(self, simname, visitdir):
         VisItOpenTraceFile("trace.%d.txt" % self.par_rank)
@@ -56,6 +59,35 @@ class Simulation:
 
     def Finalize(self):
         VisItCloseTraceFile()
+
+    def export_vtk(self):
+        filename="updateplots%04d" %self.saveCounter
+        opts = VISIT_INVALID_HANDLE;
+        hvars = VisIt_NameList_alloc()
+        if hvars != VISIT_INVALID_HANDLE:
+            VisIt_NameList_addName(hvars, "default")
+
+            opts = VisIt_OptionList_alloc()
+            if opts != VISIT_INVALID_HANDLE:
+                # FileFormat 0: Legacy ASCII
+                # FileFormat 1: Legacy Binary
+                # FileFormat 2: XML ASCII
+                # FileFormat 3: XML Binary
+                VisIt_OptionList_setValueE(opts, "FileFormat", 3)
+
+                if VisItExportDatabaseWithOptions(filename, "VTK_1.0",
+                                              hvars, opts) == VISIT_OKAY:
+                    self.saveCounter += 1
+                    print("Exported",filename)
+                else:
+                    print("The db could not be exported to",filename)
+            else:
+                print("could not allocate options for export")
+
+            if opts != VISIT_INVALID_HANDLE:
+                VisIt_OptionList_free(opts)
+
+            VisIt_NameList_free(hvars)
 
     def SimulateOneTimestep(self):
         self.cycle = self.cycle + 1
@@ -99,6 +131,8 @@ class Simulation:
         elif cmd == "addplot":
             VisItExecuteCommand('AddPlot("Pseudocolor", "zonal")\n')
             VisItExecuteCommand('DrawPlots()\n')
+        elif cmd == "exportVTK":
+            self.export_vtvty()
 
     def GetInputFromConsole(self):
         return VisItReadConsole()
@@ -430,6 +464,7 @@ class ParallelSimulation(Simulation):
 #
 def main():
     sim = Simulation()
+    # update this to point to the correct location of visit's bin directory (don't include bin)
     sim.Initialize("updateplots", "../../..")
     #sim = ParallelSimulation()
     #sim.Initialize("updateplots_par", "../../..")


### PR DESCRIPTION
### Description
Added OptionList_setValueE methods to libsim, implemented as int.
Fixes crash attempting to set enum DB export options from libsim.
Resolves #5735

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?
I added 'exportVTK' options to the updateplots simulation examples (python and c), than ran those simulations and verified the export works.

I also added a test to the updateplots simulation regression test to call that simulation method.
However, due to #17008 it has to be commented out until the crash is fixed.


### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
