### PR TITLE
Add patches for python configure and configure.ac.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -45,6 +45,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where the test suite files displayed in the dashboard produced by the regression test suite were blank.</li>
   <li>Enhanced build_visit to apply a patch to fix a compile issue with p7zip with gcc 10.3 on Ubuntu 21.04.</li>
   <li>Enhanced build_visit so that it worked on systems that only have Python 3 installed.</li>
+  <li>Enhanced build_visit to apply a patch that fixes a compile issue with Python on MacOS 11.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
Fixes build problem on MacOS 11.
Patches obtained from diff between python-3.7.12 and python-3.7.7.

Came about from [discussion 17013](https://github.com/visit-dav/visit/discussions/17013) and this [python issue](https://bugs.python.org/issue41100).

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran build_visit from this branch (on linux) and ensured the patch was applied successfully.
I then moved the patch so it is only applied for Darwin systems.


### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
