### PR TITLE
Fix pick failure with rectilinear grids and external-to-problem ghosts.

### DIFF
--- a/src/avt/Queries/Pick/avtLocateCellQuery.C
+++ b/src/avt/Queries/Pick/avtLocateCellQuery.C
@@ -176,7 +176,7 @@ avtLocateCellQuery::Execute(vtkDataSet *ds, const int dom)
     // Don't use the RectilinearGrid fast-path if there are ghosts, as it
     // takes longer to remove the ghosts than to use the fast-path.
     if ( ds->GetDataObjectType() != VTK_RECTILINEAR_GRID ||
-         dataAtts.GetContainsGhostZones())
+         dataAtts.GetContainsExteriorBoundaryGhosts())
     {
         if (topodim == 1) // Lines
         {

--- a/src/avt/Queries/Pick/avtLocateCellQuery.C
+++ b/src/avt/Queries/Pick/avtLocateCellQuery.C
@@ -143,10 +143,10 @@ avtLocateCellQuery::~avtLocateCellQuery()
 //    Remove constraint that lines should only be 2D spatially.
 //
 //    Kathleen Biagas, Tue Sep 14 09:48:24 PDT 2021
-//    Don't use Rectilinear grid fast-path if there are ghosts. They would
-//    need to be removed and it takes longer to remove them than to use the
-//    slower path.  Resolves pick failure on rectilinear grids with ghosts
-//    external to problem completely surrounding real zones.
+//    Don't use Rectilinear grid fast-path if there are exterior boundary
+//    ghosts. They would need to be removed and it takes longer to remove them
+//    than to use the slower path.  Resolves pick failure on rectilinear grids
+//    with ghosts external to problem completely surrounding real zones.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Pick/avtLocateCellQuery.C
+++ b/src/avt/Queries/Pick/avtLocateCellQuery.C
@@ -18,6 +18,7 @@
 #include <DebugStream.h>
 #include <vtkVisItCellLocator.h>
 #include <vtkVisItUtility.h>
+#include <TimingsManager.h>
 
 #include <math.h>
 #include <float.h>
@@ -142,6 +143,12 @@ avtLocateCellQuery::~avtLocateCellQuery()
 //    Kathleen Biagas, Thu Jun 29 13:02:07 PDT 2017
 //    Remove constraint that lines should only be 2D spatially.
 //
+//    Kathleen Biagas, Tue Sep 14 09:48:24 PDT 2021
+//    Don't use Rectilinear grid fast-path if there are ghosts. They would
+//    need to be removed and it takes longer to remove them than to use the
+//    slower path.  Resolves pick failure on rectilinear grids with ghosts
+//    external to problem completely surrounding real zones.
+//
 // ****************************************************************************
 
 void
@@ -167,8 +174,10 @@ avtLocateCellQuery::Execute(vtkDataSet *ds, const int dom)
     int foundCell = -1;
 
     // Find the cell, intersection point, and distance along the ray.
-    //
-    if (ds->GetDataObjectType() != VTK_RECTILINEAR_GRID)
+    // Don't use the RectilinearGrid fast-path if there are ghosts, as it
+    // takes longer to remove the ghosts than to use the fast-path.
+    if ( ds->GetDataObjectType() != VTK_RECTILINEAR_GRID ||
+         dataAtts.GetContainsGhostZones())
     {
         if (topodim == 1) // Lines
         {

--- a/src/avt/Queries/Pick/avtLocateCellQuery.C
+++ b/src/avt/Queries/Pick/avtLocateCellQuery.C
@@ -18,7 +18,6 @@
 #include <DebugStream.h>
 #include <vtkVisItCellLocator.h>
 #include <vtkVisItUtility.h>
-#include <TimingsManager.h>
 
 #include <math.h>
 #include <float.h>

--- a/src/avt/Queries/Pick/avtLocateNodeQuery.C
+++ b/src/avt/Queries/Pick/avtLocateNodeQuery.C
@@ -160,12 +160,10 @@ avtLocateNodeQuery::Execute(vtkDataSet *ds, const int dom)
             }
         }
     }
-#if 0
     else
     {
         foundNode = RGridFindNode(ds, dist, isect);
     }
-#endif
 
     if ((foundNode != -1) && (dist < minDist))
     {

--- a/src/avt/Queries/Pick/avtLocateNodeQuery.C
+++ b/src/avt/Queries/Pick/avtLocateNodeQuery.C
@@ -104,6 +104,12 @@ avtLocateNodeQuery::~avtLocateNodeQuery()
 //    Kathleen Biagas, Thu Jun 29 13:02:07 PDT 2017
 //    Remove constraint that lines should only be 2D spatially.
 //
+//    Kathleen Biagas, Tue Sep 14 09:48:24 PDT 2021
+//    Don't use Rectilinear grid fast-path if there are ghosts. They would
+//    need to be removed and it takes longer to remove them than to use the
+//    slower path.  Resolves pick failure on rectilinear grids with ghosts
+//    external to problem completely surrounding real zones.
+//
 // ****************************************************************************
 
 void
@@ -129,7 +135,10 @@ avtLocateNodeQuery::Execute(vtkDataSet *ds, const int dom)
 
     // Find the cell, intersection point, and distance along the ray.
     //
-    if (ds->GetDataObjectType() != VTK_RECTILINEAR_GRID)
+    // Don't use the RectilinearGrid fast-path if there are ghosts.  It
+    // takes longer to remove the ghosts than it does to use the slower path.
+    if (ds->GetDataObjectType() != VTK_RECTILINEAR_GRID ||
+        info.GetAttributes().GetContainsGhostZones())
     {
         if (topodim == 1) // LINES
         {
@@ -151,10 +160,12 @@ avtLocateNodeQuery::Execute(vtkDataSet *ds, const int dom)
             }
         }
     }
+#if 0
     else
     {
         foundNode = RGridFindNode(ds, dist, isect);
     }
+#endif
 
     if ((foundNode != -1) && (dist < minDist))
     {

--- a/src/avt/Queries/Pick/avtLocateNodeQuery.C
+++ b/src/avt/Queries/Pick/avtLocateNodeQuery.C
@@ -105,10 +105,10 @@ avtLocateNodeQuery::~avtLocateNodeQuery()
 //    Remove constraint that lines should only be 2D spatially.
 //
 //    Kathleen Biagas, Tue Sep 14 09:48:24 PDT 2021
-//    Don't use Rectilinear grid fast-path if there are ghosts. They would
-//    need to be removed and it takes longer to remove them than to use the
-//    slower path.  Resolves pick failure on rectilinear grids with ghosts
-//    external to problem completely surrounding real zones.
+//    Don't use Rectilinear grid fast-path if there are exterior boundary
+//    ghosts. They would need to be removed and it takes longer to remove them
+//    than to use the slower path.  Resolves pick failure on rectilinear grids
+//    with ghosts external to problem completely surrounding real zones.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Pick/avtLocateNodeQuery.C
+++ b/src/avt/Queries/Pick/avtLocateNodeQuery.C
@@ -138,7 +138,7 @@ avtLocateNodeQuery::Execute(vtkDataSet *ds, const int dom)
     // Don't use the RectilinearGrid fast-path if there are ghosts.  It
     // takes longer to remove the ghosts than it does to use the slower path.
     if (ds->GetDataObjectType() != VTK_RECTILINEAR_GRID ||
-        info.GetAttributes().GetContainsGhostZones())
+        info.GetAttributes().GetContainsExteriorBoundaryGhosts())
     {
         if (topodim == 1) // LINES
         {

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where VisIt would hang when connecting to a remote system running Linux when connecting from a Linux or macOS system.</li>
   <li>Pick output of filename on Windows has been made consistent with output for linux: path is stripped off.</li>
   <li>Command recording for GlobalLineoutAttributes now works correctly.</li>
+  <li>Fixed pick failure for Rectilinear grids when real zones are completely surrounded by ghost zones.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Don't user rectilinear grid fast-path in Locate queries if ghosts
are present. The slower path is faster than removing ghosts from
the rectilinear grid.

### Description

Resolves #17014

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the test suite with success.
Pick now succeeds with the user's test data.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
