### PR TITLE
Fix pick failure with rectilinear grids and external-to-problem ghosts. (#17020)

### DIFF
--- a/src/avt/Queries/Pick/avtLocateNodeQuery.C
+++ b/src/avt/Queries/Pick/avtLocateNodeQuery.C
@@ -104,6 +104,12 @@ avtLocateNodeQuery::~avtLocateNodeQuery()
 //    Kathleen Biagas, Thu Jun 29 13:02:07 PDT 2017
 //    Remove constraint that lines should only be 2D spatially.
 //
+//    Kathleen Biagas, Tue Sep 14 09:48:24 PDT 2021
+//    Don't use Rectilinear grid fast-path if there are exterior boundary
+//    ghosts. They would need to be removed and it takes longer to remove them
+//    than to use the slower path.  Resolves pick failure on rectilinear grids
+//    with ghosts external to problem completely surrounding real zones.
+//
 // ****************************************************************************
 
 void
@@ -129,7 +135,10 @@ avtLocateNodeQuery::Execute(vtkDataSet *ds, const int dom)
 
     // Find the cell, intersection point, and distance along the ray.
     //
-    if (ds->GetDataObjectType() != VTK_RECTILINEAR_GRID)
+    // Don't use the RectilinearGrid fast-path if there are ghosts.  It
+    // takes longer to remove the ghosts than it does to use the slower path.
+    if (ds->GetDataObjectType() != VTK_RECTILINEAR_GRID ||
+        info.GetAttributes().GetContainsExteriorBoundaryGhosts())
     {
         if (topodim == 1) // LINES
         {

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where VisIt would hang when connecting to a remote system running Linux when connecting from a Linux or macOS system.</li>
   <li>Pick output of filename on Windows has been made consistent with output for linux: path is stripped off.</li>
   <li>Command recording for GlobalLineoutAttributes now works correctly.</li>
+  <li>Fixed pick failure for Rectilinear grids when real zones are completely surrounded by ghost zones.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Don't user rectilinear grid fast-path in Locate queries if exterior boundary ghosts
are present. The slower path is faster than removing ghosts from
the rectilinear grid.

Resolves #17014 

Merge from 3.2RC 

