### PR TITLE
Port WData plugin to Windows.

### DIFF
--- a/src/databases/WData/CMakeLists.txt
+++ b/src/databases/WData/CMakeLists.txt
@@ -2,8 +2,8 @@
 PROJECT(WData_database)
 
 INCLUDE(${VISIT_SOURCE_DIR}/CMake/PluginMacros.cmake)
-ADD_DATABASE_CODE_GEN_TARGETS(WData)
 
+ADD_DATABASE_CODE_GEN_TARGETS(WData)
 
 SET(COMMON_SOURCES
 WDataPluginInfo.C
@@ -48,9 +48,6 @@ ${VISIT_INCLUDE_DIR}/avt/Pipeline/Sources
 ${VISIT_INCLUDE_DIR}/avt/VisWindow/VisWindow
 ${VISIT_INCLUDE_DIR}/visit_vtk/full
 ${VISIT_INCLUDE_DIR}/visit_vtk/lightweight
-${VTKh_INCLUDE_DIRS}
-${VTKM_DIR}/include/vtkm-1.2
-${VTKM_DIR}/include/vtkm-1.2/vtkm/thirdparty/taotuple
 ${VTK_INCLUDE_DIRS}
 )
 
@@ -62,23 +59,36 @@ SET(INSTALLTARGETS IWDataDatabase)
 
 IF(NOT VISIT_ENGINE_ONLY AND NOT VISIT_DBIO_ONLY)
     ADD_LIBRARY(MWDataDatabase ${LIBM_SOURCES})
-    TARGET_LINK_LIBRARIES(MWDataDatabase visitcommon avtdbatts avtdatabase_ser -lm )
+    TARGET_LINK_LIBRARIES(MWDataDatabase visitcommon avtdbatts avtdatabase_ser )
+    if(NOT WIN32)
+        target_link_libraries(MWDataDatabase m)
+    endif()
+
     ADD_TARGET_DEFINITIONS(MWDataDatabase MDSERVER)
     SET(INSTALLTARGETS ${INSTALLTARGETS} MWDataDatabase)
 ENDIF(NOT VISIT_ENGINE_ONLY AND NOT VISIT_DBIO_ONLY)
 
 ADD_LIBRARY(EWDataDatabase_ser ${LIBE_SOURCES})
-TARGET_LINK_LIBRARIES(EWDataDatabase_ser visitcommon avtdatabase_ser avtpipeline_ser -lm )
+TARGET_LINK_LIBRARIES(EWDataDatabase_ser visitcommon avtdatabase_ser avtpipeline_ser )
+if(NOT WIN32)
+    target_link_libraries(EWDataDatabase_ser m)
+endif()
+
 ADD_TARGET_DEFINITIONS(EWDataDatabase_ser ENGINE)
 SET(INSTALLTARGETS ${INSTALLTARGETS} EWDataDatabase_ser)
 
 IF(VISIT_PARALLEL)
     ADD_PARALLEL_LIBRARY(EWDataDatabase_par ${LIBE_SOURCES})
-    TARGET_LINK_LIBRARIES(EWDataDatabase_par visitcommon avtdatabase_par avtpipeline_par -lm )
+    TARGET_LINK_LIBRARIES(EWDataDatabase_par visitcommon avtdatabase_par avtpipeline_par )
+    if(NOT WIN32)
+        target_link_libraries(EWDataDatabase_par m)
+    endif()
+
     ADD_TARGET_DEFINITIONS(EWDataDatabase_par ENGINE)
     SET(INSTALLTARGETS ${INSTALLTARGETS} EWDataDatabase_par)
 ENDIF(VISIT_PARALLEL)
 
 VISIT_INSTALL_DATABASE_PLUGINS(${INSTALLTARGETS})
 VISIT_PLUGIN_TARGET_RTOD(databases ${INSTALLTARGETS})
+VISIT_PLUGIN_TARGET_FOLDER(databases WData ${INSTALLTARGETS})
 

--- a/src/databases/WData/WData.code
+++ b/src/databases/WData/WData.code
@@ -1,0 +1,5 @@
+Target: xml2cmake
+Condition: NOT WIN32
+MLinkLibraries: m
+ELinkLibraries: m
+

--- a/src/databases/WData/WData.xml
+++ b/src/databases/WData/WData.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0"?>
   <Plugin name="WData" type="database" label="WDATA format reader" version="0.2.0" enabled="true" mdspecificcode="false" engspecificcode="false" onlyengine="false" noengine="false" dbtype="MTSD" haswriter="false" hasoptions="false" filePatternsStrict="false" opensWholeDirectory="false">
-    <CXXFLAGS>
-    </CXXFLAGS>
-    <LIBS>
-      -lm 
-    </LIBS>
     <FilePatterns>
       *.wtxt
     </FilePatterns>
-    <Attribute name="" purpose="" persistent="true" keyframe="true" exportAPI="" exportInclude="">
+    <Attribute name="" purpose="" persistent="true" keyframe="true" exportAPI="" exportInclude="" codefile="WData.code">
     </Attribute>
   </Plugin>

--- a/src/databases/WData/avtWDataFileFormat.h
+++ b/src/databases/WData/avtWDataFileFormat.h
@@ -20,20 +20,35 @@ typedef std::complex<float> Complex;
 
 #include "wdata.h"
 
+// ****************************************************************************
+//  Class: WDataVariable
+//
+//  Purpose:
+//
+//  Programmer: gabrielw
+//  Creation:   Wed Jul 29 19:18:00 PST 2020
+//
+//  Modifications:
+//    Kathleen Biagas, Wed Sept 22, 2021
+//    Have getVariable, isScalar and isVector return false to fix compile error
+//    on Windows.  Cast numberOfVariables return to int. Remove unneeded ';'.
+//
+// ****************************************************************************
+
 class WDataVariable
 {
 public:
     WDataVariable(wdata_metadata *wdmd, int varid, int precdowngrade);
-    virtual ~WDataVariable() { ; };
+    virtual ~WDataVariable() { ; }
 
-    virtual bool getVariable(const char *_varname, int cycleid, float *data_for_visit) { ; };
+    virtual bool getVariable(const char *_varname, int cycleid, float *data_for_visit) { return false; }
 
-    int numberOfVariables() { return varname.size(); };
-    std::string getIthVariableName(int ith) { return varname[ith]; };
-    std::string getIthVariableUnit(int ith) { return varunit[ith]; };
+    int numberOfVariables() { return int(varname.size()); }
+    std::string getIthVariableName(int ith) { return varname[ith]; }
+    std::string getIthVariableUnit(int ith) { return varunit[ith]; }
 
-    virtual bool isScalar() { ; };
-    virtual bool isVector() { ; };
+    virtual bool isScalar() { return false; }
+    virtual bool isVector() { return false; }
 
 protected:
     int loadCycle(int cycleid);

--- a/src/databases/WData/wdata.c
+++ b/src/databases/WData/wdata.c
@@ -13,8 +13,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
 #include <libgen.h>
+#else
+#include <direct.h> /* for _getcwd, _chdir */
+#define getcwd _getcwd
+#define chdir _chdir
+#endif
 // #include <complex.h>
 #include <ctype.h>
 
@@ -75,7 +81,7 @@ void wdata_goback_wrkdir(wdata_metadata *md)
 
 static char *str_tolower(char *str)
 {
-    int str_len = strlen(str) + 1;
+    int str_len = int(strlen(str)) + 1;
     int j;
 
     for (j = 0; j < str_len; j++)
@@ -425,7 +431,14 @@ int wdata_parse_metadata_file(const char *file_name, wdata_metadata *md)
     // set working dir to be consistent with wtxt file location
     char ctmp[MD_CHAR_LGTH];
     strcpy(ctmp, file_name);
+#ifdef _WIN32
+    /* KSB 9-22-2021, Windows doesn't have 'dirname', so use _splitpath_s.*/
+    char dtmp[MD_CHAR_LGTH];
+    if (_splitpath_s(ctmp, NULL, 0, dtmp, MD_CHAR_LGTH, NULL, 0, NULL, 0) == 0)
+        strcpy(md->wrkdir, dtmp);
+#else
     strcpy(md->wrkdir, dirname(ctmp));
+#endif
     md->issetwrkdir = WRKDIR_SET;
 
     // check corretness


### PR DESCRIPTION
Added code file for conditional addition of 'm' library to target-link libraries.

Regenerate CMakeLists.txt with develop version of xml2cmake.

Fix Windows compile errors related to functions not returning a value when they should, and for use of unix-only getcwd, chdir and dirname.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix
* [ ] New feature
* [ ] Documentation update
* [X] Other <!-- please explain with a note below -->
   Port WData plugin to Windows.

### How Has This Been Tested?

I compiled on linux and windows successfully with the changes.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
