### PR TITLE
fix movie & cinema test hang

### DIFF
--- a/src/test/HtmlPython.py
+++ b/src/test/HtmlPython.py
@@ -65,8 +65,8 @@ class Parser:
             else:
                 tokenize.tokenize(text.readline,self)
         except tokenize.TokenError as ex:
-            msg = ex[0]
-            line = ex[1][0]
+            msg = ex.args[0]
+            line = ex.args[1][0]
             self.out.write("<h3>ERROR: %s</h3>%s\n" % (
                 msg, self.raw[self.lines[line]:]))
         self.out.write('</font></pre></body></html>')

--- a/src/test/tests/hybrid/cinema-a.py
+++ b/src/test/tests/hybrid/cinema-a.py
@@ -206,9 +206,8 @@ def main():
     db = MakeShortWave()
     test0(db)
     test1(db)
-    #test0(db)
 
-    #os.unlink(db)
+    os.unlink(db)
 
 main()
 Exit()

--- a/src/test/tests/hybrid/cinema-a.py
+++ b/src/test/tests/hybrid/cinema-a.py
@@ -23,16 +23,22 @@
 #    Added call to CloseComputeEngine to GenerateCinema method, since the
 #    cinema script launches its own. Prevents a hang when run in parallel.
 #
+#    Kathleen Biagas, Tue Sep 21 17:22:58 PDT 2021
+#    Removed CloseComputeEngine, it prevented the non-cinema-generation parts
+#    of the test from running in parallel.  If the nightlies use srun,
+#    add "--overlap" srun option.  This allows cinema test to succeed in
+#    parallel with recent changes to slurm.
+#
 # ----------------------------------------------------------------------------
 import os
 import subprocess
 
 def GenerateCinema(cinemaArgs):
-    CloseComputeEngine()
+    args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema"] + cinemaArgs
     if TestEnv.params["parallel"]:
-        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + cinemaArgs
-    else:
-        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema"] + cinemaArgs
+        args = args + ["-np", "2", "-l", TestEnv.params["parallel_launch"]]
+        if TestEnv.params["parallel_launch"] == "srun":
+            args = args + ["-la", "--overlap"]
     p = subprocess.check_output(args)
     return p
 
@@ -200,8 +206,9 @@ def main():
     db = MakeShortWave()
     test0(db)
     test1(db)
+    #test0(db)
 
-    os.unlink(db)
+    #os.unlink(db)
 
 main()
 Exit()

--- a/src/test/tests/hybrid/cinema-c.py
+++ b/src/test/tests/hybrid/cinema-c.py
@@ -22,16 +22,22 @@
 #    Added call to CloseComputeEngine to GenerateCinema method, since the
 #    cinema script launches its own. Prevents a hang when run in parallel.
 #
+#    Kathleen Biagas, Tue Sep 21 17:22:58 PDT 2021
+#    Removed CloseComputeEngine, it prevented the non-cinema-generation parts
+#    of the test from running in parallel.  If the nightlies use srun,
+#    add "--overlap" srun option.  This allows cinema test to succeed in
+#    parallel with recent changes to slurm.
+#
 # ----------------------------------------------------------------------------
 
 import math, os, string, subprocess, zlib
 
 def GenerateCinema(cinemaArgs):
-    CloseComputeEngine()
+    args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema"] + cinemaArgs
     if TestEnv.params["parallel"]:
-        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + cinemaArgs
-    else:
-        args = [TestEnv.params["visit_bin"], "-noconfig", "-cinema"] + cinemaArgs
+        args = args + ["-np", "2", "-l", TestEnv.params["parallel_launch"]]
+        if TestEnv.params["parallel_launch"] == "srun":
+            args = args + ["-la", "--overlap"]
     p = subprocess.check_output(args)
     return p
 

--- a/src/test/tests/hybrid/movie.py
+++ b/src/test/tests/hybrid/movie.py
@@ -23,6 +23,12 @@
 #     Added call to CloseComputeEngine to GenerateMovie method, since the
 #     movie script launches its own. Prevents a hang when run in parallel.
 #
+#     Kathleen Biagas, Tue Sep 21 17:22:58 PDT 2021
+#     Removed CloseComputeEngine, it prevented the non-movie-generation parts
+#     of the test from running in parallel.  If the nightlies use srun,
+#     add "--overlap" srun option.  This allows cinema test to succeed in
+#     parallel with recent changes to slurm.
+#
 # ----------------------------------------------------------------------------
 import os
 import subprocess
@@ -30,11 +36,11 @@ import visit_utils
 from PIL import Image
 
 def GenerateMovie(movieArgs):
-    CloseComputeEngine()
+    args = [TestEnv.params["visit_bin"], "-noconfig", "-movie"] + movieArgs
     if TestEnv.params["parallel"]:
-        args = [TestEnv.params["visit_bin"], "-movie", "-noconfig", "-np", "2", "-l", TestEnv.params["parallel_launch"]] + movieArgs
-    else:
-        args = [TestEnv.params["visit_bin"], "-movie", "-noconfig"] + movieArgs
+        args = args + ["-np", "2", "-l", TestEnv.params["parallel_launch"]]
+        if TestEnv.params["parallel_launch"] == "srun":
+            args = args + ["-la", "--overlap"]
     p = subprocess.check_output(args)
     return p
 

--- a/src/test/visit_test_main.py
+++ b/src/test/visit_test_main.py
@@ -2300,6 +2300,10 @@ def TestBatchSimulation(sim):
 #    Mark C. Miller, Fri Jun 29 08:51:36 PDT 2018
 #    Replaced surface with pascal
 #
+#    Kathleen Biagas, Fri Sep 24 08:49:01 PDT 2021
+#    Add --overlap option to srun, to work around recent changes to slurm,
+#    which prevented movie-generation processes from running.
+#
 # ----------------------------------------------------------------------------
 class Simulation(object):
     def __init__(self, vdir, s, sim2, np=1, batch=False):
@@ -2350,14 +2354,14 @@ class Simulation(object):
                     f.write("#!/bin/sh\n")
                     f.write("cd %s\n" % os.path.abspath(os.curdir))
                     f.write("ulimit -c 0\n")
-                    f.write("srun -n %d" % self.np)
+                    f.write("srun --overlap -n %d" % self.np)
                     for a in args:
                         f.write(" %s" % a)
                     f.write("\n")
                     f.close()
                     args = ["msub", "-l", "nodes=1:ppn=12", msubscript]
                 else:
-                    args = ["srun", "-n", str(self.np)] + args
+                    args = ["srun", "--overlap", "-n", str(self.np)] + args
             else:
                 args = ["mpiexec", "-n", str(self.np)] + args
         else:
@@ -2806,7 +2810,7 @@ def InitTestEnv():
             if TestEnv.params["parallel_launch"] == "mpirun":
                 haveParallelEngine = (OpenComputeEngine(TestEnv.params["data_host"], ("-np", "2")) == 1)
             elif TestEnv.params["parallel_launch"] == "srun":
-                haveParallelEngine = (OpenComputeEngine(TestEnv.params["data_host"], ("-l", "srun", "-np", "2")) == 1)
+                haveParallelEngine = (OpenComputeEngine(TestEnv.params["data_host"], ("-l", "srun", "-la", "--overlap", "-np", "2")) == 1)
         if haveParallelEngine == False:
             Exit()
         else:

--- a/src/visitpy/cli/cli.C
+++ b/src/visitpy/cli/cli.C
@@ -177,6 +177,11 @@ extern "C" void cli_runscript(const char *);
 //    Cyrus Harrison, Wed Feb 24 16:09:45 PST 2021
 //    Adjustments for Pyside 2 support. 
 //
+//    Kathleen Biagas, Fri Sep 24 08:36:43 PDT 2021
+//    When processing args, look for '-sla' or '-la' and skip the next arg,
+//    as '-s' is a viable option that could be passed to srun via -sla or -la
+//    and we don't that option to be proccessed as a cli '-s' option.
+//
 // ****************************************************************************
 
 int
@@ -294,6 +299,26 @@ main(int argc, char *argv[])
             }
         }
 #else
+        else if(strcmp(argv[i], "-sla") == 0 && (i+1 < argc))
+        {
+            // skip next arg, since it may be '-s'
+            // Pass the array along to the visitmodule.
+            argv2[argc2++] = argv[i];
+            argv_after_s[argc_after_s++] = argv[i];
+            argv2[argc2++] = argv[i+1];
+            argv_after_s[argc_after_s++] = argv[i+1];
+
+            ++i;
+        }
+        else if(strcmp(argv[i], "-la") == 0 && (i+1 < argc))
+        {
+            // skip next arg, since it may be '-s'
+            argv2[argc2++] = argv[i];
+            argv_after_s[argc_after_s++] = argv[i];
+            argv2[argc2++] = argv[i+1];
+            argv_after_s[argc_after_s++] = argv[i+1];
+            ++i;
+        }
         else if(strcmp(argv[i], "-s") == 0 && (i+1 < argc))
         {
             runFile = argv[i+1];


### PR DESCRIPTION
### Preamble
My original fix for #16995 was to have the movie and cinema tests close the compute engine before launching their own parallel process for movie/cinema generation.

Problem with that fix was that the generation step also closes the engine it uses, leaving the rest of the steps in these regression tests to run with a serial engine.

I did some research on the error from the original hang:
`srun: Job 7341481 step creation still disabled, retrying (Requested nodes are busy)`

And came across this [discussion](https://github.com/open-mpi/ompi/issues/8378#issuecomment-761223699) that ties the error to specific updates to slurm.  

Slurm on our testing machine was updated on August 12 from version 20.02.6 to 20.11.8.  This is when the movie and cinema tests began to hang.

While some of the more problematic job step-launch changes were reverted in 20.11.3 (and thus are not part of the version we are running), the update notes found [here](https://schedmd.com/news.php?id=253#OPT_253) indicate the possible need to add '--overlap' argument to srun. (see notes for 20.11.3).

### Description
This PR:
1) fixes an error in HtmlPython.py when processing TokenError
2) modifies cli argument-parsing to skip '-la' and '-sla' and their arguments, to prevent handling srun's '-s' option as a 'cli -s' option.
3) Fixes makemovie.py's processing of '-la' (which created an endless loop).
4) adds '--overlap' to srun for the entire test suite.
It resolves the movie/cinema hang without the need for these tests to call CloseComputeEngine. It also resolves the current cinema-a failure in scalable,parallel,icet mode.

However, I see some strangeness at the end of the test suite log, even though all the tests passed:

```
Traceback (most recent call last):
  File "/usr/WS1/kbonnell/Branches/CleanDevelop/visit/src/test/visit_test_suite.py", line 943, in launch_tests
    results = p.get(opts["timeout"]) # used to make sure ctl-c doesn't hang
  File "/usr/workspace/wsa/visit/visit/thirdparty_shared/3.2.0/toss3/python/3.7.7/linux-x86_64_gcc-6.1/lib/python3.7/multiprocessing/pool.py", line 653, in get
    raise TimeoutError
multiprocessing.context.TimeoutError
<Unknown Exception>:
<Missing result from test databases/ANALYZE, assuming Killed>
<Missing result from test databases/ANSYS, assuming Killed>
...
<Missing result from test unit/atts_assign, assuming Killed>
<Missing result from test unit/default_methods, assuming Killed>
[Test suite run complete @ 2021:09:23:17:19:26 (wall time = 3601)]
!! Test suite run finished with 313 errors.
[Cleanup: Waiting for delayed writes]
[Cleanup: Removing _run directory]
<Error Removing _run Directory> /usr/WS1/kbonnell/Branches/CleanDevelop/testall_output/_run
```


<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the entire test suite in parallel and scalable,parallel,icet modes on pascal with all  passing results.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
