### PR TITLE
Add Qt patch to fix compile error with gcc-11.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -46,7 +46,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where the test suite files displayed in the dashboard produced by the regression test suite were blank.</li>
   <li>Enhanced build_visit to apply a patch to fix a compile issue with p7zip with gcc 10.3 on Ubuntu 21.04.</li>
   <li>Enhanced build_visit so that it worked on systems that only have Python 3 installed.</li>
-  <li>Enhanced build_visit to apply a patch that fixes a compile issue with Python on MacOS 11.</li>
+  <li>Enhanced build_visit to apply a patch that fixes a compile issue with Qt and gcc-11.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -207,6 +207,10 @@ function qt_license_prompt
 function apply_qt_patch
 {
     if [[ ${QT_VERSION} == 5.14.2 ]] ; then
+        apply_qt_5142_numeric_limits_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
         if [[ "$OPSYS" == "Linux" ]]; then
             if [[ "$DO_MESAGL" == "yes" ]] ; then
                 apply_qt_5142_linux_mesagl_patch
@@ -229,6 +233,71 @@ function apply_qt_patch
             fi
         fi
     fi
+    return 0
+}
+
+function apply_qt_5142_numeric_limits_patch
+{   
+    info "Patching qt 5.14.2 for numeric-limits" 
+    patch -p0 <<EOF
+diff -c qtbase/src/corelib/global/qendian.h.orig c qtbase/src/corelib/global/qendian.h
+*** qtbase/src/corelib/global/qendian.h.orig	Wed Oct 13 20:10:58 2021
+--- qtbase/src/corelib/global/qendian.h	Wed Oct 13 20:11:12 2021
+***************
+*** 47,52 ****
+--- 47,53 ----
+  // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+  #include <stdlib.h>
+  #include <string.h>
++ #include <limits>
+  
+  #ifdef min // MSVC
+  #undef min
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.14.2 for numeric-limits patch1 failed"
+        return 1
+    fi
+
+    patch -p0 <<EOF
+diff -c qtbase/src/corelib/global/qfloat16.h.orig c qtbase/src/corelib/global/qfloat16.h
+*** qtbase/src/corelib/global/qfloat16.h.orig	Wed Oct 13 20:09:19 2021
+--- qtbase/src/corelib/global/qfloat16.h	Wed Oct 13 20:09:50 2021
+***************
+*** 44,49 ****
+--- 44,50 ----
+  #include <QtCore/qglobal.h>
+  #include <QtCore/qmetatype.h>
+  #include <string.h>
++ #include <limits>
+  
+  #if defined(QT_COMPILER_SUPPORTS_F16C) && defined(__AVX2__) && !defined(__F16C__)
+  // All processors that support AVX2 do support F16C too. That doesn't mean
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.14.2 for numeric-limits patch2 failed"
+        return 1
+    fi
+    patch -p0 <<EOF
+diff -c qtbase/src/corelib/text/qbytearraymatcher.h.orig c qtbase/src/corelib/text/qbytearraymatcher.h
+*** qtbase/src/corelib/text/qbytearraymatcher.h.orig	Wed Oct 13 20:11:58 2021
+--- qtbase/src/corelib/text/qbytearraymatcher.h	Wed Oct 13 20:12:21 2021
+***************
+*** 41,46 ****
+--- 41,47 ----
+  #define QBYTEARRAYMATCHER_H
+  
+  #include <QtCore/qbytearray.h>
++ #include <limits>
+  
+  QT_BEGIN_NAMESPACE
+  
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.14.2 for numeric-limits patch3 failed"
+        return 1
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
### Description

Resolves #17065

The patch adds` #include <limits>` to three files.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I created a container with gcc-11 (since I didn't have access to gcc-11 on other machines).
I was able to build qt successfully with the new patch in the container.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
