### PR TITLE
Update the Trinity host profile to no longer use the gateway.

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.2.2</font></b></p>
 <ul>
   <li>The VTK reader has been expanded to support .pvd files.</li>
+  <li>Updated the Los Alamos National Laboratory's Trinity host profile to no longer use the gateway.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/hosts/llnl_closed/host_lanl_closed_trinity.xml
+++ b/src/resources/hosts/llnl_closed/host_lanl_closed_trinity.xml
@@ -4,8 +4,6 @@
     <Field name="hostAliases" type="string">tr-fe#.lanl.gov tr-fe#</Field>
     <Field name="hostNickname" type="string">LANL Trinity</Field>
     <Field name="directory" type="string">/usr/projects/views/visit</Field>
-    <Field name="useGateway" type="bool">true</Field>
-    <Field name="gatewayHost" type="string">red-wtrw.lanl.gov</Field>
     <Field name="clientHostDetermination" type="string">MachineName</Field>
     <Object name="LaunchProfile">
         <Field name="profileName" type="string">serial</Field>


### PR DESCRIPTION
### Description

Resolves #17049

Updated the the Trinity host profile to no longer use the gateway.

### Type of change

* [X] New feature

### How Has This Been Tested?

I connected client/server from jade to trinity using the new host profile and it worked fine.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
