### PR TITLE
Update the Trinity host profile to no longer use the gateway. (#17142)

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.2.2</font></b></p>
 <ul>
   <li>The VTK reader has been expanded to support .pvd files.</li>
+  <li>Updated the Los Alamos National Laboratory's Trinity host profile to no longer use the gateway.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/hosts/llnl_closed/host_lanl_closed_trinity.xml
+++ b/src/resources/hosts/llnl_closed/host_lanl_closed_trinity.xml
@@ -4,8 +4,6 @@
     <Field name="hostAliases" type="string">tr-fe#.lanl.gov tr-fe#</Field>
     <Field name="hostNickname" type="string">LANL Trinity</Field>
     <Field name="directory" type="string">/usr/projects/views/visit</Field>
-    <Field name="useGateway" type="bool">true</Field>
-    <Field name="gatewayHost" type="string">red-wtrw.lanl.gov</Field>
     <Field name="clientHostDetermination" type="string">MachineName</Field>
     <Object name="LaunchProfile">
         <Field name="profileName" type="string">serial</Field>


### PR DESCRIPTION
Resolves #17049 
Merge from the 3.2RC to develop.