### PR TITLE
Task/brugger1/2012 12 07 fix parallel hang

### DIFF
--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -29,6 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Pick output of filename on Windows has been made consistent with output for linux: path is stripped off.</li>
   <li>Command recording for GlobalLineoutAttributes now works correctly.</li>
   <li>Fixed pick failure for Rectilinear grids when real zones are completely surrounded by ghost zones.</li>
+  <li>Fixed a bug where VisIt would hang when working with a AMR meshes and the number of active patches was less than the number of processors and the patches were not rectilinear.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #17172 

Fixed a bug where VisIt would hang when working with a AMR meshes and the number of active patches was less than the number of processors and the patches were not rectilinear. There was a test checking if any of the meshes were not rectilinear and returning if there were. On the processors that didn't have any meshes, the test would get skipped and it wouldn't return early. This got the processors out of sync with a later global communication causing a hang. I added a global communication as part of the test to sync all the processors so that they would all either proceed or return early.

### Type of change

* [X] Bug fix

### How Has This Been Tested?

I ran tested with Andy Cook's data and was able to replicate the failure. I then tried again with the fix and it worked. With his SAMRAI file, he had 20 patches at level 1. When running with 24 processors and turning off level 1, there were only 20 patches and VisIt hung with the current version and worked with the fix.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
