### PR TITLE
Fix a bug where mpeg encoding erroneously indicates it failed.

### DIFF
--- a/src/bin/makemovie.py
+++ b/src/bin/makemovie.py
@@ -2685,6 +2685,16 @@ class MakeMovie(object):
                     self.Debug(1, line)
                 else:
                     self.Debug(5, line)
+            # Wait for the process to terminate. If we don't wait then it's
+            # possible that the return code could end up being "None", which
+            # will cause the "if (r == 0):" test below to fail, which we
+            # don't want. There is mention that wait can cause a hang if
+            # stdout is a PIPE, which it is, and the child produces enough
+            # data such that it blocks waiting for the OS pipe buffer to
+            # accept more data. I wouldn't expect this to happen since we
+            # only get here when there is no more data being sent by the
+            # child.
+            proc.wait()
             r = proc.returncode
                 
             self.Debug(1, "mpeg2encode returned %s" % r)

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Command recording for GlobalLineoutAttributes now works correctly.</li>
   <li>Fixed pick failure for Rectilinear grids when real zones are completely surrounded by ghost zones.</li>
   <li>Fixed a bug where VisIt would hang when working with a AMR meshes and the number of active patches was less than the number of processors and the patches were not rectilinear.</li>
+  <li>Fixed a bug where encoding an mpeg movie on an Ubuntu 21 system failed.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

This together with https://github.com/visit-dav/visit/pull/16985 resolves #17191.

Corrected a bug where the makemovie.py could erroneously report that the movie wasn't corrected in the case of creating a movie with mpeg2encode.

### Type of change

* [X] Bug fix

### How Has This Been Tested?

I tested the change on an ubuntu 21 system with and without ffmpeg installed. Without ffmpeg installed it ended up using mpeg2encode and with ffmpeg installed it used ffmpeg. In both cases the movies generated were correct. I also tested the change on quartz and that worked as well.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
