### PR TITLE
Fix a bug where mpeg encoding erroneously indicates it failed. (#17192)

### DIFF
--- a/src/bin/makemovie.py
+++ b/src/bin/makemovie.py
@@ -2688,6 +2688,16 @@ class MakeMovie(object):
                     self.Debug(1, line)
                 else:
                     self.Debug(5, line)
+            # Wait for the process to terminate. If we don't wait then it's
+            # possible that the return code could end up being "None", which
+            # will cause the "if (r == 0):" test below to fail, which we
+            # don't want. There is mention that wait can cause a hang if
+            # stdout is a PIPE, which it is, and the child produces enough
+            # data such that it blocks waiting for the OS pipe buffer to
+            # accept more data. I wouldn't expect this to happen since we
+            # only get here when there is no more data being sent by the
+            # child.
+            proc.wait()
             r = proc.returncode
                 
             self.Debug(1, "mpeg2encode returned %s" % r)

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Command recording for GlobalLineoutAttributes now works correctly.</li>
   <li>Fixed pick failure for Rectilinear grids when real zones are completely surrounded by ghost zones.</li>
   <li>Fixed a bug where VisIt would hang when working with a AMR meshes and the number of active patches was less than the number of processors and the patches were not rectilinear.</li>
+  <li>Fixed a bug where encoding an mpeg movie on an Ubuntu 21 system failed.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #17191 
Merge from the 3.2RC to develop.