### PR TITLE
Correct reading of long64 data from Uintah files.

### DIFF
--- a/data/uintah_test_data.7z
+++ b/data/uintah_test_data.7z
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef62301c237d1d9262b180dfd113161275a8f24e90afd5d37b0f58dccbc324fd
+size 3405

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed pick failure for Rectilinear grids when real zones are completely surrounded by ghost zones.</li>
   <li>Fixed a bug where VisIt would hang when working with a AMR meshes and the number of active patches was less than the number of processors and the patches were not rectilinear.</li>
   <li>Fixed a bug where encoding an mpeg movie on an Ubuntu 21 system failed.</li>
+  <li>Fixed a bug in the Uintah reader where long64 data was read as zeroes. This primarily impacted particle ids.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/databases/uintah.py
+++ b/src/test/tests/databases/uintah.py
@@ -1,0 +1,58 @@
+# ----------------------------------------------------------------------------
+#  CLASSES: nightly
+#
+#  Test Case:  uintah.py
+#
+#  Programmer: Eric Brugger
+#  Date:       Tue Jan  4 13:05:47 PST 2022
+#
+#  Modifications:
+#
+# ----------------------------------------------------------------------------
+RequiredDatabasePlugin("Xdmf")
+
+def test_particle():
+    TestSection("Particle data")
+    OpenDatabase(pjoin(data_path("uintah_test_data"), "index.xml"))
+    AddPlot("Pseudocolor", "p.particleID/*")
+    pc = PseudocolorAttributes()
+    pc.pointType = pc.Point
+    pc.pointSizePixels = 40
+    SetPlotOptions(pc)
+    DrawPlots()
+
+    v = View3DAttributes()
+    v.viewNormal = (0, -1, 0)
+    v.focus = (0.01, 0.01, 0.015)
+    v.viewUp = (0, 0, 1)
+    v.viewAngle = 30
+    v.parallelScale = 0.0206155
+    v.nearPlane = -0.0412311
+    v.farPlane = 0.0412311
+    v.imagePan = (0, 0)
+    v.imageZoom = 1
+    v.perspective = 0
+    SetView3D(v)
+    Test("Particle_00")
+
+    ChangeActivePlotsVar("p.particleID/0")
+    Test("Particle_01")
+
+    ChangeActivePlotsVar("p.particleID/1")
+    Test("Particle_02")
+
+    ChangeActivePlotsVar("p.mass/*")
+    Test("Particle_03")
+
+    ChangeActivePlotsVar("p.mass/0")
+    Test("Particle_04")
+
+    ChangeActivePlotsVar("p.mass/1")
+    Test("Particle_05")
+
+def main():
+    test_particle()
+
+main()
+Exit()
+

--- a/src/test/tests/databases/uintah.py
+++ b/src/test/tests/databases/uintah.py
@@ -50,6 +50,14 @@ def test_particle():
     ChangeActivePlotsVar("p.mass/1")
     Test("Particle_05")
 
+    PickAtts = GetPickAttributes()
+    PickAtts.variables = ("p.particleID/*")
+    SetPickAttributes(PickAtts)
+    SetQueryOutputToObject()
+    p = NodePick(0, 0)
+    id = p['p.particleID/*']
+    TestValueEQ("Particle ID", id, 281474976710656., 0)
+
 def main():
     test_particle()
 

--- a/test/baseline/databases/uintah/Particle_00.png
+++ b/test/baseline/databases/uintah/Particle_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b063fdc4c49dadd207ba249898b6e5fb316d349b1de4539085ba3c359095ba67
+size 950

--- a/test/baseline/databases/uintah/Particle_01.png
+++ b/test/baseline/databases/uintah/Particle_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29788adbea5cf1efaf7fc6cc58418fe6965ec1a8ff81c22151f4eb6e0bfacef8
+size 933

--- a/test/baseline/databases/uintah/Particle_02.png
+++ b/test/baseline/databases/uintah/Particle_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:747d069048f568aa24c25c3d77109ce60937c9552841bb50cbbfbed9cec570b1
+size 933

--- a/test/baseline/databases/uintah/Particle_03.png
+++ b/test/baseline/databases/uintah/Particle_03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b063fdc4c49dadd207ba249898b6e5fb316d349b1de4539085ba3c359095ba67
+size 950

--- a/test/baseline/databases/uintah/Particle_04.png
+++ b/test/baseline/databases/uintah/Particle_04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29788adbea5cf1efaf7fc6cc58418fe6965ec1a8ff81c22151f4eb6e0bfacef8
+size 933

--- a/test/baseline/databases/uintah/Particle_05.png
+++ b/test/baseline/databases/uintah/Particle_05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:747d069048f568aa24c25c3d77109ce60937c9552841bb50cbbfbed9cec570b1
+size 933


### PR DESCRIPTION
### Description

Resolves #17212 

I added a patch to build_visit for the Uintah library to fix a bug reading long64 data. The was a missing template method for handling long64. The patch adds it. This fixes the reading of particle IDs which are long long int. While I was at it, I added some Uintah particle data for testing and added some tests for Uintah particle data. Note that we didn't have any Uintah data or tests previously.

### Type of change

* [X] Bug fix

### How Has This Been Tested?

I used build_visit to build the Unitah library with the code that adds the patches on quartz. I then built VisIt against that new Uintah library and the images where correct for the sample data provided.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
