### PR TITLE
Rename Grammar.h and Token.h since python also has headers by those names

### DIFF
--- a/src/common/expr/ExprParser.C
+++ b/src/common/expr/ExprParser.C
@@ -4,7 +4,7 @@
 
 #include <ExprParser.h>
 #include <ExprNode.h>
-#include <Token.h>
+#include <VisItToken.h>
 #include <SymbolSet.h>
 #include <Sequence.h>
 #include <Rule.h>

--- a/src/common/parser/Grammar.C
+++ b/src/common/parser/Grammar.C
@@ -2,9 +2,9 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#include "Grammar.h"
+#include "VisItGrammar.h"
 #include "Colors.h"
-#include "Token.h"
+#include "VisItToken.h"
 #include <stdio.h>
 #include <set>
 

--- a/src/common/parser/Parser.C
+++ b/src/common/parser/Parser.C
@@ -3,7 +3,7 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 #include <VisItParser.h>
-#include <Token.h>
+#include <VisItToken.h>
 #include <SymbolSet.h>
 #include <Sequence.h>
 #include <Rule.h>

--- a/src/common/parser/Symbol.C
+++ b/src/common/parser/Symbol.C
@@ -5,7 +5,7 @@
 #include "Symbol.h"
 #include "Dictionary.h"
 #include "Rule.h"
-#include "Token.h"
+#include "VisItToken.h"
 using std::vector;
 using std::string;
 using std::map;

--- a/src/common/parser/Token.C
+++ b/src/common/parser/Token.C
@@ -2,7 +2,7 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#include "Token.h"
+#include "VisItToken.h"
 
 using std::string;
 

--- a/src/common/parser/VisItGrammar.h
+++ b/src/common/parser/VisItGrammar.h
@@ -2,8 +2,8 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#ifndef GRAMMAR_H
-#define GRAMMAR_H
+#ifndef VISIT_GRAMMAR_H
+#define VISIT_GRAMMAR_H
 #include <parser_exports.h>
 
 #include "Symbol.h"

--- a/src/common/parser/VisItToken.h
+++ b/src/common/parser/VisItToken.h
@@ -2,8 +2,8 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#ifndef TOKEN_H
-#define TOKEN_H
+#ifndef VISIT_TOKEN_H
+#define VISIT_TOKEN_H
 #include <parser_exports.h>
 
 #include <string>

--- a/src/common/parser/testparser.C
+++ b/src/common/parser/testparser.C
@@ -2,9 +2,9 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#include "Token.h"
+#include "VisItToken.h"
 #include "Scanner.h"
-#include "Grammar.h"
+#include "VisItGrammar.h"
 #include "VisItParser.h"
 #include "ParseException.h"
 #include "Symbol.h"


### PR DESCRIPTION
Resolves #17205.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ensured the code base compiles.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
