### PR TITLE
Rename Grammar.h and Token.h since python also has headers by those names

### DIFF
--- a/src/common/expr/ExprGrammar.h
+++ b/src/common/expr/ExprGrammar.h
@@ -6,7 +6,7 @@
 #define EXPRGRAMMAR_H
 #include <expr_exports.h>
 
-#include "Grammar.h"
+#include "VisItGrammar.h"
 
 // ****************************************************************************
 //  Class:  ExprGrammar

--- a/src/common/expr/ExprParser.C
+++ b/src/common/expr/ExprParser.C
@@ -4,7 +4,7 @@
 
 #include <ExprParser.h>
 #include <ExprNode.h>
-#include <Token.h>
+#include <VisItToken.h>
 #include <SymbolSet.h>
 #include <Sequence.h>
 #include <Rule.h>

--- a/src/common/expr/ExprToken.h
+++ b/src/common/expr/ExprToken.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <stdlib.h>
 #include <ExprParseTreeNode.h>
-#include <Token.h>
+#include <VisItToken.h>
 
 enum TokenType {
     TT_NoToken    = 0,

--- a/src/common/parser/Grammar.C
+++ b/src/common/parser/Grammar.C
@@ -2,9 +2,9 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#include "Grammar.h"
+#include "VisItGrammar.h"
 #include "Colors.h"
-#include "Token.h"
+#include "VisItToken.h"
 #include <stdio.h>
 #include <set>
 

--- a/src/common/parser/Parser.C
+++ b/src/common/parser/Parser.C
@@ -3,7 +3,7 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 #include <VisItParser.h>
-#include <Token.h>
+#include <VisItToken.h>
 #include <SymbolSet.h>
 #include <Sequence.h>
 #include <Rule.h>

--- a/src/common/parser/Scanner.h
+++ b/src/common/parser/Scanner.h
@@ -10,7 +10,7 @@
 #include <visitstream.h>
 #include <string>
 
-#include "Token.h"
+#include "VisItToken.h"
 
 // ****************************************************************************
 //  Class:  Scanner

--- a/src/common/parser/Symbol.C
+++ b/src/common/parser/Symbol.C
@@ -5,7 +5,7 @@
 #include "Symbol.h"
 #include "Dictionary.h"
 #include "Rule.h"
-#include "Token.h"
+#include "VisItToken.h"
 using std::vector;
 using std::string;
 using std::map;

--- a/src/common/parser/Token.C
+++ b/src/common/parser/Token.C
@@ -2,7 +2,7 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#include "Token.h"
+#include "VisItToken.h"
 
 using std::string;
 

--- a/src/common/parser/VisItGrammar.h
+++ b/src/common/parser/VisItGrammar.h
@@ -2,8 +2,8 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#ifndef GRAMMAR_H
-#define GRAMMAR_H
+#ifndef VISIT_GRAMMAR_H
+#define VISIT_GRAMMAR_H
 #include <parser_exports.h>
 
 #include "Symbol.h"

--- a/src/common/parser/VisItParser.h
+++ b/src/common/parser/VisItParser.h
@@ -9,11 +9,11 @@
 #include <vector>
 #include <visitstream.h>
 
-#include <Token.h>
+#include <VisItToken.h>
 #include <ParseTreeNode.h>
 #include <Symbol.h>
 #include <State.h>
-#include <Grammar.h>
+#include <VisItGrammar.h>
 
 // ****************************************************************************
 //  Class:  ParseElem

--- a/src/common/parser/VisItToken.h
+++ b/src/common/parser/VisItToken.h
@@ -2,8 +2,8 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#ifndef TOKEN_H
-#define TOKEN_H
+#ifndef VISIT_TOKEN_H
+#define VISIT_TOKEN_H
 #include <parser_exports.h>
 
 #include <string>

--- a/src/common/parser/testparser.C
+++ b/src/common/parser/testparser.C
@@ -2,9 +2,9 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#include "Token.h"
+#include "VisItToken.h"
 #include "Scanner.h"
-#include "Grammar.h"
+#include "VisItGrammar.h"
 #include "VisItParser.h"
 #include "ParseException.h"
 #include "Symbol.h"


### PR DESCRIPTION
Merge from 3.2RC

Resolves #17205.

