### PR TITLE
two blueprint plugin bug fixes

### DIFF
--- a/src/databases/Blueprint/avtBlueprintDataAdaptor.C
+++ b/src/databases/Blueprint/avtBlueprintDataAdaptor.C
@@ -186,7 +186,22 @@ Blueprint_MultiCompArray_To_VTKDataArray(const Node &n,
 }
 
 
-
+// ****************************************************************************
+//  Method: ConduitArrayToVTKDataArray
+//
+//  Purpose:
+//   Constructs a vtkDataArray from a Conduit mcarray.
+//
+//  Arguments:
+//   n:    Blueprint Field Values Node
+//
+//  Programmer: Cyrus Harrison
+//  Creation:   Sat Jul  5 11:38:31 PDT 2014 (?)
+//
+//  Modifications:
+//    Cyrus Harrison, Thu Jan 13 11:14:20 PST 2022
+//    Add support for unsigned long and unsigned long long.
+//
 // ****************************************************************************
 vtkDataArray *
 ConduitArrayToVTKDataArray(const conduit::Node &n)
@@ -251,6 +266,24 @@ ConduitArrayToVTKDataArray(const conduit::Node &n)
                                                                               ntuples,
                                                                               retval);
     }
+    else if (vals_dtype.is_unsigned_long())
+    {
+        retval = vtkUnsignedLongArray::New();
+        Blueprint_MultiCompArray_To_VTKDataArray<CONDUIT_NATIVE_UNSIGNED_LONG>(n,
+                                                                               ncomps,
+                                                                               ntuples,
+                                                                               retval);
+    }
+#if CONDUIT_USE_LONG_LONG
+    else if (vals_dtype.id() == CONDUIT_NATIVE_UNSIGNED_LONG_LONG_ID)
+    {
+        retval = vtkUnsignedLongLongArray::New();
+        Blueprint_MultiCompArray_To_VTKDataArray<CONDUIT_NATIVE_UNSIGNED_LONG_LONG>(n,
+                                                                                    ncomps,
+                                                                                    ntuples,
+                                                                                    retval);
+    }
+#endif
     else if (vals_dtype.is_char())
     {
         retval = vtkCharArray::New();
@@ -573,7 +606,7 @@ StructuredTopologyToVTKStructuredGrid(const Node &n_coords,
 //  Method: HomogeneousShapeTopologyToVTKCellArray
 //
 //  Purpose:
-//   Constructs a vtkDataArray that contains a refined mfem mesh field variable.
+//   Constructs a vtkCell array from a Blueprint topology
 //
 //  Arguments:
 //   n_topo:    Blueprint Topology

--- a/src/databases/Blueprint/avtBlueprintDataAdaptor.C
+++ b/src/databases/Blueprint/avtBlueprintDataAdaptor.C
@@ -569,11 +569,26 @@ StructuredTopologyToVTKStructuredGrid(const Node &n_coords,
     return sgrid;
 }
 
-
+// ****************************************************************************
+//  Method: HomogeneousShapeTopologyToVTKCellArray
+//
+//  Purpose:
+//   Constructs a vtkDataArray that contains a refined mfem mesh field variable.
+//
+//  Arguments:
+//   n_topo:    Blueprint Topology
+//
+//  Programmer: Cyrus Harrison
+//  Creation:   Sat Jul  5 11:38:31 PDT 2014
+//
+//  Modifications:
+//    Chris Laganella, Thu Jan 13 11:07:26 PST 2022
+//    Fix bug where index array could be copied in interloop
+//
 // ****************************************************************************
 vtkCellArray *
 HomogeneousShapeTopologyToVTKCellArray(const Node &n_topo,
-                                       int npts)
+                                       int /* npts -- UNUSED */)
 {
     vtkCellArray *ca = vtkCellArray::New();
     vtkIdTypeArray *ida = vtkIdTypeArray::New();
@@ -603,19 +618,20 @@ HomogeneousShapeTopologyToVTKCellArray(const Node &n_topo,
 
         int_array topo_conn;
         ida->SetNumberOfTuples(ncells * (csize + 1));
+
+        Node n_tmp;
+        if(n_topo["elements/connectivity"].dtype().is_int())
+        {
+            topo_conn = n_topo["elements/connectivity"].as_int_array();
+        }
+        else
+        {
+            n_topo["elements/connectivity"].to_int_array(n_tmp);
+            topo_conn = n_tmp.as_int_array();
+        }
+
         for (int i = 0 ; i < ncells; i++)
         {
-            Node n_tmp;
-            if(n_topo["elements/connectivity"].dtype().is_int())
-            {
-                topo_conn = n_topo["elements/connectivity"].as_int_array();
-            }
-            else
-            {
-                n_topo["elements/connectivity"].to_int_array(n_tmp);
-                topo_conn = n_tmp.as_int_array();
-            }
-
             ida->SetComponent((csize+1)*i, 0, csize);
             for (int j = 0; j < csize; j++)
             {

--- a/src/resources/help/en_US/relnotes3.2.2.html
+++ b/src/resources/help/en_US/relnotes3.2.2.html
@@ -21,6 +21,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.2.2</font></b></p>
 <ul>
+  <li>Fixed a bug in the Blueprint Database Plugin preventing unsigned 64-bit array field values.</li>
+  <li>Fixed a bug in the Blueprint Database Plugin that caused unnecessary copies of topology connectivity arrays.</li>
   <li>Fixed a bug in the Blueprint Database Plugin where YAML or JSON root files were rewritten on open, which could strip comments and change the file entires. The root file is now opened in a read only mode.</li>
   <li>Fixed a bug where versions of VisIt that supported hardware accelerated rendering would display a black image in the visualization window.</li>
   <li>Fixed a crash when saving images greater than approximately 8,000 x 8,000. Now images can be saved up to 16,384 x 16,384.</li>


### PR DESCRIPTION
### Description

- Bug fix from  @Laganellac to avoid copying connectivity array in inner loop
- Adds support for unsigned 64-bit fields

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

Tested by compiling on my mac. 

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
