### PR TITLE
apply #5725 to develop

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -393,18 +393,17 @@ function build_cgns
 
     # Disable fortran
     FORTRANARGS="--with-fortran=no"
-
     set -x
-    if [[ "$OPSYS" == "Darwin" ]] ; then
-        env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
-            CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
-            LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV" \
-            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
-    else
-        env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
-            CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
-            ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
-    fi
+
+    info "    env CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
+        CFLAGS=\"$C_OPT_FLAGS\" CXXFLAGS=\"$CXX_OPT_FLAGS\" \
+        LDFLAGS=\"$LDFLAGS_ENV\" LIBS=\"$LIBS_ENV\" \
+        ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix=\"$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH\""
+
+    env CXX="$CXX_COMPILER" CC="$C_COMPILER" \
+        CFLAGS="$CFLAGS $C_OPT_FLAGS" CXXFLAGS="$CXXFLAGS $CXX_OPT_FLAGS" \
+        LDFLAGS="$LDFLAGS_ENV" LIBS="$LIBS_ENV" \
+        ./configure --enable-64bit --enable-cgnstools=no ${cf_build_type} $H5ARGS $FORTRANARGS --prefix="$VISITDIR/cgns/$CGNS_VERSION/$VISITARCH"
     set +x
 
     if [[ $? != 0 ]] ; then

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -502,6 +502,15 @@ function build_silo
     fi 
 
     set -x
+
+    info "./configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
+        CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
+        $FORTRANARGS \
+        --prefix=\"$VISITDIR/silo/$SILO_VERSION/$VISITARCH\" \
+        $WITHHDF5ARG $WITHSZIPARG $WITHSILOQTARG $WITHSHAREDARG $WITH_HZIP_AND_FPZIP\
+        --enable-install-lite-headers --without-readline \
+        $ZLIBARGS $SILO_EXTRA_OPTIONS ${extra_ac_flags}"
+
     # In order to ensure $FORTRANARGS is expanded to build the arguments to
     # configure, we wrap the invokation in 'sh -c "..."' syntax
     sh -c "./configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \


### PR DESCRIPTION
### Description

I believe that we did not apply #5725 to develop when it was merged to the 3.2 RC.

This PR attempts to remedy this and I think this needs careful consideration.

I looked at blames, etc to convince myself this was the case.  It would be great if others to look at this sideways to make sure I didn't miss something big.

Also, I am a bit worried there could  be other cases where we missed a merge like this?  Can we audit other PRs?

Note: For the `bv_silo` changes, the differences were a bunch of `<CR>` (carriage returns) in a patch, that might not be obvious when we look at it on github. 


### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Other <!-- please explain with a note below -->

missing merge?

### How Has This Been Tested?

### Checklist:

~~- [x] I have followed the [style guidelines][1] of this project.~~
~~- [x] I have performed a self-review of my own code.~~
~~- [x] I have commented my code where applicable.~~
~~- [x] I have updated the release notes.~~
~~- [x] I have made corresponding changes to the documentation.~~
~~- [x] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
