### PR TITLE
Change RequiredDatabasePlugin in uintah.py test from Xdmf to Uintah.

### DIFF
--- a/src/test/tests/databases/uintah.py
+++ b/src/test/tests/databases/uintah.py
@@ -9,7 +9,7 @@
 #  Modifications:
 #
 # ----------------------------------------------------------------------------
-RequiredDatabasePlugin("Xdmf")
+RequiredDatabasePlugin("Uintah")
 
 def test_particle():
     TestSection("Particle data")


### PR DESCRIPTION
### Description

Resolves #17224 

I changed the `RequiredDatabasePlugin` call in the `uintah.py` test from `Xdmf` to `Uintah`. This was a typo on my part when I created the tests.

### Type of change

* [X] Bug fix

### How Has This Been Tested?

This hasn't been tested.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
