### PR TITLE
Upate build_visit to build the 3.2.2 tagged release.

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -36,7 +36,7 @@
 #5  bv_<module>_depends_on [not implemented yet], also may be removed in favor of xml structure
 #6. bv_<module>_build builds the module
 
-export VISIT_VERSION=${VISIT_VERSION:-"3.2.1"}
+export VISIT_VERSION=${VISIT_VERSION:-"3.2.2"}
 
 ####
 # Trunk:
@@ -48,17 +48,17 @@ export VISIT_VERSION=${VISIT_VERSION:-"3.2.1"}
 ###
 # RC Branch:
 ###
-export TRUNK_BUILD="no"
-export RC_BUILD="yes"
-export TAGGED_BUILD="no"
+#export TRUNK_BUILD="no"
+#export RC_BUILD="yes"
+#export TAGGED_BUILD="no"
 
 
 ###
 # Tagged Release:
 ###
-#export TRUNK_BUILD="no"
-#export RC_BUILD="no"
-#export TAGGED_BUILD="yes"
+export TRUNK_BUILD="no"
+export RC_BUILD="no"
+export TAGGED_BUILD="yes"
 
 export INITIAL_PWD=$PWD
 


### PR DESCRIPTION
### Description

I updated the build_visit script to build the 3.2.2 tagged release. After I tag the release I will change build_visit back to building the 3.2RC. These changes will not go onto develop.

### Type of change

* [X] New feature

### How Has This Been Tested?

I can't tested this yet, since it's a bit of a chicken and egg situation, since I want this change to be present when I tag 3.2.2 but I can't test it until I tag 3.2.2. I will test it after the fact, but these are trivial changes, so they should work.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis

This will not be merged to develop.