### PR TITLE
Update the Dockerfile for the CI from Ubuntu18 toUbuntu20.

### DIFF
--- a/scripts/ci/docker/Dockerfile
+++ b/scripts/ci/docker/Dockerfile
@@ -1,10 +1,12 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
 # Project developers.  See the top-level LICENSE file for dates and other
 # details.  No copyright assignment is required to contribute to VisIt.
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER Cyrus Harrison <cyrush@llnl.gov>
 
 # fetch build env
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=American/Los_Angeles
 RUN apt-get update && apt-get install -y \
     git \
     git-lfs \
@@ -25,6 +27,7 @@ RUN apt-get update && apt-get install -y \
     libx11-xcb-dev \
     libxcb-dri2-0-dev \
     libxcb-xfixes0-dev \
+    libxkbcommon-dev \
     libffi-dev \
     xutils-dev \
     xorg-dev \

--- a/src/resources/help/en_US/relnotes3.3.0.html
+++ b/src/resources/help/en_US/relnotes3.3.0.html
@@ -126,6 +126,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>There is now a WIN32DEFINES xml tag for database plugins, used to specify preprocessor defines needed by a plugin on Windows. If the needed define comes from a thirdparty library, the Find module for that library should set a CMake var with those defines that the plugin could then use in the .xml file. See FindCGNS.cmake and CGNS.xml for an example.</li>
   <li>The minimum required version of CMake is now 3.14, the version built by build_visit.</li> 
   <li>The programs qtviswinExample, qtvtkExample, qvtkopenglExample were added to help with debugging OpenGL issues.</li>
+  <li>Updated the Dockerfile for the CI to use Ubuntu20 instead of Ubuntu18.</li> 
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

I updated the Dockerfile for the CI from Ubuntu18 to Ubuntu20. This fixes compiler crashes building Qt, when creating the CI container on my Windows system. Most likely this was because of memory limits with the gcc compiler in Ubuntu18, but I couldn't get around this.

### Type of change

* [X] New feature

### How Has This Been Tested?

I used the new Dockerfile to build a new CI container.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
