### PR TITLE
Fix temp-image saving location for a couple of regression tests.

### DIFF
--- a/src/test/tests/faulttolerance/savewindow.py
+++ b/src/test/tests/faulttolerance/savewindow.py
@@ -10,6 +10,12 @@
 #
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #    Added ability to swtich between Silo's HDF5 and PDB data.
+#
+#    Kathleen Biagas, Tue Feb 8, 2022
+#    Use run_dir as outputDirectory instead of current. It is in the
+#    testing output directory and is cleaned up on exit.
+#    Added taskkill for Windows to kill the engine.
+#
 # ----------------------------------------------------------------------------
 
 import os
@@ -18,7 +24,7 @@ TurnOnAllAnnotations()
 
 swa = SaveWindowAttributes()
 swa.outputToCurrentDirectory = 0
-swa.outputDirectory = "current"
+swa.outputDirectory = TestEnv.params["run_dir"]
 SetSaveWindowAttributes(swa)
 
 OpenDatabase(silo_data_path("wave.visit"))
@@ -30,11 +36,14 @@ pa = GetProcessAttributes("engine")
 enginePid = int(pa.pids[0])
 
 s = ""
-# TODO_WINDOWS THIS WONT WORK ON WINDOWS
+
 for i in range(6):
     TimeSliderSetState(i)
     if i == 3:
-        os.system("kill -9 %d"%enginePid)
+        if sys.platform.startswith("win"):
+            os.system("taskkill.exe /F /PID %d /T"%enginePid)
+        else:
+            os.system("kill -9 %d"%enginePid)
     try:
         SaveWindow()
     except Exception as inst:

--- a/src/test/tests/rendering/scalable.py
+++ b/src/test/tests/rendering/scalable.py
@@ -43,6 +43,9 @@
 #    Kathleen Biagas, Fri Jul  7 13:41:36 PDT 2017
 #    Don't run this test if the parallel engine doesn't exist.
 #
+#    Kathleen Biagas, Tue Feb 8 2022
+#    Use run_dir for location of saving windows, it is cleaned up on exit.
+#
 # ----------------------------------------------------------------------------
 
 if not sys.platform.startswith("win"):
@@ -142,7 +145,7 @@ srModeHistory=""
 # function to save temporary windows used to force renders
 def MySaveWindow():
     swa = GetSaveWindowAttributes()
-    swa.fileName = "current/scalable_tmp.png"
+    swa.fileName = pjoin(TestEnv.params["run_dir"], "scalable_tmp.png")
     swa.format = swa.PNG
     swa.family = 0
     SetSaveWindowAttributes(swa)


### PR DESCRIPTION
Use 'run_dir' as it is guaranteed to exist, is cleaned up on exit, and works on all platforms.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the tests on Windows and Pascal with success.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
