### PR TITLE
Add anisotroic refinement support to Chombo

### DIFF
--- a/data/Chombo_test_data.7z
+++ b/data/Chombo_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efded3497de1d9b688a3787158015eabc1c1f1708d4f86634acdb0589faf924a
-size 27703744
+oid sha256:b85b040cb8691db6b877cf32f3486d8ed166c589d64a375fe1b1da146fe529fc
+size 27757877

--- a/src/databases/Chombo/avtChomboFileFormat.C
+++ b/src/databases/Chombo/avtChomboFileFormat.C
@@ -840,17 +840,33 @@ avtChomboFileFormat::InitializeReader(void)
         hid_t dx_id = H5Aopen_name(level, "vec_dx");
         if (dx_id >= 0)
         {
+            double dtmp[4];
             if (dimension == 2)
             {
                 doublevect2d dx_tmp;
-                H5Aread(dx_id, doublevect2d_id, &dx_tmp);
+                if (H5Aread(dx_id, doublevect2d_id, &dx_tmp) < 0)
+                {
+                    if (H5Aread(dx_id, H5T_NATIVE_DOUBLE, &dtmp[0]) >= 0) // try as simple array
+                    {
+                        dx_tmp.x = dtmp[0];
+                        dx_tmp.y = dtmp[1];
+                    }
+                }
                 dx[i].push_back(dx_tmp.x);
                 dx[i].push_back(dx_tmp.y);
             }
             else if (dimension == 3)
             {
                 doublevect3d dx_tmp;
-                H5Aread(dx_id, doublevect3d_id, &dx_tmp);
+                if (H5Aread(dx_id, doublevect3d_id, &dx_tmp) < 0)
+                {
+                    if (H5Aread(dx_id, H5T_NATIVE_DOUBLE, &dtmp[0]) >= 0) // try as simple array
+                    {
+                        dx_tmp.x = dtmp[0];
+                        dx_tmp.y = dtmp[1];
+                        dx_tmp.z = dtmp[2];
+                    }
+                }
                 dx[i].push_back(dx_tmp.x);
                 dx[i].push_back(dx_tmp.y);
                 dx[i].push_back(dx_tmp.z);
@@ -858,7 +874,16 @@ avtChomboFileFormat::InitializeReader(void)
             else
             {
                 doublevect4d dx_tmp;
-                H5Aread(dx_id, doublevect4d_id, &dx_tmp);
+                if (H5Aread(dx_id, doublevect4d_id, &dx_tmp) < 0)
+                {
+                    if (H5Aread(dx_id, H5T_NATIVE_DOUBLE, &dtmp[0]) >= 0) // try as simple array
+                    {
+                        dx_tmp.x = dtmp[0];
+                        dx_tmp.y = dtmp[1];
+                        dx_tmp.z = dtmp[2];
+                        dx_tmp.u = dtmp[3];
+                    }
+                }
                 dx[i].push_back(dx_tmp.x);
                 dx[i].push_back(dx_tmp.y);
                 dx[i].push_back(dx_tmp.z);
@@ -885,17 +910,33 @@ avtChomboFileFormat::InitializeReader(void)
             hid_t rr_id = H5Aopen_name(level, "vec_ref_ratio");
             if (rr_id >= 0)
             {
+                int itmp[4];
                 if (dimension == 2)
                 {
                     intvect2d rr_tmp;
-                    H5Aread(rr_id, intvect2d_id, &rr_tmp);
+                    if (H5Aread(rr_id, intvect2d_id, &rr_tmp) < 0)
+                    {
+                        if (H5Aread(rr_id, H5T_NATIVE_INT, &itmp[0]) >= 0) // try as simple array
+                        {
+                            rr_tmp.i = itmp[0];
+                            rr_tmp.j = itmp[1];
+                        }
+                    }
                     refinement_ratio[i].push_back(rr_tmp.i);
                     refinement_ratio[i].push_back(rr_tmp.j);
                 }
                 else if (dimension == 3)
                 {
                     intvect3d rr_tmp;
-                    H5Aread(rr_id, intvect3d_id, &rr_tmp);
+                    if (H5Aread(rr_id, intvect3d_id, &rr_tmp) < 0)
+                    {
+                        if (H5Aread(rr_id, H5T_NATIVE_INT, &itmp[0]) >= 0) // try as simple array
+                        {
+                            rr_tmp.i = itmp[0];
+                            rr_tmp.j = itmp[1];
+                            rr_tmp.k = itmp[2];
+                        }
+                    }
                     refinement_ratio[i].push_back(rr_tmp.i);
                     refinement_ratio[i].push_back(rr_tmp.j);
                     refinement_ratio[i].push_back(rr_tmp.k);

--- a/src/databases/Chombo/avtChomboFileFormat.C
+++ b/src/databases/Chombo/avtChomboFileFormat.C
@@ -396,6 +396,26 @@ add_var(hid_t loc_id, const char *varname, void *opData)
   return 0;
 }
 
+//
+// Purpose: Open HDF5 file with close degree semi
+//
+// Programmer: Mark C. Miller, Wed Feb  9 13:35:50 PST 2022
+//
+static hid_t OpenHDF5File(char const *fname)
+{
+    hid_t retval;
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+    retval = H5Fopen(fname, H5F_ACC_RDONLY, fapl);
+    H5Pclose(fapl);
+    return retval;
+}
+
+//
+//  Modifications
+//    Mark C. Miller, Wed Feb  9 13:37:12 PST 2022
+//    Use new method, OpenHDF5File, to open the file.
+//
 void
 avtChomboFileFormat::InitializeReader(void)
 {
@@ -416,7 +436,7 @@ avtChomboFileFormat::InitializeReader(void)
     //
     // Open file
     //
-    file_handle = H5Fopen(filenames[0], H5F_ACC_RDONLY, H5P_DEFAULT);
+    file_handle = OpenHDF5File(filenames[0]);
     if (file_handle < 0)
     {
         EXCEPTION1(InvalidDBTypeException, "Cannot be a Chombo file, since "
@@ -1387,7 +1407,7 @@ avtChomboFileFormat::InitializeReader(void)
             FileFunctions::VisItStat_t fs;
             if (FileFunctions::VisItStat(mappingFilename.c_str(), &fs) == 0)
             {
-                hid_t mapping_file_handle = H5Fopen(mappingFilename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+                hid_t mapping_file_handle = OpenHDF5File(mappingFilename.c_str());
                 if (mapping_file_handle > 0)
                 {
                     hid_t slash = H5Gopen(mapping_file_handle, "/");
@@ -2398,6 +2418,11 @@ class LookUpOrderCmp
         const int *order2Var;
 };
 
+//
+//  Modifications
+//    Mark C. Miller, Wed Feb  9 13:38:49 PST 2022
+//    Use new method, OpenHDF5File, to open file.
+//
 vtkDataSet *
 avtChomboFileFormat::GetMesh(int patch, const char *meshname)
 {
@@ -2648,7 +2673,7 @@ avtChomboFileFormat::GetMesh(int patch, const char *meshname)
 
         if (file_handle < 0)
         {
-            file_handle = H5Fopen(filenames[0], H5F_ACC_RDONLY, H5P_DEFAULT);
+            file_handle = OpenHDF5File(filenames[0]);
             if (file_handle < 0)
             {
                 EXCEPTION1(InvalidDBTypeException, "Cannot be a Chombo file, since "
@@ -2996,6 +3021,8 @@ avtChomboFileFormat::GetMesh(int patch, const char *meshname)
 //    Initial bare-bones support for 4D Chombo files (fairly limited and 
 //    "hackish")
 //
+//    Mark C. Miller, Wed Feb  9 13:39:31 PST 2022
+//    Use new method, OpenHDF5File, to open the file.
 // ****************************************************************************
 
 vtkDataArray *
@@ -3112,7 +3139,7 @@ avtChomboFileFormat::GetVar(int patch, const char *varname)
         snprintf(name, 1024, "level_%d", level);
         if (file_handle < 0)
         {
-            file_handle = H5Fopen(filenames[0], H5F_ACC_RDONLY, H5P_DEFAULT);
+            file_handle = OpenHDF5File(filenames[0]);
             if (file_handle < 0)
             {
                 EXCEPTION1(InvalidDBTypeException, "Cannot be a Chombo file, since "
@@ -3226,7 +3253,7 @@ avtChomboFileFormat::GetVar(int patch, const char *varname)
         {
             if (file_handle < 0)
             {
-                file_handle = H5Fopen(filenames[0], H5F_ACC_RDONLY, H5P_DEFAULT);
+                file_handle = OpenHDF5File(filenames[0]);
                 if (file_handle < 0)
                 {
                     EXCEPTION1(InvalidDBTypeException, "Cannot be a Chombo file, since "
@@ -3309,6 +3336,8 @@ avtChomboFileFormat::GetVar(int patch, const char *varname)
 //    Initial bare-bones support for 4D Chombo files (fairly limited and 
 //    "hackish")
 //
+//    Mark C. Miller, Wed Feb  9 13:40:08 PST 2022
+//    Use new method, OpenHDF5File, to open file.
 // ****************************************************************************
 
 vtkDataArray *
@@ -3461,7 +3490,7 @@ avtChomboFileFormat::GetVectorVar(int patch, const char *varname)
             snprintf(name, 1024, "level_%d", level);
             if (file_handle < 0)
             {
-                file_handle = H5Fopen(filenames[0], H5F_ACC_RDONLY, H5P_DEFAULT);
+                file_handle = OpenHDF5File(filenames[0]);
                 if (file_handle < 0)
                 {
                     EXCEPTION1(InvalidDBTypeException, "Cannot be a Chombo file, since "

--- a/src/databases/Chombo/avtChomboFileFormat.C
+++ b/src/databases/Chombo/avtChomboFileFormat.C
@@ -378,6 +378,12 @@ avtChomboFileFormat::ActivateTimestep(void)
 //    Initial bare-bones support for 4D Chombo files (fairly limited and 
 //    "hackish")
 //
+//    Mark C. Miller, Wed Feb  9 11:15:05 PST 2022
+//    Add contingency read logic for prob_lo, aspect_ratio, vec_dx and
+//    vec_ref_ratio to read these as simple arrays instead of structy types.
+//    The HDF5 library will fail the reads if you don't give it a compatible
+//    memory type to read into and the new logic allows for either case.
+//
 // ****************************************************************************
 
 extern "C"  herr_t

--- a/src/databases/Chombo/avtChomboFileFormat.C
+++ b/src/databases/Chombo/avtChomboFileFormat.C
@@ -585,7 +585,15 @@ avtChomboFileFormat::InitializeReader(void)
             doublevect probLoBuff;
             if (H5Aread(probLo_id, (dimension == 2 ? doublevect2d_id : doublevect3d_id), &probLoBuff) < 0)
             {
-                EXCEPTION1(InvalidDBTypeException, "Cannot read \"prob_lo\".");
+                double tmp[4];
+                if (H5Aread(probLo_id, H5T_NATIVE_DOUBLE, &tmp[0]) < 0) // try reading as simple array
+                { 
+                    EXCEPTION1(InvalidDBTypeException, "Cannot read \"prob_lo\".");
+                }
+                probLo[0] = tmp[0];
+                probLo[1] = tmp[1];
+                if (dimension > 2)
+                    probLo[2] = tmp[2];
             }
             else
             {
@@ -621,7 +629,15 @@ avtChomboFileFormat::InitializeReader(void)
             doublevect aspectRatioBuff;
             if (H5Aread(aspectRatio_id, (dimension == 2 ? doublevect2d_id : doublevect3d_id), &aspectRatioBuff) < 0)
             {
-                EXCEPTION1(InvalidDBTypeException, "Cannot read \"aspect_ratio\".");
+                double tmp[4];
+                if (H5Aread(aspectRatio_id, H5T_NATIVE_DOUBLE, &tmp[0]) < 0) // try reading as simple array
+                {
+                    EXCEPTION1(InvalidDBTypeException, "Cannot read \"aspect_ratio\".");
+                }
+                aspectRatio[0] = tmp[0];
+                aspectRatio[1] = tmp[1];
+                if (dimension > 2)
+                    aspectRatio[2] = tmp[2];
             }
             else
             {

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -29,6 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.2.3</font></b></p>
 <ul>
   <li>Updated the Ohio Supercomputing Center host profiles.</li>
+  <li>Chombo plugin now supports anisotropic refinements.</li>
   <li></li>
 </ul>
 

--- a/src/test/tests/databases/Chombo.py
+++ b/src/test/tests/databases/Chombo.py
@@ -51,6 +51,39 @@ def test0(datapath):
     DeleteAllPlots()
     CloseDatabase(db)
 
+def test1(datapath):
+    TestSection("More distinct refinements")
+
+    db = pjoin(datapath,"chombo.visit")
+    OpenDatabase(db)
+
+    AddPlot("Subset", "patches")
+    AddPlot("Contour", "P_y_Over_Rho")
+    DrawPlots()
+    v = GetView2D()
+    v.fullFrameActivationMode = v.On
+    SetView2D(v)
+
+    Test("Chombo_1_00")
+
+    ResetView()
+    DeleteAllPlots()
+    CloseDatabase(db)
+
+def test2(datapath):
+    TestSection("Anisotropic refinement")
+
+    db = pjoin(datapath,"aniso_refin.2d.hdf5")
+    OpenDatabase(db)
+    AddPlot("Mesh", "Mesh")
+    AddPlot("Subset", "levels")
+    DrawPlots()
+
+    Test("Chombo_2_00")
+
+    DeleteAllPlots()
+    CloseDatabase(db)
+
 def main():
     TurnOffAllAnnotations()
 
@@ -58,6 +91,8 @@ def main():
 
     datapath = data_path("Chombo_test_data")
     test0(datapath)
+    test1(datapath)
+    test2(datapath)
 
     InvertBackgroundColor()
 

--- a/test/baseline/databases/Chombo/Chombo_1_00.png
+++ b/test/baseline/databases/Chombo/Chombo_1_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1126890179e8beb666074aab6865d4ec70dc78f7c7f4cf8614163668990a6273
+size 1707

--- a/test/baseline/databases/Chombo/Chombo_2_00.png
+++ b/test/baseline/databases/Chombo/Chombo_2_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d8d37a22b0962dc70a82cf98d8679765e88848792d6d50de28606d90c30c784
+size 1313


### PR DESCRIPTION
### Description

Resolves #17318

This adds support for anisotropic refinements to Chombo plugin. For the most part, the plugin was already setup to handle this. The problem was the HDF5 read logic to tease the information from the file. Normally, HDF5 attributes named `"dx"` (spacing) and `"ref_ratio"` are *scalar* double and integer attributes associated with each *level* group in the file. In theory, for anisotropic cases, the attributes would be named `"vec_dx"` and `"vec_ref_ratio"`. However, an early data file I was given did not have this and instead had arrays (e.g. not scalars) for `"dx"` and `"ref_ratio"`. Later, a data file I was given did have `"vec_dx"` and `"vec_ref_ratio"` as arrays. That said, the plugin was written to assume those attributes would actually be struct types of the form `struct {double dx; double dy; double dz;}` and `struct {int ref_ratio_x; int ref_ratio_y; int ref_ratio_z}`. HDF5 is not friendly about reading between these types. The reader *must know* the correct *memory* type to read the data into and the plugin was failing.

Being unsure of what to expect in the way of Chombo file structure, I adjusted things so that it will read anisotropic data stored either as simple arrays in `"dx"` and `"ref_ratio"` or as simple arrays in `"vec_dx"` and `"vec_ref_ratio"` and left the logic already there that attempts to read into structy types.

I fixed a problem where the plugin was not opening the file with `H5F_CLOSE_SEMI` also.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I added test baselines and tests to `chombo.py` for anisotropic refinement using the file the user provided.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
