### PR TITLE
Fix volume plot generation of vtkError messages

### DIFF
--- a/src/plots/Volume/avtVolumePlot.C
+++ b/src/plots/Volume/avtVolumePlot.C
@@ -27,6 +27,7 @@
 #include <VolumeAttributes.h>
 
 #include <DebugStream.h>
+#include <InvalidLimitsException.h>
 #include <ImproperUseException.h>
 #include <LostConnectionException.h>
 
@@ -251,6 +252,10 @@ avtVolumePlot::Create()
 //    Have the legend reflect the scaling (log, linear, skew).  Also make sure
 //    that accurate numbers are put the legends range.
 //
+//    Kathleen Biagas, Mon Feb 7, 2022
+//    Only set the legend range when mapper has input. Also added checks
+//    for valid ranges.
+//
 // ****************************************************************************
 
 void
@@ -263,18 +268,28 @@ avtVolumePlot::SetAtts(const AttributeGroup *a)
 
     SetLegendOpacities();
 
-    double min = 0., max = 1.;
+    // SetAtts can be called before the mapper has data, so don't set
+    // legend's range unless there is input, as invalid ranges can cause
+    // vtkError messages
     if (*(mapper->GetInput()) != NULL)
+    {
+        double min = 0., max = 1.;
         mapper->GetRange(min, max);
-    if (atts.GetUseColorVarMin())
-    {
-        min = atts.GetColorVarMin();
+
+        if (atts.GetUseColorVarMin())
+        {
+            min = atts.GetColorVarMin();
+        }
+        if (atts.GetUseColorVarMax())
+        {
+            max = atts.GetColorVarMax();
+        }
+        if (min >= max)
+        {
+            EXCEPTION1(InvalidLimitsException, false);
+        }
+        varLegend->SetRange(min, max);
     }
-    if (atts.GetUseColorVarMax())
-    {
-        max = atts.GetColorVarMax();
-    }
-    varLegend->SetRange(min, max);
     if (atts.GetScaling() == VolumeAttributes::Linear)
         varLegend->SetScaling(0);
     else if (atts.GetScaling() == VolumeAttributes::Log)
@@ -551,16 +566,16 @@ bool GetLogicalBounds(avtDataObject_p input,int &width,int &height, int &depth)
 //
 //    Alister Maguire, Tue Dec 11 10:18:31 PST 2018
 //    With the new default renderer, the only time we don't resample
-//    is when we have a single domain rectilinear mesh. 
+//    is when we have a single domain rectilinear mesh.
 //
 // ****************************************************************************
 
 bool DataMustBeResampled(avtDataObject_p input)
 {
-    // 
-    // Unless we have a single domain rectilinear mesh, 
-    // we must resample. 
-    // 
+    //
+    // Unless we have a single domain rectilinear mesh,
+    // we must resample.
+    //
     avtMeshType mt = input->GetInfo().GetAttributes().GetMeshType();
     if (mt != AVT_RECTILINEAR_MESH)
     {
@@ -577,7 +592,7 @@ bool DataMustBeResampled(avtDataObject_p input)
     {
          //
          // If we have multiple domains, we still need to resample
-         // onto a single domain. 
+         // onto a single domain.
          //
          if (md->GetNDomains(datts.GetVariableName()) > 1)
              return true;
@@ -587,7 +602,7 @@ bool DataMustBeResampled(avtDataObject_p input)
     {
         //
         // We don't know how many domains we have... resample to
-        // be safe. 
+        // be safe.
         //
         return true;
     }
@@ -646,8 +661,8 @@ bool DataMustBeResampled(avtDataObject_p input)
 //    Replaced the Texture3D renderer with the Default renderer.
 //
 //    Alister Maguire, Tue Dec 11 10:18:31 PST 2018
-//    The new default renderer requires a single domain rectilinear dataset. 
-//    I've updated the logic to address this. 
+//    The new default renderer requires a single domain rectilinear dataset.
+//    I've updated the logic to address this.
 //
 // ****************************************************************************
 

--- a/src/plots/Volume/avtVolumePlot.C
+++ b/src/plots/Volume/avtVolumePlot.C
@@ -284,7 +284,7 @@ avtVolumePlot::SetAtts(const AttributeGroup *a)
         {
             max = atts.GetColorVarMax();
         }
-        if (min >= max)
+        if (min > max)
         {
             EXCEPTION1(InvalidLimitsException, false);
         }


### PR DESCRIPTION
### Description

Don't set LegendRange if mapper didn't have input.
Also added check for invalid range(min >= max) and throw exception.
Resolves #17307.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?
Ran the steps is the bug ticket, no error messages were generated.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
