### PR TITLE
Ubuntu 20 uses LANGUAGE env var for setting local language (#17322)

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -130,6 +130,21 @@ do
     fi
 done
 
+# Handle possible language spec
+have_lang=no
+for arg in $@
+do
+    if test "$have_lang" = "yes"; then
+        lang=$arg
+        export LANG="$lang"
+        export LANGUAGE="$lang"
+        break
+    fi
+    if test "$arg" = "-lang"; then
+        have_lang=yes
+    fi
+done
+
 # If we have a two digit version number, find the latest patch associated
 # with that two digit version. 
 if expr "$version" : '[0-9]\+\.[0-9]\+$' > /dev/null; then


### PR DESCRIPTION
Push 32RC work merged to 32RC in 1790f6b964a2749743ad626b1000679c15bd2321 to `develop`

it looks like the `-lang` option work was only on 32RC and this PR merges the whole code block that supports it.