### PR TITLE
Fix pluginVsInstall failure with Blueprint plugin.

### DIFF
--- a/src/CMake/PluginVsInstall.cmake.in
+++ b/src/CMake/PluginVsInstall.cmake.in
@@ -92,6 +92,9 @@
 #   Use @filtered_VTKm_INCLUDE_DIRS@  for setting VTKm_INCLUDE_DIRS
 #   instead of setting manually.
 #
+#   Kathleen Biagas, Mon Feb 28 13:48:42 PST 2022
+#   Added CONDUIT_HAVE_PARTITION_FLATTEN.
+#
 #****************************************************************************/
 
 ##
@@ -311,6 +314,7 @@ set(XDMF_LIB @XDMF_LIB@)
 set(CONDUIT_INCLUDE_DIR  ${VISIT_INCLUDE_DIR}/conduit/conduit)
 set(CONDUIT_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
 set(CONDUIT_LIB @CONDUIT_LIB@)
+set(CONDUIT_HAVE_PARTITION_FLATTEN @CONDUIT_HAVE_PARTITION_FLATTEN@)
 if(VISIT_PARALLEL)
     set(CONDUIT_MPI_INCLUDE_DIR ${VISIT_INCLUDE_DIR}/conduit/conduit)
     set(CONDUIT_MPI_LIBRARY_DIR ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})


### PR DESCRIPTION
### Description
Added CONDUIT_HAVE_PARTITION_FLATTEN to PluginVsInstall.cmake.in.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I compiled and ran the pluginVsInstall tests successfully on pascal.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
