### PR TITLE
removed angle brackets from const values in const exprs

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -1640,6 +1640,9 @@ QvisExpressionsWindow::UpdateStandardExpressionEditor(const QString &expr_def)
 //    Eddie Rusu, Mon Sep 23 10:33:50 PDT 2019
 //    Added divide expression with optional arguments.
 //
+//    Justin Privitera, Thu 03 Mar 2022 10:41:04 AM PST
+//    Removed angle brackets from all constant functions.
+//
 // ****************************************************************************
 
 QString
@@ -1767,7 +1770,7 @@ QvisExpressionsWindow::ExpandFunction(const QString &func_name)
              func_name == "point_constant" ||
              func_name == "nodal_constant" )
     {
-        res += QString("(<meshvar>, <constantvalue>)");
+        res += QString("(<meshvar>, constantvalue)");
         doParens = false;
     }
     else if(func_name == "average_over_time" || func_name == "min_over_time"

--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -1641,7 +1641,8 @@ QvisExpressionsWindow::UpdateStandardExpressionEditor(const QString &expr_def)
 //    Added divide expression with optional arguments.
 //
 //    Justin Privitera, Thu 03 Mar 2022 10:41:04 AM PST
-//    Removed angle brackets from all constant functions.
+//    Removed angle brackets from constantvalue field 
+//    in all 4 constant functions.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -21,7 +21,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.2.3</font></b></p>
 <ul>
-  <li></li>
+  <li>Fixed a bug with expression insert-function for constant expressions, so usage is clearer. </li>
   <li></li>
 </ul>
 


### PR DESCRIPTION
### Description

Resolves #17302

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Angle brackets have been removed around the `constantvalue` field. This reduces confusion when using these functions.

```
*_constant(<meshvar>, <constantvalue>)
```
has become
```
*_constant(<meshvar>, constantvalue)
```

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
I build VisIt on Ubuntu 20 and ran the gui to make sure that these changes had been made correctly.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
