### PR TITLE
move curl, divergence, gradient, and laplacian functions from mics. to vector submenu

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -164,6 +164,10 @@
 //    Eddie Rusu, Mon Sep 23 10:33:50 PDT 2019
 //    Added "divide" function under the "Math" menu.
 //
+//    Justin Privitera, Fri 04 Mar 2022 02:03:33 PM PST
+//    moved curl, divergence, gradient exprs, and laplacian
+//    from misc. submenu to vector submenu
+//
 // ****************************************************************************
 
 struct ExprNameList
@@ -274,8 +278,14 @@ const char *expr_vector[] = {
     "color4",
     "colorlookup",
     "cross",
+    "curl",
+    "divergence",
     "dot",
+    "gradient",
     "hsvcolor",
+    "ij_gradient",
+    "ijk_gradient",
+    "Laplacian",
     "magnitude",
     "normalize",
     NULL
@@ -344,20 +354,14 @@ const char *expr_misc[] = {
     "bin",
     "cell_constant",
     "conn_components",
-    "curl",
     "curve_domain",
     "curve_integrate",
     "curve_swapxy",
     "cycle",
-    "divergence",
     "enumerate",
     "gauss_curvature",
-    "gradient",
-    "ij_gradient",
-    "ijk_gradient",
     "isnan",
     "lambda2",
-    "Laplacian",
     "map",
     "mean_curvature",
     "nodal_constant",

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -22,7 +22,6 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.2.3</font></b></p>
 <ul>
   <li>Fixed a bug with expression insert-function for constant expressions, so usage is clearer. </li>
-  <li>Moved divergence, curl, gradient, and laplacian functions from mics. to vector submenu. </li>
 </ul>
 
 <a name="Enhancements"></a>
@@ -31,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the Ohio Supercomputing Center host profiles.</li>
   <li>Chombo plugin now supports anisotropic refinements.</li>
   <li>The WData database reader was added.</li>
+  <li>Moved divergence, curl, gradient, and laplacian functions from mics. to vector submenu. </li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -22,7 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.2.3</font></b></p>
 <ul>
   <li>Fixed a bug with expression insert-function for constant expressions, so usage is clearer. </li>
-  <li></li>
+  <li>Moved divergence, curl, gradient, and laplacian functions from mics. to vector submenu. </li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -30,7 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the Ohio Supercomputing Center host profiles.</li>
   <li>Chombo plugin now supports anisotropic refinements.</li>
   <li>The WData database reader was added.</li>
-  <li>Moved divergence, curl, gradient, and laplacian functions from mics. to vector submenu. </li>
+  <li>Moved the <i>divergence</i>, <i>curl</i>, <i>Laplacian</i>, and <i>gradient</i> functions from the <i>Miscellaneous</i> submenu to the <i>Vector</i> submenu within the <i>Insert function...</i> menu in the Expressions window. </li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #2042

I moved the specified functions from the misc. menu to the vector menu in the gui.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?
I built visit on Ubuntu 20 and made sure the gui reflected the changes I made.
<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- [ ] ~~I have made corresponding changes to the documentation.~~
- [ ] ~~I have added debugging support to my changes.~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] ~~I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] ~~I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
