### PR TITLE
Expand available macros for text annotations

### DIFF
--- a/src/avt/VisWindow/CMakeLists.txt
+++ b/src/avt/VisWindow/CMakeLists.txt
@@ -43,6 +43,7 @@ Colleagues/VisWinTriad.C
 Colleagues/VisWinUserInfo.C
 Colleagues/VisWinView.C
 Colleagues/avtAnnotationColleague.C
+Colleagues/avtAnnotationWithTextColleague.C
 Colleagues/avtImageColleague.C
 Colleagues/avtLegendAttributesColleague.C
 Colleagues/avtLine2DColleague.C

--- a/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.C
@@ -2,10 +2,8 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-// ************************************************************************* //
-//                              avtText2DColleague.C                         //
-// ************************************************************************* //
-#include <avtText2DColleague.h>
+#include <avtAnnotationWithTextColleague.h>
+#include <avtDataAttributes.h>
 #include <VisWindow.h>
 #include <VisWindowColleagueProxy.h>
 
@@ -15,17 +13,17 @@
 #include <vtkVisItTextActor.h>
 #include <vtkTextProperty.h>
 
-#define TIME_IDENTIFIER "$time"
-#define CYCLE_IDENTIFIER "$cycle"
+#include <memory>
 
-double avtText2DColleague::initialTime = 0.;
-int    avtText2DColleague::initialCycle = 0;
+#warning MAKE ME A UNIQUE_PTR
+// std::unique_ptr<avtDataAttributes const *> avtAnnotationWithTextColleague::initialDataAttributes(new avtDataAttributes);
+avtDataAttributes *avtAnnotationWithTextColleague::initialDataAttributes = new avtDataAttributes;
 
 // ****************************************************************************
-// Method: avtText2DColleague::avtText2DColleague
+// Method: avtAnnotationWithTextColleague::avtAnnotationWithText
 //
 // Purpose: 
-//   Constructor for the avtText2DColleague class.
+//   Constructor for the avtAnnotationWithText class.
 //
 // Arguments:
 //   m : The vis window proxy.
@@ -42,46 +40,20 @@ int    avtText2DColleague::initialCycle = 0;
 //   
 // ****************************************************************************
 
-avtText2DColleague::avtText2DColleague(VisWindowColleagueProxy &m) 
+avtAnnotationWithTextColleague::avtAnnotationWithTextColleague(VisWindowColleagueProxy &m) 
     : avtAnnotationColleague(m)
 {
-    useForegroundForTextColor = true;
-    addedToRenderer = false;
     textFormatString = 0;
     textString = 0;
-    currentTime = initialTime;
-    currentCycle = initialCycle;
-
-    //
-    // Create and position the actor.
-    //
-    textActor = vtkVisItTextActor::New();
-    textActor->SetTextScaleMode(vtkTextActor::TEXT_SCALE_MODE_VIEWPORT);
-    textActor->SetTextHeight(0.03);
-    SetText("2D text annotation");
-    vtkCoordinate *pos = textActor->GetPositionCoordinate();
-    pos->SetCoordinateSystemToNormalizedViewport();
-    pos->SetValue(0.5, 0.5, 0.);
-
-    // Make sure that the actor initially has the right fg color.
-    double fgColor[3];
-    mediator.GetForegroundColor(fgColor);
-    SetForegroundColor(fgColor[0], fgColor[1], fgColor[2]);
-    textActor->GetTextProperty()->SetOpacity(1.);
-
-    // Store the foreground color into the text color.
-    int ifgColor[3];
-    ifgColor[0] = int((float)fgColor[0] * 255.f);
-    ifgColor[1] = int((float)fgColor[1] * 255.f);
-    ifgColor[2] = int((float)fgColor[2] * 255.f);
-    textColor = ColorAttribute(ifgColor[0], ifgColor[1], ifgColor[2], 255);
+    currentDataAttributes = new avtDataAttributes;
+    currentDataAttributes->Copy(*initialDataAttributes);
 }
 
 // ****************************************************************************
-// Method: avtText2DColleague::~avtText2DColleague
+// Method: avtAnnotationWithTextColleague::~avtAnnotationWithText
 //
 // Purpose: 
-//   Destructor for the avtText2DColleague class.
+//   Destructor for the avtAnnotationWithText class.
 //
 // Programmer: Brad Whitlock
 // Creation:   Wed Nov 5 14:18:31 PST 2003
@@ -92,352 +64,15 @@ avtText2DColleague::avtText2DColleague(VisWindowColleagueProxy &m)
 //
 // ****************************************************************************
 
-avtText2DColleague::~avtText2DColleague()
+avtAnnotationWithTextColleague::~avtAnnotationWithTextColleague()
 {
-    if (textActor)
-        textActor->Delete();
     delete [] textString;
     delete [] textFormatString;
+    delete currentDataAttributes;
 }
 
 // ****************************************************************************
-// Method: avtText2DColleague::AddToRenderer
-//
-// Purpose: 
-//   This method adds the text actor to the renderer.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:52:19 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void 
-avtText2DColleague::AddToRenderer()
-{
-    if(!addedToRenderer && ShouldBeAddedToRenderer())
-    {
-        mediator.GetForeground()->AddActor2D(textActor);
-        addedToRenderer = true;
-    }
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::RemoveFromRenderer
-//
-// Purpose: 
-//   This method removes the text actor from the renderer.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:52:38 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void
-avtText2DColleague::RemoveFromRenderer()
-{
-    if(addedToRenderer)
-    {
-        mediator.GetForeground()->RemoveActor2D(textActor);
-        addedToRenderer = false;
-    }
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::Hide
-//
-// Purpose: 
-//   This method toggles the visible flag and either adds or removes the text
-//   actor to/from the renderer.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:52:57 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void
-avtText2DColleague::Hide()
-{
-    SetVisible(!GetVisible());
-
-    if(addedToRenderer)
-        RemoveFromRenderer();
-    else
-        AddToRenderer();
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::ShouldBeAddedToRenderer
-//
-// Purpose: 
-//   This method returns whether or not the text actor should be added to the
-//   renderer.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:53:36 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-bool
-avtText2DColleague::ShouldBeAddedToRenderer() const
-{
-    return GetVisible() && mediator.HasPlots();
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::SetOptions
-//
-// Purpose: 
-//   This method sets the text actor's properties from the values in the
-//   annotation object.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:54:02 PST 2003
-//
-// Modifications:
-//    Brad Whitlock, Tue Aug 31 11:56:56 PDT 2004
-//    I added code to set the object's visibility so objects that are not
-//    visible remain invisible when restoring a session file.
-//
-//    Brad Whitlock, Thu Mar 22 15:02:23 PST 2007
-//    Changed FieldsEqual due to state object changes.
-//
-// ****************************************************************************
-
-void
-avtText2DColleague::SetOptions(const AnnotationObject &annot)
-{
-    // Get the current options.
-    AnnotationObject currentOptions;
-    GetOptions(currentOptions);
-
-    //
-    // The text color has changed or the useForegroundForTextColor flag
-    // has changed.
-    //
-    if(annot.GetUseForegroundForTextColor() != useForegroundForTextColor ||
-       annot.GetTextColor() != textColor)
-    {
-        // Record the text color that should be used when we're not using
-        // the foreground text color.
-        textColor = annot.GetTextColor();
-        useForegroundForTextColor = annot.GetUseForegroundForTextColor();
-
-        // Compute the text opacity.
-        double tc[4];
-        tc[3] = double(textColor.Alpha()) / 255.;
-
-        // Set the text color using the foreground color or the text color.
-        if(useForegroundForTextColor)
-        {
-            // Get the foreground color.
-            double fgColor[3];
-            mediator.GetForegroundColor(fgColor);
-            textActor->GetTextProperty()->SetColor(fgColor[0], fgColor[1], fgColor[2]);
-        }
-        else
-        {
-            // Compute the text color as double.
-            tc[0] = double(textColor.Red()) / 255.;
-            tc[1] = double(textColor.Green()) / 255.;
-            tc[2] = double(textColor.Blue()) / 255.;
-            textActor->GetTextProperty()->SetColor(tc[0], tc[1], tc[2]);
-        }
-
-        // Set the text opacity.
-        textActor->GetTextProperty()->SetOpacity(tc[3]);
-    }
-
-    //
-    // Set the labels if the text vector is different
-    //
-    bool textChanged = false;
-    if(currentOptions.GetText() != annot.GetText())
-    {
-        const stringVector &text = annot.GetText();
-        if(text.size() > 0)
-            SetText(text[0].c_str());
-        else
-            SetText("");
-        textChanged = true;
-    }
-
-    //
-    // Set the font properties if they are different.
-    //
-    if(currentOptions.GetFontFamily() != annot.GetFontFamily())
-    {
-        int ff = annot.GetFontFamily();
-        if(ff == 0)
-            textActor->GetTextProperty()->SetFontFamilyToArial();
-        else if(ff == 1)
-            textActor->GetTextProperty()->SetFontFamilyToCourier();
-        else if(ff == 2)
-            textActor->GetTextProperty()->SetFontFamilyToTimes();
-    }
-    if(currentOptions.GetFontBold() != annot.GetFontBold())
-        textActor->GetTextProperty()->SetBold(annot.GetFontBold()?1:0);
-    if(currentOptions.GetFontItalic() != annot.GetFontItalic())
-        textActor->GetTextProperty()->SetItalic(annot.GetFontItalic()?1:0);
-    if(currentOptions.GetFontShadow() != annot.GetFontShadow())
-        textActor->GetTextProperty()->SetShadow(annot.GetFontShadow()?1:0);
-
-    //
-    // Set the position coordinates if they are different
-    //
-    if(!currentOptions.FieldsEqual(4, &annot) ||
-       !currentOptions.FieldsEqual(5, &annot) || textChanged)
-    {
-        const double *p1 = annot.GetPosition();
-        const double *p2 = annot.GetPosition2();
-        vtkCoordinate *pos = textActor->GetPositionCoordinate();
-        pos->SetCoordinateSystemToNormalizedViewport();
-        pos->SetValue(p1[0], p1[1], 0.);
-        textActor->SetTextHeight(p2[0]);
-    }
-
-    //
-    // Set the object's visibility.
-    //
-    if(currentOptions.GetVisible() != annot.GetVisible())
-    {
-        SetVisible(annot.GetVisible());
-        if(annot.GetVisible())
-            AddToRenderer();
-        else
-            RemoveFromRenderer();
-    }
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::GetOptions
-//
-// Purpose: 
-//   This method stores the text label's attributes in an object that can
-//   be passed back to the client.
-//
-// Arguments:
-//   annot : The AnnotationObject to populate.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Oct 30 14:13:21 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void
-avtText2DColleague::GetOptions(AnnotationObject &annot)
-{
-    annot.SetObjectType(AnnotationObject::Text2D);
-    annot.SetVisible(GetVisible());
-    annot.SetActive(GetActive());
-
-    annot.SetPosition(textActor->GetPosition());
-    // Store the width and height in position2.
-    double p2wh[3];
-    p2wh[0] = textActor->GetTextHeight();
-    p2wh[1] = 0.;
-    p2wh[2] = 0.;
-    annot.SetPosition2(p2wh);
-
-    // Store the text color and opacity.
-    annot.SetTextColor(textColor);
-    annot.SetUseForegroundForTextColor(useForegroundForTextColor);
-
-    // Store the font properties into the annotation object.
-    int ff = textActor->GetTextProperty()->GetFontFamily();
-    AnnotationObject::FontFamily aff;
-    if(ff == VTK_ARIAL)
-        aff = AnnotationObject::Arial;
-    else if(ff == VTK_COURIER)
-        aff = AnnotationObject::Courier;
-    else if(ff == VTK_TIMES)
-        aff = AnnotationObject::Times;
-    else
-        aff = AnnotationObject::Arial;
-    annot.SetFontFamily(aff);
-    annot.SetFontBold(textActor->GetTextProperty()->GetBold() > 0);
-    annot.SetFontItalic(textActor->GetTextProperty()->GetItalic() > 0);
-    annot.SetFontShadow(textActor->GetTextProperty()->GetShadow() > 0);
-
-    stringVector text;
-    text.push_back(textFormatString);
-    annot.SetText(text);
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::SetForegroundColor
-//
-// Purpose: 
-//   This method is called when the vis window's foreground color changes.
-//
-// Arguments:
-//   r,g,b : The new foreground color.
-//
-// Programmer: Brad Whitlock
-// Creation:   Wed Nov 5 14:18:20 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void
-avtText2DColleague::SetForegroundColor(double r, double g, double b)
-{
-    if(useForegroundForTextColor)
-        textActor->GetTextProperty()->SetColor(r, g, b);
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::HasPlots
-//
-// Purpose: 
-//   This method is called when the vis window gets some plots. We use this
-//   signal to add the text actor to the renderer.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:56:06 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void
-avtText2DColleague::HasPlots(void)
-{
-    AddToRenderer();
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::NoPlots
-//
-// Purpose: 
-//   This method is called when the vis window has no plots. We use this signal
-//   to remove the text actor from the renderer.
-//
-// Programmer: Brad Whitlock
-// Creation:   Thu Nov 6 15:56:42 PST 2003
-//
-// Modifications:
-//   
-// ****************************************************************************
-
-void
-avtText2DColleague::NoPlots(void)
-{
-    RemoveFromRenderer();
-}
-
-// ****************************************************************************
-// Method: avtText2DColleague::UpdatePlotList
+// Method: avtAnnotationWithTextColleague::UpdatePlotList
 //
 // Purpose: 
 //   This method is called when the plot list changes. Its job is to make sure
@@ -459,92 +94,31 @@ avtText2DColleague::NoPlots(void)
 // ****************************************************************************
 
 void
-avtText2DColleague::UpdatePlotList(std::vector<avtActor_p> &lst)
+avtAnnotationWithTextColleague::UpdatePlotList(std::vector<avtActor_p> &lst)
 {
     if(lst.size() > 0 && textFormatString != 0)
     {
-        avtDataAttributes &atts = lst[0]->GetBehavior()->GetInfo().GetAttributes();
-        currentTime = atts.GetTime();
-        currentCycle = atts.GetCycle();
+        // update current copy of data attributes
+        currentDataAttributes->Copy(lst[0]->GetBehavior()->GetInfo().GetAttributes());
 
-        std::string formatString(textFormatString);
-        std::string::size_type pos;
-        if((pos = formatString.find(TIME_IDENTIFIER)) != std::string::npos ||
-           (pos = formatString.find(CYCLE_IDENTIFIER)) != std::string::npos)
-            SetText(textFormatString);
-
-        // Set the initial values from the current values.
-        initialTime = currentTime;
-        initialCycle = currentCycle;
+        // update initial data attributes to current
+        initialDataAttributes->Copy(*currentDataAttributes);
     }
 }
 
-// ****************************************************************************
-// Method: avtText2DColleague::SetText
-//
-// Purpose: 
-//   Updates the text string.
-//
-// Note:       This code matches avtTimeSliderColleague::SetText.
-//
-// Programmer: Brad Whitlock
-// Creation:   Wed Nov 5 14:17:22 PST 2003
-//
-// Modifications:
-//    Jeremy Meredith, Wed Mar 11 12:33:20 EDT 2009
-//    Added $cycle support.
-//
-// ****************************************************************************
-
-void
-avtText2DColleague::SetText(const char *formatString)
+// Caller must delete what is returned
+char *
+avtAnnotationWithTextColleague::CreateAnnotationString(const char *formatString)
 {
-    if(formatString == 0)
-        return;
-
-    // Save the format string. Don't do it in the case that the formatString
-    // pointer is the same as textFormatString, which is how we get here from
-    // UpdatePlotList.
-    size_t len = strlen(formatString);
-    if(textFormatString != formatString)
-    {
-        delete [] textFormatString;
-        textFormatString = new char[len + 1];
-        strcpy(textFormatString, formatString);
-    }
-
-    // Replace $time with the time if the format string contains $time.
-    delete [] textString;
-    std::string fmtStr(textFormatString);
-    std::string::size_type pos;
-    if((pos=fmtStr.find(TIME_IDENTIFIER)) != std::string::npos)
-    {
-        size_t tlen = strlen(TIME_IDENTIFIER);
-        std::string left(fmtStr.substr(0, pos));
-        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
-        char tmp[100];
-        snprintf(tmp, 100, "%g", currentTime);
-        len = left.size() + strlen(tmp) + right.size() + 1;
-        textString = new char[len];
-        snprintf(textString, len, "%s%s%s", left.c_str(), tmp, right.c_str());
-    }
-    else if((pos=fmtStr.find(CYCLE_IDENTIFIER)) != std::string::npos)
-    {
-        size_t tlen = strlen(CYCLE_IDENTIFIER);
-        std::string left(fmtStr.substr(0, pos));
-        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
-        char tmp[100];
-        snprintf(tmp, 100, "%d", currentCycle);
-        len = left.size() + strlen(tmp) + right.size() + 1;
-        textString = new char[len];
-        snprintf(textString, len, "%s%s%s", left.c_str(), tmp, right.c_str());
-    }
+    char *retval = new char[100]();
+    if (!strcmp(formatString, "$time"))
+        snprintf(retval, 100, "%g", currentDataAttributes->GetTime());
+    else if (!strcmp(formatString, "$cycle"))
+        snprintf(retval, 100, "%d", currentDataAttributes->GetCycle());
+    else if (!strcmp(formatString, "$index"))
+        snprintf(retval, 100, "%d", currentDataAttributes->GetTimeIndex());
     else
-    {
-        textString = new char[len + 1];
-        strcpy(textString, formatString);
-    }
-
-    if(textActor)
-        textActor->SetInput(textString);
+        snprintf(retval, 100, "%s", formatString);
+#warning FIXME: USE C++ EQUIV OF STRCPY
+    return retval;
 }

--- a/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.C
@@ -43,8 +43,10 @@ avtDataAttributes *avtAnnotationWithTextColleague::initialDataAttributes = new a
 avtAnnotationWithTextColleague::avtAnnotationWithTextColleague(VisWindowColleagueProxy &m) 
     : avtAnnotationColleague(m)
 {
-    textFormatString = 0;
-    textString = 0;
+    textFormatString = new char[1];
+    textFormatString[0] = '\0';
+    textString = new char[1];
+    textString[0] = '\0';
     currentDataAttributes = new avtDataAttributes;
     currentDataAttributes->Copy(*initialDataAttributes);
 }
@@ -106,10 +108,62 @@ avtAnnotationWithTextColleague::UpdatePlotList(std::vector<avtActor_p> &lst)
     }
 }
 
+#define TIME_IDENTIFIER "$time"
+#define CYCLE_IDENTIFIER "$cycle"
+#define INDEX_IDENTIFIER "$index"
+
 // Caller must delete what is returned
 char *
 avtAnnotationWithTextColleague::CreateAnnotationString(const char *formatString)
 {
+    char *retval;
+
+    size_t len = strlen(formatString);
+    std::string fmtStr(formatString);
+    std::string::size_type pos;
+    if((pos=fmtStr.find(TIME_IDENTIFIER)) != std::string::npos)
+    {
+        size_t tlen = strlen(TIME_IDENTIFIER);
+        std::string left(fmtStr.substr(0, pos));
+        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
+        char tmp[100];
+        snprintf(tmp, 100, "%g", currentDataAttributes->GetTime());
+        len = left.size() + strlen(tmp) + right.size() + 1;
+        retval = new char[len + 1];
+        snprintf(retval, len, "%s%s%s", left.c_str(), tmp, right.c_str());
+    }
+    else if((pos=fmtStr.find(CYCLE_IDENTIFIER)) != std::string::npos)
+    {
+        size_t tlen = strlen(CYCLE_IDENTIFIER);
+        std::string left(fmtStr.substr(0, pos));
+        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
+        char tmp[100];
+        snprintf(tmp, 100, "%d", currentDataAttributes->GetCycle());
+        len = left.size() + strlen(tmp) + right.size() + 1;
+        retval = new char[len + 1];
+        snprintf(retval, len, "%s%s%s", left.c_str(), tmp, right.c_str());
+    }
+    else if((pos=fmtStr.find(INDEX_IDENTIFIER)) != std::string::npos)
+    {
+        size_t tlen = strlen(INDEX_IDENTIFIER);
+        std::string left(fmtStr.substr(0, pos));
+        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
+        char tmp[100];
+        snprintf(tmp, 100, "%d", currentDataAttributes->GetTimeIndex());
+        len = left.size() + strlen(tmp) + right.size() + 1;
+        retval = new char[len + 1];
+        snprintf(retval, len, "%s%s%s", left.c_str(), tmp, right.c_str());
+    }
+    else
+    {
+        retval = new char[len + 1];
+        strcpy(retval, formatString);
+    }
+
+    return retval;
+
+
+#if 0
     char *retval = new char[100]();
     if (!strcmp(formatString, "$time"))
         snprintf(retval, 100, "%g", currentDataAttributes->GetTime());
@@ -119,6 +173,6 @@ avtAnnotationWithTextColleague::CreateAnnotationString(const char *formatString)
         snprintf(retval, 100, "%d", currentDataAttributes->GetTimeIndex());
     else
         snprintf(retval, 100, "%s", formatString);
-#warning FIXME: USE C++ EQUIV OF STRCPY
     return retval;
+#endif
 }

--- a/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.C
@@ -1,0 +1,550 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+// ************************************************************************* //
+//                              avtText2DColleague.C                         //
+// ************************************************************************* //
+#include <avtText2DColleague.h>
+#include <VisWindow.h>
+#include <VisWindowColleagueProxy.h>
+
+#include <AnnotationObject.h>
+
+#include <vtkRenderer.h>
+#include <vtkVisItTextActor.h>
+#include <vtkTextProperty.h>
+
+#define TIME_IDENTIFIER "$time"
+#define CYCLE_IDENTIFIER "$cycle"
+
+double avtText2DColleague::initialTime = 0.;
+int    avtText2DColleague::initialCycle = 0;
+
+// ****************************************************************************
+// Method: avtText2DColleague::avtText2DColleague
+//
+// Purpose: 
+//   Constructor for the avtText2DColleague class.
+//
+// Arguments:
+//   m : The vis window proxy.
+//
+// Programmer: Brad Whitlock
+// Creation:   Wed Nov 5 14:13:14 PST 2003
+//
+// Modifications:
+//    Jeremy Meredith, Wed Mar 11 12:33:20 EDT 2009
+//    Added $cycle support.
+//
+//    Tom Fogal, Fri Jan 28 15:26:59 MST 2011
+//    VTK API change.
+//   
+// ****************************************************************************
+
+avtText2DColleague::avtText2DColleague(VisWindowColleagueProxy &m) 
+    : avtAnnotationColleague(m)
+{
+    useForegroundForTextColor = true;
+    addedToRenderer = false;
+    textFormatString = 0;
+    textString = 0;
+    currentTime = initialTime;
+    currentCycle = initialCycle;
+
+    //
+    // Create and position the actor.
+    //
+    textActor = vtkVisItTextActor::New();
+    textActor->SetTextScaleMode(vtkTextActor::TEXT_SCALE_MODE_VIEWPORT);
+    textActor->SetTextHeight(0.03);
+    SetText("2D text annotation");
+    vtkCoordinate *pos = textActor->GetPositionCoordinate();
+    pos->SetCoordinateSystemToNormalizedViewport();
+    pos->SetValue(0.5, 0.5, 0.);
+
+    // Make sure that the actor initially has the right fg color.
+    double fgColor[3];
+    mediator.GetForegroundColor(fgColor);
+    SetForegroundColor(fgColor[0], fgColor[1], fgColor[2]);
+    textActor->GetTextProperty()->SetOpacity(1.);
+
+    // Store the foreground color into the text color.
+    int ifgColor[3];
+    ifgColor[0] = int((float)fgColor[0] * 255.f);
+    ifgColor[1] = int((float)fgColor[1] * 255.f);
+    ifgColor[2] = int((float)fgColor[2] * 255.f);
+    textColor = ColorAttribute(ifgColor[0], ifgColor[1], ifgColor[2], 255);
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::~avtText2DColleague
+//
+// Purpose: 
+//   Destructor for the avtText2DColleague class.
+//
+// Programmer: Brad Whitlock
+// Creation:   Wed Nov 5 14:18:31 PST 2003
+//
+// Modifications:
+//    Burlen Loring, Mon Jul 14 14:04:31 PDT 2014
+//    fix alloc-dealloc-mismatch (operator new [] vs operator delete)
+//
+// ****************************************************************************
+
+avtText2DColleague::~avtText2DColleague()
+{
+    if (textActor)
+        textActor->Delete();
+    delete [] textString;
+    delete [] textFormatString;
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::AddToRenderer
+//
+// Purpose: 
+//   This method adds the text actor to the renderer.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:52:19 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void 
+avtText2DColleague::AddToRenderer()
+{
+    if(!addedToRenderer && ShouldBeAddedToRenderer())
+    {
+        mediator.GetForeground()->AddActor2D(textActor);
+        addedToRenderer = true;
+    }
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::RemoveFromRenderer
+//
+// Purpose: 
+//   This method removes the text actor from the renderer.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:52:38 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void
+avtText2DColleague::RemoveFromRenderer()
+{
+    if(addedToRenderer)
+    {
+        mediator.GetForeground()->RemoveActor2D(textActor);
+        addedToRenderer = false;
+    }
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::Hide
+//
+// Purpose: 
+//   This method toggles the visible flag and either adds or removes the text
+//   actor to/from the renderer.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:52:57 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void
+avtText2DColleague::Hide()
+{
+    SetVisible(!GetVisible());
+
+    if(addedToRenderer)
+        RemoveFromRenderer();
+    else
+        AddToRenderer();
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::ShouldBeAddedToRenderer
+//
+// Purpose: 
+//   This method returns whether or not the text actor should be added to the
+//   renderer.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:53:36 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+bool
+avtText2DColleague::ShouldBeAddedToRenderer() const
+{
+    return GetVisible() && mediator.HasPlots();
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::SetOptions
+//
+// Purpose: 
+//   This method sets the text actor's properties from the values in the
+//   annotation object.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:54:02 PST 2003
+//
+// Modifications:
+//    Brad Whitlock, Tue Aug 31 11:56:56 PDT 2004
+//    I added code to set the object's visibility so objects that are not
+//    visible remain invisible when restoring a session file.
+//
+//    Brad Whitlock, Thu Mar 22 15:02:23 PST 2007
+//    Changed FieldsEqual due to state object changes.
+//
+// ****************************************************************************
+
+void
+avtText2DColleague::SetOptions(const AnnotationObject &annot)
+{
+    // Get the current options.
+    AnnotationObject currentOptions;
+    GetOptions(currentOptions);
+
+    //
+    // The text color has changed or the useForegroundForTextColor flag
+    // has changed.
+    //
+    if(annot.GetUseForegroundForTextColor() != useForegroundForTextColor ||
+       annot.GetTextColor() != textColor)
+    {
+        // Record the text color that should be used when we're not using
+        // the foreground text color.
+        textColor = annot.GetTextColor();
+        useForegroundForTextColor = annot.GetUseForegroundForTextColor();
+
+        // Compute the text opacity.
+        double tc[4];
+        tc[3] = double(textColor.Alpha()) / 255.;
+
+        // Set the text color using the foreground color or the text color.
+        if(useForegroundForTextColor)
+        {
+            // Get the foreground color.
+            double fgColor[3];
+            mediator.GetForegroundColor(fgColor);
+            textActor->GetTextProperty()->SetColor(fgColor[0], fgColor[1], fgColor[2]);
+        }
+        else
+        {
+            // Compute the text color as double.
+            tc[0] = double(textColor.Red()) / 255.;
+            tc[1] = double(textColor.Green()) / 255.;
+            tc[2] = double(textColor.Blue()) / 255.;
+            textActor->GetTextProperty()->SetColor(tc[0], tc[1], tc[2]);
+        }
+
+        // Set the text opacity.
+        textActor->GetTextProperty()->SetOpacity(tc[3]);
+    }
+
+    //
+    // Set the labels if the text vector is different
+    //
+    bool textChanged = false;
+    if(currentOptions.GetText() != annot.GetText())
+    {
+        const stringVector &text = annot.GetText();
+        if(text.size() > 0)
+            SetText(text[0].c_str());
+        else
+            SetText("");
+        textChanged = true;
+    }
+
+    //
+    // Set the font properties if they are different.
+    //
+    if(currentOptions.GetFontFamily() != annot.GetFontFamily())
+    {
+        int ff = annot.GetFontFamily();
+        if(ff == 0)
+            textActor->GetTextProperty()->SetFontFamilyToArial();
+        else if(ff == 1)
+            textActor->GetTextProperty()->SetFontFamilyToCourier();
+        else if(ff == 2)
+            textActor->GetTextProperty()->SetFontFamilyToTimes();
+    }
+    if(currentOptions.GetFontBold() != annot.GetFontBold())
+        textActor->GetTextProperty()->SetBold(annot.GetFontBold()?1:0);
+    if(currentOptions.GetFontItalic() != annot.GetFontItalic())
+        textActor->GetTextProperty()->SetItalic(annot.GetFontItalic()?1:0);
+    if(currentOptions.GetFontShadow() != annot.GetFontShadow())
+        textActor->GetTextProperty()->SetShadow(annot.GetFontShadow()?1:0);
+
+    //
+    // Set the position coordinates if they are different
+    //
+    if(!currentOptions.FieldsEqual(4, &annot) ||
+       !currentOptions.FieldsEqual(5, &annot) || textChanged)
+    {
+        const double *p1 = annot.GetPosition();
+        const double *p2 = annot.GetPosition2();
+        vtkCoordinate *pos = textActor->GetPositionCoordinate();
+        pos->SetCoordinateSystemToNormalizedViewport();
+        pos->SetValue(p1[0], p1[1], 0.);
+        textActor->SetTextHeight(p2[0]);
+    }
+
+    //
+    // Set the object's visibility.
+    //
+    if(currentOptions.GetVisible() != annot.GetVisible())
+    {
+        SetVisible(annot.GetVisible());
+        if(annot.GetVisible())
+            AddToRenderer();
+        else
+            RemoveFromRenderer();
+    }
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::GetOptions
+//
+// Purpose: 
+//   This method stores the text label's attributes in an object that can
+//   be passed back to the client.
+//
+// Arguments:
+//   annot : The AnnotationObject to populate.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Oct 30 14:13:21 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void
+avtText2DColleague::GetOptions(AnnotationObject &annot)
+{
+    annot.SetObjectType(AnnotationObject::Text2D);
+    annot.SetVisible(GetVisible());
+    annot.SetActive(GetActive());
+
+    annot.SetPosition(textActor->GetPosition());
+    // Store the width and height in position2.
+    double p2wh[3];
+    p2wh[0] = textActor->GetTextHeight();
+    p2wh[1] = 0.;
+    p2wh[2] = 0.;
+    annot.SetPosition2(p2wh);
+
+    // Store the text color and opacity.
+    annot.SetTextColor(textColor);
+    annot.SetUseForegroundForTextColor(useForegroundForTextColor);
+
+    // Store the font properties into the annotation object.
+    int ff = textActor->GetTextProperty()->GetFontFamily();
+    AnnotationObject::FontFamily aff;
+    if(ff == VTK_ARIAL)
+        aff = AnnotationObject::Arial;
+    else if(ff == VTK_COURIER)
+        aff = AnnotationObject::Courier;
+    else if(ff == VTK_TIMES)
+        aff = AnnotationObject::Times;
+    else
+        aff = AnnotationObject::Arial;
+    annot.SetFontFamily(aff);
+    annot.SetFontBold(textActor->GetTextProperty()->GetBold() > 0);
+    annot.SetFontItalic(textActor->GetTextProperty()->GetItalic() > 0);
+    annot.SetFontShadow(textActor->GetTextProperty()->GetShadow() > 0);
+
+    stringVector text;
+    text.push_back(textFormatString);
+    annot.SetText(text);
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::SetForegroundColor
+//
+// Purpose: 
+//   This method is called when the vis window's foreground color changes.
+//
+// Arguments:
+//   r,g,b : The new foreground color.
+//
+// Programmer: Brad Whitlock
+// Creation:   Wed Nov 5 14:18:20 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void
+avtText2DColleague::SetForegroundColor(double r, double g, double b)
+{
+    if(useForegroundForTextColor)
+        textActor->GetTextProperty()->SetColor(r, g, b);
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::HasPlots
+//
+// Purpose: 
+//   This method is called when the vis window gets some plots. We use this
+//   signal to add the text actor to the renderer.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:56:06 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void
+avtText2DColleague::HasPlots(void)
+{
+    AddToRenderer();
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::NoPlots
+//
+// Purpose: 
+//   This method is called when the vis window has no plots. We use this signal
+//   to remove the text actor from the renderer.
+//
+// Programmer: Brad Whitlock
+// Creation:   Thu Nov 6 15:56:42 PST 2003
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+void
+avtText2DColleague::NoPlots(void)
+{
+    RemoveFromRenderer();
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::UpdatePlotList
+//
+// Purpose: 
+//   This method is called when the plot list changes. Its job is to make sure
+//   that the time slider always shows the right time.
+//
+// Arguments:
+//   lst : The plot list.
+//
+// Programmer: Brad Whitlock
+// Creation:   Wed Dec 3 12:46:37 PDT 2003
+//
+// Modifications:
+//    Jeremy Meredith, Wed Mar 11 12:33:20 EDT 2009
+//    Added $cycle support.
+//
+//    Brad Whitlock, Mon Dec 10 11:41:13 PST 2012
+//    Set initial values from the current values.
+//
+// ****************************************************************************
+
+void
+avtText2DColleague::UpdatePlotList(std::vector<avtActor_p> &lst)
+{
+    if(lst.size() > 0 && textFormatString != 0)
+    {
+        avtDataAttributes &atts = lst[0]->GetBehavior()->GetInfo().GetAttributes();
+        currentTime = atts.GetTime();
+        currentCycle = atts.GetCycle();
+
+        std::string formatString(textFormatString);
+        std::string::size_type pos;
+        if((pos = formatString.find(TIME_IDENTIFIER)) != std::string::npos ||
+           (pos = formatString.find(CYCLE_IDENTIFIER)) != std::string::npos)
+            SetText(textFormatString);
+
+        // Set the initial values from the current values.
+        initialTime = currentTime;
+        initialCycle = currentCycle;
+    }
+}
+
+// ****************************************************************************
+// Method: avtText2DColleague::SetText
+//
+// Purpose: 
+//   Updates the text string.
+//
+// Note:       This code matches avtTimeSliderColleague::SetText.
+//
+// Programmer: Brad Whitlock
+// Creation:   Wed Nov 5 14:17:22 PST 2003
+//
+// Modifications:
+//    Jeremy Meredith, Wed Mar 11 12:33:20 EDT 2009
+//    Added $cycle support.
+//
+// ****************************************************************************
+
+void
+avtText2DColleague::SetText(const char *formatString)
+{
+    if(formatString == 0)
+        return;
+
+    // Save the format string. Don't do it in the case that the formatString
+    // pointer is the same as textFormatString, which is how we get here from
+    // UpdatePlotList.
+    size_t len = strlen(formatString);
+    if(textFormatString != formatString)
+    {
+        delete [] textFormatString;
+        textFormatString = new char[len + 1];
+        strcpy(textFormatString, formatString);
+    }
+
+    // Replace $time with the time if the format string contains $time.
+    delete [] textString;
+    std::string fmtStr(textFormatString);
+    std::string::size_type pos;
+    if((pos=fmtStr.find(TIME_IDENTIFIER)) != std::string::npos)
+    {
+        size_t tlen = strlen(TIME_IDENTIFIER);
+        std::string left(fmtStr.substr(0, pos));
+        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
+        char tmp[100];
+        snprintf(tmp, 100, "%g", currentTime);
+        len = left.size() + strlen(tmp) + right.size() + 1;
+        textString = new char[len];
+        snprintf(textString, len, "%s%s%s", left.c_str(), tmp, right.c_str());
+    }
+    else if((pos=fmtStr.find(CYCLE_IDENTIFIER)) != std::string::npos)
+    {
+        size_t tlen = strlen(CYCLE_IDENTIFIER);
+        std::string left(fmtStr.substr(0, pos));
+        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
+        char tmp[100];
+        snprintf(tmp, 100, "%d", currentCycle);
+        len = left.size() + strlen(tmp) + right.size() + 1;
+        textString = new char[len];
+        snprintf(textString, len, "%s%s%s", left.c_str(), tmp, right.c_str());
+    }
+    else
+    {
+        textString = new char[len + 1];
+        strcpy(textString, formatString);
+    }
+
+    if(textActor)
+        textActor->SetInput(textString);
+}

--- a/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.h
+++ b/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.h
@@ -2,78 +2,42 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-// ************************************************************************* //
-//                              VisWinUserInfo.h                             //
-// ************************************************************************* //
-
-#ifndef VIS_WIN_USER_INFO_H
-#define VIS_WIN_USER_INFO_H
+#ifndef AVT_ANNOTATION_WITH_TEXT_H
+#define AVT_ANNOTATION_WITH_TEXT_H
 #include <viswindow_exports.h>
 #include <avtAnnotationColleague.h>
-#include <ColorAttribute.h>
 
-class vtkVisItTextActor;
+class avtDataAttributes;
 
 // ****************************************************************************
-// Class: avtText2DColleague
+// Class: avtAnnotationWithTextColleague
 //
-// Purpose:
-//   This colleague is a text label that can be shown in the vis window.
+// Purpose: A class that shares the bulk of functionality related to text
+//    handling and in particular, text macros of the form $<keyword> that name
+//    members of avtDataAttributes, for any annotation colleagues involving
+//    text.
 //
-// Notes:      
-//
-// Programmer: Brad Whitlock
-// Creation:   Wed Nov 5 14:09:57 PST 2003
-//
-// Modifications:
-//    Jeremy Meredith, Wed Mar 11 12:33:20 EDT 2009
-//    Added $cycle support.
-//
-//    Brad Whitlock, Mon Sep 19 15:44:40 PDT 2011
-//    Switch to vtkVisItTextActor.
+// Mark C. Miller, Mon Mar  7 10:26:40 PST 2022
 //
 // ****************************************************************************
 
-class VISWINDOW_API avtText2DColleague : public avtAnnotationColleague
+class VISWINDOW_API avtAnnotationWithTextColleague : public avtAnnotationColleague
 {
 public:
-    avtText2DColleague(VisWindowColleagueProxy &);
-    virtual ~avtText2DColleague();
+    avtAnnotationWithTextColleague(VisWindowColleagueProxy &);
+    virtual ~avtAnnotationWithTextColleague();
 
-    virtual void AddToRenderer();
-    virtual void RemoveFromRenderer();
-    virtual void Hide();
-
-    virtual std::string TypeName() const { return "Text2D"; }
-
-    // Methods to set and get the annotation's properties.
-    virtual void SetOptions(const AnnotationObject &annot);
-    virtual void GetOptions(AnnotationObject &annot);
-
-    // Methods that are called in response to vis window events.
-    virtual void SetForegroundColor(double r, double g, double b);
-    virtual void HasPlots(void);
-    virtual void NoPlots(void);
     virtual void UpdatePlotList(std::vector<avtActor_p> &lst);
+
 protected:
-    bool ShouldBeAddedToRenderer() const;
-    void SetText(const char *text);
+    char *CreateAnnotationString(char const *fmtStr);
 
-    static double initialTime;
-    static int    initialCycle;
+    static avtDataAttributes *initialDataAttributes;
 
-    vtkVisItTextActor *textActor;
-    char           *textFormatString;
-    char           *textString;
-    double          currentTime;
-    int             currentCycle;
+    char                     *textFormatString; // fmt string from user
+    char                     *textString; // string produced from fmt
 
-    bool            useForegroundForTextColor;
-    bool            addedToRenderer;
-    ColorAttribute  textColor;
+    avtDataAttributes        *currentDataAttributes;
 };
 
-
 #endif
-
-

--- a/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.h
+++ b/src/avt/VisWindow/Colleagues/avtAnnotationWithTextColleague.h
@@ -1,0 +1,79 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+// ************************************************************************* //
+//                              VisWinUserInfo.h                             //
+// ************************************************************************* //
+
+#ifndef VIS_WIN_USER_INFO_H
+#define VIS_WIN_USER_INFO_H
+#include <viswindow_exports.h>
+#include <avtAnnotationColleague.h>
+#include <ColorAttribute.h>
+
+class vtkVisItTextActor;
+
+// ****************************************************************************
+// Class: avtText2DColleague
+//
+// Purpose:
+//   This colleague is a text label that can be shown in the vis window.
+//
+// Notes:      
+//
+// Programmer: Brad Whitlock
+// Creation:   Wed Nov 5 14:09:57 PST 2003
+//
+// Modifications:
+//    Jeremy Meredith, Wed Mar 11 12:33:20 EDT 2009
+//    Added $cycle support.
+//
+//    Brad Whitlock, Mon Sep 19 15:44:40 PDT 2011
+//    Switch to vtkVisItTextActor.
+//
+// ****************************************************************************
+
+class VISWINDOW_API avtText2DColleague : public avtAnnotationColleague
+{
+public:
+    avtText2DColleague(VisWindowColleagueProxy &);
+    virtual ~avtText2DColleague();
+
+    virtual void AddToRenderer();
+    virtual void RemoveFromRenderer();
+    virtual void Hide();
+
+    virtual std::string TypeName() const { return "Text2D"; }
+
+    // Methods to set and get the annotation's properties.
+    virtual void SetOptions(const AnnotationObject &annot);
+    virtual void GetOptions(AnnotationObject &annot);
+
+    // Methods that are called in response to vis window events.
+    virtual void SetForegroundColor(double r, double g, double b);
+    virtual void HasPlots(void);
+    virtual void NoPlots(void);
+    virtual void UpdatePlotList(std::vector<avtActor_p> &lst);
+protected:
+    bool ShouldBeAddedToRenderer() const;
+    void SetText(const char *text);
+
+    static double initialTime;
+    static int    initialCycle;
+
+    vtkVisItTextActor *textActor;
+    char           *textFormatString;
+    char           *textString;
+    double          currentTime;
+    int             currentCycle;
+
+    bool            useForegroundForTextColor;
+    bool            addedToRenderer;
+    ColorAttribute  textColor;
+};
+
+
+#endif
+
+

--- a/src/avt/VisWindow/Colleagues/avtText2DColleague.h
+++ b/src/avt/VisWindow/Colleagues/avtText2DColleague.h
@@ -3,13 +3,13 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 // ************************************************************************* //
-//                              VisWinUserInfo.h                             //
+//                              avtText2DColleague.h                         //
 // ************************************************************************* //
 
-#ifndef VIS_WIN_USER_INFO_H
-#define VIS_WIN_USER_INFO_H
+#ifndef AVT_TEXT_2D_COLLEAGUE_H 
+#define AVT_TEXT_2D_COLLEAGUE_H 
 #include <viswindow_exports.h>
-#include <avtAnnotationColleague.h>
+#include <avtAnnotationWithTextColleague.h>
 #include <ColorAttribute.h>
 
 class vtkVisItTextActor;
@@ -34,7 +34,7 @@ class vtkVisItTextActor;
 //
 // ****************************************************************************
 
-class VISWINDOW_API avtText2DColleague : public avtAnnotationColleague
+class VISWINDOW_API avtText2DColleague : public avtAnnotationWithTextColleague
 {
 public:
     avtText2DColleague(VisWindowColleagueProxy &);
@@ -59,21 +59,11 @@ protected:
     bool ShouldBeAddedToRenderer() const;
     void SetText(const char *text);
 
-    static double initialTime;
-    static int    initialCycle;
-
     vtkVisItTextActor *textActor;
-    char           *textFormatString;
-    char           *textString;
-    double          currentTime;
-    int             currentCycle;
-
-    bool            useForegroundForTextColor;
-    bool            addedToRenderer;
-    ColorAttribute  textColor;
+    char              *textString;
+    bool               useForegroundForTextColor;
+    bool               addedToRenderer;
+    ColorAttribute     textColor;
 };
 
-
 #endif
-
-

--- a/src/avt/VisWindow/Colleagues/avtText2DColleague.h
+++ b/src/avt/VisWindow/Colleagues/avtText2DColleague.h
@@ -60,7 +60,6 @@ protected:
     void SetText(const char *text);
 
     vtkVisItTextActor *textActor;
-    char              *textString;
     bool               useForegroundForTextColor;
     bool               addedToRenderer;
     ColorAttribute     textColor;

--- a/src/avt/VisWindow/Colleagues/avtText3DColleague.h
+++ b/src/avt/VisWindow/Colleagues/avtText3DColleague.h
@@ -9,7 +9,7 @@
 #ifndef VIS_WIN_TEXT3D_COLLEAGUE_H
 #define VIS_WIN_TEXT3D_COLLEAGUE_H
 #include <viswindow_exports.h>
-#include <avtAnnotationColleague.h>
+#include <avtAnnotationWithTextColleague.h>
 #include <ColorAttribute.h>
 
 class vtkFollower;
@@ -35,7 +35,7 @@ class vtkVectorText;
 //   
 // ****************************************************************************
 
-class VISWINDOW_API avtText3DColleague : public avtAnnotationColleague
+class VISWINDOW_API avtText3DColleague : public avtAnnotationWithTextColleague
 {
 public:
     avtText3DColleague(VisWindowColleagueProxy &);
@@ -64,19 +64,12 @@ protected:
     void SetText(const char *text);
     void UpdateActorScale();
 
-    static double initialTime;
-    static int    initialCycle;
-
     // Make a heap-allocated structure to prevent weird errors on MacOS X/gcc 4.0.1
     struct Text3DInformation
     {
         ColorAttribute  textColor;
         bool            positionInitialized;
         bool            scaleInitialized;
-        char           *textFormatString;
-        char           *textString;
-        double          currentTime;
-        int             currentCycle;
 
         bool            useForegroundForTextColor;
         bool            useRelativeHeight;

--- a/src/avt/VisWindow/Colleagues/avtTimeSliderColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtTimeSliderColleague.C
@@ -18,6 +18,7 @@
 #define DEFAULT_Y       0.01
 #define DEFAULT_WIDTH   0.4
 #define DEFAULT_HEIGHT  0.05
+#define DEFAULT_STRING  "Time=$time"
 #define TEXT_SCALING_CORRECTION 0.666667
 
 // ****************************************************************************
@@ -83,9 +84,7 @@ avtTimeSliderColleague::avtTimeSliderColleague(VisWindowColleagueProxy &m) :
     //
     textActor = vtkVisItTextActor::New();
     textActor->SetTextScaleMode(vtkTextActor::TEXT_SCALE_MODE_VIEWPORT);
-#warning FIXME: USE OF EXPLICIT STRING
-    std::string defaultString("Time="); defaultString += "$time";
-    SetText(defaultString.c_str(), "%g");
+    SetText(DEFAULT_STRING, "%g");
     vtkCoordinate *pos = textActor->GetPositionCoordinate();
     pos->SetCoordinateSystemToNormalizedViewport();
     GetTextRect(DEFAULT_X, DEFAULT_Y, DEFAULT_WIDTH, DEFAULT_HEIGHT, rect);
@@ -347,7 +346,7 @@ avtTimeSliderColleague::SetOptions(const AnnotationObject &annot)
         if(text.size() > 1)
             SetText(text[0].c_str(), text[1].c_str());
         else
-            SetText("", "%g");
+            SetText(DEFAULT_STRING, "%g");
     }
 
     //

--- a/src/avt/VisWindow/Colleagues/avtTimeSliderColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtTimeSliderColleague.C
@@ -18,12 +18,7 @@
 #define DEFAULT_Y       0.01
 #define DEFAULT_WIDTH   0.4
 #define DEFAULT_HEIGHT  0.05
-#define TIME_IDENTIFIER "$time"
-#define CYCLE_IDENTIFIER "$cycle"
 #define TEXT_SCALING_CORRECTION 0.666667
-
-double avtTimeSliderColleague::initialTime = 0.;
-int    avtTimeSliderColleague::initialCycle = 0;
 
 // ****************************************************************************
 // Method: avtTimeSliderColleague::avtTimeSliderColleague
@@ -63,16 +58,12 @@ int    avtTimeSliderColleague::initialCycle = 0;
 // ****************************************************************************
 
 avtTimeSliderColleague::avtTimeSliderColleague(VisWindowColleagueProxy &m) :
-    avtAnnotationColleague(m)
+    avtAnnotationWithTextColleague(m)
 {
     useForegroundForTextColor = true;
     addedToRenderer = false;
-    textFormatString = 0;
     timeFormatString = 0;
-    textString = 0;
     timeDisplayMode = 0;
-    currentTime = initialTime;
-    currentCycle = initialCycle;
     timeScale = 1.;
     timeOffset = 0.;
 
@@ -92,7 +83,8 @@ avtTimeSliderColleague::avtTimeSliderColleague(VisWindowColleagueProxy &m) :
     //
     textActor = vtkVisItTextActor::New();
     textActor->SetTextScaleMode(vtkTextActor::TEXT_SCALE_MODE_VIEWPORT);
-    std::string defaultString("Time="); defaultString += TIME_IDENTIFIER;
+#warning FIXME: USE OF EXPLICIT STRING
+    std::string defaultString("Time="); defaultString += "$time";
     SetText(defaultString.c_str(), "%g");
     vtkCoordinate *pos = textActor->GetPositionCoordinate();
     pos->SetCoordinateSystemToNormalizedViewport();
@@ -673,19 +665,10 @@ avtTimeSliderColleague::UpdatePlotList(std::vector<avtActor_p> &lst)
                 break;
             }
         }
-        avtDataAttributes &atts = lst[plotIndex]->GetBehavior()->GetInfo().GetAttributes();
-        currentTime = atts.GetTime();
-        currentCycle = atts.GetCycle();
 
-        std::string formatString(textFormatString);
-        std::string::size_type pos;
-        if((pos = formatString.find(TIME_IDENTIFIER)) != std::string::npos ||
-           (pos = formatString.find(CYCLE_IDENTIFIER)) != std::string::npos)
-            SetText(textFormatString, timeFormatString);
+        avtAnnotationWithTextColleague::UpdatePlotList(lst);
+        SetText(textFormatString, timeFormatString);
 
-        // Save the current values for new instances of this class.
-        initialTime = currentTime;
-        initialCycle = currentCycle;
     }
 }
 
@@ -715,61 +698,31 @@ avtTimeSliderColleague::UpdatePlotList(std::vector<avtActor_p> &lst)
 void
 avtTimeSliderColleague::SetText(const char *formatString, const char *timeFormat)
 {
-    if(formatString == 0)
+    if (formatString == 0)
         return;
 
     // Save the format string. Don't do it in the case that the formatString
     // pointer is the same as textFormatString, which is how we get here from
     // UpdatePlotList.
     size_t len = strlen(formatString);
-    if(textFormatString != formatString)
+    if (textFormatString != formatString)
     {
         delete [] textFormatString;
         textFormatString = new char[len + 1];
         strcpy(textFormatString, formatString);
     }
     size_t tf_len = strlen(timeFormat);
-    if(timeFormatString != timeFormat)
+    if (timeFormatString != timeFormat)
     {
         delete [] timeFormatString;
         timeFormatString = new char[tf_len + 1];
         strcpy(timeFormatString, timeFormat);
     }
 
-    // Replace $time with the time if the format string contains $time.
     delete [] textString;
-    std::string fmtStr(textFormatString);
-    std::string::size_type pos;
-    if((pos=fmtStr.find(TIME_IDENTIFIER)) != std::string::npos)
-    {
-        size_t tlen = strlen(TIME_IDENTIFIER);
-        std::string left(fmtStr.substr(0, pos));
-        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
-        char tmp[100];
-        double t = currentTime * timeScale + timeOffset;
-        snprintf(tmp, 100, timeFormat, t);
-        len = left.size() + strlen(tmp) + right.size() + 1;
-        textString = new char[len];
-        snprintf(textString, len, "%s%s%s", left.c_str(), tmp, right.c_str());
-    }
-    else if((pos=fmtStr.find(CYCLE_IDENTIFIER)) != std::string::npos)
-    {
-        size_t tlen = strlen(CYCLE_IDENTIFIER);
-        std::string left(fmtStr.substr(0, pos));
-        std::string right(fmtStr.substr(pos + tlen, fmtStr.size() - pos - tlen));
-        char tmp[100];
-        snprintf(tmp, 100, "%d", currentCycle);
-        len = left.size() + strlen(tmp) + right.size() + 1;
-        textString = new char[len];
-        snprintf(textString, len, "%s%s%s", left.c_str(), tmp, right.c_str());
-    }
-    else
-    {
-        textString = new char[len + 1];
-        strcpy(textString, formatString);
-    }
+    textString = CreateAnnotationString(textFormatString);
 
-    if(textActor)
+    if (textActor)
         textActor->SetInput(textString);
 }
 

--- a/src/avt/VisWindow/Colleagues/avtTimeSliderColleague.h
+++ b/src/avt/VisWindow/Colleagues/avtTimeSliderColleague.h
@@ -5,7 +5,7 @@
 #ifndef AVT_TIME_SLIDER_COLLEAGUE_H
 #define AVT_TIME_SLIDER_COLLEAGUE_H
 #include <viswindow_exports.h>
-#include <avtAnnotationColleague.h>
+#include <avtAnnotationWithTextColleague.h>
 #include <ColorAttribute.h>
 
 class vtkVisItTextActor;
@@ -38,7 +38,7 @@ class vtkTimeSliderActor;
 //
 // ****************************************************************************
 
-class VISWINDOW_API avtTimeSliderColleague : public avtAnnotationColleague
+class VISWINDOW_API avtTimeSliderColleague : public avtAnnotationWithTextColleague
 {
 public:
     avtTimeSliderColleague(VisWindowColleagueProxy &);
@@ -70,18 +70,11 @@ private:
     void  GetTextRect(double, double, double, double, double *) const;
     void  GetSliderRect(double, double, double, double, double *) const;
 
-    static double      initialTime;
-    static int         initialCycle;
-
     vtkTimeSliderActor *timeSlider;
     vtkVisItTextActor  *textActor;
-    char               *textFormatString;
-    char               *textString;
     char               *timeFormatString;
     int                timeDisplayMode;
 
-    double             currentTime;
-    int                currentCycle;
     double             timeScale;
     double             timeOffset;
     bool               useForegroundForTextColor;


### PR DESCRIPTION
### Description

Is the bulk of a solution for #5242 but the final fixes for that need to go on develop

* Eliminates duplication of coding blocks and associated data members for handling `$time` and `$cycle` macros in three associated annotation colleague classes.
* Makes for easy expansion of new `$<keyword>` macros for any named metadata from `avtDataAttributes`
* Adds a number of new macros that were obvious/easy extensions.
* Adds ability to specify sprintf-style formatting strings to process data associated with text macros

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Manually for now but will add tests to test suite for it

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
