### PR TITLE
interior folder name change for blueprint testdata

### DIFF
--- a/data/blueprint_v0.8.2_braid_examples_test_data.7z
+++ b/data/blueprint_v0.8.2_braid_examples_test_data.7z
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7974801a709b31e0c74dfae7883b36b47ea2b01d5a98c128fa6696dee0d07afb
-size 496884
+oid sha256:9ce45b37573c1e5baae417014d0da4c4826cf2d6bf810202f5640cd4f25e3443
+size 514737

--- a/src/test/tests/databases/blueprint.py
+++ b/src/test/tests/databases/blueprint.py
@@ -25,7 +25,7 @@ from os.path import join as pjoin
 bp_test_dir = "blueprint_v0.3.1_test_data"
 bp_venn_test_dir = "blueprint_v0.7.0_venn_test_data"
 bp_mfem_test_dir = "blueprint_v0.3.1_mfem_test_data"
-bp_0_8_2_test_dir = "blueprint_v0.8.2_braid_examples"
+bp_0_8_2_test_dir = "blueprint_v0.8.2_braid_examples_test_data"
 
 braid_2d_hdf5_root = data_path(pjoin(bp_test_dir,"braid_2d_examples.blueprint_root_hdf5"))
 braid_3d_hdf5_root = data_path(pjoin(bp_test_dir,"braid_3d_examples.blueprint_root_hdf5"))


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Changes the name of the folder inside the 7z file `data/blueprint_v0.8.2_braid_examples_test_data.7z` so it also has `test_data` in the name, and changes the name in the python script `blueprint.py` that opens that folder.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the `blueprint.py` test script and it passed with no errors, meaning the folder was successfully opened and the name change caused no issues.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [ ] ~~I have commented my code where applicable.~~
- [ ] ~~I have updated the release notes.~~
- [ ] ~~I have made corresponding changes to the documentation.~~
- [ ] ~~I have added debugging support to my changes.~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] ~~I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
