### PR TITLE
Clarify line length policy

### DIFF
--- a/src/doc/dev_manual/ContributingToDocumentation/index.rst
+++ b/src/doc/dev_manual/ContributingToDocumentation/index.rst
@@ -199,7 +199,7 @@ There are many advantages to using a single sentence per line mostly having to d
 This practice, of course, does not apply to source code.
 It applies only to ascii files that are intended to represent, more or less, human readable prose.
 Going forward, we will not reformat existing documentation to a sentence per line en masse.
-However, when updates to documentation are made we will encourage developers to follow this practice and request changes in PRs when it is not followed.
+However, when updating any *existing* paragraph or adding new paragraphs, we will encourage developers to follow this practice for the *whole* paragraph and request changes in PRs when it is not followed.
 
 .. _contributing_images:
 


### PR DESCRIPTION
### Description

Clarify practice regarding line length. That is, when an *existing* paragraph is touched, the whole paragraph should be re-formatted as per the new line length policy.

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* [x] Documentation update
* ~~[ ]~~ Other <!-- please explain with a note below -->

### How Has This Been Tested?

It hasn't.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
