### PR TITLE
Fix scalable,parallel,icet regressions with new session files.

### DIFF
--- a/src/test/tests/queries/pickonionpeel.session
+++ b/src/test/tests/queries/pickonionpeel.session
@@ -6123,7 +6123,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>

--- a/src/test/tests/session/colortable.session
+++ b/src/test/tests/session/colortable.session
@@ -6153,7 +6153,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>

--- a/src/test/tests/session/selection.session
+++ b/src/test/tests/session/selection.session
@@ -6239,7 +6239,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>

--- a/src/test/tests/session/sessionview1.session
+++ b/src/test/tests/session/sessionview1.session
@@ -6137,7 +6137,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>

--- a/src/test/tests/session/sessionview2.session
+++ b/src/test/tests/session/sessionview2.session
@@ -5297,7 +5297,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>

--- a/src/test/tests/session/textannot.session
+++ b/src/test/tests/session/textannot.session
@@ -10451,7 +10451,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>

--- a/src/test/tests/session/wavecontour.session
+++ b/src/test/tests/session/wavecontour.session
@@ -5727,7 +5727,6 @@
                             </Object>
                         </Object>
                         <Field name="scalableAutoThreshold" type="int">2000000</Field>
-                        <Field name="scalableActivationMode" type="int">2</Field>
                         <Field name="compactDomainsAutoThreshold" type="int">256</Field>
                         <Field name="compactDomainsActivationMode" type="int">2</Field>
                         <Field name="notifyForEachRender" type="bool">false</Field>


### PR DESCRIPTION
Removed 'scalableActivationMode' field from 'Viewer Window' object node.
It interferes with scalable,parallel,icet mode.
I entered a ticket #17455 to look into this.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the failing tests in all testing modes with success.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
