### PR TITLE
Wrap VTK_PY_LIBS in quotes in bv_vtk.sh

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1686,7 +1686,7 @@ function build_vtk
 
             vopts="${vopts} -DVTK_WRAP_PYTHON:BOOL=true"
             vopts="${vopts} -DPYTHON_EXECUTABLE:FILEPATH=${py}"
-            vopts="${vopts} -DPYTHON_EXTRA_LIBS:STRING=${VTK_PY_LIBS}"
+            vopts="${vopts} -DPYTHON_EXTRA_LIBS:STRING=\"${VTK_PY_LIBS}\""
             vopts="${vopts} -DPYTHON_INCLUDE_DIR:PATH=${pyinc}"
             vopts="${vopts} -DPYTHON_LIBRARY:FILEPATH=${pylib}"
             if [[ "$DO_PYTHON2" == "no" ]]; then


### PR DESCRIPTION
Without the quotes, only the first item listed is actually passed to the VTK build system, and can cause a configure error
(perhaps only with newer cmake?)

Prompted by  Discussion #17483

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

The change was tested on the customers system, and on pascal.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
