### PR TITLE
Remove sphinx_lfs_content extension

### DIFF
--- a/src/doc/conf.py
+++ b/src/doc/conf.py
@@ -43,8 +43,6 @@ if os.environ.get('READTHEDOCS'):
     from subprocess import call
     call(['pip', 'install', 'sphinx-notfound-page'])
     extensions.append('notfound.extension')
-    call(['python', '-m', 'pip', 'install', 'sphinx_lfs_content'])
-    extensions.append('sphinx_lfs_content')
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:


### PR DESCRIPTION
### Description

Discontinue the `sphinx_lfs_continue`...it causes our bandwidth quota to soar!! 😞 

Some images will break. Will fix in another update.