### PR TITLE
Wrap VTK_PY_LIBS in quotes. (#17484)

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1686,7 +1686,7 @@ function build_vtk
 
             vopts="${vopts} -DVTK_WRAP_PYTHON:BOOL=true"
             vopts="${vopts} -DPYTHON_EXECUTABLE:FILEPATH=${py}"
-            vopts="${vopts} -DPYTHON_EXTRA_LIBS:STRING=${VTK_PY_LIBS}"
+            vopts="${vopts} -DPYTHON_EXTRA_LIBS:STRING=\"${VTK_PY_LIBS}\""
             vopts="${vopts} -DPYTHON_INCLUDE_DIR:PATH=${pyinc}"
             vopts="${vopts} -DPYTHON_LIBRARY:FILEPATH=${pylib}"
             if [[ "$DO_PYTHON2" == "no" ]]; then


### PR DESCRIPTION
Without the quotes, only the first item listed is actually passed
to the VTK build system, and can cause a configure error
(perhaps only with newer cmake?)

Merge from 3.2RC

