### PR TITLE
Check size of visit_dist_data.tar.xz before deciding to untar.

### DIFF
--- a/src/tools/data/datagen/CMakeLists.txt
+++ b/src/tools/data/datagen/CMakeLists.txt
@@ -74,6 +74,11 @@
 #
 #   Mark C. Miller, Wed Mar 23 21:12:34 PDT 2022
 #   Elim use of 7z in favor of vanilla tar
+#
+#   Kathleen Biagas, Fri Mar 25 11:41:48 PDT 2022
+#   Test the size of visit_dist_data.tar.xz to ensure its the real one
+#   and not the lfs'd version. Otherwise untar will fail.
+#
 #****************************************************************************
 
 MESSAGE(STATUS "Configuring VisIt Data Generation Targets")
@@ -341,7 +346,7 @@ ENDIF(SILO_FOUND)
 #
 #  Kathleen Biagas, Wed Oct  2 14:19:36 PDT 2013
 #  Added PROGRAM6432 env var to search as I discovered that 32-bit cmake
-#  running on 64-bit Windows 8 reports 'Program Files (x86)' for 
+#  running on 64-bit Windows 8 reports 'Program Files (x86)' for
 #  'ENV${PROGRAMFILES}'.
 #
 #-----------------------------------------------------------------------------
@@ -375,7 +380,20 @@ endif()
 # Add install command for contents of "data"
 #-----------------------------------------------------------------------------
 
-IF(EXISTS ${VISIT_SOURCE_DIR}/../data/visit_dist_data.tar.xz)
+set(USE_VISIT_DIST_DATA_TARBALL false)
+
+if(EXISTS ${VISIT_SOURCE_DIR}/../data/visit_dist_data.tar.xz)
+    # Need to test the size of visit_dist_data, because untar will fail if
+    # its the lfs'd version of the file and not the real one. This happens
+    # with build_visit,  because lfs content isn't pulled.
+
+    file(SIZE ${VISIT_SOURCE_DIR}/../data/visit_dist_data.tar.xz VDD_SIZE)
+    if(VDD_SIZE GREATER 200) # lfs'd files are generally ~130.
+        set(USE_VISIT_DIST_DATA_TARBALL true)
+    endif()
+endif()
+
+IF(USE_VISIT_DIST_DATA_TARBALL)
     SET(DIST_UNTAR_CMD "${TAR_CMD} ${UNTAR_ARGS} ${VISIT_SOURCE_DIR}/../data/visit_dist_data.tar.xz")
     INSTALL(CODE "execute_process(COMMAND ${DIST_UNTAR_CMD} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )")
     INSTALL(

--- a/src/tools/data/datagen/CMakeLists.txt
+++ b/src/tools/data/datagen/CMakeLists.txt
@@ -388,7 +388,7 @@ if(EXISTS ${VISIT_SOURCE_DIR}/../data/visit_dist_data.tar.xz)
     # with build_visit,  because lfs content isn't pulled.
 
     file(SIZE ${VISIT_SOURCE_DIR}/../data/visit_dist_data.tar.xz VDD_SIZE)
-    if(VDD_SIZE GREATER 200) # lfs'd files are generally ~130.
+    if(VDD_SIZE GREATER 200) # lfs'd files are generally ~130 bytes.
         set(USE_VISIT_DIST_DATA_TARBALL true)
     endif()
 endif()


### PR DESCRIPTION
### Description
Prevent untar failure during build_visit when the file is the lfs'd version not the real one.
Was causing build_visit to fail (develop version).




### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I reran build visit from develop with the change sucessfully.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
