### PR TITLE
case insensitive alpha sort of db plugin names in open file as type pulldown AND in plugin manager

### DIFF
--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -385,18 +385,12 @@ QvisFileOpenWindow::UpdateWindow(bool doAll)
 //
 //   Cyrus Harrison, Tue Jun 24 11:15:28 PDT 2008
 //   Initial Qt4 Port.
+// 
+//   Justin Privitera, Tue Apr 19 12:07:06 PDT 2022
+//   Sorted the filetype names alphabetically so the lower case filetypes are 
+//   not at the end of the list.
 //
 // ****************************************************************************
-
-bool whichstringfirst(const QString &a, const QString &b)
-{
-    std::cout << "\tstart of whichstringfirst" << std::endl;
-    bool result;
-    std::cout << "\t\tcomparing " << a.toLocal8Bit().data() << " to " << b.toLocal8Bit().data() << std::endl;
-    result = a.compare(b, Qt::CaseInsensitive);
-    std::cout << "\tend of whichstringfirst" << std::endl;
-    return result;
-}
 
 void
 QvisFileOpenWindow::UpdateFileFormatComboBox()
@@ -416,7 +410,7 @@ QvisFileOpenWindow::UpdateFileFormatComboBox()
     fileFormatComboBox->addItem(tr("Guess from file name/extension"));
     FileOpenOptions *opts = GetViewerState()->GetFileOpenOptions();
 
-    std::vector<QString> filetypes;
+    QStringList *filetypes = new QStringList();
     
     for (int i = 0 ; i < nTypes ; i++)
     {
@@ -424,30 +418,17 @@ QvisFileOpenWindow::UpdateFileFormatComboBox()
         {
             if (opts->GetTypeNames()[j] == plugins.GetTypes()[i] && opts->GetEnabled()[j] )
             {
-                filetypes.push_back(plugins.GetTypes()[i].c_str());
+                filetypes->push_back(plugins.GetTypes()[i].c_str());
                 break;
             }
         }
     }
 
-    // for (int i = 0; i < filetypes.size(); i ++)
-    // {
-    //     std::cout << filetypes[i].toLocal8Bit().data() << std::endl;
-    // }
+    filetypes->sort(Qt::CaseInsensitive);
 
-    // std::cout << "checkpoint 1" << std::endl;
-
-    // // sort the names
-    // std::sort(filetypes.begin(), 
-    //           filetypes.end(),
-    //           whichstringfirst);
-    //           // [](QString a, QString b) { return a.compare(b, Qt::CaseInsensitive); });
-
-    // std::cout << "checkpoint 2" << std::endl;
-
-    for (int i = 0; i < filetypes.size(); i ++)
+    for (int i = 0; i < filetypes->size(); i ++)
     {
-        fileFormatComboBox->addItem(filetypes[i]);
+        fileFormatComboBox->addItem((*filetypes)[i]);
     }
 
     if (!oldtype.isNull())

--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -388,6 +388,16 @@ QvisFileOpenWindow::UpdateWindow(bool doAll)
 //
 // ****************************************************************************
 
+bool whichstringfirst(const QString &a, const QString &b)
+{
+    std::cout << "\tstart of whichstringfirst" << std::endl;
+    bool result;
+    std::cout << "\t\tcomparing " << a.toLocal8Bit().data() << " to " << b.toLocal8Bit().data() << std::endl;
+    result = a.compare(b, Qt::CaseInsensitive);
+    std::cout << "\tend of whichstringfirst" << std::endl;
+    return result;
+}
+
 void
 QvisFileOpenWindow::UpdateFileFormatComboBox()
 {
@@ -405,6 +415,8 @@ QvisFileOpenWindow::UpdateFileFormatComboBox()
     int nTypes = plugins.GetTypes().size();
     fileFormatComboBox->addItem(tr("Guess from file name/extension"));
     FileOpenOptions *opts = GetViewerState()->GetFileOpenOptions();
+
+    std::vector<QString> filetypes;
     
     for (int i = 0 ; i < nTypes ; i++)
     {
@@ -412,10 +424,30 @@ QvisFileOpenWindow::UpdateFileFormatComboBox()
         {
             if (opts->GetTypeNames()[j] == plugins.GetTypes()[i] && opts->GetEnabled()[j] )
             {
-                fileFormatComboBox->addItem(plugins.GetTypes()[i].c_str());
+                filetypes.push_back(plugins.GetTypes()[i].c_str());
                 break;
             }
         }
+    }
+
+    for (int i = 0; i < filetypes.size(); i ++)
+    {
+        std::cout << filetypes[i].toLocal8Bit().data() << std::endl;
+    }
+
+    std::cout << "checkpoint 1" << std::endl;
+
+    // sort the names
+    std::sort(filetypes.begin(), 
+              filetypes.end(),
+              whichstringfirst);
+              // [](QString a, QString b) { return a.compare(b, Qt::CaseInsensitive); });
+
+    std::cout << "checkpoint 2" << std::endl;
+
+    for (int i = 0; i < filetypes.size(); i ++)
+    {
+        fileFormatComboBox->addItem(filetypes[i]);
     }
 
     if (!oldtype.isNull())

--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -430,20 +430,20 @@ QvisFileOpenWindow::UpdateFileFormatComboBox()
         }
     }
 
-    for (int i = 0; i < filetypes.size(); i ++)
-    {
-        std::cout << filetypes[i].toLocal8Bit().data() << std::endl;
-    }
+    // for (int i = 0; i < filetypes.size(); i ++)
+    // {
+    //     std::cout << filetypes[i].toLocal8Bit().data() << std::endl;
+    // }
 
-    std::cout << "checkpoint 1" << std::endl;
+    // std::cout << "checkpoint 1" << std::endl;
 
-    // sort the names
-    std::sort(filetypes.begin(), 
-              filetypes.end(),
-              whichstringfirst);
-              // [](QString a, QString b) { return a.compare(b, Qt::CaseInsensitive); });
+    // // sort the names
+    // std::sort(filetypes.begin(), 
+    //           filetypes.end(),
+    //           whichstringfirst);
+    //           // [](QString a, QString b) { return a.compare(b, Qt::CaseInsensitive); });
 
-    std::cout << "checkpoint 2" << std::endl;
+    // std::cout << "checkpoint 2" << std::endl;
 
     for (int i = 0; i < filetypes.size(); i ++)
     {

--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -452,40 +452,47 @@ QvisPluginWindow::UpdateWindow(bool doAll)
     if (doAll || selectedSubject == fileOpenOptions)
     {
         listDatabases->clear();
-        listDatabases->setSortingEnabled(true);
-        listDatabases->sortByColumn(1, Qt::AscendingOrder);
+        listDatabases->setSortingEnabled(false);
+        // listDatabases->sortByColumn(1, Qt::AscendingOrder);
 
         databaseItems.clear();
         databaseIndexes.clear();
 
-        std::vector <std::pair <QTreeWidgetItem *, int >> plugins;
+        std::vector<std::pair<std::string, int>> plugins;
 
-        for (int i=0; i<fileOpenOptions->GetNumOpenOptions(); i++)
-        {            
+        for (int i = 0; i < fileOpenOptions->GetNumOpenOptions(); i ++)
+        {
+            std::string plugin_name = fileOpenOptions->GetTypeNames()[i].c_str();
+            std::transform(
+                plugin_name.begin(), 
+                plugin_name.end(), 
+                plugin_name.begin(),
+                [](unsigned char c) { return std::tolower(c); });
+            plugins.push_back(std::make_pair(plugin_name, i));
+        }
+
+        std::sort(plugins.begin(), plugins.end(),
+            [](std::pair<std::string, int> a, std::pair<std::string, int> b)
+            {
+                return a.first < b.first;
+            });
+
+        for (int i = 0; i < plugins.size(); i ++)
+        {
+            int index = plugins[i].second;
             QTreeWidgetItem *item = new QTreeWidgetItem(listDatabases);
-            item->setCheckState(0,fileOpenOptions->GetEnabled()[i] ? Qt::Checked : Qt::Unchecked);
+            item->setCheckState(0,fileOpenOptions->GetEnabled()[index] ? Qt::Checked : Qt::Unchecked);
 
-            item->setText(1,fileOpenOptions->GetTypeNames()[i].c_str());
+            item->setText(1,fileOpenOptions->GetTypeNames()[index].c_str());
 
-            if (fileOpenOptions->GetOpenOptions(i).GetNumberOfOptions() == 0)
+            if (fileOpenOptions->GetOpenOptions(index).GetNumberOfOptions() == 0)
                 item->setText(2, "  ");
             else
                 item->setText(2, tr("yes"));
 
-            std::cout << item->text(1).toLocal8Bit().data() << std::endl;
-
-            plugins.push_back(std::make_pair(item, i));
-
-            // databaseItems.push_back(item);
-            // databaseIndexes.push_back(i);
+            databaseItems.push_back(item);
+            databaseIndexes.push_back(index);
         }
-
-        for (int i = 0; i < plugins.size(); i ++)
-        {
-            databaseItems.push_back(plugins[i].first);
-            databaseIndexes.push_back(plugins[i].second);
-        }
-
 
         databaseOptionsSetButton->setEnabled(false);
         dbAddToPreferedButton->setEnabled(false);

--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -471,6 +471,9 @@ QvisPluginWindow::UpdateWindow(bool doAll)
 
             databaseItems.push_back(item);
             databaseIndexes.push_back(i);
+            // so it looks like I will want to sort these
+            // make a vector of pairs
+            // and sort based on the string living inside of `item`
         }
         databaseOptionsSetButton->setEnabled(false);
         dbAddToPreferedButton->setEnabled(false);

--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -453,15 +453,16 @@ QvisPluginWindow::UpdateWindow(bool doAll)
     {
         listDatabases->clear();
         listDatabases->setSortingEnabled(false);
-        // listDatabases->sortByColumn(1, Qt::AscendingOrder);
 
         databaseItems.clear();
         databaseIndexes.clear();
 
+        // Necessary to sort the plugin names so they appear in 
+        // alphabetical case-insensitive order.
         std::vector<std::pair<std::string, int>> plugins;
-
         for (int i = 0; i < fileOpenOptions->GetNumOpenOptions(); i ++)
         {
+            // Here we populate the list of plugin names.
             std::string plugin_name = fileOpenOptions->GetTypeNames()[i].c_str();
             std::transform(
                 plugin_name.begin(), 
@@ -479,6 +480,9 @@ QvisPluginWindow::UpdateWindow(bool doAll)
 
         for (int i = 0; i < plugins.size(); i ++)
         {
+            // Now that we have the plugins in the correct order, we can 
+            // retrieve the required data and add items to `listDatabases` in
+            // the correct order.
             int index = plugins[i].second;
             QTreeWidgetItem *item = new QTreeWidgetItem(listDatabases);
             item->setCheckState(0,fileOpenOptions->GetEnabled()[index] ? Qt::Checked : Qt::Unchecked);

--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -457,6 +457,9 @@ QvisPluginWindow::UpdateWindow(bool doAll)
 
         databaseItems.clear();
         databaseIndexes.clear();
+
+        std::vector <std::pair <QTreeWidgetItem *, int >> plugins;
+
         for (int i=0; i<fileOpenOptions->GetNumOpenOptions(); i++)
         {            
             QTreeWidgetItem *item = new QTreeWidgetItem(listDatabases);
@@ -469,12 +472,21 @@ QvisPluginWindow::UpdateWindow(bool doAll)
             else
                 item->setText(2, tr("yes"));
 
-            databaseItems.push_back(item);
-            databaseIndexes.push_back(i);
-            // so it looks like I will want to sort these
-            // make a vector of pairs
-            // and sort based on the string living inside of `item`
+            std::cout << item->text(1).toLocal8Bit().data() << std::endl;
+
+            plugins.push_back(std::make_pair(item, i));
+
+            // databaseItems.push_back(item);
+            // databaseIndexes.push_back(i);
         }
+
+        for (int i = 0; i < plugins.size(); i ++)
+        {
+            databaseItems.push_back(plugins[i].first);
+            databaseIndexes.push_back(plugins[i].second);
+        }
+
+
         databaseOptionsSetButton->setEnabled(false);
         dbAddToPreferedButton->setEnabled(false);
 

--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -429,6 +429,9 @@ QvisPluginWindow::Update(Subject *s)
 //
 //    Brad Whitlock, Thu Feb  4 16:54:47 PST 2010
 //    I rewrote the code for plots and operators so it uses a data model.
+// 
+//    Justin Privitera, Fri Apr 22 11:55:32 PDT 2022
+//    Added case-insensitive alphabetization of database plugin names.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Moved the <i>divergence</i>, <i>curl</i>, <i>Laplacian</i>, and <i>gradient</i> functions from the <i>Miscellaneous</i> submenu to the <i>Vector</i> submenu within the <i>Insert function...</i> menu in the Expressions window. </li>
   <li>Added implicit points topology support to the Blueprint Plugin.</li>
   <li>Added polyhedral mesh support to the Blueprint Plugin. Now, if you ask visit to read a polyhedral mesh, it will automatically convert the mesh to a tetrahedral mesh, as well as convert the fields as needed. It will also keep track of original element ids so that you don't see the new lines from the resulting tetrahedra.</li>
+  <li>In the file open window, next to "Open file as type:" when you click "Guess from file name/extension", the list of file types is now sorted in alphabetical case-insensitive order. The same change has been made in the list of Databases in the Plugin Manager.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #17560 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
1. In the file open window, next to "Open file as type:" when you click <kbd>Guess from file name/extension</kbd>, the list of file types is now sorted in alphabetical case-insensitive order.
2. In the Plugin Manager, the same change has been made to the list of Databases. On Windows (and Mac?), the plugin names were already sorted alphabetically and case-insensitive in the Plugin Manager, however, this was not the case on Linux. My best guess is that there is a different implementation of [`QTreeView::sortByColumn`](https://doc.qt.io/qt-5/qtreeview.html#sortByColumn) across systems. This change should standardize the ordering.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
I have built VisIt on rztopaz toss3 and observed the changes.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
