### PR TITLE
Material ordering corrected in unv database plugin

### DIFF
--- a/src/databases/unv/avtunvFileFormat.C
+++ b/src/databases/unv/avtunvFileFormat.C
@@ -4840,7 +4840,10 @@ avtunvFileFormat::GetAuxiliaryData(const char *var, const char *type, void *,Des
                 if (debuglevel >= 3) fprintf(stdout,"Material #cells=%d\n",dims[0]);
 #endif
                 for (itre = meshUnvElements.begin(); itre != meshUnvElements.end(); itre++)
-                    matlist[itre->number] = itre->matid;
+                    {
+                        matlist[k] = itre->matid;
+                        k++ ;
+                    }
             }
 
 #if INTERACTIVEPLOT


### PR DESCRIPTION

### Description
When Ideas mesh is not in order, material view was erroneous ; it did not follow the proper order.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

I found the error on a renumbered mesh with materials.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
~~ [ ] I have updated the release notes.~~
~~ [ ] I have made corresponding changes to the documentation.~~
~~ [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~
I would like @markcmiller86  to review this PR.
As it is a bug fix

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
