### PR TITLE
Enhance the XRayImage query documentation.

### DIFF
--- a/src/doc/using_visit/Quantitative/Query.rst
+++ b/src/doc/using_visit/Quantitative/Query.rst
@@ -396,8 +396,8 @@ XRay Image
     +------+-------------------+----------------------------------------------+
     |      | "tif" or 3        | TIFF image format.                           |
     +------+-------------------+----------------------------------------------+
-    |      | "rawfloats" or 4  | File of 32 bit floating point values in IEEE |
-    |      |                   | format.                                      |
+    |      | "rawfloats" or 4  | File of 32 or 64 bit floating point values   |
+    |      |                   | in IEEE format.                              |
     +------+-------------------+----------------------------------------------+
     |      | "bov" or 5        | BOV (Brick Of Values) format, which consists |
     |      |                   | of a text header |br| file describing a      |
@@ -425,6 +425,24 @@ XRay Image
     |                          | of the file is "ray_bounds.vtk".             |
     +------+-------------------+----------------------------------------------+
     
+    When specifying "bov" or "rawfloats" output, the value can be either 32 or 64 bit floating point values.
+    The number of bits is determined by the number of bits in the data being processed.
+
+    When specifying "bov" output, 2 files are created for each variable.
+    One contains the "intensity" and the other the "path_length".
+    The files are named "outputXX.bof" and "outputXX.bov" with "XX" being a sequence number.
+    The "intensity" variables are first followed by the "path_length" variables in the sequence.
+    For example, if the input array variables were composed of 2 scalar variables, the files would be named as follows:
+
+    * output00.bof
+    * output00.bov - "intensity" from the first variable of the array variable.
+    * output01.bof
+    * output01.bov - "intensity" from the second variable of the array variable.
+    * output02.bof
+    * output02.bov - "path_length" from the first variable of the array variable.
+    * output03.bof
+    * output03.bov - "path_length" from the second variable of the array variable.
+
     The query also takes arguments that specify the orientation of the camera
     in 3 dimensions. This can take 2 forms. The first is a simplified
     specification that gives limited control over the camera and a complete

--- a/src/doc/using_visit/Quantitative/Query.rst
+++ b/src/doc/using_visit/Quantitative/Query.rst
@@ -405,13 +405,14 @@ XRay Image
     +------+-------------------+----------------------------------------------+
     | *family_files*           | A flag indicating if the output files should |
     |                          | be familied. The default is |br| off. If it  |
-    |                          | is off then the output file is output.ext,   |
-    |                          | where "ext" is the file |br| extension. If   |
-    |                          | the file exists it will overwrite the file.  |
-    |                          | If it is on, then |br| the output file is    |
-    |                          | outputXXXX.ext, where XXXX is chosen to be   |
-    |                          | the |br| smallest integer not to overwrite   |
-    |                          | any existing files.                          |
+    |                          | is off then the output file is               |
+    |                          | ``output.ext``, where ``ext`` is the file    |
+    |                          | |br| extension. If the file exists it will   |
+    |                          | overwrite the file. If it is on, then |br|   |
+    |                          | the output file is ``outputXXXX.ext``,       |
+    |                          | where ``XXXX`` is chosen                     |
+    |                          | to be the |br| smallest integer not to       |
+    |                          | overwrite any existing files.                |
     +------+-------------------+----------------------------------------------+
     | *image_size*             | The width and height of the image in pixels. |
     |                          | The default is 200 x 200.                    |
@@ -422,26 +423,26 @@ XRay Image
     +------+-------------------+----------------------------------------------+
     | *output_ray_bounds*      | Output the ray bounds as a bounding box in a |
     |                          | VTK file. The default is off. |br| The name  |
-    |                          | of the file is "ray_bounds.vtk".             |
+    |                          | of the file is ``ray_bounds.vtk``.           |
     +------+-------------------+----------------------------------------------+
     
     When specifying "bov" or "rawfloats" output, the value can be either 32 or 64 bit floating point values.
     The number of bits is determined by the number of bits in the data being processed.
 
     When specifying "bov" output, 2 files are created for each variable.
-    One contains the "intensity" and the other the "path_length".
-    The files are named "outputXX.bof" and "outputXX.bov" with "XX" being a sequence number.
-    The "intensity" variables are first followed by the "path_length" variables in the sequence.
+    One contains the ``intensity`` and the other the ``path_length``.
+    The files are named ``outputXX.bof`` and ``outputXX.bov`` with ``XX`` being a sequence number.
+    The ``intensity`` variables are first followed by the ``path_length`` variables in the sequence.
     For example, if the input array variables were composed of 2 scalar variables, the files would be named as follows:
 
     * output00.bof
-    * output00.bov - "intensity" from the first variable of the array variable.
+    * output00.bov - ``intensity`` from the first variable of the array variable.
     * output01.bof
-    * output01.bov - "intensity" from the second variable of the array variable.
+    * output01.bov - ``intensity`` from the second variable of the array variable.
     * output02.bof
-    * output02.bov - "path_length" from the first variable of the array variable.
+    * output02.bov - ``path_length`` from the first variable of the array variable.
     * output03.bof
-    * output03.bov - "path_length" from the second variable of the array variable.
+    * output03.bov - ``path_length`` from the second variable of the array variable.
 
     The query also takes arguments that specify the orientation of the camera
     in 3 dimensions. This can take 2 forms. The first is a simplified


### PR DESCRIPTION
### Description

Resolves #17297 

Improved the XRayImage query documentation to document the fact that "intensity" and "path_length" are produced when specifying "bov" output.

### Type of change

* [X] Documentation update

### How Has This Been Tested?

I created the documentation on quart with no warnings or errors. I proofread the changes.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
