### PR TITLE
Increase test suite timeout for a mode from 3600 to 7200 seconds.

### DIFF
--- a/src/test/visit_test_suite.py
+++ b/src/test/visit_test_suite.py
@@ -481,7 +481,7 @@ def default_suite_options():
                       "host_profile_dir": "",
                       "retry":False,
                       "index":None,
-                      "timeout":3600,
+                      "timeout":7200,
                       "nprocs":nprocs_def,
                       "ctest":False,
                       "display_failed":False,
@@ -707,8 +707,8 @@ def parse_args():
                       help="load test cases from a specific index file")
     parser.add_option("--timeout",
                       type="int",
-                      default=defs["timeout"], # total timeout of one hour
-                      help="total test suite timeout in seconds [default = 3600]")
+                      default=defs["timeout"], # total timeout of two hours
+                      help="total test suite timeout in seconds [default = 7200]")
     parser.add_option("-n","--num-processes",
                       dest="nprocs",
                       type=int,


### PR DESCRIPTION
### Description

Increased the execution timeout for the running of a single mode of the test suite from 3600 to 7200 seconds. The tests weren't all finishing within the 3600 limit, 7200 should be sufficient.

### Type of change

* [X] Bug fix

### How Has This Been Tested?

No testing has been done. It's a fairly trivial change and shouldn't do any harm. We'll find out for sure when the test suite runs.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
