### PR TITLE
Add ending ~~ for type of change options

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,18 @@ Resolves # <!-- If this PR is unrelated to a ticket, please erase this line -->
 
 <!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
 
+<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
+     This is to facilitate striking them out when they do not apply.
+     One just has to add ~~ characters just before the opening square bracket [ -->
+
 ### Type of change
 
 <!-- Please check one of the boxes below -->
 
-* [ ] Bug fix
-* [ ] New feature
-* [ ] Documentation update
-* [ ] Other <!-- please explain with a note below -->
+* [ ] Bug fix~~
+* [ ] New feature~~
+* [ ] Documentation update~~
+* [ ] Other~~ <!-- please explain with a note below -->
 
 ### How Has This Been Tested?
 


### PR DESCRIPTION
I've grown tired of having to add `~~` to both *beginning* and *endiing* of the 4 **type of change** options and this is to add the ending ones anyways so we can handle similarly to how we handle checlist items.

### Description

Resolves # <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
