### PR TITLE
Type to choose plugin in the file open window

### DIFF
--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -184,6 +184,18 @@ QvisFileOpenWindow::SetFilename(const QString &f)
 //    David Camp, Thu Aug 27 09:40:00 PDT 2015
 //    Added a filename field if showFilename is true. For Session dialog.
 //    Also hide files if Session dialog.
+// 
+//   Justin Privitera, Tue May 17 11:06:11 PDT 2022
+//   1) Fixed an issue where the list of plugins in the file open window could 
+//   disappear when selecting plugins from the list multiple times.
+//   2) In the plugin selection in the file open window, users can now delete 
+//   the text that is there and start typing the name of the plugin that they 
+//   wish to open files with, and VisIt will autocomplete the entered text to 
+//   select a plugin. This was accomplished by making the fileFormatComboBox
+//   "editable", but making its "insertPolicy" be "NoInsert". In this way,
+//   users can type whatever they need in the box and the box will attempt
+//   to autocomplete what they are typing, but they cannot add new entries to
+//   the plugin list.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -246,6 +246,11 @@ QvisFileOpenWindow::CreateWindowContents()
     QLabel *openFileAsTypeLabel = new QLabel(tr("Open file as type:"));
     fileFormatLayout->addWidget(openFileAsTypeLabel);
     fileFormatComboBox = new QComboBox(central);
+    fileFormatComboBox->setEditable(true);
+    fileFormatComboBox->setInsertPolicy(QComboBox::NoInsert);
+    fileFormatComboBox->setMaxVisibleItems(50);
+    // needs qt 5.15; at the time of writing we use qt 5.14
+    // fileFormatComboBox->setPlaceholderText("Guess from file name/extension");
     fileFormatLayout->addWidget(fileFormatComboBox, 10);
     setDefaultOptionsForFormatButton = new QPushButton(
            tr("Set default open options..."), central);

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -39,7 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added polyhedral mesh support to the Blueprint Plugin. Now, if you ask visit to read a polyhedral mesh, it will automatically convert the mesh to a tetrahedral mesh, as well as convert the fields as needed. It will also keep track of original element ids so that you don't see the new lines from the resulting tetrahedra.</li>
   <li>In the file open window, next to "Open file as type:" when you click "Guess from file name/extension", the list of file types is now sorted in alphabetical case-insensitive order. The same change has been made in the list of Databases in the Plugin Manager.</li>
   <li>VisIt-generated expressions are no longer included in VTK, Blueprint, and Silo exports.</li>
-  <li>In the file open window, users can now start typing the name of the plugin that they wish to open files with, and VisIt will autocomplete the entered text to select a plugin.</li>
+  <li>In the plugin selection in the file open window, users can now delete the text that is there and start typing the name of the plugin that they wish to open files with, and VisIt will autocomplete the entered text to select a plugin.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.2.3.html
+++ b/src/resources/help/en_US/relnotes3.2.3.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Ensure variable names from PlainText reader have no leading or trailing whitespace.</li>
   <li>Fixed a time slider widget window resize bug so that now the main gui window width is not locked and can be shrunk and expanded.</li>
   <li>VisIt can now build successfully with ADIOS enabled while MPI is disabled.</li>
+  <li>Fixed an issue where the list of plugins in the file open window could disappear when selecting plugins from the list multiple times.</li>
 </ul>
 
 <a name="Enhancements"></a>
@@ -38,6 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added polyhedral mesh support to the Blueprint Plugin. Now, if you ask visit to read a polyhedral mesh, it will automatically convert the mesh to a tetrahedral mesh, as well as convert the fields as needed. It will also keep track of original element ids so that you don't see the new lines from the resulting tetrahedra.</li>
   <li>In the file open window, next to "Open file as type:" when you click "Guess from file name/extension", the list of file types is now sorted in alphabetical case-insensitive order. The same change has been made in the list of Databases in the Plugin Manager.</li>
   <li>VisIt-generated expressions are no longer included in VTK, Blueprint, and Silo exports.</li>
+  <li>In the file open window, users can now start typing the name of the plugin that they wish to open files with, and VisIt will autocomplete the entered text to select a plugin.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #17545 <!-- If this PR is unrelated to a ticket, please erase this line -->
Resolves #17619

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
The plugin list disappearing bug has been fixed.

In the file open window, when you are selecting which plugin to use, you now have two options:
1) you can click the dropdown as before, and select a plugin either with the mouse or by typing a letter to select the first plugin that starts with that letter.
2) you can delete the text where it says "Guess from file name/extension" and start typing the name of your favorite plugin and it will guess which one you are trying to type; you can press tab to autocomplete.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Ran a few different tests that use the database open options on rztopaz toss3; everything works just fine.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
