### PR TITLE
add python_found guard for python logic

### DIFF
--- a/src/CMake/PluginVsInstallHelpers.cmake
+++ b/src/CMake/PluginVsInstallHelpers.cmake
@@ -14,6 +14,10 @@
 #   Added logic for retrieving and filtering VTKm includes that come from
 #   interface libraries.
 #
+#   Cyrus Harrison, Thu May 19 11:42:31 PDT 2022
+#   Add PYTHON_FOUND guard for python path related logic to avoid
+#   error with empty path passed to get_filename_component
+#
 #******************************************************************************
 
 
@@ -289,8 +293,12 @@ if(UNIX)
    # python3's include dir has an 'm' after the version. For ease of 
    # use with future versions, and to save having to figure this out again
    # get and use the last part of the PYTHON_INCLUDE_DIR
-   get_filename_component(py_inc_base ${PYTHON_INCLUDE_DIR} NAME)
-   set(python_include_relative_path "/python/include/${py_inc_base}")
+   if(PYTHON_FOUND)
+       get_filename_component(py_inc_base ${PYTHON_INCLUDE_DIR} NAME)
+       set(python_include_relative_path "/python/include/${py_inc_base}")
+   else()
+       set(python_include_relative_path "")
+   endif()
    set(exodusii_include_relative_path "/exodusii/inc")
    set(vtk_include_relative_path "/vtk/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}")
 else(UNIX)


### PR DESCRIPTION
### Description

Resolves #17663

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Testing in CI.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
