### PR TITLE
Add a patch to build_visit for building Xdmf with gcc 11.2.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.0.html
+++ b/src/resources/help/en_US/relnotes3.3.0.html
@@ -128,7 +128,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Build features added in version 3.3</font></b></p>
 <ul>
   <li>Build_visit was modified to do an out-of-source build for Qt.</li>
-  <li>Build Feature 2</li>
+  <li>Build_visit was enhanced to patch Xdmf so that it builds with gcc 11.2.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_xdmf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xdmf.sh
@@ -77,7 +77,7 @@ function bv_xdmf_ensure
 #                         Function 8.19, build_xdmf                           #
 # *************************************************************************** #
 
-function apply_xdmf_patch
+function apply_xdmf_patch1
 {
    patch -p0 << \EOF
 diff -c a/libsrc/FXdmfValuesBinary.cxx Xdmf/libsrc/XdmfValuesBinary.cxx
@@ -102,7 +102,7 @@ diff -c a/libsrc/FXdmfValuesBinary.cxx Xdmf/libsrc/XdmfValuesBinary.cxx
       //char * path = new char [ strlen(this->DOM->GetWorkingDirectory())+strlen(DataSetName) + 1 ];
 EOF
     if [[ $? != 0 ]] ; then
-        warn "boxlib patch failed."
+        warn "Xdmf patch1 failed."
         return 1
     fi
 
@@ -114,9 +114,9 @@ function apply_xdmf_osx_patch
 {
     info "Patching Xdmf 2.1.1 for Xcode 9 and up . . ."
     patch -p0 << \EOF
-diff -c Xdmf/libsrc/orig/XdmfDsmComm.cxx Xdmf/libsrc/XdmfDsmComm.cxx
-*** Xdmf/libsrc/orig/XdmfDsmComm.cxx	Thu Aug 23 22:05:42 2018
---- Xdmf/libsrc/XdmfDsmComm.cxx	Thu Aug 23 21:27:43 2018
+diff -c Xdmf/libsrc/XdmfDsmComm.cxx.orig Xdmf/libsrc/XdmfDsmComm.cxx
+*** Xdmf/libsrc/XdmfDsmComm.cxx.orig    Thu Aug 23 22:05:42 2018
+--- Xdmf/libsrc/XdmfDsmComm.cxx         Thu Aug 23 21:27:43 2018
 ***************
 *** 50,56 ****
           XdmfErrorMessage("Cannot Receive Message of Length = " << Msg->Length);
@@ -160,9 +160,64 @@ EOF
     return 0;
 }
 
-function apply_xdmf1_patch
+function apply_xdmf_gcc_11_2_patch
+{
+    info "Patching Xdmf 2.1.1 for gcc 11.2 . . ."
+    patch -p0 << \EOF
+diff -c Xdmf/libsrc/XdmfDsmComm.cxx.orig Xdmf/libsrc/XdmfDsmComm.cxx
+*** Xdmf/libsrc/XdmfDsmComm.cxx.orig    Fri May 20 12:34:02 2022
+--- Xdmf/libsrc/XdmfDsmComm.cxx         Fri May 20 12:34:50 2022
+***************
+*** 50,56 ****
+          XdmfErrorMessage("Cannot Receive Message of Length = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+!     if(Msg->Data <= 0 ){
+          XdmfErrorMessage("Cannot Receive Message into Data Buffer = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+--- 50,56 ----
+          XdmfErrorMessage("Cannot Receive Message of Length = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+!     if(Msg->Data == (void*)0 ){
+          XdmfErrorMessage("Cannot Receive Message into Data Buffer = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+***************
+*** 64,70 ****
+          XdmfErrorMessage("Cannot Send Message of Length = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+!     if(Msg->Data <= 0 ){
+          XdmfErrorMessage("Cannot Send Message from Data Buffer = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+--- 64,70 ----
+          XdmfErrorMessage("Cannot Send Message of Length = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+!     if(Msg->Data == (void*)0 ){
+          XdmfErrorMessage("Cannot Send Message from Data Buffer = " << Msg->Length);
+          return(XDMF_FAIL);
+      }
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Xdmf 2.1.1 gcc 11.2 failed."
+        return 1
+    fi
+
+    return 0;
+}
+
+function apply_xdmf_patch
 {
     if [[ ${XDMF_VERSION} == 2.1.1 ]] ; then
+        apply_xdmf_patch1
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+
         if [[ "$OPSYS" == "Darwin" ]] ; then
                 XCODE_VERSION="$(/usr/bin/xcodebuild -version)"
                 # this will catch Xcode 10 +, we don't have to worry about
@@ -171,9 +226,23 @@ function apply_xdmf1_patch
                 if [[ "$XCODE_VERSION" == "Xcode 9"* ||
                       "$XCODE_VERSION" == "Xcode 1"* ]] ; then
                     apply_xdmf_osx_patch
+                    if [[ $? != 0 ]] ; then
+                        return 1
+                    fi
                 fi
         fi
+
+        if [[ "$OPSYS" == "Linux" ]]; then
+            if [[ "$C_COMPILER" == "gcc" ]]; then
+                apply_xdmf_gcc_11_2_patch
+                if [[ $? != 0 ]] ; then
+                    return 1
+                fi
+            fi
+        fi
     fi
+
+    return 0;
 }
 
 function build_xdmf
@@ -195,7 +264,6 @@ function build_xdmf
     #
     info "Patching Xdmf . . ."
     apply_xdmf_patch
-    apply_xdmf1_patch
     if [[ $? != 0 ]] ; then
         if [[ $untarred_xdmf == 1 ]] ; then
             warn "Giving up on Xdmf build because the patch failed."


### PR DESCRIPTION
### Description

Resolves #17301 

I enhanced build_visit to patch Xdmf so that it compiles with gcc 11.2. I also fixed a cut and paste error in one of the messages associated with an existing patch. I also cleaned up the existing patching code.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I created an ubuntu 22.04 container that has gcc 11.2 as the default. I ran the current develop version build_visit and I was able to replicate the failure building Xdmf. I then removed the Xdmf directory and ran a version of build_visit with my fixes and it built Xdmf fine.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
