### PR TITLE
bov writter: add data file bugfix and improve error messages

### DIFF
--- a/src/databases/BOV/avtBOVWriter.C
+++ b/src/databases/BOV/avtBOVWriter.C
@@ -385,6 +385,11 @@ ResampleGrid(vtkRectilinearGrid *rgrid, float *ptr, float *samples, int numCompo
 //    Kathleen Biagas, Wed Nov 18 2020
 //    Replace VISIT_LONG_LONG with long long.
 //
+//    Cyrus Harrison, Fri Jun 10 16:22:37 PDT 2022
+//    Bug fix for relative paths appearing in bov data file entry.
+//    Use `.bof` suffix for output data files.
+//    Improve error messages.
+//
 // ****************************************************************************
 
 void

--- a/src/databases/BOV/avtBOVWriter.C
+++ b/src/databases/BOV/avtBOVWriter.C
@@ -22,6 +22,8 @@
 #include <avtDatabaseMetaData.h>
 #include <avtParallel.h>
 
+#include <FileFunctions.h>
+
 #include <InvalidDBTypeException.h>
 #include <InvalidFilesException.h>
 #include <ImproperUseException.h>
@@ -445,12 +447,21 @@ avtBOVWriter::WriteChunk(vtkDataSet *ds, int chunk)
         deletePtr = true;
     }
 
-    char filename[1024];
-    sprintf(filename, "%s.bov", stem.c_str());
+    std::string root_file = stem + ".bov";
     ofstream *ofile = NULL;
     if (PAR_Rank() == 0)
     {
-        ofile = new ofstream(filename);
+        ofile = new ofstream(root_file.c_str());
+        if(!ofile->is_open())
+        {
+            std::ostringstream err_msg;
+            err_msg << "Could not open root bov file: '" << root_file << "'."
+                       " Do you lack write access "
+                       "on the destination filesystem?";
+            EXCEPTION1(InvalidFilesException,
+                       err_msg.str());
+        }
+
         *ofile << "#BOV version: 1.0" << endl;
         *ofile << "# file written by VisIt conversion program " << endl;
     }
@@ -500,15 +511,25 @@ avtBOVWriter::WriteChunk(vtkDataSet *ds, int chunk)
         if (numDecimals < 4)
             numDecimals = 4;
 
-        char str[1024];
-        sprintf(str, "%s_%%0.%dd.bof.gz", stem.c_str(), numDecimals);
         if (PAR_Rank() == 0)
-            *ofile << "DATA_FILE: " << str << endl;
+        {
+            // This needs to the stem w/o any pre-fixed directories,
+            // or else BOV header is bad
+            char fname_data_cstr[1024];
+            sprintf(fname_data_cstr, "%s_%%0.%dd.bof.gz", stem.c_str(), numDecimals);
+            std::string fname_data = FileFunctions::Basename(std::string(fname_data_cstr));
+            *ofile << "DATA_FILE: " << fname_data << endl;
+        }
     }
     else
     {
         if (PAR_Rank() == 0)
-            *ofile << "DATA_FILE: " << stem.c_str() << endl;
+        {
+            // This needs to the stem w/o any pre-fixed directories,
+            // or else BOV header is bad
+            std::string fname_data = FileFunctions::Basename(std::string(stem)) + ".bof";
+            *ofile << "DATA_FILE: " << fname_data << endl;
+        }
     }
 
     if (PAR_Rank() == 0)
@@ -620,16 +641,18 @@ avtBOVWriter::WriteChunk(vtkDataSet *ds, int chunk)
         //
         if (gzCompress)
         { 
-            char fmt[1024]; 
-            sprintf(fmt, "%s.gz", stem.c_str());
-            gzFile gz_handle = gzopen(fmt, "w");
+            std::string fname = stem + ".bof.gz";
+            gzFile gz_handle = gzopen(fname.c_str(), "w");
 
             if(gz_handle == NULL)
             {
                 if (deletePtr) delete [] ptr;
-                    EXCEPTION1(InvalidFilesException,
-                           "Could not open stem file.  Do you lack write access "
-                           "on the destination filesystem?");
+                std::ostringstream err_msg;
+                err_msg << "Could not open data file: '" << fname << "'."
+                           " Do you lack write access "
+                           "on the destination filesystem?";
+                EXCEPTION1(InvalidFilesException,
+                           err_msg.str());
             }
 
             gzwrite(gz_handle, ptr, nvals*sizeof(float));
@@ -637,13 +660,17 @@ avtBOVWriter::WriteChunk(vtkDataSet *ds, int chunk)
         }
         else
         {
-            FILE *file_handle = fopen(stem.c_str(), "w");
+            std::string fname = stem + ".bof";
+            FILE *file_handle = fopen(fname.c_str(), "w");
             if(file_handle == NULL)
             {
                 if (deletePtr) delete [] ptr;
+                std::ostringstream err_msg;
+                err_msg << "Could not open data file: '" << fname << "'."
+                           " Do you lack write access "
+                           "on the destination filesystem?";
                 EXCEPTION1(InvalidFilesException,
-                           "Could not open stem file.  Do you lack write access "
-                           "on the destination filesystem?");
+                           err_msg.str());
             }
             else
             {
@@ -685,22 +712,33 @@ avtBOVWriter::WriteChunk(vtkDataSet *ds, int chunk)
                         sprintf(fmt, "%s_%%0.%dd.bof.gz", stem.c_str(), numDecimals);
                         sprintf(str, fmt, brick);
                         gzFile gz_handle = gzopen(str, "w");
+                        if(gz_handle == NULL)
+                        {
+                            if (deletePtr) delete [] ptr;
+                            std::ostringstream err_msg;
+                            err_msg << "Could not open data file: '" << str << "'."
+                                       " Do you lack write access "
+                                       "on the destination filesystem?";
+                            EXCEPTION1(InvalidFilesException,
+                                       err_msg.str());
+                        }
                         gzwrite(gz_handle, samples, 
                                 vals_per_bricklet*sizeof(float));
                         gzclose(gz_handle);
                     }
                     else if (gzCompress)
                     {
-                        char fmt[1024]; 
-                        sprintf(fmt, "%s.gz", stem.c_str());
-                        gzFile gz_handle = gzopen(fmt, "w");
-
+                        std::string fname =  stem + ".bof.gz";
+                        gzFile gz_handle = gzopen(fname.c_str(), "w");
                         if(gz_handle == NULL)
                         {
                             if (deletePtr) delete [] ptr;
-                                EXCEPTION1(InvalidFilesException,
-                                       "Could not open stem file.  Do you lack write access "
-                                       "on the destination filesystem?");
+                            std::ostringstream err_msg;
+                            err_msg << "Could not open data file: '" << fname << "'."
+                                       " Do you lack write access "
+                                       "on the destination filesystem?";
+                            EXCEPTION1(InvalidFilesException,
+                                       err_msg.str());
                         }
 
                         gzwrite(gz_handle, samples, vals_per_bricklet*sizeof(float));
@@ -708,7 +746,18 @@ avtBOVWriter::WriteChunk(vtkDataSet *ds, int chunk)
                     }
                     else
                     {
-                        FILE *file_handle = fopen(stem.c_str(), "w");
+                        std::string fname =  stem + ".bof";
+                        FILE *file_handle = fopen(fname.c_str(), "w");
+                        if(file_handle == NULL)
+                        {
+                            if (deletePtr) delete [] ptr;
+                            std::ostringstream err_msg;
+                            err_msg << "Could not open data file: '" << fname << "'."
+                                       " Do you lack write access "
+                                       "on the destination filesystem?";
+                            EXCEPTION1(InvalidFilesException,
+                                       err_msg.str());
+                        }
                         fwrite(samples, sizeof(float), vals_per_bricklet, 
                                file_handle);
                         fclose(file_handle);

--- a/src/viewer/core/actions/IOActions.C
+++ b/src/viewer/core/actions/IOActions.C
@@ -129,6 +129,9 @@ ExportDBAction::GetActivePlotNetworkIds(ViewerPlotList *plist, intVector &networ
 //   ExportDatabases has new signature with return atts.
 //   Add location of export to message returned to user.
 //
+//   Cyrus Harrison, Mon Jun 13 12:08:19 PDT 2022
+//   Fix how path is display when dirname is empty.
+//
 // ****************************************************************************
 
 void
@@ -208,11 +211,17 @@ ExportDBAction::Execute()
                                 host = "";
                             else
                                 host += ":";
+                            std::string path = exportAtts.GetDirname();
+                            // don't add '/' if dir name is empty,
+                            // b/c it will make it look like we wrote
+                            // to the root file system
+                            if(!path.empty())
+                              path += "/";
                             GetViewerMessaging()->Message(
-                                TR("Exported database time state %1 to %2%3/%4").
+                                TR("Exported database time state %1 to %2%3%4").
                                 arg(i).
                                 arg(host).
-                                arg(exportAtts.GetDirname()).
+                                arg(path).
                                 arg(exportAtts.GetFilename()));
                         }
                         else
@@ -252,10 +261,16 @@ ExportDBAction::Execute()
                 host = "";
             else
                 host += ":";
+            std::string path = exportAtts.GetDirname();
+            // don't add '/' if dir name is empty,
+            // b/c it will make it look like we wrote
+            // to the root file system
+            if(!path.empty())
+              path += "/";
             GetViewerMessaging()->Message(
-                TR("Exported database to %1%2/%3").
+                TR("Exported database to %1%2%3").
                 arg(host).
-                arg(exportAtts.GetDirname()).
+                arg(path).
                 arg(exportAtts.GetFilename()));
         }
         else


### PR DESCRIPTION
### Description

Resolves #17735 and #17641

- Adds more details (the actual file names) to error messages related failed attempts to open a file for writing. 
- Changes the data file name to have a `.bof` extension, instead of no extension (#17641)
- Fixes the data file path in the `.bov` file, by stripping directory if part of file name so we only write the filename (#17735)



### Type of change

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested exporting on my mac. 

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
