### PR TITLE
Update avtWDataFileFormat.C

### DIFF
--- a/src/databases/WData/avtWDataFileFormat.C
+++ b/src/databases/WData/avtWDataFileFormat.C
@@ -178,25 +178,25 @@ WDataComplexVariable::WDataComplexVariable(wdata_metadata *wdmd, int varid, int 
     for (int i = 0; i < md->nlink; i++)
         if (strcmp(md->link[i].linkto, md->var[vid].name) == 0)
         {
-            varlabel = md->link[vid].name;
+            varlabel = md->link[i].name;
             varlabel += "_abs";
             varname.push_back(varlabel);
             varunit.push_back(md->var[vid].unit);
             trans.push_back(cabs);
 
-            varlabel = md->link[vid].name;
+            varlabel = md->link[i].name;
             varlabel += "_arg";
             varname.push_back(varlabel);
             varunit.push_back("PI");
             trans.push_back(carg);
 
-            varlabel = md->link[vid].name;
+            varlabel = md->link[i].name;
             varlabel += "_re";
             varname.push_back(varlabel);
             varunit.push_back(md->var[vid].unit);
             trans.push_back(cre);
 
-            varlabel = md->link[vid].name;
+            varlabel = md->link[i].name;
             varlabel += "_im";
             varname.push_back(varlabel);
             varunit.push_back(md->var[vid].unit);

--- a/src/databases/WData/avtWDataFileFormat.C
+++ b/src/databases/WData/avtWDataFileFormat.C
@@ -139,6 +139,8 @@ bool WDataRealVariable::getVariable(const char *_varname, int cycleid, float *da
 // =======================================================================================
 // ============================= WDataComplexVariable ====================================
 // =======================================================================================
+// Modifications:
+//   @Belyor on GitHub: Bugfix. Array iterator had a wrong name
 WDataComplexVariable::WDataComplexVariable(wdata_metadata *wdmd, int varid, int precdowngrade) : WDataVariable(wdmd, varid, precdowngrade)
 {
     // allocate memory for data


### PR DESCRIPTION
Bugfix in WData database plugin.

### Description

Bugfix. Array iterator had a wrong name

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

The bug was noticed by on of the developer in the group and fixed. Now we want to incorporate it to the visit plugin 3.2RC

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
