### PR TITLE
Add patch to bv_mili.sh to fix mili configure bug not passing along CFLAGS.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -213,6 +213,68 @@ EOF
     return 0
 }
 
+function apply_mili_221_cflags_patch
+{
+    patch -p0 << \EOF
+diff -c mili-22.1/configure.orig mili-22.1/configure
+*** mili-22.1/configure.orig      Mon Jun 13 12:08:41 2022
+--- mili-22.1/configure           Mon Jun 13 12:09:33 2022
+***************
+*** 4361,4382 ****
+  
+      case $CC in
+        *icc)
+!         CC_FLAGS_DEBUG="-g $WORD_SIZE "
+!         CC_FLAGS_OPT="-O3 $WORD_SIZE "
+!         CC_FLAGS_LD_DEBUG="-g $WORD_SIZE"
+!         CC_FLAGS_LD_OPT="-O3 $WORD_SIZE"
+          ;;
+        *xlc)
+!         CC_FLAGS_DEBUG="-g $WORD_SIZE "
+!         CC_FLAGS_OPT="-O4 $WORD_SIZE "
+!         CC_FLAGS_LD_DEBUG="-g $WORD_SIZE"
+!         CC_FLAGS_LD_OPT="-O4"
+          ;;
+        *gcc)
+!         CC_FLAGS_DEBUG="-g $WORD_SIZE "
+!         CC_FLAGS_OPT="-O4 $WORD_SIZE "
+!         CC_FLAGS_LD_DEBUG="-g $WORD_SIZE"
+!         CC_FLAGS_LD_OPT="-O4 $WORD_SIZE"
+          ;;
+        *cc)
+          ;;
+--- 4361,4382 ----
+  
+      case $CC in
+        *icc)
+!         CC_FLAGS_DEBUG="$CFLAGS -g $WORD_SIZE "
+!         CC_FLAGS_OPT="$CFLAGS -O3 $WORD_SIZE "
+!         CC_FLAGS_LD_DEBUG="$CFLAGS -g $WORD_SIZE"
+!         CC_FLAGS_LD_OPT="$CFLAGS -O3 $WORD_SIZE"
+          ;;
+        *xlc)
+!         CC_FLAGS_DEBUG="$CFLAGS -g $WORD_SIZE "
+!         CC_FLAGS_OPT="$CFLAGS -O4 $WORD_SIZE "
+!         CC_FLAGS_LD_DEBUG="$CFLAGS -g $WORD_SIZE"
+!         CC_FLAGS_LD_OPT="$CFLAGS -O4"
+          ;;
+        *gcc)
+!         CC_FLAGS_DEBUG="$CFLAGS -g $WORD_SIZE "
+!         CC_FLAGS_OPT="$CFLAGS -O4 $WORD_SIZE "
+!         CC_FLAGS_LD_DEBUG="$CFLAGS -g $WORD_SIZE"
+!         CC_FLAGS_LD_OPT="$CFLAGS -O4 $WORD_SIZE"
+          ;;
+        *cc)
+          ;;
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Unable to apply CFLAGS patch to Mili 22.1"
+        return 1
+    fi
+
+    return 0
+}
+
 function apply_mili_patch
 {
     if [[ "$OPSYS" == "Darwin" ]]; then
@@ -225,6 +287,13 @@ function apply_mili_patch
             return 1
         fi
         apply_mili_151_darwin_patch3
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+    fi
+
+    if [[ ${MILI_VERSION} == 22.1 ]] ; then
+        apply_mili_221_cflags_patch
         if [[ $? != 0 ]] ; then
             return 1
         fi


### PR DESCRIPTION
### Description

I added a patch to bv_mili.sh to patch configure so that it passes CFLAGS to the C compiler. There was a configure flag to add "-fPIC" to the CFLAGS in bv_mili.sh, which is required by libraries used by VisIt. Since the CFLAGS weren't passed along to the C compiler, the link of the mili reader failed.

I don't know how I missed this in my testing of the new mili library, I must have accidently tested the previous mili library rather than the new one I upgraded to.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I build VisIt on quartz and then ran the mili tests. They all passed.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
