### PR TITLE
direct fix to add guard for builds without conduit

### DIFF
--- a/src/CMake/FindConduit.cmake
+++ b/src/CMake/FindConduit.cmake
@@ -45,7 +45,9 @@ if(EXISTS ${CONDUIT_DIR}/python-modules/conduit)
                 )
 endif()
 
-set(HAVE_CONDUIT TRUE CACHE BOOL "Have Conduit libraries")
+if(CONDUIT_FOUND)
+    set(HAVE_CONDUIT TRUE CACHE BOOL "Have Conduit libraries")
+endif()
 
 # Temporary, allow users to build VisIt with older Conduit
 #  and disable partition/flatten support conditionally


### PR DESCRIPTION
### Description

Resolves #17723 

Adds guard to set HAVE_CONDUIT only when Conduit was found. 

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested compile w/o conduit.

### Checklist:

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
