### PR TITLE
Add crack_width expression

### DIFF
--- a/src/avt/Expressions/CMakeLists.txt
+++ b/src/avt/Expressions/CMakeLists.txt
@@ -53,6 +53,9 @@
 #    Justin Privitera, Wed Mar 30 12:45:19 PDT 2022
 #    Added avtGhostZoneIdExpression.
 #
+#    Kathleen Biagas, Wed June 15, 2022
+#    Added General/avtCrackWidthExpression.C
+#
 #****************************************************************************/
 
 SET(ABSTRACT_SOURCES
@@ -126,6 +129,7 @@ General/avtColorComposeExpression.C
 General/avtConnComponentsExpression.C
 General/avtConstantFunctionExpression.C
 General/avtCoordinateExtremaExpression.C
+General/avtCrackWidthExpression.C
 General/avtCurlExpression.C
 General/avtCurveDomainExpression.C
 General/avtCurveExpression.C

--- a/src/avt/Expressions/General/avtCrackWidthExpression.C
+++ b/src/avt/Expressions/General/avtCrackWidthExpression.C
@@ -202,7 +202,7 @@ avtCrackWidthExpression::ProcessArguments(ArgsExpr *args,
 //
 //  Purpose:
 //      Called to calc the expression results.
-//      This duplicates code in operators/CracksClipper/vtkCrackWidthFilter
+//      This duplicates code in operators/CracksClipper/vtkCrackWidthFilter.
 //
 //  Programmer: Kathleen Biagas
 //  Creation:   June 13, 2022

--- a/src/avt/Expressions/General/avtCrackWidthExpression.C
+++ b/src/avt/Expressions/General/avtCrackWidthExpression.C
@@ -1,0 +1,344 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+// ****************************************************************************
+//   avtCrackWidthExpression.C
+// ****************************************************************************
+
+#include <avtCrackWidthExpression.h>
+
+#include <avtExprNode.h>
+#include <Expression.h>
+#include <ExpressionException.h>
+#include <ExpressionList.h>
+#include <ImproperUseException.h>
+#include <ParsingExprList.h>
+
+#include <vtkVisItUtility.h>
+
+#include <vtkCell.h>
+#include <vtkCellData.h>
+#include <vtkDataSet.h>
+#include <vtkDataSetWriter.h>
+#include <vtkDataArray.h>
+#include <vtkDoubleArray.h>
+#include <vtkMassProperties.h>
+#include <vtkSlicer.h>
+
+namespace avtCrackWidthExpression_Internal
+{
+    vtkNew<vtkSlicer> Slicer;
+    vtkNew<vtkMassProperties> MassProp;
+
+    void
+    SetInput(vtkDataSet* ds)
+    {
+        Slicer->SetInputData(ds);
+    }
+
+    double
+    LengthForCell(vtkIdType cellId, 
+                  const double *center, const double *dir, const double zVol,
+                  const double L1L2)
+    {
+        double L = 0;
+        if (L1L2 == 0)
+        {
+            Slicer->SetCellList(&cellId, 1);
+            Slicer->SetNormal(const_cast<double*>(dir));
+            Slicer->SetOrigin(const_cast<double*>(center));
+            MassProp->SetInputConnection(Slicer->GetOutputPort());
+            MassProp->Update();
+            L =  zVol / MassProp->GetSurfaceArea();
+        }
+        else
+        {
+            L = zVol / L1L2;
+        }
+        return L;
+    }
+
+
+    void OrderThem(double delta[3], int co[3])
+    {
+        int min, mid, max;
+        if (delta[0] <= delta[1] && delta[0] <= delta[2])
+            min = 0; 
+        else if (delta[1] <= delta[0] && delta[1] <= delta[2])
+            min = 1; 
+        else 
+            min = 2; 
+
+        if (delta[0] >= delta[1] && delta[0] >= delta[2])
+            max = 0; 
+        else if (delta[1] >= delta[0] && delta[1] >= delta[2])
+            max = 1; 
+        else 
+            max = 2; 
+
+        if (min == 0)
+            mid = (max == 1 ? 2 : 1);    
+        else if (min == 1)
+            mid = (max == 2 ? 0 : 2);    
+        else 
+            mid = (max == 0 ? 1 : 0);    
+
+        co[0] = max;
+        co[1] = mid;
+        co[2] = min;
+    }
+}
+
+// ****************************************************************************
+//  Method: avtCrackWidthExpression constructor
+//
+//  Purpose:
+//      Defines the constructor.  Note: this should not be inlined in the header
+//      because it causes problems for certain compilers.
+//
+//  Programmer: Kathleen Biagas
+//  Creation:   June 13, 2022
+//
+// ****************************************************************************
+avtCrackWidthExpression::avtCrackWidthExpression()
+{
+    crackNum = 0;
+}
+
+
+// ****************************************************************************
+//  Method: avtCrackWidthExpression destructor
+//
+//  Purpose:
+//      Defines the destructor.  Note: this should not be inlined in the header
+//      because it causes problems for certain compilers.
+//
+//  Programmer: Kathleen Biagas
+//  Creation:   June 13, 2022
+//
+// ****************************************************************************
+avtCrackWidthExpression::~avtCrackWidthExpression()
+{
+}
+
+
+// ****************************************************************************
+//  Method: avtCrackWidthExpression::ProcessArguments
+//
+//  Purpose:
+//      Parses arguments.
+//
+//  Arguments:
+//      args      Expression arguments
+//      state     Expression pipeline state
+//
+//  Programmer: Kathleen Biagas
+//  Creation:   June 13, 2022
+//
+// ****************************************************************************
+
+void
+avtCrackWidthExpression::ProcessArguments(ArgsExpr *args,
+                                          ExprPipelineState *state)
+{
+    // Get the argument list and number of arguments.
+    std::vector<ArgExpr*> *arguments = args->GetArgs();
+    size_t nargs = arguments->size();
+    if (nargs != 6)
+    {
+        EXCEPTION2(ExpressionException, outputVariableName,
+                   "crack_width(): Incorrect syntax.\n"
+                   " usage: crack_width(crack_num, crack1_dir, crack2_dir, crack3_dir, strain_tensor, vol_expr)\n");
+    }
+
+    // crack_num_argument variable.
+    ExprParseTreeNode *tree0 = (*arguments)[0]->GetExpr();
+    if (tree0->GetTypeName()  == "IntegerConst")
+    {
+        int val = dynamic_cast<IntegerConstExpr*>(tree0)->GetValue();
+        if (val < 1 || val > 3)
+            EXCEPTION2(ExpressionException, outputVariableName,
+                       "avtCrackWidthExpression: Invalid crack_num argument.\n"
+                       "Must be 1, 2, or 3");
+        crackNum = val;
+    }
+    else
+    {
+        EXCEPTION2(ExpressionException, outputVariableName,
+                   "avtCrackWidthExpression: Invalid crack_num argument.\n"
+                   "Must be 1, 2, or 3");
+    }
+
+    // crack1 variable.
+    avtExprNode *tree1 = dynamic_cast<avtExprNode*>((*arguments)[1]->GetExpr());
+    tree1->CreateFilters(state);
+
+    // crack2 variable.
+    avtExprNode *tree2 = dynamic_cast<avtExprNode*>((*arguments)[2]->GetExpr());
+    tree2->CreateFilters(state);
+
+    // crack3 variable.
+    avtExprNode *tree3 = dynamic_cast<avtExprNode*>((*arguments)[3]->GetExpr());
+    tree3->CreateFilters(state);
+
+    // strain variable.
+    avtExprNode *tree4 = dynamic_cast<avtExprNode*>((*arguments)[4]->GetExpr());
+    tree4->CreateFilters(state);
+
+    // volume expression variable.
+    avtExprNode *tree5 = dynamic_cast<avtExprNode*>((*arguments)[5]->GetExpr());
+    tree5->CreateFilters(state);
+
+}
+
+// ****************************************************************************
+//  Method: avtCrackWidthExpression::DeriveVariable
+//
+//  Purpose:
+//      Called to calc the expression results.
+//
+//  Programmer: Kathleen Biagas
+//  Creation:   June 13, 2022
+//
+// ****************************************************************************
+
+vtkDataArray *
+avtCrackWidthExpression::DeriveVariable(vtkDataSet *inDS, int )
+{
+    vtkCellData *inCD = inDS->GetCellData();
+
+    vtkDataArray *crackVars[3];
+    crackVars[0]  = inCD->GetArray(varnames[0]);
+    crackVars[1]  = inCD->GetArray(varnames[1]);
+    crackVars[2]  = inCD->GetArray(varnames[2]);
+    vtkDataArray *strainVar = inCD->GetArray(varnames[3]);
+    vtkDataArray *vol   = inCD->GetArray(varnames[4]);
+
+    if(crackVars[0] == nullptr ||
+       crackVars[1] == nullptr ||
+       crackVars[2] == nullptr ||
+       strainVar == nullptr    ||
+       vol == nullptr)
+    {
+        EXCEPTION0(ImproperUseException);
+    }
+
+    avtCrackWidthExpression_Internal::SetInput(inDS);
+
+    //
+    // formula for calculating crack width:
+    //    crackwidth = L * (1 - (exp(-delta))  
+    //    where: 
+    //      L = ZoneVol / (Area perpendicular to crackdir)
+    //        find Area by slicing the cell by plane with origin == cell center
+    //        and Normal == crackdir.  Take area of that slice.
+    //
+    //      delta = T11 for crack dir1 = component 0 of strain_tensor 
+    //              T22 for crack dir2 = component 4 of strain_tensor
+    //              T33 for crack dir3 = component 8 of strain_tensor
+    //
+
+    // 
+    // step through cells, calculating cell centers and crack widths for 
+    // each crack direction.  Terminate early when possible.
+    // 
+
+    vtkIdType numCells = inDS->GetNumberOfCells();
+    vtkDoubleArray *crackWidths[3];
+
+    crackWidths[0] = vtkDoubleArray::New();
+    crackWidths[0]->SetNumberOfComponents(1);
+    crackWidths[0]->SetNumberOfTuples(numCells);
+
+    crackWidths[1] = vtkDoubleArray::New();
+    crackWidths[1]->SetNumberOfComponents(1);
+    crackWidths[1]->SetNumberOfTuples(numCells);
+
+    crackWidths[2] = vtkDoubleArray::New();
+    crackWidths[2]->SetNumberOfComponents(1);
+    crackWidths[2]->SetNumberOfTuples(numCells);
+
+    vtkDoubleArray *crackWidth = nullptr;
+
+    double deltaC = 0, L, cw, zVol, *dir = NULL, *maxCW = NULL;
+    int crackOrder[3];
+    double delta[3];
+
+    for (vtkIdType cellId = 0; cellId < numCells; cellId++)
+    {
+        double center[3] = {VTK_FLOAT_MAX, VTK_FLOAT_MAX, VTK_FLOAT_MAX};
+        delta[0] = strainVar->GetComponent(cellId, 0);
+        delta[1] = strainVar->GetComponent(cellId, 4);
+        delta[2] = strainVar->GetComponent(cellId, 8);
+
+        if (delta[0] == 0 && delta[1] == 0 && delta[2] == 0)
+        {
+          crackWidths[0]->SetValue(cellId, 0);
+          crackWidths[1]->SetValue(cellId, 0);
+          crackWidths[2]->SetValue(cellId, 0);
+          continue;
+        }
+
+        avtCrackWidthExpression_Internal::OrderThem(delta, crackOrder);
+
+        vtkCell *cell = inDS->GetCell(cellId);
+        vtkVisItUtility::GetCellCenter(cell, center);
+  
+        zVol = vol->GetComponent(cellId, 0);
+
+        double L1L2 = 1.; 
+        for (int crack = 0; crack < 3; ++crack)
+        {
+            crackWidth = crackWidths[crackOrder[crack]];
+            dir = crackVars[crackOrder[crack]]->GetTuple(cellId);
+            deltaC = delta[crackOrder[crack]];
+            if (deltaC == 0 || (dir[0] == 0 && dir[1] == 0 && dir[2] == 0))
+            {
+                crackWidth->SetValue(cellId, 0);
+                continue;
+            }
+
+            if (crack < 2)
+            {
+                L = avtCrackWidthExpression_Internal::LengthForCell(
+                        cellId, center, dir, zVol, 0);
+                L1L2 *= L;
+            }
+            else 
+            {
+                L = avtCrackWidthExpression_Internal::LengthForCell(
+                        cellId, center, dir, zVol, L1L2);
+            }
+            cw = L*(1.0-exp(-deltaC));
+            crackWidth->SetValue(cellId, cw);
+        }
+    }
+
+
+    // if a return-all option is set (eg for use by cracks clipper)
+    // create a vector instead of scalar, each component corresponding
+    // to a crack num.  cracks clipper would have to separate them.
+    if (crackNum == 1)
+    {
+        crackWidths[1]->Delete();
+        crackWidths[2]->Delete();
+        crackWidths[0]->SetName(outputVariableName);
+        return crackWidths[0];
+    }
+    else if (crackNum == 2)
+    {
+        crackWidths[0]->Delete();
+        crackWidths[2]->Delete();
+        crackWidths[1]->SetName(outputVariableName);
+        return crackWidths[1];
+    }
+    else
+    {
+        crackWidths[0]->Delete();
+        crackWidths[1]->Delete();
+        crackWidths[2]->SetName(outputVariableName);
+        return crackWidths[2];
+    }
+}
+

--- a/src/avt/Expressions/General/avtCrackWidthExpression.C
+++ b/src/avt/Expressions/General/avtCrackWidthExpression.C
@@ -50,7 +50,9 @@ namespace avtCrackWidthExpression_Internal
             Slicer->SetOrigin(const_cast<double*>(center));
             MassProp->SetInputConnection(Slicer->GetOutputPort());
             MassProp->Update();
-            L =  zVol / MassProp->GetSurfaceArea();
+            double sa = MassProp->GetSurfaceArea();
+            if (sa != 0.)
+                L =  zVol / sa;
         }
         else
         {

--- a/src/avt/Expressions/General/avtCrackWidthExpression.C
+++ b/src/avt/Expressions/General/avtCrackWidthExpression.C
@@ -26,6 +26,9 @@
 #include <vtkMassProperties.h>
 #include <vtkSlicer.h>
 
+//
+// This duplicates code in operators/CracksClipper/vtkCrackWidthFilter
+//
 namespace avtCrackWidthExpression_Internal
 {
     vtkNew<vtkSlicer> Slicer;
@@ -199,6 +202,7 @@ avtCrackWidthExpression::ProcessArguments(ArgsExpr *args,
 //
 //  Purpose:
 //      Called to calc the expression results.
+//      This duplicates code in operators/CracksClipper/vtkCrackWidthFilter
 //
 //  Programmer: Kathleen Biagas
 //  Creation:   June 13, 2022

--- a/src/avt/Expressions/General/avtCrackWidthExpression.h
+++ b/src/avt/Expressions/General/avtCrackWidthExpression.h
@@ -1,0 +1,58 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
+
+// ****************************************************************************
+//  avtCrackWidthExpression.h
+// ****************************************************************************
+
+#ifndef AVT_CRACKWIDTH_EXPRESSION_H
+#define AVT_CRACKWIDTH_EXPRESSION_H
+
+
+#include <avtMultipleInputExpressionFilter.h>
+
+
+// ****************************************************************************
+//  Class: avtCrackWidthExpression
+//
+//  Purpose:  Calculates crack width, given a crack_dir (vector),
+//            strain (tensor), crack number, and cell volume (scalar).
+//
+//  Programmer: Kathleen Biagas 
+//  Creation:   June 13, 2022
+//
+// ****************************************************************************
+
+
+class EXPRESSION_API avtCrackWidthExpression : public avtMultipleInputExpressionFilter
+{
+public:
+                   avtCrackWidthExpression();
+    virtual       ~avtCrackWidthExpression();
+
+    void           ProcessArguments(ArgsExpr *, ExprPipelineState *) override;
+    int            NumVariableArguments() override
+                       { return 5; }
+    const char    *GetType(void) override
+                       { return "avtCrackWidthExpression"; }
+    const char    *GetDescription(void) override
+                       { return "Calculate crack width"; }
+
+protected:
+
+    int            GetVariableDimension(void) override
+                       { return 1; }
+
+    vtkDataArray  *DeriveVariable(vtkDataSet *, int ) override;
+
+private:
+   int crackNum;
+
+};
+
+
+
+
+
+#endif /* AVT_CRACKWIDTH_EXPRESSION_H */

--- a/src/avt/Expressions/General/avtCrackWidthExpression.h
+++ b/src/avt/Expressions/General/avtCrackWidthExpression.h
@@ -9,9 +9,7 @@
 #ifndef AVT_CRACKWIDTH_EXPRESSION_H
 #define AVT_CRACKWIDTH_EXPRESSION_H
 
-
 #include <avtMultipleInputExpressionFilter.h>
-
 
 // ****************************************************************************
 //  Class: avtCrackWidthExpression
@@ -23,7 +21,6 @@
 //  Creation:   June 13, 2022
 //
 // ****************************************************************************
-
 
 class EXPRESSION_API avtCrackWidthExpression : public avtMultipleInputExpressionFilter
 {
@@ -50,9 +47,5 @@ private:
    int crackNum;
 
 };
-
-
-
-
 
 #endif /* AVT_CRACKWIDTH_EXPRESSION_H */

--- a/src/avt/Expressions/Management/avtExprNode.C
+++ b/src/avt/Expressions/Management/avtExprNode.C
@@ -33,6 +33,7 @@
 #include <avtConnComponentsExpression.h>
 #include <avtConstantCreatorExpression.h>
 #include <avtConstantFunctionExpression.h>
+#include <avtCrackWidthExpression.h>
 #include <avtCurvatureExpression.h>
 #include <avtCurveDomainExpression.h>
 #include <avtCurveExpression.h>
@@ -480,6 +481,9 @@ avtVectorExpr::CreateFilters(ExprPipelineState *state)
 //    Changed MinMax expression creation so that they construct with doMin
 //    as a construction parameter.
 //
+//    Kathleen Biagas, Wed June 15, 2022
+//    Added crack_width.
+//
 // ****************************************************************************
 
 avtExpressionFilter *
@@ -545,6 +549,8 @@ avtFunctionExpr::CreateFilters(string functionName)
         return new avtMergeTreeExpression(false);
     if (functionName == "local_threshold")
         return new avtLocalThresholdExpression();
+    if (functionName == "crack_width")
+        return new avtCrackWidthExpression();
     if (functionName == "python" || functionName == "py")
 #ifdef VISIT_PYTHON_FILTERS
         return new avtPythonExpression();

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1956,6 +1956,17 @@ conn components Function: ``conn_components()`` : ``conn_components(expr0)``
 resrad Function: ``resrad()`` : ``resrad(expr0)``
     No description available.
 
+.. _CrackWidth_Expression_Function:
+
+crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
+    Calculates crack width.
+    crack_num      : number of crack (1, 2, or 3). 
+    crack1_dir     : direction vector for crack 1. 
+    crack2_dir     : direction vector for crack 2. 
+    crack3_dir     : direction vector for crack 3. 
+    strain_tensor  : strain tensor
+    mesh_name      : name of the mesh
+
 Time Iteration Expressions
 """"""""""""""""""""""""""
 

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1959,14 +1959,18 @@ resrad Function: ``resrad()`` : ``resrad(expr0)``
 .. _CrackWidth_Expression_Function:
 
 crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
-    Calculates crack width.
-    crack_num      : number of crack (1, 2, or 3). 
-    crack1_dir     : direction vector for crack 1. 
-    crack2_dir     : direction vector for crack 2. 
-    crack3_dir     : direction vector for crack 3. 
-    strain_tensor  : strain tensor
-    mesh_name      : name of the mesh
 
+    Calculates crack width using the following formula:
+        crackwidth = L * (1 - (exp(-delta))  
+        where: 
+          L = ZoneVol / (Area perpendicular to crack_dir)
+            find Area by slicing the cell by plane with origin == cell center
+            and Normal == crack_dir.  Take area of that slice.
+    
+          delta = T11 for crack dir1 = component 0 of strain_tensor 
+                  T22 for crack dir2 = component 4 of strain_tensor
+                  T33 for crack dir3 = component 8 of strain_tensor
+   
 Time Iteration Expressions
 """"""""""""""""""""""""""
 

--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -175,6 +175,9 @@
 //    Justin Privitera, Wed Mar 30 12:50:59 PDT 2022
 //    Added "ghost_zoneid" expression under mesh submenu.
 //
+//    Kathleen Biagas, Wed Jun 15 2022
+//    Added crack_width to misc submenu.
+//
 // ****************************************************************************
 
 struct ExprNameList
@@ -367,6 +370,7 @@ const char *expr_misc[] = {
     "bin",
     "cell_constant",
     "conn_components",
+    "crack_width",
     "curve_domain",
     "curve_integrate",
     "curve_swapxy",
@@ -1661,12 +1665,14 @@ QvisExpressionsWindow::UpdateStandardExpressionEditor(const QString &expr_def)
 //    Removed angle brackets from constantvalue field 
 //    in all 4 constant functions.
 //
+//    Kathleen Biagas, Wed Jun 15 2022
+//    Added crack_width.
+//
 // ****************************************************************************
 
 QString
 QvisExpressionsWindow::ExpandFunction(const QString &func_name)
 {
-
     QString res;
     bool doParens = (func_name.length() >= 2);
 
@@ -1855,6 +1861,11 @@ QvisExpressionsWindow::ExpandFunction(const QString &func_name)
     else if (func_name == "divide")
     {
         res += QString("(<val_numerator>, <val_denominator>, [<div_by_zero_value>, <tolerance>])");
+        doParens = false;
+    }
+    else if (func_name == "crack_width")
+    {
+        res += QString("(crack_number, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))");
         doParens = false;
     }
 

--- a/src/operators/CracksClipper/vtkCrackWidthFilter.C
+++ b/src/operators/CracksClipper/vtkCrackWidthFilter.C
@@ -371,6 +371,9 @@ vtkCrackWidthFilter::RequestData(
 //    I modified the function to return the effective length in the crack
 //    direction instead of the crack width and changed the name to match.
 //
+//    Kathleen Biagas, Wed June 15, 2022
+//    Guard against divide-by-zero.
+//
 // ***************************************************************************
 
 double
@@ -386,7 +389,9 @@ vtkCrackWidthFilter::LengthForCell(vtkCell *cell, vtkIdType cellId,
     this->Slicer->SetOrigin(const_cast<double*>(center));
     this->MassProp->SetInputConnection(this->Slicer->GetOutputPort());
     this->MassProp->Update();
-    L =  zVol / this->MassProp->GetSurfaceArea();
+    double sa = this->MassProp->GetSurfaceArea();
+    if (sa != 0.)
+        L =  zVol / sa;
     }
   else
     {

--- a/src/operators/CracksClipper/vtkCrackWidthFilter.C
+++ b/src/operators/CracksClipper/vtkCrackWidthFilter.C
@@ -93,6 +93,8 @@ vtkCrackWidthFilter::~vtkCrackWidthFilter()
 //  Method: vtkCrackWidthFilter_OrderThem 
 //
 //  Purpose: Creates a max-to-min ordering based on the passed deltas. 
+//  
+//  Notes:  This code is duplicated in avtCrackWidthExpression.
 //
 //  Programmer: Kathleen Bonnell
 //  Creation:   October 13, 2006 
@@ -136,6 +138,8 @@ vtkCrackWidthFilter_OrderThem(double delta1, double delta2, double delta3,
 //  Method: vtkCrackWidthFilter::RequestData
 //
 //  Purpose: Executes this filter.
+//  
+//  Notes:  This code is duplicated in avtCrackWidthExpression.
 //
 //  Programmer: Kathleen Bonnell
 //  Creation:   August 22, 2005
@@ -344,6 +348,8 @@ vtkCrackWidthFilter::RequestData(
 //  Purpose: Determines the effective length in the crack direction for a
 //           given cell
 //  
+//  Notes:  This code is duplicated in avtCrackWidthExpression.
+//
 //  Arguments:
 //    cell      The cell.
 //    cellId    The id of the cell.

--- a/src/resources/help/en_US/relnotes3.3.0.html
+++ b/src/resources/help/en_US/relnotes3.3.0.html
@@ -110,6 +110,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Moved the <i>divergence</i>, <i>curl</i>, <i>Laplacian</i>, and <i>gradient</i> functions from the <i>Miscellaneous</i> submenu to the <i>Vector</i> submenu within the <i>Insert function...</i> menu in the Expressions window. </li>
   <li>Added new <i>ghost_zoneid</i> function to the <i>Mesh</i> submenu in the Expressions window.</li>
+  <li>Added new <i>crack_width</i> function to the <i>Misc</i> submenu in the Expressions window.</li>
 </ul>
 
 <a name="Query_changes"></a>


### PR DESCRIPTION
### Description

Resolves #3350
Added crack_width expression,.

I added it's signature to the expression docs, and updated the release notes.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [X] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I verified it returns the same values as used by the CracksClipper operator for test data on hand.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
