### PR TITLE
Restore X Ray Image Query Output Type setting as integer

### DIFF
--- a/src/doc/using_visit/Quantitative/Query.rst
+++ b/src/doc/using_visit/Quantitative/Query.rst
@@ -396,26 +396,26 @@ XRay Image
     +------+-------------------+----------------------------------------------+
     | *output_type*            | The format of the image. The default is PNG. |
     +------+-------------------+----------------------------------------------+
-    |      | "bmp"             | BMP image format.                            |
+    |      | "bmp" or 0        | BMP image format.                            |
     +------+-------------------+----------------------------------------------+
-    |      | "jpeg"            | JPEG image format.                           |
+    |      | "jpeg" or 1       | JPEG image format.                           |
     +------+-------------------+----------------------------------------------+
-    |      | "png"             | PNG image format.                            |
+    |      | "png" or 2        | PNG image format.                            |
     +------+-------------------+----------------------------------------------+
-    |      | "tif"             | TIFF image format.                           |
+    |      | "tif" or 3        | TIFF image format.                           |
     +------+-------------------+----------------------------------------------+
-    |      | "rawfloats"       | File of 32 or 64 bit floating point values   |
+    |      | "rawfloats" or 4  | File of 32 or 64 bit floating point values   |
     |      |                   | in IEEE format.                              |
     +------+-------------------+----------------------------------------------+
-    |      | "bov"             | BOV (Brick Of Values) format, which consists |
+    |      | "bov" or 5        | BOV (Brick Of Values) format, which consists |
     |      |                   | of a text header |br| file describing a      |
     |      |                   | rawfloats file.                              |
     +------+-------------------+----------------------------------------------+
-    |      | "json"            | Conduit JSON output.                         |
+    |      | "json" or 6       | Conduit JSON output.                         |
     +------+-------------------+----------------------------------------------+
-    |      | "hdf5"            | Conduit HDF5 output.                         |
+    |      | "hdf5" or 7       | Conduit HDF5 output.                         |
     +------+-------------------+----------------------------------------------+
-    |      | "yaml"            | Conduit YAML output.                         |
+    |      | "yaml" or 8       | Conduit YAML output.                         |
     +------+-------------------+----------------------------------------------+
     | *output_dir*             | The output directory. The default is "."     |
     +------+-------------------+----------------------------------------------+

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -38,7 +38,7 @@ AddPlot("Pseudocolor", "d")
 DrawPlots()
 
 # old style argument passing
-Query("XRay Image", "png", ".", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
+Query("XRay Image", 2, ".", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
 
 
 if not os.path.isdir(out_path("current","queries")):
@@ -70,7 +70,7 @@ AddPlot("Pseudocolor", "d")
 DrawPlots()
 
 #create our own dictionary
-params = dict(output_type="png", output_dir=".", divide_emis_by_absorb=1, origin=(0.0, 2.5, 10.0), up_vector=(0, 1, 0), theta=0, phi=0, width = 10., height=10., image_size=(300, 300), vars=("da", "pa"))
+params = dict(output_type=2, output_dir=".", divide_emis_by_absorb=1, origin=(0.0, 2.5, 10.0), up_vector=(0, 1, 0), theta=0, phi=0, width = 10., height=10., image_size=(300, 300), vars=("da", "pa"))
 Query("XRay Image", params)
 
 os.rename("output00.png", out_path(out_base,"xrayimage02.png"))

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -11870,6 +11870,32 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
             // upVector is a new param, don't support in old-style calls.
             params["useUpVector"] = 0;
         }
+        else
+        {
+            PyErr_Clear();
+            parse_success = PyArg_ParseTuple(args, "sisidddddddii|O", &queryName,
+                                             &arg1, &outputDir, &arg2,
+                                             &(darg1[0]), &(darg1[1]), &(darg1[2]),
+                                             &(darg2[0]), &(darg2[1]), 
+                                             &(darg3[0]), &(darg3[1]), 
+                                             &(ps[0]), &(ps[1]), &tuple);
+            if (parse_success)
+            {
+                debug3 << mn << "parsed " <<  queryName 
+                       << " with 3rd attempt (sisidddddddii)" << endl;
+                params["output_type"] = arg1;
+                params["output_dir"] = outputDir;
+                params["divide_emis_by_absorb"] = arg2;
+                params["origin"] = darg1;
+                params["theta"] = darg2[0];
+                params["phi"] = darg2[1];
+                params["width"] = darg3[0];
+                params["height"] = darg3[1];
+                params["image_size"] = ps;
+                // upVector is a new param, don't support in old-style calls.
+                params["useUpVector"] = 0;
+            }
+        }
     }
 
     if (!parse_success)
@@ -11884,7 +11910,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
              strcmp(dump, "dumpSteps") == 0))
         {
             debug3 << mn << "parsed " << queryName 
-                   << " with 3rd attempt (ss)" << endl;
+                   << " with 4th attempt (ss)" << endl;
             params["dump_steps"] = 1;
         }
         else
@@ -11901,7 +11927,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
         if (parse_success)
         {
             debug3 << mn << "parsed " << queryName 
-                   << " with 4th attempt (sidddddd)" << endl;
+                   << " with 5th attempt (sidddddd)" << endl;
             //HohlraumFlux without DivEmisByAsborb
             params["num_lines"] = arg1;
             params["ray_center"] = darg1;
@@ -11920,7 +11946,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
         if (parse_success)
         {
            debug3 << mn << "parsed " << queryName 
-                  << " with 5th attempt (siidd)" << endl;
+                  << " with 6th attempt (siidd)" << endl;
            // Line-Scan type queries:
            //Chord Length Distribution
            //Ray Length Distribution
@@ -11945,7 +11971,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
             if (std::string(queryName) == "Shapelet Decomposition")
             { 
                debug3 << mn << "parsed " << queryName 
-                      << " with 6th attempt (sdis)" << endl;
+                      << " with 7th attempt (sdis)" << endl;
                 params["beta"] = darg1[0];
                 params["nmax"] = arg1;
                 params["recomp_file"] = std::string(output_name);
@@ -11963,7 +11989,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
         if (parse_success)
         {
             debug3 << mn << "parsed " << queryName 
-                   << " with 7th attempt (sdi)" << endl;
+                   << " with 8th attempt (sdi)" << endl;
             // args for Zone Center and Node Coords need a special fix here.
             std::string qname(queryName);
             if(qname == "Zone Center" || qname == "Node Coords" )
@@ -11990,7 +12016,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
         if (parse_success)
         {
             debug3 << mn << "parsed " << queryName 
-                   << " with 8th attempt (sii)" << endl;
+                   << " with 9th attempt (sii)" << endl;
         }
     }
     
@@ -12002,7 +12028,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
         if (parse_success)
         {
             debug3 << mn << "parsed " << queryName 
-                   << " with 9th attempt (si)" << endl;
+                   << " with 10th attempt (si)" << endl;
             // SpatialExtents with 0/1 for "use_actual_data"
             // Global Node Coords/Zone Center with int for element id 
             if (strncmp(queryName, "SpatialExtents", 14)==0)
@@ -12021,7 +12047,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
         if (parse_success)
         {
             debug3 << mn << "parsed " << queryName 
-                   << " with 10th attempt (s)" << endl;
+                   << " with 11th attempt (s)" << endl;
         }
     }
     


### PR DESCRIPTION
### Description

Resolves #17792 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
At some point it was intended that the x ray image query would take an integer to specify the output type instead of a string with the name of the output type. That functionality has been restored.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [x] New feature~~
* [x] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Made some of the tests use this alternate way of specifying output type. They pass on rztopaz.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
