### PR TITLE
Add missing double quotes to info statements in bv_mili.sh.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -72,7 +72,7 @@ function bv_mili_ensure
 
 function apply_mili_151_darwin_patch1
 {
-    info "Applying Mili 15.1 darwin patch 1.
+    info "Applying Mili 15.1 darwin patch 1."
     patch -p0 << \EOF
 diff -c mili/src/mesh_u.c mili.patched/src/mesh_u.c
 *** mili/src/mesh_u.c   2015-09-22 13:20:42.000000000 -0700
@@ -105,7 +105,7 @@ EOF
 
 function apply_mili_151_darwin_patch2
 {
-    info "Applying Mili 15.1 darwin patch 2.
+    info "Applying Mili 15.1 darwin patch 2."
     patch -p0 << \EOF
 *** mili/Makefile.Library       2013-12-10 12:55:55.000000000 -0800
 --- mili.patched/Makefile.Library       2015-10-20 13:37:27.000000000 -0700
@@ -131,7 +131,7 @@ EOF
 
 function apply_mili_151_darwin_patch3
 {
-    info "Applying Mili 15.1 darwin patch 3.
+    info "Applying Mili 15.1 darwin patch 3."
     patch -p0 << \EOF
 *** mili/src/mili_internal.h    2015-09-17 13:26:32.000000000 -0700
 --- mili.patched/src/mili_internal.h    2015-10-20 16:57:21.000000000 -0700
@@ -218,7 +218,7 @@ EOF
 
 function apply_mili_221_cflags_patch
 {
-    info "Applying Mili 22.1 CFLAGS patch.
+    info "Applying Mili 22.1 CFLAGS patch."
     patch -p0 << \EOF
 diff -c mili-22.1/configure.orig mili-22.1/configure
 *** mili-22.1/configure.orig    2022-06-16 13:45:39.195734000 -0700


### PR DESCRIPTION
### Description

Added missing closing double quotes from several `info` statements in `bv_mili.sh`.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran the following build_visit command on quartz and it succeeded.
```
./build_visit3_3_0 --no-thirdparty --no-visit --mili --makeflags -j4
```

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
