### PR TITLE
Fix a bug exporting gzip compressed bov files.

### DIFF
--- a/src/test/tests/databases/export_db.py
+++ b/src/test/tests/databases/export_db.py
@@ -505,7 +505,7 @@ def test_bov():
     ExportDatabase(e, opts)
     time.sleep(1)
     TestValueEQ("test_bov_uncompressed.bov exists", os.path.isfile("test_bov_uncompressed.bov"), True)
-    TestValueEQ("test_bov_uncompressed exists", os.path.isfile("test_bov_uncompressed"), True)
+    TestValueEQ("test_bov_uncompressed.bof exists", os.path.isfile("test_bov_uncompressed.bof"), True)
     ReplaceDatabase("test_bov_uncompressed.bov")
     Test("export_db_5_01")
 
@@ -517,15 +517,11 @@ def test_bov():
     ExportDatabase(e, opts)
     time.sleep(1)
     TestValueEQ("test_bov_gzip.bov exists", os.path.isfile("test_bov_gzip.bov"), True)
-    TestValueEQ("test_bov_gzip.gz exists", os.path.isfile("test_bov_gzip.gz"), True)
-    with gzip.open("test_bov_gzip.gz", "rb") as f_in:
-        with open("test_bov_gzip", "wb") as f_out:
-            shutil.copyfileobj(f_in, f_out);
+    TestValueEQ("test_bov_gzip.bof.gz exists", os.path.isfile("test_bov_gzip.bof.gz"), True)
     ReplaceDatabase("test_bov_gzip.bov")
     Test("export_db_5_02")
 
     DeleteAllPlots()
-
 
 def test_vtk_tetrahedralize():
     dbs_noext = ["ucd3d", "specmix_ucd"]


### PR DESCRIPTION
### Description

Corrected a bug in exporting gzip compressed `bov` files where the name of the compressed `bof` file didn't include the `.gz` extension in the `bov` file.
Corrected some bugs in the `export_db` `bov` tests.
The test suite should now pass.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran the `databases/export_db.py` test on quartz and it passed.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
