### PR TITLE
Fix build_visit error messages

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -1253,7 +1253,7 @@ function run_build_visit()
     fi
 
     if [[ "$ANY_ERRORS" == "yes" ]] ; then
-        echo "command line arguments are used incorrectly. unrecognized options..."
+        echo "command line arguments are used incorrectly. see above..."
         exit 1
     fi
 

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -189,7 +189,11 @@ function error
              "the VisIt project via https://visit-help.llnl.gov. You may "\
              "need to compress the ${LOG_FILE} using a program like gzip "\
              "so it will fit within the size limits for attachments."
-        info "Log file full path: " `pwd`/${LOG_FILE}
+        if [[ -n "$START_DIR" ]]; then
+            info "Log file full path: " ${START_DIR}/${LOG_FILE}
+        else
+            info "Log file full path: " $(pwd)/${LOG_FILE}
+        fi
     fi
     exit 1
 }


### PR DESCRIPTION
### Description

Resolves #17522 
Resolves another issue with error message about unrecognized args

The orig. error message was using `pwd` to specify path to `build_visit_log`. But, what `pwd` would resolve to would depend on where in the build process the error message was issued. Eventually, most builds begin with a `cd` to the build dir. In that case, `pwd` would resolve to the build dir.

I changed the logic to use `$START_DIR` which is the `pwd` from where `build_visit` was invoked.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I manually fiddled with `bv_zlib.sh` to cause it to fail and confirmed the error message is corrected.
 
### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
