### PR TITLE
fix volumePlot.py test crash + bonus change to docs

### DIFF
--- a/src/doc/python_scripting/quickrecipes.rst
+++ b/src/doc/python_scripting/quickrecipes.rst
@@ -944,7 +944,6 @@ Existing color tables can retreived by name via ``GetColorTable`` as in: ::
     smoothing = Linear  # NONE, Linear, CubicSpline
     equalSpacingFlag = 0
     discreteFlag = 0
-    categoryName = "Standard"
 
 The ``colors`` field of the ``ControlPoint`` represent the (Red,Green,Blue,Alpha) channels of the color and must be in the range (0, 255).
 The numbers indicate the contribution each channel makes to the overall color.

--- a/src/test/tests/plots/volumePlot.py
+++ b/src/test/tests/plots/volumePlot.py
@@ -502,7 +502,6 @@ def TestCommandRecording():
     VolumeAtts.colorControlPoints.smoothing = VolumeAtts.colorControlPoints.Linear
     VolumeAtts.colorControlPoints.equalSpacingFlag = 0
     VolumeAtts.colorControlPoints.discreteFlag = 0
-    VolumeAtts.colorControlPoints.categoryName = ""
     VolumeAtts.opacityAttenuation = 1
     VolumeAtts.opacityMode = VolumeAtts.GaussianMode
     VolumeAtts.opacityControlPoints.SetNumControlPoints(20)


### PR DESCRIPTION
### Description
Fixes the volumePlot test. The issue was that the `categoryName` field was deleted for CCPLs, so setting it led to a crash. I also found a place in the docs that mentioned `categoryName` in relation to color tables, so I deleted it.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* [x] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Ran the volumePlot test and it passed. Ran on rztopaz.
Docs build looks good too.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
