### PR TITLE
Add processOldVersions to CCPL to handle deprecated categoryName field

### DIFF
--- a/src/common/state/ColorControlPointList.C
+++ b/src/common/state/ColorControlPointList.C
@@ -1901,3 +1901,49 @@ void ColorControlPointList::SetNumControlPoints(const int n)
     Select(ID_controlPoints, (void*)&controlPoints);
 }
 
+// ****************************************************************************
+// Method: ColorControlPointList::ProcessOldVersions
+//
+// Purpose:
+//   This method allows handling of older config/session files that may
+//   contain fields that are no longer present or have been modified/renamed.
+//
+// Programmer: Justin Privitera
+// Creation:   June 27 2022
+//
+// Modifications:
+//
+// ****************************************************************************
+#include <visit-config.h>
+#ifdef VIEWER
+#include <avtCallback.h>
+#endif
+
+void
+ColorControlPointList::ProcessOldVersions(DataNode *parentNode,
+                                          const char *configVersion)
+{
+#if VISIT_OBSOLETE_AT_VERSION(3,5,0)
+#error This code is obsolete in this version. Please remove it.
+#else
+    if(parentNode == 0)
+        return;
+
+    DataNode *searchNode = parentNode->GetNode("ColorControlPointList");
+    if(searchNode == 0)
+        return;
+
+    if (VersionLessThan(configVersion, "3.3.0"))
+    {
+        DataNode *k = 0;
+        if ((k = searchNode->GetNode("categoryName")) != 0)
+        {
+#ifdef VIEWER
+            avtCallback::IssueWarning(DeprecationMessage("categoryName", "3.5.0"));
+#endif
+            searchNode->RemoveNode(k);
+        }
+    }
+#endif
+}
+

--- a/src/common/state/ColorControlPointList.code
+++ b/src/common/state/ColorControlPointList.code
@@ -1,3 +1,50 @@
+Target: xml2python
+Code: PyColorControlPointList_getattr
+Prefix:
+#include <visit-config.h>
+Postfix:
+#if VISIT_OBSOLETE_AT_VERSION(3,5,0)
+#error This code is obsolete in this version. Please remove it.
+#else
+    // Try and handle legacy fields in ColorControlPointList
+
+    //
+    // Removed in 3.3.0
+    //
+    if(strcmp(name, "categoryName") == 0)
+    {
+        PyErr_WarnEx(NULL,
+                    "categoryName is no longer a valid ColorControlPointList "
+                    "attribute.\nIt's value is being ignored, please remove "
+                    "it from your script.\n", 3);
+        return PyString_FromString("");
+    }
+#endif
+
+
+Code: PyColorControlPointList_setattr
+Prefix:
+#include <visit-config.h>
+Postfix:
+#if VISIT_OBSOLETE_AT_VERSION(3,5,0)
+#error This code is obsolete in this version. Please remove it.
+#else
+    // Try and handle legacy fields in ColorControlPointList
+    if(obj == &NULL_PY_OBJ)
+    {
+        //
+        // Removed in 3.3.0
+        //
+        if(strcmp(name, "categoryName") == 0)
+        {
+            PyErr_WarnEx(NULL, "'categoryName' is obsolete. It is being ignored.", 3);
+            Py_INCREF(Py_None);
+            obj = Py_None;
+        }
+    }
+#endif
+
+Target: xml2atts
 Function: EvalCubicSpline
 Declaration: float EvalCubicSpline(float t, const float *allX, const float *allY, int n) const;
 Definition:
@@ -1028,3 +1075,52 @@ ColorControlPointList_SetNumControlPoints(PyObject *self, PyObject *args)
     return Py_None;
 }
 
+Target: xml2atts
+Function: ProcessOldVersions
+Declaration: virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
+Definition:
+// ****************************************************************************
+// Method: ColorControlPointList::ProcessOldVersions
+//
+// Purpose:
+//   This method allows handling of older config/session files that may
+//   contain fields that are no longer present or have been modified/renamed.
+//
+// Programmer: Justin Privitera
+// Creation:   June 27 2022
+//
+// Modifications:
+//
+// ****************************************************************************
+#include <visit-config.h>
+#ifdef VIEWER
+#include <avtCallback.h>
+#endif
+
+void
+ColorControlPointList::ProcessOldVersions(DataNode *parentNode,
+                                          const char *configVersion)
+{
+#if VISIT_OBSOLETE_AT_VERSION(3,5,0)
+#error This code is obsolete in this version. Please remove it.
+#else
+    if(parentNode == 0)
+        return;
+
+    DataNode *searchNode = parentNode->GetNode("ColorControlPointList");
+    if(searchNode == 0)
+        return;
+
+    if (VersionLessThan(configVersion, "3.3.0"))
+    {
+        DataNode *k = 0;
+        if ((k = searchNode->GetNode("categoryName")) != 0)
+        {
+#ifdef VIEWER
+            avtCallback::IssueWarning(DeprecationMessage("categoryName", "3.5.0"));
+#endif
+            searchNode->RemoveNode(k);
+        }
+    }
+#endif
+}

--- a/src/common/state/ColorControlPointList.h
+++ b/src/common/state/ColorControlPointList.h
@@ -121,6 +121,7 @@ public:
     std::string GetTagsAsString();
     bool HasTag(std::string tag);
     void SetNumControlPoints(const int n);
+    virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
 
     // IDs that can be used to identify fields in case statements
     enum {

--- a/src/common/state/ColorControlPointList.xml
+++ b/src/common/state/ColorControlPointList.xml
@@ -49,4 +49,6 @@
     </Function>
     <Function name="ColorControlPointList_SetNumControlPoints" user="true" member="true">
     </Function>
+    <Function name="ProcessOldVersions" user="true" member="true">
+    </Function>
   </Attribute>

--- a/src/common/state/ColorTableAttributes.code
+++ b/src/common/state/ColorTableAttributes.code
@@ -9,7 +9,7 @@ Postfix:
     // Try and handle legacy fields in ColorTableAttributes
 
     //
-    // Removed in 3.5.0
+    // Removed in 3.3.0
     //
     if(strcmp(name, "activeContinuous") == 0)
     {
@@ -838,6 +838,7 @@ ColorTableAttributes::SetAllActive()
     }
 }
 
+Target: xml2atts
 Function: ProcessOldVersions
 Declaration: virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
 Definition:

--- a/src/test/tests/plots/volumePlot.py
+++ b/src/test/tests/plots/volumePlot.py
@@ -502,6 +502,7 @@ def TestCommandRecording():
     VolumeAtts.colorControlPoints.smoothing = VolumeAtts.colorControlPoints.Linear
     VolumeAtts.colorControlPoints.equalSpacingFlag = 0
     VolumeAtts.colorControlPoints.discreteFlag = 0
+    VolumeAtts.colorControlPoints.categoryName = ""
     VolumeAtts.opacityAttenuation = 1
     VolumeAtts.opacityMode = VolumeAtts.GaussianMode
     VolumeAtts.opacityControlPoints.SetNumControlPoints(20)

--- a/src/visitpy/visitpy/PyColorControlPointList.C
+++ b/src/visitpy/visitpy/PyColorControlPointList.C
@@ -528,6 +528,7 @@ static PyObject *ColorControlPointList_richcompare(PyObject *self, PyObject *oth
 PyObject *
 PyColorControlPointList_getattr(PyObject *self, char *name)
 {
+#include <visit-config.h>
     if(strcmp(name, "controlPoints") == 0)
         return ColorControlPointList_GetControlPoints(self, NULL);
     if(strcmp(name, "smoothing") == 0)
@@ -548,6 +549,23 @@ PyColorControlPointList_getattr(PyObject *self, char *name)
     if(strcmp(name, "tagNames") == 0)
         return ColorControlPointList_GetTagNames(self, NULL);
 
+#if VISIT_OBSOLETE_AT_VERSION(3,5,0)
+#error This code is obsolete in this version. Please remove it.
+#else
+    // Try and handle legacy fields in ColorControlPointList
+
+    //
+    // Removed in 3.3.0
+    //
+    if(strcmp(name, "categoryName") == 0)
+    {
+        PyErr_WarnEx(NULL,
+                    "categoryName is no longer a valid ColorControlPointList "
+                    "attribute.\nIt's value is being ignored, please remove "
+                    "it from your script.\n", 3);
+        return PyString_FromString("");
+    }
+#endif
 
     // Add a __dict__ answer so that dir() works
     if (!strcmp(name, "__dict__"))
@@ -566,6 +584,7 @@ PyColorControlPointList_getattr(PyObject *self, char *name)
 int
 PyColorControlPointList_setattr(PyObject *self, char *name, PyObject *args)
 {
+#include <visit-config.h>
     PyObject NULL_PY_OBJ;
     PyObject *obj = &NULL_PY_OBJ;
 
@@ -578,6 +597,23 @@ PyColorControlPointList_setattr(PyObject *self, char *name, PyObject *args)
     else if(strcmp(name, "tagNames") == 0)
         obj = ColorControlPointList_SetTagNames(self, args);
 
+#if VISIT_OBSOLETE_AT_VERSION(3,5,0)
+#error This code is obsolete in this version. Please remove it.
+#else
+    // Try and handle legacy fields in ColorControlPointList
+    if(obj == &NULL_PY_OBJ)
+    {
+        //
+        // Removed in 3.3.0
+        //
+        if(strcmp(name, "categoryName") == 0)
+        {
+            PyErr_WarnEx(NULL, "'categoryName' is obsolete. It is being ignored.", 3);
+            Py_INCREF(Py_None);
+            obj = Py_None;
+        }
+    }
+#endif
     if (obj != NULL && obj != &NULL_PY_OBJ)
         Py_DECREF(obj);
 

--- a/src/visitpy/visitpy/PyColorTableAttributes.C
+++ b/src/visitpy/visitpy/PyColorTableAttributes.C
@@ -641,7 +641,7 @@ PyColorTableAttributes_getattr(PyObject *self, char *name)
     // Try and handle legacy fields in ColorTableAttributes
 
     //
-    // Removed in 3.5.0
+    // Removed in 3.3.0
     //
     if(strcmp(name, "activeContinuous") == 0)
     {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

Added in processOldVersions for CCPL to handle the deprecated `categoryName`.
Also added comment to ColorTableAttributes to correct any confusion.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Added back in the line that sets `categoryName` to `volumePlot.py`, tested and ran on rztopaz.
Also ran w/ CLI and tried getting and setting `categoryName` to test the output messages.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
