### PR TITLE
Patch Qt for hunspell includes on macOS

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -299,6 +299,14 @@ function apply_qt_patch
                 sed -i "s/\/usr\/lib64/\/usr\/lib/" ./qtbase/mkspecs/linux-icc-64/qmake.conf
             fi
         fi
+        if [[ "$OPSYS" == "Darwin" ]]; then
+            if [[ $(echo $MACOSX_DEPLOYMENT_TARGET | tr -d '.') -ge 1014 ]]; then
+                apply_qt_5142_macOS_1014_hunspell_patch
+                if [[ $? != 0 ]] ; then
+                    return 1
+                fi
+            fi
+        fi
     fi
     return 0
 }
@@ -619,7 +627,7 @@ EOF
         return 1
     fi
 
-    return 0;
+    return 0
 }
 
 function apply_qt_5142_linux_opengl_patch
@@ -677,7 +685,67 @@ EOF
         return 1
     fi
 
-    return 0;
+    return 0
+}
+
+function apply_qt_5142_macOS_1014_hunspell_patch
+{   
+    info "Patching qt 5.14.2 for macOS 10.14 hunspell"
+    patch -p0 <<EOF
+diff -c qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellworker_p.h.orig qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellworker_p.h
+*** qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellworker_p.h.orig
+--- qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellworker_p.h
+***************
+*** 48,54 ****
+  #include <QSharedPointer>
+  #include <QVector>
+  #include <QLoggingCategory>
+! #include <hunspell/hunspell.h>
+  #include <QtHunspellInputMethod/qhunspellinputmethod_global.h>
+  
+  QT_BEGIN_NAMESPACE
+--- 48,54 ----
+  #include <QSharedPointer>
+  #include <QVector>
+  #include <QLoggingCategory>
+! #include <hunspell.h>
+  #include <QtHunspellInputMethod/qhunspellinputmethod_global.h>
+  
+  QT_BEGIN_NAMESPACE
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Patching qt 5.14.2 for macOS 10.14 hunspell failed."
+        return 1
+    fi
+
+    patch -p0 <<EOF
+diff -c qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellinputmethod_p.cpp.orig qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellinputmethod_p.cpp
+*** qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellinputmethod_p.cpp.orig
+--- qtvirtualkeyboard/src/plugins/hunspell/hunspellinputmethod/hunspellinputmethod_p.cpp
+***************
+*** 29,35 ****
+  
+  #include <QtHunspellInputMethod/private/hunspellinputmethod_p_p.h>
+  #include <QtVirtualKeyboard/qvirtualkeyboardinputcontext.h>
+! #include <hunspell/hunspell.h>
+  #include <QStringList>
+  #include <QDir>
+  #include <QTextCodec>
+--- 29,35 ----
+  
+  #include <QtHunspellInputMethod/private/hunspellinputmethod_p_p.h>
+  #include <QtVirtualKeyboard/qvirtualkeyboardinputcontext.h>
+! #include <hunspell.h>
+  #include <QStringList>
+  #include <QDir>
+  #include <QTextCodec>
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Patching qt 5.14.2 for macOS 10.14 hunspell failed."
+        return 1
+    fi
+
+    return 0
 }
 
 function build_qt


### PR DESCRIPTION
### Description

Ran into Qt build error for `3.3RC` on `macOS`...
```
In file included from /Users/miller86/visit/visit/33rc/release/build-mb-3.3.0-darwin-10.14-x86_64-release/thirdparty_shared/qt-everywhere-src-5.14.2/qtvirtualkeyboard/include/QtHunspellInputMethod/5.14.2/QtHunspellInputMethod/private/hunspellworker_p.h:1:
/Users/miller86/visit/visit/33rc/release/build-mb-3.3.0-darwin-10.14-x86_64-release/thirdparty_shared/qt-everywhere-src-5.14.2/qtvirtualkeyboard/include/QtHunspellInputMethod/5.14.2/QtHunspellInputMethod/private/../../../../../src/plugins/hunspell/hunspellinputmethod/hunspellworker_p.h:51:10: fatal error: 'hunspell/hunspell.h' file not found
#include <hunspell/hunspell.h>
         ^~~~~~~~~~~~~~~~~~~~~
```
This patch to Qt fixes that.


### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
