### PR TITLE
Update Aneurysm.rst

### DIFF
--- a/src/doc/tutorials/Aneurysm.rst
+++ b/src/doc/tutorials/Aneurysm.rst
@@ -435,7 +435,7 @@ through the 3D mesh.
 8. Click *Apply* and *Dismiss*.
 9. Go to *Operators->Slicing->Slice*.
 10. Open the Slice operator attributes window.
-11. Set *Normal* to *Arbitrary* and to "0 1 0".
+11. Set *Normal* to *Arbitrary* and to "0 -1 0".
 12. Set *Origin* to *Intercept* and to "3".
 13. Uncheck *Project to 2D*.
 14. Click *Make default*, *Apply* and *Dismiss*.
@@ -493,9 +493,13 @@ cell-by-cell basis.
 
 You will then get the error message saying: *The 'normals' expression failed because The Surface normal expression can only be calculated on surfaces. Use the ExternalSurface operator to generate the external surface of this object. You must also use the DeferExpression operator to defer the evaluation of this expression until after the external surface operator*. In fact, VisIt_ cannot use the name *Mesh* which refers to the original 3D mesh. It needs to defer the evaluation until after the Slice operator is applied. Thus, we need to add the Defer Expression operator.
 
-8. Go to *Operators->Analysis->DeferExpression*.
-9. Open the DeferExpression operator attributes window.
-10. Go to *Variables->Vectors->normals*.
+8. Go to *Operators->Geometry->ExternalSurface*.
+9. Open the ExternalSurface operator attribues window.
+10. Uncheck *Find external edges for 2D datasets*. 
+11. Click *Apply* and *Dismiss*.
+12. Go to *Operators->Analysis->DeferExpression*.
+13. Open the DeferExpression operator attributes window.
+14. Go to *Variables->Vectors->normals*.
 
 .. figure:: images/Aneurysm-DeferExpression.png
 


### PR DESCRIPTION
The normals calculation portion of this no longer works. I had to add the External Surface operator as well as changing the normals of the slice as they were pointing in the wrong direction.

### Description
Fixing example in docs that no longer works. VisIt version 3.2.2

Resolves # <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [x] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Linux build of VisIt @ v3.2.2

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- ~~[ ] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
