### PR TITLE
Fix some CMake errors with Blosc.

### DIFF
--- a/src/CMake/FindBlosc.cmake
+++ b/src/CMake/FindBlosc.cmake
@@ -6,5 +6,5 @@
 
 INCLUDE(${VISIT_SOURCE_DIR}/CMake/SetUpThirdParty.cmake)
 
-SET_UP_THIRD_PARTY(BLOSC lib include blosc)
+SET_UP_THIRD_PARTY(BLOSC LIBS blosc)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -503,6 +503,9 @@
 #    Kathleen Biagas, Thu Jun 16, 2022 
 #    Changed minimum cmake version to 3.15.
 #
+#    Eric Brugger, Tue Jul  5 09:10:18 PDT 2022
+#    Added support for the Blosc library.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
@@ -911,6 +914,7 @@ VISIT_3RDPARTY_VAR(ADIOS_DIR     "Path containing the ADIOS library's include an
 VISIT_3RDPARTY_VAR(ADIOS2_DIR     "Path containing the ADIOS library's include and lib")
 VISIT_3RDPARTY_VAR(ADIOS2_PAR_DIR "Path containing the ADIOS MPI library's include and lib")
 VISIT_3RDPARTY_VAR(ADVIO_DIR     "Path containing the AdvIO library's include and lib")
+VISIT_3RDPARTY_VAR(BLOSC_DIR     "Path containing the Blosc library's include and lib")
 VISIT_3RDPARTY_VAR(BOOST_DIR     "Path containing the BOOST library's include and lib")
 VISIT_3RDPARTY_VAR(BOXLIB_DIR    "Path containing the Boxlib library's include and lib")
 VISIT_3RDPARTY_VAR(CFITSIO_DIR   "Path containing the CFITSIO library's include and lib")
@@ -1368,6 +1372,9 @@ IF(NOT VISIT_BUILD_MINIMAL_PLUGINS OR VISIT_SELECTED_DATABASE_PLUGINS)
 
     # Configure advio support.
     INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindADVIO.cmake)
+
+    # Configure blosc support.
+    INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindBlosc.cmake)
 
     # Configure Boxlib support.
     INCLUDE(${VISIT_SOURCE_DIR}/CMake/FindBoxlib.cmake)


### PR DESCRIPTION
### Description

Fixed some cmake related errors with Blosc. The blosc library wasn't showing up in the packages generated by building the code. The first issue was that the call to `SET_UP_THIRD_PARTY` was incorrect. The signature for that function was changed at about the same time Blosc support was added. The second was there was some missing cmake logic necessary for adding a new package.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I build VisIt on quartz and verified that it built properly and that the package generated included the blosc library.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
