### PR TITLE
Modify cmake to look in additional directories for the libicu libraries.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2081,6 +2081,9 @@ if(LINUX)
     # Install the system libraries required by Qt to the lib directory.
     # The versions of these libraries change frequently, so including
     # them means VisIt may continue to run even if the OS is upgraded.
+    # "/lib64" is for rhel7 and fedora31, "/usr/lib/x86_64-linux-gnu"
+    # is for ubuntu 18, debian 10 and debian 11, "/lib/x86_64-linux-gnu"
+    # is for ubuntu 20.
     #-------------------------------------------------------------------------
     if(EXISTS "/lib64/libicui18n.so")
         file(GLOB libicui18n_libs "/lib64/libicui18n.so*")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -507,7 +507,7 @@
 #    Added support for the Blosc library.
 #
 #    Eric Brugger, Thu Jul  7 13:07:51 PDT 2022
-#    Added another directory to look for libicui18n, libicudata and libicuuc.
+#    Added other directories to look for libicui18n, libicudata and libicuuc.
 #
 #****************************************************************************
 
@@ -2095,6 +2095,15 @@ if(LINUX)
         file(GLOB libicui18n_libs "/lib/x86_64-linux-gnu/libicui18n.so*")
         file(GLOB libicudata_libs "/lib/x86_64-linux-gnu/libicudata.so*")
         file(GLOB libicuuc_libs "/lib/x86_64-linux-gnu/libicuuc.so*")
+        install(FILES ${libicui18n_libs} ${libicudata_libs} ${libicuuc_libs}
+                DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                            GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                            WORLD_READ             WORLD_EXECUTE)
+    elseif(EXISTS "/usr/lib/x86_64-linux-gnu/libicui18n.so")
+        file(GLOB libicui18n_libs "/usr/lib/x86_64-linux-gnu/libicui18n.so*")
+        file(GLOB libicudata_libs "/usr/lib/x86_64-linux-gnu/libicudata.so*")
+        file(GLOB libicuuc_libs "/usr/lib/x86_64-linux-gnu/libicuuc.so*")
         install(FILES ${libicui18n_libs} ${libicudata_libs} ${libicuuc_libs}
                 DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
                 PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -506,6 +506,9 @@
 #    Eric Brugger, Tue Jul  5 09:10:18 PDT 2022
 #    Added support for the Blosc library.
 #
+#    Eric Brugger, Thu Jul  7 13:07:51 PDT 2022
+#    Added another directory to look for libicui18n, libicudata and libicuuc.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
@@ -2083,6 +2086,15 @@ if(LINUX)
         file(GLOB libicui18n_libs "/lib64/libicui18n.so*")
         file(GLOB libicudata_libs "/lib64/libicudata.so*")
         file(GLOB libicuuc_libs "/lib64/libicuuc.so*")
+        install(FILES ${libicui18n_libs} ${libicudata_libs} ${libicuuc_libs}
+                DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                            GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                            WORLD_READ             WORLD_EXECUTE)
+    elseif(EXISTS "/lib/x86_64-linux-gnu/libicui18n.so")
+        file(GLOB libicui18n_libs "/lib/x86_64-linux-gnu/libicui18n.so*")
+        file(GLOB libicudata_libs "/lib/x86_64-linux-gnu/libicudata.so*")
+        file(GLOB libicuuc_libs "/lib/x86_64-linux-gnu/libicuuc.so*")
         install(FILES ${libicui18n_libs} ${libicudata_libs} ${libicuuc_libs}
                 DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
                 PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -33,7 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.3.1</font></b></p>
 <ul>
-  <li>feature 1</li>
+  <li>Enhanced the cmake packaging logic that adds the <code>libicui18n</code>, <code>libicudata</code> and <code>libicuuc</code> system libraries used by Qt to the lib directory to look in additional directories for the libraries to work on a broader set of operating systems.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

I recently added `cmake` logic to include 3 libicu libraries in the binary distributions. I looked for them in `/lib64`. It turns out the libraries can be located in other directories on other distributions. I added logic to check those directories as well. I checked Fedora 31, Debian 10, Debian 11, Ubuntu 18 and Ubuntu 20.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran `build_visit` on an Ubuntu18 system and the libraries were found.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
