### PR TITLE
Enabled familying of bp outputs from the x ray image query

### DIFF
--- a/src/gui/ColorTableObserver.C
+++ b/src/gui/ColorTableObserver.C
@@ -104,7 +104,7 @@ ColorTableObserver::Update(Subject *)
         const intVector &active = colorAtts->GetActive();
 
         // This should never happen. Resetting the names will reset the active
-        // array as well, and make very color table active. However, this does
+        // array as well, and make every color table active. However, this does
         // happen; when loading settings from config/session files, `names` is
         // populated but `active` is left empty. Ideally, loading settings
         // would correctly preserve which color tables are active, but this

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -190,14 +190,14 @@ QvisColorTableWindow::CreateWindowContents()
     innerDefaultTopLayout->addLayout(innerDefaultLayout);
     innerDefaultLayout->setColumnMinimumWidth(1, 10);
 
-    defaultContinuous = new QvisNoDefaultColorTableButton(defaultGroup);
+    defaultContinuous = new QvisNoDefaultColorTableButton(defaultGroup, false);
     connect(defaultContinuous, SIGNAL(selectedColorTable(const QString &)),
             this, SLOT(setDefaultContinuous(const QString &)));
     innerDefaultLayout->addWidget(defaultContinuous, 0, 1);
     defaultContinuousLabel = new QLabel(tr("Continuous"), defaultGroup);
     innerDefaultLayout->addWidget(defaultContinuousLabel, 0, 0);
 
-    defaultDiscrete = new QvisNoDefaultColorTableButton(defaultGroup);
+    defaultDiscrete = new QvisNoDefaultColorTableButton(defaultGroup, true);
     connect(defaultDiscrete, SIGNAL(selectedColorTable(const QString &)),
             this, SLOT(setDefaultDiscrete(const QString &)));
     innerDefaultLayout->addWidget(defaultDiscrete, 1, 1);

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -5095,7 +5095,9 @@ ViewerSubject::HandleColorTable()
         {
             // Clear all of the color tables.
             QvisColorTableButton::clearAllColorTables();
+            QvisColorTableButton::setColorTableAttributes(colorAtts);
             QvisNoDefaultColorTableButton::clearAllColorTables();
+            QvisNoDefaultColorTableButton::setColorTableAttributes(colorAtts);
 
             int nNames = colorAtts->GetNumColorTables();
             const stringVector &names = colorAtts->GetNames();

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -290,7 +290,9 @@ QvisNoDefaultColorTableButton::getColorTable() const
 void
 QvisNoDefaultColorTableButton::popupPressed()
 {
-    if(isDown() && (colorTableMenuDiscrete || colorTableMenuContinuous))
+    bool allDiscrete = colorTableMenuDiscrete && defDiscrete;
+    bool allContinuous = colorTableMenuContinuous && !defDiscrete;
+    if (isDown() && (allDiscrete || allContinuous))
     {
         int menuW, menuH;
         if (defDiscrete)

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -384,6 +384,7 @@ void
 QvisNoDefaultColorTableButton::colorTableSelected(QAction *action)
 {
     int index;
+    // TODO this is bugged; these indices are not the same
     if (defDiscrete)
         index = colorTableMenuActionGroupDiscrete->actions().indexOf(action);
     else

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -292,23 +292,14 @@ QvisNoDefaultColorTableButton::popupPressed()
 {
     if(isDown() && (colorTableMenuDiscrete || colorTableMenuContinuous))
     {
-        // If the popup menu does not have anything in it, fill it up.
-        if (defDiscrete)
-            if (!popupHasEntriesDiscrete)
-                regeneratePopupMenu();
-        else
-            if (!popupHasEntriesContinuous)
-                regeneratePopupMenu();
-
-        QPoint p1(mapToGlobal(rect().bottomLeft()));
-        QPoint p2(mapToGlobal(rect().topRight()));
-        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
-                            p1.y() + ((p2.y() - p1.y()) >> 1));
-
         int menuW, menuH;
-        // Disconnect all other color table buttons.
         if (defDiscrete)
         {
+            // If the popup menu does not have anything in it, fill it up.
+            if (!popupHasEntriesDiscrete)
+                regeneratePopupMenu();
+
+            // Disconnect all other color table buttons.
             for(size_t i = 0; i < buttons.size(); ++i)
                 disconnect(colorTableMenuActionGroupDiscrete, SIGNAL(triggered(QAction *)),
                            buttons[i], SLOT(colorTableSelected(QAction *)));
@@ -320,6 +311,11 @@ QvisNoDefaultColorTableButton::popupPressed()
         }
         else
         {
+            // If the popup menu does not have anything in it, fill it up.
+            if (!popupHasEntriesContinuous)
+                regeneratePopupMenu();
+
+            // Disconnect all other color table buttons.
             for(size_t i = 0; i < buttons.size(); ++i)
                 disconnect(colorTableMenuActionGroupContinuous, SIGNAL(triggered(QAction *)),
                            buttons[i], SLOT(colorTableSelected(QAction *)));
@@ -329,6 +325,11 @@ QvisNoDefaultColorTableButton::popupPressed()
             menuW = colorTableMenuContinuous->sizeHint().width();
             menuH = colorTableMenuContinuous->sizeHint().height();
         }
+
+        QPoint p1(mapToGlobal(rect().bottomLeft()));
+        QPoint p2(mapToGlobal(rect().topRight()));
+        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
+                            p1.y() + ((p2.y() - p1.y()) >> 1));
 
         // Figure out a good place to popup the menu.
         int menuX = buttonMiddle.x();
@@ -570,7 +571,7 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
     if (defDiscrete)
     {
         QList<QAction*> actions = colorTableMenuActionGroupDiscrete->actions();
-        for(int i = 0; i < actions.count(); ++i)
+        for (int i = 0; i < actions.count(); ++i)
             colorTableMenuActionGroupDiscrete->removeAction(actions[i]);
         colorTableMenuDiscrete->clear();
 
@@ -589,7 +590,7 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
     else
     {
         QList<QAction*> actions = colorTableMenuActionGroupContinuous->actions();
-        for(int i = 0; i < actions.count(); ++i)
+        for (int i = 0; i < actions.count(); ++i)
             colorTableMenuActionGroupContinuous->removeAction(actions[i]);
         colorTableMenuContinuous->clear();
 

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -231,7 +231,7 @@ debug1 <<"    ctName: " << ctName.toStdString() << endl;
         colorTable = ctName;
         setText(colorTable);
         setToolTip(colorTable);
-        setIcon(getIcon(ctName, defDiscrete));
+        setIcon(getIcon(ctName));
     }
     else
     {
@@ -239,7 +239,7 @@ debug1 <<"    ctName: " << ctName.toStdString() << endl;
         colorTable = colorTableNames[0];
         setText(colorTable);
         setToolTip(colorTable);
-        setIcon(getIcon(colorTable, defDiscrete));
+        setIcon(getIcon(colorTable));
     }
 debug1 << "QvisNoDefaultColorTableButton::setColorTable ... done" << endl;
 }
@@ -393,7 +393,7 @@ QvisNoDefaultColorTableButton::colorTableSelected(QAction *action)
 
     emit selectedColorTable(ctName);
     setText(ctName);
-    setIcon(getIcon(ctName, defDiscrete));
+    setIcon(getIcon(ctName));
     setToolTip(ctName);
 }
 
@@ -480,7 +480,7 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
     {
         if (getColorTableIndex(buttons[i]->getColorTable()) != -1)
         {
-            buttons[i]->setIcon(getIcon(buttons[i]->text(), defDiscrete));
+            buttons[i]->setIcon(getIcon(buttons[i]->text()));
         }
         // If there are no available color tables, we don't want the 
         // entries to change.            
@@ -601,17 +601,16 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
 // ****************************************************************************
 
 QIcon
-QvisNoDefaultColorTableButton::getIcon(const QString &ctName, 
-                                       bool defaultDiscrete)
+QvisNoDefaultColorTableButton::getIcon(const QString &ctName)
 {
-    QList<QAction*> a;
-    if (defaultDiscrete)
-        a = colorTableMenuActionGroupDiscrete->actions();
-    else        
-        a = colorTableMenuActionGroupContinuous->actions();
-    for(int i = 0; i < a.size(); ++i)
-        if(a[i]->text() == ctName)
-            return a[i]->icon();
+    QList<QAction*> a1 = colorTableMenuActionGroupDiscrete->actions();
+    QList<QAction*> a2 = colorTableMenuActionGroupContinuous->actions();
+    for (int i = 0; i < a1.size(); ++i)
+        if (a1[i]->text() == ctName)
+            return a1[i]->icon();
+    for (int i = 0; i < a2.size(); ++i)
+        if (a2[i]->text() == ctName)
+            return a2[i]->icon();
 
     return makeIcon(ctName);
 }

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -74,7 +74,7 @@ private slots:
 private:
     static int  getColorTableIndex(const QString &ctName);
     void regeneratePopupMenu();
-    static QIcon getIcon(const QString &, bool defaultDiscrete);
+    static QIcon getIcon(const QString &);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -88,7 +88,8 @@ private:
     static bool                    popupHasEntriesContinuous;
     static ColorTableButtonVector  buttons;
 
-    static QStringList             colorTableNames;
+    static QStringList             colorTableNamesDiscrete;
+    static QStringList             colorTableNamesContinuous;
     static ColorTableAttributes   *colorTableAtts;
     bool                           defDiscrete;
 };

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -74,14 +74,16 @@ private slots:
 private:
     static int  getColorTableIndex(const QString &ctName);
     void regeneratePopupMenu();
-    static QIcon getIcon(const QString &);
+    static QIcon getIcon(const QString &, bool defaultDiscrete);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;
 
     static int                     numInstances;
-    QMenu                         *colorTableMenu;
-    static QActionGroup           *colorTableMenuActionGroup;
+    static QMenu                  *colorTableMenuDiscrete;
+    static QActionGroup           *colorTableMenuActionGroupDiscrete;
+    static QMenu                  *colorTableMenuContinuous;
+    static QActionGroup           *colorTableMenuActionGroupContinuous;
     static bool                    popupHasEntriesDiscrete;
     static bool                    popupHasEntriesContinuous;
     static ColorTableButtonVector  buttons;

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -53,7 +53,7 @@ class WINUTIL_API QvisNoDefaultColorTableButton : public QPushButton
 
     typedef std::vector<QvisNoDefaultColorTableButton *> ColorTableButtonVector;
 public:
-    QvisNoDefaultColorTableButton(QWidget *parent);
+    QvisNoDefaultColorTableButton(QWidget *parent, bool discrete);
     virtual ~QvisNoDefaultColorTableButton();
     virtual QSize sizeHint() const;
     virtual QSizePolicy sizePolicy () const;
@@ -73,20 +73,22 @@ private slots:
     void colorTableSelected(QAction *);
 private:
     static int  getColorTableIndex(const QString &ctName);
-    static void regeneratePopupMenu();
+    void regeneratePopupMenu();
     static QIcon getIcon(const QString &);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;
 
     static int                     numInstances;
-    static QMenu                  *colorTableMenu;
+    QMenu                         *colorTableMenu;
     static QActionGroup           *colorTableMenuActionGroup;
-    static bool                    popupHasEntries;
+    static bool                    popupHasEntriesDiscrete;
+    static bool                    popupHasEntriesContinuous;
     static ColorTableButtonVector  buttons;
 
     static QStringList             colorTableNames;
     static ColorTableAttributes   *colorTableAtts;
+    bool                           defDiscrete;
 };
 
 #endif


### PR DESCRIPTION
### Description

Resolves #17790 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
When I originally added bp output to the xray query in #17703, I ignored the familying logic for output filenames in the interest of time. Blueprint outputs use a different naming convention (they include the cycle in the filename) which made it confusing to reconcile the different naming conventions when file familying was enabled. The changes in this PR have rectified this issue, and now you can family bp outputs.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz toss3. The x ray tests passed and file saving behavior looked as I expected.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
