### PR TITLE
Enabled familying of bp outputs from the x ray image query

### DIFF
--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1069,6 +1069,7 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
         // Create the file base name.
         //
         std::stringstream baseName;
+        const int cycle = GetInput()->GetInfo().GetAttributes().GetCycle();
         bool keepTrying = true;
         while (keepTrying)
         {
@@ -1093,7 +1094,12 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
                 std::stringstream fileName;
                 if (outputDir != ".")
                     fileName << outputDir.c_str() << "/";
-                fileName << baseName.str() << "00." << file_extensions[outputType];
+                fileName << baseName.str();
+                if (outputTypeIsBlueprint(outputType))
+                    fileName << ".cycle_" << std::setfill('0') << std::setw(6) << cycle;
+                else
+                    fileName << "00";
+                fileName << "." << file_extensions[outputType];
 
                 ifstream ifile(fileName.str());
                 if (!ifile.fail() && iFileFamily < 9999)
@@ -1284,7 +1290,6 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             data_out["fields/path_length/strides"].set(data_out["fields/intensities/strides"]);
 
             data_out["state/time"] = GetInput()->GetInfo().GetAttributes().GetTime();
-            const int cycle = GetInput()->GetInfo().GetAttributes().GetCycle();
             data_out["state/cycle"] = cycle;
             data_out["state/xray_view/normal/x"] = normal[0];
             data_out["state/xray_view/normal/y"] = normal[1];

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1325,7 +1325,10 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
                 baseName << out_filename << ".cycle_" << std::setfill('0') 
                     << std::setw(6) << cycle;
                 out_filename = baseName.str();
-                out_filename_w_path = outputDir + "/" + out_filename;
+                if (outputDir == ".")
+                    out_filename_w_path = out_filename;
+                else
+                    out_filename_w_path = outputDir + "/" + out_filename;
 
                 // Note to future developers: The following lines are a workaround to a bug found in
                 // conduit 0.8.3; see this issue for more information: 

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1073,14 +1073,15 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
         while (keepTrying)
         {
             keepTrying = false;
-            if (familyFiles && !outputTypeIsBlueprint(outputType))
+            if (familyFiles)
             {
                 //
                 // Create the file base name and increment the family number.
                 //
                 baseName.clear();
                 baseName.str(std::string());
-                baseName << "output" << std::setfill('0') << std::setw(4) << iFileFamily << ".";
+                baseName << "output" << std::setfill('0') << std::setw(4) << iFileFamily;
+                if (!outputTypeIsBlueprint(outputType)) baseName << ".";
 
                 if (iFileFamily < 9999) iFileFamily++;
 

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -22,12 +22,13 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.3.1</font></b></p>
 <ul>
   <li>Fixed a bug with the color table window where the list of color tables could be populated even when no tags were selected.</li>
+  <li>Fixed a discrepancy with the x ray image query where, if blueprint output was requested, the result message from the query would display differently than the other output types.</li>
 </ul>
 
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.3.1</font></b></p>
 <ul>
-  <li>feature 1</li>
+  <li>Blueprint output for the x ray image query now supports file familying.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #17790 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
When I originally added bp output to the xray query in #17703, I ignored the familying logic for output filenames in the interest of time. Blueprint outputs use a different naming convention (they include the cycle in the filename) which made it confusing to reconcile the different naming conventions when file familying was enabled. The changes in this PR have rectified this issue, and now you can family bp outputs. I also fixed an issue with the output message for bp outputs when you didn't specify a directory for the output.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz toss3. The x ray tests passed and file saving behavior looked as I expected.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
