### PR TITLE
Add a patch for Mili in build_visit to eliminate a duplicate definition error.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -33,7 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.3.1</font></b></p>
 <ul>
-  <li>feature 1</li>
+  <li>Added a patch to build_visit so that mili will build on Debian 11 systems using gcc 10.2."</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -371,6 +371,35 @@ EOF
     return 0
 }
 
+function apply_mili_221_write_funcs_patch
+{
+    #
+    # write_funcs is not needed and having it in the header leads to
+    # multiple definitions, which gcc 10.2 on Debian 11 doesn't like.
+    #
+    patch -p0 << \EOF
+diff -c mili-22.1/src/mili_internal.h.orig mili-22.1/src/mili_internal.h
+*** mili-22.1/src/mili_internal.h.orig  Tue Jul 12 10:49:05 2022
+--- mili-22.1/src/mili_internal.h       Tue Jul 12 10:49:29 2022
+***************
+*** 674,680 ****
+  /* dep.c - routines for handling architecture dependencies. */
+  Return_value set_default_io_routines( Mili_family *fam );
+  Return_value set_state_data_io_routines( Mili_family *fam );
+- void (*write_funcs[QTY_PD_ENTRY_TYPES + 1])();
+  
+  /* svar.c - routines for managing state variables. */
+  Bool_type valid_svar_data( Aggregate_type atype, char *name,
+--- 674,679 ----
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Unable to apply write funcs patch to Mili 22.1"
+        return 1
+    fi
+
+    return 0
+}
+
 function apply_mili_patch
 {
     if [[ "$OPSYS" == "Darwin" ]]; then
@@ -394,6 +423,10 @@ function apply_mili_patch
             return 1
         fi
         apply_mili_221_blueos_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+        apply_mili_221_write_funcs_patch
         if [[ $? != 0 ]] ; then
             return 1
         fi


### PR DESCRIPTION
### Description

Resolves #17851

I added a patch to `build_visit` for building the Mili library that removes an unneeded variable that is defined in a header file, that results in the variable being defined multiple times.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I rebuilt the Mili library on quartz using the new `build_visit`. There were no compilation errors. The nightly test suite runs on quartz and includes some Mili tests and those tests were successful, so the library must still function properly as well.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
