### PR TITLE
Add a patch for Mili in build_visit to eliminate a duplicate definition error. (#17867)

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Dev_changes"></a>
 <p><b><font size="4">Changes for VisIt developers in version 3.3.1</font></b></p>
 <ul>
+  <li>Added a patch to build_visit so that mili will build on Debian 11 systems using gcc 10.2."</li>
   <li>Enhanced the cmake packaging logic that adds the <code>libicui18n</code>, <code>libicudata</code> and <code>libicuuc</code> system libraries used by Qt to the lib directory to look in additional directories for the libraries to work on a broader set of operating systems.</li>
 </ul>
 

--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -371,6 +371,35 @@ EOF
     return 0
 }
 
+function apply_mili_221_write_funcs_patch
+{
+    #
+    # write_funcs is not needed and having it in the header leads to
+    # multiple definitions, which gcc 10.2 on Debian 11 doesn't like.
+    #
+    patch -p0 << \EOF
+diff -c mili-22.1/src/mili_internal.h.orig mili-22.1/src/mili_internal.h
+*** mili-22.1/src/mili_internal.h.orig  Tue Jul 12 10:49:05 2022
+--- mili-22.1/src/mili_internal.h       Tue Jul 12 10:49:29 2022
+***************
+*** 674,680 ****
+  /* dep.c - routines for handling architecture dependencies. */
+  Return_value set_default_io_routines( Mili_family *fam );
+  Return_value set_state_data_io_routines( Mili_family *fam );
+- void (*write_funcs[QTY_PD_ENTRY_TYPES + 1])();
+  
+  /* svar.c - routines for managing state variables. */
+  Bool_type valid_svar_data( Aggregate_type atype, char *name,
+--- 674,679 ----
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Unable to apply write funcs patch to Mili 22.1"
+        return 1
+    fi
+
+    return 0
+}
+
 function apply_mili_patch
 {
     if [[ "$OPSYS" == "Darwin" ]]; then
@@ -394,6 +423,10 @@ function apply_mili_patch
             return 1
         fi
         apply_mili_221_blueos_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+        apply_mili_221_write_funcs_patch
         if [[ $? != 0 ]] ; then
             return 1
         fi


### PR DESCRIPTION
Resolves #17851
Merge from the 3.3RC to develop.