### PR TITLE
Continuous CT button can now only select continuous CT's, Discrete CT Button only discrete CT's

### DIFF
--- a/src/gui/ColorTableObserver.C
+++ b/src/gui/ColorTableObserver.C
@@ -104,7 +104,7 @@ ColorTableObserver::Update(Subject *)
         const intVector &active = colorAtts->GetActive();
 
         // This should never happen. Resetting the names will reset the active
-        // array as well, and make very color table active. However, this does
+        // array as well, and make every color table active. However, this does
         // happen; when loading settings from config/session files, `names` is
         // populated but `active` is left empty. Ideally, loading settings
         // would correctly preserve which color tables are active, but this

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -190,14 +190,14 @@ QvisColorTableWindow::CreateWindowContents()
     innerDefaultTopLayout->addLayout(innerDefaultLayout);
     innerDefaultLayout->setColumnMinimumWidth(1, 10);
 
-    defaultContinuous = new QvisNoDefaultColorTableButton(defaultGroup);
+    defaultContinuous = new QvisNoDefaultColorTableButton(defaultGroup, false);
     connect(defaultContinuous, SIGNAL(selectedColorTable(const QString &)),
             this, SLOT(setDefaultContinuous(const QString &)));
     innerDefaultLayout->addWidget(defaultContinuous, 0, 1);
     defaultContinuousLabel = new QLabel(tr("Continuous"), defaultGroup);
     innerDefaultLayout->addWidget(defaultContinuousLabel, 0, 0);
 
-    defaultDiscrete = new QvisNoDefaultColorTableButton(defaultGroup);
+    defaultDiscrete = new QvisNoDefaultColorTableButton(defaultGroup, true);
     connect(defaultDiscrete, SIGNAL(selectedColorTable(const QString &)),
             this, SLOT(setDefaultDiscrete(const QString &)));
     innerDefaultLayout->addWidget(defaultDiscrete, 1, 1);

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -173,6 +173,10 @@ QvisColorTableWindow::~QvisColorTableWindow()
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Completely redid the gui to remove categories and add tags.
+// 
+//   Justin Privitera, Wed Jul 13 15:24:42 PDT 2022
+//   Called `QvisNoDefaultColorTableButton` constructor with its new boolean
+//   argument that signals if the button is discrete or continuous.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -27,7 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.3.1</font></b></p>
 <ul>
-  <li>feature 1</li>
+  <li>In the color table window, the popup menu accessed via clicking on the default continuous color table button now correctly only displays continuous color tables, and the popup menu accessed from clicking on the default discrete color table button now correctly only displays discrete color tables.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -5073,6 +5073,10 @@ ViewerSubject::HandleSILAttsUpdated(const string &host,
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed category from call to addColorTable().
+// 
+//   Justin Privitera, Wed Jul 13 15:24:42 PDT 2022
+//   Added `setColorTableAttributes` call for the QvisColorTableButton and
+//   QvisNoDefaultColorTableButton.
 //
 // ****************************************************************************
 

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -5095,7 +5095,9 @@ ViewerSubject::HandleColorTable()
         {
             // Clear all of the color tables.
             QvisColorTableButton::clearAllColorTables();
+            QvisColorTableButton::setColorTableAttributes(colorAtts);
             QvisNoDefaultColorTableButton::clearAllColorTables();
+            QvisNoDefaultColorTableButton::setColorTableAttributes(colorAtts);
 
             int nNames = colorAtts->GetNumColorTables();
             const stringVector &names = colorAtts->GetNames();

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -52,6 +52,10 @@ ColorTableAttributes *QvisNoDefaultColorTableButton::colorTableAtts = NULL;
 //
 //   Brad Whitlock, Fri May  9 11:23:57 PDT 2008
 //   Qt 4.
+// 
+//   Justin Privitera, Wed Jul 13 15:24:42 PDT 2022
+//   Added `discrete` boolean argument to set the buttonType to 
+//   discrete or continuous. Used it to index into arrays.
 //
 // ****************************************************************************
 
@@ -92,6 +96,10 @@ QvisNoDefaultColorTableButton::QvisNoDefaultColorTableButton(QWidget *parent,
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed mappedColorTableNames.
+// 
+//   Justin Privitera, Wed Jul 13 15:24:42 PDT 2022
+//   Deleted only the static pieces of the button that belong to the button 
+//   being deleted.
 //
 // ****************************************************************************
 
@@ -198,6 +206,9 @@ QvisNoDefaultColorTableButton::sizePolicy() const
 //
 //   Brad Whitlock, Tue Jan 17 11:41:44 PDT 2006
 //   Added a tooltip so long color table names can be put in a tooltip.
+// 
+//   Justin Privitera, Wed Jul 13 15:24:42 PDT 2022
+//   Using buttonType to index into the array vars.
 //
 // ****************************************************************************
 
@@ -278,6 +289,8 @@ QvisNoDefaultColorTableButton::getButtonType() const
 // Creation:   Sat Jun 16 20:10:16 PST 2001
 //
 // Modifications:
+//    Justin Privitera, Wed Jul 13 15:19:47 PDT 2022
+//    Index into all the vars since they are now arrays.
 //   
 // ****************************************************************************
 
@@ -290,6 +303,11 @@ QvisNoDefaultColorTableButton::popupPressed()
         if (!popupHasEntries[buttonType])
             regeneratePopupMenu();
 
+        QPoint p1(mapToGlobal(rect().bottomLeft()));
+        QPoint p2(mapToGlobal(rect().topRight()));
+        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
+                            p1.y() + ((p2.y() - p1.y()) >> 1));
+
         // Disconnect all other color table buttons.
         for(size_t i = 0; i < buttons.size(); ++i)
             disconnect(colorTableMenuActionGroup[buttonType], SIGNAL(triggered(QAction *)),
@@ -297,11 +315,6 @@ QvisNoDefaultColorTableButton::popupPressed()
         // Connect this colorbutton to the popup menu.
         connect(colorTableMenuActionGroup[buttonType], SIGNAL(triggered(QAction *)),
                 this, SLOT(colorTableSelected(QAction *)));
-
-        QPoint p1(mapToGlobal(rect().bottomLeft()));
-        QPoint p2(mapToGlobal(rect().topRight()));
-        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
-                            p1.y() + ((p2.y() - p1.y()) >> 1));
 
         // Figure out a good place to popup the menu.
         int menuW = colorTableMenu[buttonType]->sizeHint().width();
@@ -353,6 +366,9 @@ QvisNoDefaultColorTableButton::popupPressed()
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed categories/grouping.
+// 
+//   Justin Privitera, Wed Jul 13 15:19:47 PDT 2022
+//   Index into the vars since they are now arrays.
 //
 // ****************************************************************************
 
@@ -384,6 +400,9 @@ QvisNoDefaultColorTableButton::colorTableSelected(QAction *action)
 // Modifications:
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed mappedColorTableNames.
+// 
+//   Justin Privitera, Wed Jul 13 15:19:47 PDT 2022
+//   Clear out both lists of color table names and set both popup bools.
 //   
 // ****************************************************************************
 
@@ -417,6 +436,9 @@ QvisNoDefaultColorTableButton::clearAllColorTables()
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed category arg and removed mappedColorTableNames.
+// 
+//   Justin Privitera, Wed Jul 13 15:19:47 PDT 2022
+//   Figure out the right destination for incoming ctNames.
 //
 // ****************************************************************************
 
@@ -445,6 +467,9 @@ QvisNoDefaultColorTableButton::addColorTable(const QString &ctName)
 // Modifications:
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Handle the case where the color tables are gone by doing nothing.
+// 
+//   Justin Privitera, Wed Jul 13 15:19:47 PDT 2022
+//   Added call to getbuttontype() to specify which button.
 //   
 // ****************************************************************************
 

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -290,7 +290,9 @@ QvisNoDefaultColorTableButton::getColorTable() const
 void
 QvisNoDefaultColorTableButton::popupPressed()
 {
-    if(isDown() && (colorTableMenuDiscrete || colorTableMenuContinuous))
+    bool allDiscrete = colorTableMenuDiscrete && defDiscrete;
+    bool allContinuous = colorTableMenuContinuous && !defDiscrete;
+    if (isDown() && (allDiscrete || allContinuous))
     {
         int menuW, menuH;
         if (defDiscrete)

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -384,6 +384,7 @@ void
 QvisNoDefaultColorTableButton::colorTableSelected(QAction *action)
 {
     int index;
+    // TODO this is bugged; these indices are not the same
     if (defDiscrete)
         index = colorTableMenuActionGroupDiscrete->actions().indexOf(action);
     else

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -206,7 +206,7 @@ QvisNoDefaultColorTableButton::setColorTable(const QString &ctName)
 {
 debug1 << "QvisNoDefaultColorTableButton::setColorTable" << endl;
 debug1 <<"    ctName: " << ctName.toStdString() << endl;
-    if(getColorTableIndex(ctName) != -1)
+    if (getColorTableIndex(ctName, buttonType) != -1)
     {
         colorTable = ctName;
         setText(colorTable);
@@ -242,6 +242,25 @@ const QString &
 QvisNoDefaultColorTableButton::getColorTable() const
 {
     return colorTable;
+}
+
+// ****************************************************************************
+// Method: QvisNoDefaultColorTableButton::getButtonType
+//
+// Purpose: 
+//   Returns the button type (continuous or discrete).
+//
+// Programmer: Justin Privitera
+// Creation:   Wed Jul 13 14:48:42 PDT 2022
+//
+// Modifications:
+//   
+// ****************************************************************************
+
+const int
+QvisNoDefaultColorTableButton::getButtonType() const
+{
+    return buttonType;
 }
 
 //
@@ -434,7 +453,8 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
 {
     for(size_t i = 0; i < buttons.size(); ++i)
     {
-        if (getColorTableIndex(buttons[i]->getColorTable()) != -1)
+        if (getColorTableIndex(
+            buttons[i]->getColorTable(), buttons[i]->getButtonType()) != -1)
         {
             buttons[i]->setIcon(getIcon(buttons[i]->text()));
         }
@@ -452,6 +472,7 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
 //
 // Arguments:
 //   ctName : The name of the color table to look for.
+//   whichButton : The index of the ct button.
 //
 // Returns:    The index of the color table, or -1.
 //
@@ -461,16 +482,18 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
 // Modifications:
 //   Kathleen Biagas, Mon Aug  4 15:59:18 PDT 2014
 //   Use the indexOf method for QStringList.
+// 
+//   Justin Privitera, Wed Jul 13 14:48:42 PDT 2022
+//   Added the whichButton argument to take into account the fact that there
+//   are 2 buttons with different colorTableNames.
 //   
 // ****************************************************************************
 
 int
-QvisNoDefaultColorTableButton::getColorTableIndex(const QString &ctName)
+QvisNoDefaultColorTableButton::getColorTableIndex(const QString &ctName,
+                                                  const int whichButton)
 {
-    int index_d = colorTableNames[DISC].indexOf(ctName);
-    int index_c = colorTableNames[CONT].indexOf(ctName);
-    // There shouldn't be any overlap, so this should be fine.
-    return index_d != -1 ? index_d : index_c;
+    return colorTableNames[whichButton].indexOf(ctName);
 }
 
 // ****************************************************************************
@@ -495,6 +518,10 @@ QvisNoDefaultColorTableButton::getColorTableIndex(const QString &ctName)
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed categories/grouping.
+// 
+//   Justin Privitera, Wed Jul 13 14:48:42 PDT 2022
+//   Most member vars this function deals with are now arrays, so indexing
+//   was added.
 //
 // ****************************************************************************
 
@@ -530,6 +557,8 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
 // Creation:   Wed Apr 25 16:04:54 PDT 2012
 //
 // Modifications:
+//   Justin Privitera, Wed Jul 13 14:48:42 PDT 2022
+//   Modified to handle the fact that there are now two lists of actions.
 //
 // ****************************************************************************
 
@@ -538,10 +567,10 @@ QvisNoDefaultColorTableButton::getIcon(const QString &ctName)
 {
     QList<QAction*> a1 = colorTableMenuActionGroup[DISC]->actions();
     QList<QAction*> a2 = colorTableMenuActionGroup[CONT]->actions();
-    for (int i = 0; i < a1.size(); ++i)
+    for (int i = 0; i < a1.size(); i ++)
         if (a1[i]->text() == ctName)
             return a1[i]->icon();
-    for (int i = 0; i < a2.size(); ++i)
+    for (int i = 0; i < a2.size(); i ++)
         if (a2[i]->text() == ctName)
             return a2[i]->icon();
 

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -292,23 +292,14 @@ QvisNoDefaultColorTableButton::popupPressed()
 {
     if(isDown() && (colorTableMenuDiscrete || colorTableMenuContinuous))
     {
-        // If the popup menu does not have anything in it, fill it up.
-        if (defDiscrete)
-            if (!popupHasEntriesDiscrete)
-                regeneratePopupMenu();
-        else
-            if (!popupHasEntriesContinuous)
-                regeneratePopupMenu();
-
-        QPoint p1(mapToGlobal(rect().bottomLeft()));
-        QPoint p2(mapToGlobal(rect().topRight()));
-        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
-                            p1.y() + ((p2.y() - p1.y()) >> 1));
-
         int menuW, menuH;
-        // Disconnect all other color table buttons.
         if (defDiscrete)
         {
+            // If the popup menu does not have anything in it, fill it up.
+            if (!popupHasEntriesDiscrete)
+                regeneratePopupMenu();
+
+            // Disconnect all other color table buttons.
             for(size_t i = 0; i < buttons.size(); ++i)
                 disconnect(colorTableMenuActionGroupDiscrete, SIGNAL(triggered(QAction *)),
                            buttons[i], SLOT(colorTableSelected(QAction *)));
@@ -320,6 +311,11 @@ QvisNoDefaultColorTableButton::popupPressed()
         }
         else
         {
+            // If the popup menu does not have anything in it, fill it up.
+            if (!popupHasEntriesContinuous)
+                regeneratePopupMenu();
+
+            // Disconnect all other color table buttons.
             for(size_t i = 0; i < buttons.size(); ++i)
                 disconnect(colorTableMenuActionGroupContinuous, SIGNAL(triggered(QAction *)),
                            buttons[i], SLOT(colorTableSelected(QAction *)));
@@ -329,6 +325,11 @@ QvisNoDefaultColorTableButton::popupPressed()
             menuW = colorTableMenuContinuous->sizeHint().width();
             menuH = colorTableMenuContinuous->sizeHint().height();
         }
+
+        QPoint p1(mapToGlobal(rect().bottomLeft()));
+        QPoint p2(mapToGlobal(rect().topRight()));
+        QPoint buttonMiddle(p1.x() + ((p2.x() - p1.x()) >> 1),
+                            p1.y() + ((p2.y() - p1.y()) >> 1));
 
         // Figure out a good place to popup the menu.
         int menuX = buttonMiddle.x();
@@ -570,7 +571,7 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
     if (defDiscrete)
     {
         QList<QAction*> actions = colorTableMenuActionGroupDiscrete->actions();
-        for(int i = 0; i < actions.count(); ++i)
+        for (int i = 0; i < actions.count(); ++i)
             colorTableMenuActionGroupDiscrete->removeAction(actions[i]);
         colorTableMenuDiscrete->clear();
 
@@ -589,7 +590,7 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
     else
     {
         QList<QAction*> actions = colorTableMenuActionGroupContinuous->actions();
-        for(int i = 0; i < actions.count(); ++i)
+        for (int i = 0; i < actions.count(); ++i)
             colorTableMenuActionGroupContinuous->removeAction(actions[i]);
         colorTableMenuContinuous->clear();
 

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -231,7 +231,7 @@ debug1 <<"    ctName: " << ctName.toStdString() << endl;
         colorTable = ctName;
         setText(colorTable);
         setToolTip(colorTable);
-        setIcon(getIcon(ctName, defDiscrete));
+        setIcon(getIcon(ctName));
     }
     else
     {
@@ -239,7 +239,7 @@ debug1 <<"    ctName: " << ctName.toStdString() << endl;
         colorTable = colorTableNames[0];
         setText(colorTable);
         setToolTip(colorTable);
-        setIcon(getIcon(colorTable, defDiscrete));
+        setIcon(getIcon(colorTable));
     }
 debug1 << "QvisNoDefaultColorTableButton::setColorTable ... done" << endl;
 }
@@ -393,7 +393,7 @@ QvisNoDefaultColorTableButton::colorTableSelected(QAction *action)
 
     emit selectedColorTable(ctName);
     setText(ctName);
-    setIcon(getIcon(ctName, defDiscrete));
+    setIcon(getIcon(ctName));
     setToolTip(ctName);
 }
 
@@ -480,7 +480,7 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
     {
         if (getColorTableIndex(buttons[i]->getColorTable()) != -1)
         {
-            buttons[i]->setIcon(getIcon(buttons[i]->text(), defDiscrete));
+            buttons[i]->setIcon(getIcon(buttons[i]->text()));
         }
         // If there are no available color tables, we don't want the 
         // entries to change.            
@@ -601,17 +601,16 @@ QvisNoDefaultColorTableButton::regeneratePopupMenu()
 // ****************************************************************************
 
 QIcon
-QvisNoDefaultColorTableButton::getIcon(const QString &ctName, 
-                                       bool defaultDiscrete)
+QvisNoDefaultColorTableButton::getIcon(const QString &ctName)
 {
-    QList<QAction*> a;
-    if (defaultDiscrete)
-        a = colorTableMenuActionGroupDiscrete->actions();
-    else        
-        a = colorTableMenuActionGroupContinuous->actions();
-    for(int i = 0; i < a.size(); ++i)
-        if(a[i]->text() == ctName)
-            return a[i]->icon();
+    QList<QAction*> a1 = colorTableMenuActionGroupDiscrete->actions();
+    QList<QAction*> a2 = colorTableMenuActionGroupContinuous->actions();
+    for (int i = 0; i < a1.size(); ++i)
+        if (a1[i]->text() == ctName)
+            return a1[i]->icon();
+    for (int i = 0; i < a2.size(); ++i)
+        if (a2[i]->text() == ctName)
+            return a2[i]->icon();
 
     return makeIcon(ctName);
 }

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -80,18 +80,14 @@ private:
     QString                        colorTable;
 
     static int                     numInstances;
-    static QMenu                  *colorTableMenuDiscrete;
-    static QActionGroup           *colorTableMenuActionGroupDiscrete;
-    static QMenu                  *colorTableMenuContinuous;
-    static QActionGroup           *colorTableMenuActionGroupContinuous;
-    static bool                    popupHasEntriesDiscrete;
-    static bool                    popupHasEntriesContinuous;
+    static QMenu                  *colorTableMenu[2];
+    static QActionGroup           *colorTableMenuActionGroup[2];
+    static bool                    popupHasEntries[2];
     static ColorTableButtonVector  buttons;
 
-    static QStringList             colorTableNamesDiscrete;
-    static QStringList             colorTableNamesContinuous;
+    static QStringList             colorTableNames[2];
     static ColorTableAttributes   *colorTableAtts;
-    bool                           defDiscrete;
+    int                            buttonType;
 };
 
 #endif

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -44,6 +44,14 @@ class ColorTableAttributes;
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Removed category arg from addColorTable and removed mappedColorTableNames.
+// 
+//   Justin Privitera, Wed Jul 13 14:48:42 PDT 2022
+//   Made numerous changes throughout the class to enforce color table 
+//   filtering, so that the Continuous ct button can only select continuous
+//   color tables, and the Discrete ct button can only select discrete color
+//   tables. Note in this file the changes to the static variables; now many
+//   are arrays with two elements. This is to facilitate different behavior for
+//   the different buttons.
 //
 // ****************************************************************************
 
@@ -60,6 +68,7 @@ public:
 
     void setColorTable(const QString &ctName);
     const QString &getColorTable() const;
+    const int getButtonType() const;
 
     // Methods to set the list of internal color tables.
     static void clearAllColorTables();
@@ -72,12 +81,13 @@ private slots:
     void popupPressed();
     void colorTableSelected(QAction *);
 private:
-    static int  getColorTableIndex(const QString &ctName);
+    static int  getColorTableIndex(const QString &ctName, const int whichButton);
     void regeneratePopupMenu();
     static QIcon getIcon(const QString &);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;
+    int                            buttonType;
 
     static int                     numInstances;
     static QMenu                  *colorTableMenu[2];
@@ -87,7 +97,6 @@ private:
 
     static QStringList             colorTableNames[2];
     static ColorTableAttributes   *colorTableAtts;
-    int                            buttonType;
 };
 
 #endif

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -74,7 +74,7 @@ private slots:
 private:
     static int  getColorTableIndex(const QString &ctName);
     void regeneratePopupMenu();
-    static QIcon getIcon(const QString &, bool defaultDiscrete);
+    static QIcon getIcon(const QString &);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -88,7 +88,8 @@ private:
     static bool                    popupHasEntriesContinuous;
     static ColorTableButtonVector  buttons;
 
-    static QStringList             colorTableNames;
+    static QStringList             colorTableNamesDiscrete;
+    static QStringList             colorTableNamesContinuous;
     static ColorTableAttributes   *colorTableAtts;
     bool                           defDiscrete;
 };

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -74,14 +74,16 @@ private slots:
 private:
     static int  getColorTableIndex(const QString &ctName);
     void regeneratePopupMenu();
-    static QIcon getIcon(const QString &);
+    static QIcon getIcon(const QString &, bool defaultDiscrete);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;
 
     static int                     numInstances;
-    QMenu                         *colorTableMenu;
-    static QActionGroup           *colorTableMenuActionGroup;
+    static QMenu                  *colorTableMenuDiscrete;
+    static QActionGroup           *colorTableMenuActionGroupDiscrete;
+    static QMenu                  *colorTableMenuContinuous;
+    static QActionGroup           *colorTableMenuActionGroupContinuous;
     static bool                    popupHasEntriesDiscrete;
     static bool                    popupHasEntriesContinuous;
     static ColorTableButtonVector  buttons;

--- a/src/winutil/QvisNoDefaultColorTableButton.h
+++ b/src/winutil/QvisNoDefaultColorTableButton.h
@@ -53,7 +53,7 @@ class WINUTIL_API QvisNoDefaultColorTableButton : public QPushButton
 
     typedef std::vector<QvisNoDefaultColorTableButton *> ColorTableButtonVector;
 public:
-    QvisNoDefaultColorTableButton(QWidget *parent);
+    QvisNoDefaultColorTableButton(QWidget *parent, bool discrete);
     virtual ~QvisNoDefaultColorTableButton();
     virtual QSize sizeHint() const;
     virtual QSizePolicy sizePolicy () const;
@@ -73,20 +73,22 @@ private slots:
     void colorTableSelected(QAction *);
 private:
     static int  getColorTableIndex(const QString &ctName);
-    static void regeneratePopupMenu();
+    void regeneratePopupMenu();
     static QIcon getIcon(const QString &);
     static QIcon makeIcon(const QString &);
 
     QString                        colorTable;
 
     static int                     numInstances;
-    static QMenu                  *colorTableMenu;
+    QMenu                         *colorTableMenu;
     static QActionGroup           *colorTableMenuActionGroup;
-    static bool                    popupHasEntries;
+    static bool                    popupHasEntriesDiscrete;
+    static bool                    popupHasEntriesContinuous;
     static ColorTableButtonVector  buttons;
 
     static QStringList             colorTableNames;
     static ColorTableAttributes   *colorTableAtts;
+    bool                           defDiscrete;
 };
 
 #endif


### PR DESCRIPTION
### Description

Resolves #17799 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
The continuous CT button in the color table window can now only select continuous color tables.
The discrete CT button in the color table window can now only select discrete color tables.

This works in tandem with the new tagging system. Tags will filter your selection further for these buttons.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [x] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz toss3 and it acted as I expected.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
