### PR TITLE
Fix bug with FindVTKh.cmake not installing the VTK-h shared libs when it was built with spack.

### DIFF
--- a/src/CMake/FindVTKh.cmake
+++ b/src/CMake/FindVTKh.cmake
@@ -16,8 +16,9 @@
 #   Set VTKm_INCLUDE_DIRS.
 #
 #   Eric Brugger, Thu 21 Jul 2022 06:39:36 PM EDT
-#   Modified the logic to handle the case where a RELWITHDEBINFO build of
-#   VTKh was created. Modified the logic not to install static libraries.
+#   Modified the logic to install the shared VTK-h libraries in the case
+#   where VTK-h was built with RELWITHDEBINFO, which is the case when spack
+#   builds VTK-h. Modified the logic to not install static libraries.
 #
 #****************************************************************************/
 

--- a/src/CMake/FindVTKh.cmake
+++ b/src/CMake/FindVTKh.cmake
@@ -15,6 +15,10 @@
 #   Kathleen Biagas, Tue Jan 21 10:46:31 PST 2020
 #   Set VTKm_INCLUDE_DIRS.
 #
+#   Eric Brugger, Thu 21 Jul 2022 06:39:36 PM EDT
+#   Modified the logic to handle the case where a RELWITHDEBINFO build of
+#   VTKh was created. Modified the logic not to install static libraries.
+#
 #****************************************************************************/
 
 IF (DEFINED VISIT_VTKH_DIR)
@@ -47,12 +51,15 @@ IF (DEFINED VISIT_VTKH_DIR)
    # all interface link dependencies
    function(get_lib_loc_and_install _lib)
        get_target_property(ttype ${_lib} TYPE)
-       if (ttype STREQUAL "INTERFACE_LIBRARY")
+       if (ttype STREQUAL "INTERFACE_LIBRARY" OR ttype STREQUAL "STATIC_LIBRARY")
            return()
        endif()
        get_target_property(i_loc ${_lib} IMPORTED_LOCATION)
        if (NOT i_loc)
          get_target_property(i_loc ${_lib} IMPORTED_LOCATION_RELEASE)
+       endif()
+       if (NOT i_loc)
+         get_target_property(i_loc ${_lib} IMPORTED_LOCATION_RELWITHDEBINFO)
        endif()
        if(i_loc)
            THIRD_PARTY_INSTALL_LIBRARY(${i_loc})

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -42,6 +42,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Added a patch to build_visit so that mili will build on Debian 11 systems using gcc 10.2."</li>
   <li>Enhanced the cmake packaging logic that adds the <code>libicui18n</code>, <code>libicudata</code> and <code>libicuuc</code> system libraries used by Qt to the lib directory to look in additional directories for the libraries to work on a broader set of operating systems.</li>
+  <li>Fixed a bug with <code>FindVTKh.cmake</code> where it wouldn't install the shared libraries when VTK-h was built with <code>spack</code>.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Resolves #17905

Modified `FindVTKh.cmake` to install the shared VTK-h libraries for the case where VTK-h was built with `RELWITHDEBINFO`, which is the case when `spack` builds VTK-h. Also modified `FindVTKh.cmake` not to install static libraries. 

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

Built VisIt on crusher using `spack`, which is where this bug was encountered. The shared VTK-h libraries were installed in the `lib` directory and the static VTK-m libraries were not.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
