### PR TITLE
do not double free resources

### DIFF
--- a/src/databases/MOAB/avtMOABFileFormat.C
+++ b/src/databases/MOAB/avtMOABFileFormat.C
@@ -92,6 +92,13 @@ avtMOABFileFormat::~avtMOABFileFormat() {
         free(file_descriptor);
         file_descriptor = NULL;
     }
+#ifdef PARALLEL
+    if (pcomm)
+    {
+        delete pcomm;
+        pcomm = NULL;
+    }
+#endif
     if (mbCore) {
         delete mbCore;
         mbCore = NULL;

--- a/src/databases/MOAB/avtMOABFileFormat.C
+++ b/src/databases/MOAB/avtMOABFileFormat.C
@@ -86,26 +86,35 @@ avtMOABFileFormat::avtMOABFileFormat(const char *filename, const DBOptionsAttrib
 //
 // ****************************************************************************
 
-avtMOABFileFormat::~avtMOABFileFormat()
-{
-	debug1 << " avtMOABFileFormat::~avtMOABFileFormat: freeing file descriptor\n";
-	if (file_descriptor)
-	{
-		free(file_descriptor);
-		file_descriptor=NULL;
-	}
-	delete mbCore;
+avtMOABFileFormat::~avtMOABFileFormat() {
+    debug1 << " avtMOABFileFormat::~avtMOABFileFormat: freeing file descriptor\n";
+    if (file_descriptor) {
+        free(file_descriptor);
+        file_descriptor = NULL;
+    }
+    if (mbCore) {
+        delete mbCore;
+        mbCore = NULL;
+    }
 }
 void
-avtMOABFileFormat::FreeUpResources(void)
-{
-	debug1 << " avtMOABFileFormat::FreeUpResources: freeing file descriptor\n";
-    free  (file_descriptor);
-    file_descriptor = NULL;
+avtMOABFileFormat::FreeUpResources(void) {
+    debug1 << " avtMOABFileFormat::FreeUpResources: freeing file descriptor\n";
+    if (file_descriptor) {
+        free(file_descriptor);
+        file_descriptor = NULL;
+    }
 #ifdef PARALLEL
-    delete pcomm;
+	if (pcomm)
+	{
+		delete pcomm;
+		pcomm = NULL;
+	}
 #endif
-    delete mbCore;
+    if (mbCore) {
+        delete mbCore;
+        mbCore = NULL;
+    }
 }
 
 void
@@ -585,7 +594,7 @@ avtMOABFileFormat::GetMesh(int domain, const char *meshname)
         //
         // Create the unstructured mesh
         //
-        vtkUnstructuredGrid *ugrid = vtkUnstructuredGrid::New(); 
+        vtkUnstructuredGrid *ugrid = vtkUnstructuredGrid::New();
 
         {
             // Get the list of vertices
@@ -607,7 +616,7 @@ avtMOABFileFormat::GetMesh(int domain, const char *meshname)
                 pts[i] = static_cast<float> (coords[i]);
             }
             coords.clear();
-            
+
             ugrid->SetPoints(points);
             points->Delete();
         }


### PR DESCRIPTION
### Description
moab plugin bug  (double freeing resources)

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
