### PR TITLE
Add VTK_VERSION to PluginVisInstall.cmake.in.

### DIFF
--- a/src/CMake/PluginVsInstall.cmake.in
+++ b/src/CMake/PluginVsInstall.cmake.in
@@ -102,6 +102,10 @@
 #   Added VISIT_ROOT_INCLUDE_DIR for ThirdParty and .cmake includes, so that
 #   VISIT_INCLUDE_DIR can be used for visit includes.
 #
+#   Kathleen Biagas, Wed Aug 10 15:41:22 PDT 2022
+#   VTK_VERSION is needed for version comparisons so that both VTK 9 and
+#   VTK 8 can be supported.
+#
 #****************************************************************************/
 
 ##
@@ -178,6 +182,7 @@ set(VISIT_SLIVR                  @VISIT_SLIVR@)
 set(VISIT_OSPRAY                 @VISIT_OSPRAY@)
 
 # Set up VTK
+set(VTK_VERSION @VTK_VERSION@)
 set(VTK_INCLUDE_DIRS ${VISIT_ROOT_INCLUDE_DIR}@vtk_include_relative_path@)
 set(VTK_LIBRARY_DIRS ${VISIT_LIBRARY_DIR})
 


### PR DESCRIPTION
Allows successful compilation of plugins vs install.

This was an oversight with phase2 VTK 9 support commit.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
