### PR TITLE
test np arrays in assignments

### DIFF
--- a/src/doc/python_scripting/python.rst
+++ b/src/doc/python_scripting/python.rst
@@ -150,6 +150,37 @@ the key whose value you want to look up to the subscript [] operator.
     for c in colors.keys(): 
        print "%s in French is: %s" % (c, colors[c]) 
 
+NumPy Arrays
+~~~~~~~~~~~~
+
+VisIt_ is often used together with NumPy.
+It is natural to want to use NumPy arrays in assignments to members of VisIt_ attribute and dictionary objects or as arguments to functions.
+For the most part, NumPy arrays do work in assignment to members of attribute objects or via setter functions on attribute objects.
+In cases where entries in a NumPy array are to be interpreted as arguments to a function, it is possible to *dereference* a NumPy array by preceding it with ``*``.
+For example, this does not work ::
+
+    NumPyArray = numpy.array([1.1,2.2,3.3,4.4])
+    va = VolumeAttributes()
+    va.SetMaterialProperties(NumPyArray)
+
+whereas this does ::
+
+    NumPyArray = numpy.array([1.1,2.2,3.3,4.4])
+    va = VolumeAttributes()
+    va.SetMaterialProperties(*NumPyArray)
+
+as well as this ::
+
+    NumPyArray = numpy.array([1.1,2.2,3.3,4.4])
+    va = VolumeAttributes()
+    va.materialProperties = NumPyArray
+
+Whenever passing NumPy arrays to VisIt_ is causing problems, it is possible to *convert* them to *list* objects using the ``.tolist()`` method as in ::
+
+    NumPyArray = numpy.array([1.1,2.2,3.3,4.4])
+    va = VolumeAttributes()
+    va.SetMaterialProperties(NumPyArray.tolist())
+
 Control flow
 ------------
 

--- a/src/test/tests/unit/atts_assign.py
+++ b/src/test/tests/unit/atts_assign.py
@@ -17,10 +17,16 @@
 #    ValueError, so change expected results in those cases.
 #
 # ----------------------------------------------------------------------------
-import copy, io, sys
+import copy, io, numpy, sys
 
 # Some useful global variables
 X = [2,4,6]
+NumPy2Int = numpy.array([1,2])
+NumPy2Flt = numpy.array([1.1,2.2])
+NumPy3Int = numpy.array([1,2,3])
+NumPy3Flt = numpy.array([1.1,2.2,3.3])
+NumPy4Int = numpy.array([1,2,3,4])
+NumPy4Flt = numpy.array([1.1,2.2,3.3,4.4])
 Max32BitInt = 2147483647
 Max32BitInt1 = Max32BitInt+1
 MaxIntAs32BitFloat = 16777216
@@ -86,7 +92,7 @@ def TestAssignmentToTuple():
         pass
 
     # The above cases can't be put in a loop. Put remaining cases in a loop
-    fails = [(1,2), (1,2,3,4), '123', (1,1+2j,3), (1,X,3), (1,'b',3), (1,None,3)]
+    fails = [(1,2), (1,2,3,4), '123', (1,1+2j,3), (1,X,3), (1,'b',3), (1,None,3), NumPy2Flt, NumPy4Flt]
     for i in range(len(fails)):
         try:
             ca.point1 = fails[i]
@@ -116,7 +122,7 @@ def TestAssignmentToTuple():
         TestFOA('ca.point1=1,2,3', LINE())
         pass
 
-    works = [(1,2,3), (1.1,2.2,3.3), tuple(X)]
+    works = [(1,2,3), (1.1,2.2,3.3), tuple(X), NumPy3Int, NumPy3Flt]
     for i in range(len(works)):
         try:
             ca.point1 = works[i]
@@ -552,6 +558,7 @@ def TestAssignmentToUCharVector():
         except:
             TestFOA('mca.changedColors=%s'%repr2(works[i]), LINE()) 
 
+    works += [NumPy3Int] # NP arrays only work via deref operator
     for i in range(len(works)):
         try:
             mca.SetChangedColors(*works[i])
@@ -610,6 +617,7 @@ def TestAssignmentToIntVector():
         except:
             TestFOA('opa.index=%s'%repr2(works[i]), LINE()) 
 
+    works += [NumPy3Int] # NP Arrays work only via deref operator
     for i in range(len(works)):
         try:
             opa.SetIndex(*works[i])
@@ -661,6 +669,7 @@ def TestAssignmentToDoubleVector():
         except:
             TestFOA('ca.contourValue=%s'%repr2(works[i]), LINE()) 
 
+    works += [NumPy3Flt] # NP Arrays work only via deref operator
     for i in range(len(works)):
         try:
             ca.SetContourValue(*works[i])
@@ -838,7 +847,8 @@ def TestAssignmentToIntArray():
             TestFOA('ra.SetReflections(%s)'%repr2(fails[i]), LINE())
             pass
 
-    works = [(0,1,0,1,0,1,0,1), (-1,100,-1,100,-1,100,-1,100), (0,True,False,1,0,1,0,1), (0,1,Max32BitInt,1,0,1,0,1)]
+    NumPyArray = numpy.array([0,1,0,1,0,1,0,1])
+    works = [(0,1,0,1,0,1,0,1), (-1,100,-1,100,-1,100,-1,100), (0,True,False,1,0,1,0,1), (0,1,Max32BitInt,1,0,1,0,1), NumPyArray]
     for i in range(len(works)):
         try:
             ra.reflections = works[i]
@@ -902,7 +912,7 @@ def TestAssignmentToFloatArray():
             TestFOA('rra.SetCenter(%s)'%repr2(fails[i]), LINE())
             pass
 
-    works = [(1,2,3), (1.1,2.2,3.3), tuple(X), (1,True,3), (1,False,3), (1,Max32BitFloatA,3)]
+    works = [(1,2,3), (1.1,2.2,3.3), tuple(X), (1,True,3), (1,False,3), (1,Max32BitFloatA,3), NumPy3Flt]
     for i in range(len(works)):
         try:
             rra.center = works[i]
@@ -973,6 +983,8 @@ def TestAssignmentToDoubleArray():
         except:
             TestFOA('va.materialProperties=%s'%repr2(works[i]), LINE())
 
+    NumPyArray = numpy.array([1.1,2.2,3.3,4.4])
+    works += [NumPyArray]
     for i in range(len(works)):
         try:
             va.SetMaterialProperties(*works[i])


### PR DESCRIPTION
### Description

It looks like we support NP arrays in CLI assignments fairly well. In some cases, it works only via the Python deref (`*`) operator. But, since it does work, I think we'd like to preserve it and know if we break it. So, this update adds some tests for it.

I guess I should add a note to the docs about this too. I will figure best place and do so and then take out of draft mode.

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

Improve testing of NumPy arrays in atts assignments.

### How Has This Been Tested?

New tests were added.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
