### PR TITLE
fix missing logic for multi-line-string

### DIFF
--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -1277,6 +1277,9 @@ FillDBOptionsFromDictionary(PyObject *obj, DBOptionsAttributes &opts)
 //    Kathleen Biagas, Fri Feb 17 2017
 //    Allow Enums to be represented by string.
 //
+//    Mark C. Miller, Mon Aug 22 19:39:54 PDT 2022
+//    Properly scope Enum case. Add MultiLineString case. Add a default with
+//    some indication of an error too.
 // ****************************************************************************
 PyObject *
 CreateDictionaryFromDBOptions(DBOptionsAttributes &opts)

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -1306,6 +1306,7 @@ CreateDictionaryFromDBOptions(DBOptionsAttributes &opts)
             PyDict_SetItemString(dict,name,PyString_FromString(opts.GetString(name).c_str()));
             break;
           case DBOptionsAttributes::Enum:
+          {
             // If you modify this section, also check the Enum case in
             // FillDBOptionsFromDictionary
             int enumIndex = opts.GetEnum(name);
@@ -1322,6 +1323,13 @@ CreateDictionaryFromDBOptions(DBOptionsAttributes &opts)
                 }
             }
             PyDict_SetItemString(dict,name,PyString_FromString(itemString.c_str()));
+            break;
+          }
+          case DBOptionsAttributes::MultiLineString:
+            PyDict_SetItemString(dict,name,PyString_FromString(opts.GetMultiLineString(name).c_str()));
+            break;
+          default:
+            PyDict_SetItemString(dict,name,PyString_FromString("ERROR - Unhandled DBOptionsAttribute type - ERROR"));
         }
         delete[] name;
     }


### PR DESCRIPTION
### Description

I think this resolves #18005.

It was far easier than I thought. That said, I worry it was so easy.

I don't really understand how a `DBOptionsAttributes::MultiLineString` is any different from a `DBOptionsAttributes::String`. The public setter/getter methods are *identical* though somehow the underlying stored thing is a `stringVector` instead of a `std::string`. That said, I don't see any logic that somehow manages the contents of the option's *value* as a vector of strings. If you compare the logic for `MultiLineString` to, for example, `Enum` which also uses an underlying `stringVector` for storage, there are remarkable differences.

I think the goal of `DBOptionsAttributes:MultiLineString` was for a string-valued option in `DBOptionsAttributes` to have embedded new-lines (and maybe carriage returns) so you could have a string which when it got printed to the user or when the user typed it in to be digested by VisIt, it could look like some jasony or yamly looking thing...

```
{
   foo: 1,
   bar: "mark",
   coords: [0,1,2]
}
```

So that each *line* of the string would be captured as one of the entries in the underlyng `stringVector` associated with it. However, there is no logic in `DBOptionsAtrributes.code` that does any of that.

So, given how it behaves, what `MultiLineString` does is already possible in the cli using Python's `"""` operator. Next, I don't think there is any support in VisIt's GUI for rendering or editing such a string in the GUI widget that gets created for `DBOptionsAttributes` for either export or for read.

This is all making me think `MultiLineString` should be removed (or maybe tested and fixed if its not working) because its just duplicating other functionality we already have.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Manually on my macOS

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
