### PR TITLE
WIP: fixes a comp failure

### DIFF
--- a/src/avt/Queries/CMakeLists.txt
+++ b/src/avt/Queries/CMakeLists.txt
@@ -221,7 +221,8 @@ ENDIF(VISIT_PYTHON_FILTERS)
 
 #********************************* SERIAL ************************************
 ADD_LIBRARY(avtquery_ser ${AVTQUERY_SOURCES})
-TARGET_LINK_LIBRARIES(avtquery_ser visitcommon avtmath avtshapelets avtexpressions_ser avtfilters_ser visit_vtk)
+find_library(LIBRT rt)
+TARGET_LINK_LIBRARIES(avtquery_ser visitcommon avtmath avtshapelets avtexpressions_ser avtfilters_ser visit_vtk ${LIBRT})
 IF(VISIT_PYTHON_FILTERS)
     TARGET_LINK_LIBRARIES(avtquery_ser avtpythonfilters_ser)
 ENDIF(VISIT_PYTHON_FILTERS)


### PR DESCRIPTION
Was getting a linker shm_open symbol missing without this.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I've only compiled and locally run the branch on my workstation. Ubuntu 20.04. Visit 3.3.0 tag build fine there, develop did not.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [ x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
