### PR TITLE
fix compile errors on Windows

### DIFF
--- a/src/common/state/ColorControlPointList.C
+++ b/src/common/state/ColorControlPointList.C
@@ -6,6 +6,7 @@
 #include <DataNode.h>
 #include <DebugStream.h>
 #include <algorithm>
+#include <cctype>
 #include <string.h>
 #include <ColorControlPoint.h>
 

--- a/src/common/state/ColorControlPointList.xml
+++ b/src/common/state/ColorControlPointList.xml
@@ -72,6 +72,9 @@
       algorithm
     </Include>
     <Include file="source" quoted="false">
+      cctype
+    </Include>
+    <Include file="source" quoted="false">
       string.h
     </Include>
   </Attribute>

--- a/src/visitpy/common/PyMapNode.h
+++ b/src/visitpy/common/PyMapNode.h
@@ -17,7 +17,7 @@ VISITPY_API PyObject *PyMapNode_Wrap(const MapNode&);
 //
 // Helper to convert a Python Dictionary  to a VisIt MapNode.
 //
-VISITPY_API static std::string PyMapNode_VoidString = "__void__";
+static std::string PyMapNode_VoidString = "__void__";
 VISITPY_API bool PyDict_To_MapNode(PyObject *, MapNode&, std::string& errmsg = PyMapNode_VoidString);
 
 #endif


### PR DESCRIPTION
Add `#include <cctype>` to ColorControlPointLists, for 'isalnum'.

Removed 'static' from PyMapNode_VoidString, to fix VS C2201 error:
must have external linkage in order to be exported/imported
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2201?view=msvc-170


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Compiled on Windows

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
