### PR TITLE
Color Tables: Delete unused tags, refactor, and fix bugs

### DIFF
--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -512,7 +512,7 @@ QvisColorTableWindow::CreateNode(DataNode *parentNode)
         std::string ct(currentColorTable.toStdString());
         node->AddNode(new DataNode("currentColorTable", ct));
         stringVector tagNames;
-        std::vector<bool> activeTags;
+        boolVector activeTags;
         for (const auto mapitem : tagList)
         {
             tagNames.emplace_back(mapitem.first);

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -508,9 +508,15 @@ QvisColorTableWindow::CreateNode(DataNode *parentNode)
         // Save the current color table.
         std::string ct(currentColorTable.toStdString());
         node->AddNode(new DataNode("currentColorTable", ct));
-        // TODO
-        // node->AddNode(new DataNode("tagList", tagList));
-        // node->AddNode(new DataNode("activeTags", activeTags));
+        stringVector tagNames;
+        std::vector<bool> activeTags;
+        for (const auto mapitem : tagList)
+        {
+            tagNames.emplace_back(mapitem.first);
+            activeTags.emplace_back(mapitem.second.active);
+        }
+        node->AddNode(new DataNode("tagList", tagNames));
+        node->AddNode(new DataNode("activeTags", activeTags));
         node->AddNode(new DataNode("tagsVisible", tagsVisible));
         node->AddNode(new DataNode("tagsMatchAny", tagsMatchAny));
     }
@@ -545,12 +551,16 @@ QvisColorTableWindow::SetFromNode(DataNode *parentNode, const int *borders)
     DataNode *node, *node2;
     if((node = winNode->GetNode("currentColorTable")) != 0)
         currentColorTable = QString(node->AsString().c_str());
-    // TODO
-    // if((node = winNode->GetNode("tagList")) != 0 && (node2 = winNode->GetNode("activeTags")) != 0)
-    // {
-    //     tagList = node->AsStringVector();
-    //     activeTags = node2->AsBoolVector();
-    // }
+    if((node = winNode->GetNode("tagList")) != 0 && (node2 = winNode->GetNode("activeTags")) != 0)
+    {
+        stringVector tagNames{node->AsStringVector()};
+        std::vector<bool> activeTags{node2->AsBoolVector()};
+        if (tagNames.size() == activeTags.size())
+        {
+            for (int i = 0; i < tagNames.size(); i ++)
+                tagList[tagNames[i]].active = activeTags[i];
+        }
+    }
     if((node = winNode->GetNode("tagsVisible")) != 0)
         tagsVisible = node->AsBool();
     if((node = winNode->GetNode("tagsMatchAny")) != 0)

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -906,8 +906,7 @@ QvisColorTableWindow::AddGlobalTag(std::string currtag, bool first_time)
 // 
 //    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
 //    Run the tag table generation the first time so we can set up the tagInfo
-//    map.
-//    Purge tagList and tagTable entries that have 0 refcount.
+//    map. Purge tagList and tagTable entries that have 0 refcount.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -815,10 +815,7 @@ QvisColorTableWindow::UpdateEditor()
 //
 // Modifications:
 //    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
-//    Tag index argument is deprecated; it is no longer needed with the 
-//    refactor.
-//    Thus there is also no need for the secret tag table column for storing
-//    the index of the tag.
+ // Eliminated tag index arg as well as need for secret tag table column.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -1009,7 +1009,7 @@ QvisColorTableWindow::UpdateTags()
 // 
 //   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
 //   Rework for accessing tag information b/c of refactor.
-//   Fix so current CT can never be set to one that is not in the CT name box.
+//   Ensure current CT name is one of the existing names.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -911,20 +911,19 @@ QvisColorTableWindow::UpdateTags()
         first_time = false;
 
         // Purge tagList/tagTable entries that have 0 refcount.
-        auto itr = tagList.begin();
-        while (itr != tagList.end())
+        for (auto itr = tagList.begin(); itr != tagList.end();)
         {
             if (itr->second.numrefs <= 0)
             {
                 // TODO err messages and guards
                 auto index = tagTable->indexOfTopLevelItem(itr->second.tagTableItem);
                 tagTable->takeTopLevelItem(index);
+                delete itr->second.tagTableItem;
+                itr = tagList.erase(itr);
             }
-            itr ++;
+            else
+                itr ++;
         }
-
-        // TODO still need to *delete* from tagList
-
         tagTable->sortByColumn(1, Qt::AscendingOrder);
     }
 }
@@ -2116,6 +2115,15 @@ QvisColorTableWindow::deleteColorTable()
         QString tmp;
         tmp = tr("Cannot delete a color table while searching is enabled. "
                  "Please disable searching first.");
+        Error(tmp);
+        return;
+    }
+
+    if (nameListBox->topLevelItemCount() == 0)
+    {
+        QString tmp;
+        tmp = tr("Not able to delete a color table; there are no color tables"
+                 " to delete.");
         Error(tmp);
         return;
     }

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -490,6 +490,9 @@ QvisColorTableWindow::CreateWindowContents()
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Added ability for tag settings to be written to config/session files.
+// 
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Now plays nice with the new tag data structure.
 //
 // ****************************************************************************
 
@@ -537,6 +540,9 @@ QvisColorTableWindow::CreateNode(DataNode *parentNode)
 // 
 //   Justin Privitera, Thu Jun 16 18:01:49 PDT 2022
 //   Added ability for tag settings to be read from config/session files.
+// 
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Now plays nice with the new tag data structure.
 //
 // ****************************************************************************
 
@@ -808,6 +814,11 @@ QvisColorTableWindow::UpdateEditor()
 // Creation:   Mon Jun 27 17:30:16 PDT 2022
 //
 // Modifications:
+//    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//    Tag index argument is deprecated; it is no longer needed with the 
+//    refactor.
+//    Thus there is also no need for the secret tag table column for storing
+//    the index of the tag.
 //
 // ****************************************************************************
 
@@ -837,6 +848,12 @@ QvisColorTableWindow::AddToTagTable(std::string currtag)
 // 
 //    Justin Privitera, Fri Aug 19 20:57:38 PDT 2022
 //    We now throw an error if there are too many tags.
+// 
+//    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//    No limit on the number of tags.
+//    Refactor allows for much cleaner interface for working with tag data.
+//    No need to collect indices of tags anymore due to refactor.
+//    Calculate refcount for each tag on the very first iteration through.
 //
 // ****************************************************************************
 
@@ -886,6 +903,11 @@ QvisColorTableWindow::AddGlobalTag(std::string currtag, bool first_time)
 //    Renamed `run_before` to `first_time`.
 //    Added guard to make sure code to fill tag table and tag list
 //    is only run as much as it needs to be run.
+// 
+//    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//    Run the tag table generation the first time so we can set up the tagInfo
+//    map.
+//    Purge tagList and tagTable entries that have 0 refcount.
 //
 // ****************************************************************************
 
@@ -984,6 +1006,10 @@ QvisColorTableWindow::UpdateTags()
 // 
 //   Justin Privitera, Wed Aug  3 19:46:13 PDT 2022
 //   The tag line edit only needs to be populated if searching is disabled.
+// 
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Rework for accessing tag information b/c of refactor.
+//   Fix so current CT can never be set to one that is not in the CT name box.
 //
 // ****************************************************************************
 
@@ -2047,6 +2073,9 @@ QvisColorTableWindow::equalSpacingToggled(bool)
 //   Justin Privitera, Wed Jul 20 14:18:20 PDT 2022
 //   Added error if users try to add a color table while searching is enabled.
 //
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Update tag refcount on creation of a new CT.
+//
 // ****************************************************************************
 
 void
@@ -2131,6 +2160,12 @@ QvisColorTableWindow::addColorTable()
 //
 //    Justin Privitera, Wed Jul 20 14:18:20 PDT 2022
 //    Error when deleting a CT while searching is enabled.
+// 
+//    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//    Error when attempting to delete a CT when there are no CTs.
+//    Error when attempting to delete a CT when one is not selected.
+//    Error when attempting to delete the last continuous or discrete CT.
+//    Update tag refcount before deleting CT.
 // 
 // ****************************************************************************
 
@@ -2257,6 +2292,9 @@ QvisColorTableWindow::highlightColorTable(QTreeWidgetItem *current,
 // Creation:   Mon Jun  6 14:02:16 PDT 2022
 //
 // Modifications:
+//    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//    The secret tag table column is gone; there is no need to read the index
+//    from it anymore. We can use the map instead.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -805,7 +805,8 @@ void
 QvisColorTableWindow::AddToTagTable(std::string currtag)
 {
     QTreeWidgetItem *item = new QTreeWidgetItem(tagTable);
-    item->setCheckState(0, tagInfo[currtag].active ? Qt::Checked : Qt::Unchecked);
+    tagList[currtag].tagTableItem = item;
+    item->setCheckState(0, tagList[currtag].active ? Qt::Checked : Qt::Unchecked);
     item->setText(1, currtag.c_str());
 }
 
@@ -833,11 +834,11 @@ void
 QvisColorTableWindow::AddGlobalTag(std::string currtag, bool first_time)
 {
     // if the given tag is NOT in the global tag list
-    if (tagInfo.find(currtag) == tagInfo.end())
+    if (tagList.find(currtag) == tagList.end())
     {
-        tagInfo[currtag];
+        tagList[currtag];
         // make the "Standard" tag active the very first time the tags are enabled
-        tagInfo[currtag].active = currtag == "Standard" && first_time;
+        tagList[currtag].active = currtag == "Standard" && first_time;
         AddToTagTable(currtag);
     }
     else
@@ -969,7 +970,7 @@ QvisColorTableWindow::UpdateNames()
         {
             bool tagFound = false;
             // go thru global tags
-            for (const auto& mapitem : tagInfo)
+            for (const auto& mapitem : tagList)
             {
                 // if the global tag is active
                 if (mapitem.second.active)
@@ -2169,7 +2170,7 @@ QvisColorTableWindow::highlightColorTable(QTreeWidgetItem *current,
 void
 QvisColorTableWindow::tagTableItemSelected(QTreeWidgetItem *item, int column)
 {
-    tagInfo[item->text(1).toStdString()].active = item->checkState(0) == Qt::Checked;
+    tagList[item->text(1).toStdString()].active = item->checkState(0) == Qt::Checked;
     UpdateNames();
     colorAtts->SetChangesMade(true);
     ctObserver.SetUpdate(true);

--- a/src/gui/QvisColorTableWindow.h
+++ b/src/gui/QvisColorTableWindow.h
@@ -100,6 +100,11 @@ public:
 //   `searchingOn`, QString `searchTerm`, QCheckBox `searchToggle`, and 
 //   functions `searchingToggled` and `searchEdited`.
 // 
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Added `TagInfo` class to store tag info all in one place.
+//   I removed the tagList and activeTags stringVectors and replaced them with
+//   the new tagList, which is a map from tagnames to `TagInfo`s.
+// 
 // ****************************************************************************
 
 class GUI_API QvisColorTableWindow : public QvisPostableWindowObserver

--- a/src/gui/QvisColorTableWindow.h
+++ b/src/gui/QvisColorTableWindow.h
@@ -31,13 +31,13 @@ class QvisColorSelectionWidget;
 class QvisColorGridWidget;
 class QvisNoDefaultColorTableButton;
 
-// TODO make a class instead so we can have default vals
-typedef struct TagMetaData
+class TagInfo
 {
-    bool active;
-    int numrefs;
-    QTreeWidgetItem *tagTableItem;
-} TagInfo;
+public:
+    bool active = false;
+    int numrefs = 0;
+    QTreeWidgetItem *tagTableItem = nullptr;
+};
 
 // ****************************************************************************
 // Class: QvisColorTableWindow

--- a/src/gui/QvisColorTableWindow.h
+++ b/src/gui/QvisColorTableWindow.h
@@ -31,6 +31,13 @@ class QvisColorSelectionWidget;
 class QvisColorGridWidget;
 class QvisNoDefaultColorTableButton;
 
+typedef struct TagMetaData
+{
+    bool active;
+    int numrefs;
+    QTreeWidgetItem *tagTableItem;
+} TagInfo;
+
 // ****************************************************************************
 // Class: QvisColorTableWindow
 //
@@ -115,7 +122,7 @@ protected:
     void UpdateColorControlPoints();
     void UpdateDiscreteSettings();
     void AddGlobalTag(std::string currtag, bool run_before);
-    void AddToTagTable(std::string currtag, int index);
+    void AddToTagTable(std::string currtag);
     void UpdateTags();
     void UpdateNames();
     void Apply(bool ignore = false);
@@ -165,8 +172,7 @@ private:
     QString                  currentColorTable;
     int                      popupMode;
     bool                     sliding;
-    stringVector             tagList;
-    std::vector<bool>        activeTags;
+    std::map<std::string, TagInfo> tagInfo;
     bool                     tagsVisible;
     bool                     tagsMatchAny;
     bool                     searchingOn;

--- a/src/gui/QvisColorTableWindow.h
+++ b/src/gui/QvisColorTableWindow.h
@@ -31,6 +31,7 @@ class QvisColorSelectionWidget;
 class QvisColorGridWidget;
 class QvisNoDefaultColorTableButton;
 
+// TODO make a class instead so we can have default vals
 typedef struct TagMetaData
 {
     bool active;
@@ -172,7 +173,7 @@ private:
     QString                  currentColorTable;
     int                      popupMode;
     bool                     sliding;
-    std::map<std::string, TagInfo> tagInfo;
+    std::map<std::string, TagInfo> tagList;
     bool                     tagsVisible;
     bool                     tagsMatchAny;
     bool                     searchingOn;

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -29,7 +29,14 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed an issue with the Tag Bar in the Manager portion of the Color Table Window that caused it to display incorrect information while using the search feature.</li>
   <li>Color Table buttons now correctly preserve their value if the selected table has been filtered out of the list of color tables.</li>
   <li>Resolved a rare issue with the default color table buttons that caused them to occasionally select a different color table if tagging and searching were enabled at the same time.</li>
-  <li>An error is now thrown if the number of color table tags exceeds capacity. VisIt can support up to 9999 tags.</li>
+  <li>Fixed a bug where the default continuous and default discrete color table buttons no longer reflected accurate information when large numbers of color tables were deleted.</li>
+  <li>Fixed a bug where if a user deleted the final continuous/discrete color table in a filtering selection, the default continuous/discrete button did not update to a fall-back color table.</li>
+  <li>Fixed an issue where the default continuous and discrete color table buttons had a different idea of what the default color tables were than other parts of VisIt.</li>
+  <li>Added a guard so it is impossible to delete the last continuous or last discrete color table.</li>
+  <li>Fixed a bug where it was possible to select a color table that was not in the tag-filtered list of color tables.</li>
+  <li>Fixed a crash caused by deleting a color table that was not in the filtered list of color tables.</li>
+  <li>Fixed a crash caused by clicking the delete button when no more color tables were in the filtered list.</li>
+
 </ul>
 
 <a name="Enhancements"></a>
@@ -41,6 +48,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added support for MFEM Low Order Refinement of piece-wise constant (L2) basis functions.</li>
   <li>The x ray image query now outputs result messages in the case of failure while running in batch mode.</li>
   <li>The Tag Bar in the Manager portion of the Color Table Window is now always visible, instead of only being visible when tag filtering was enabled.</li>
+  <li>Color Table Tags are now deleted once no more color tables are associated with them.</li>
+  <li>There is no longer a limit to the number of color table tags VisIt supports.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -5077,6 +5077,10 @@ ViewerSubject::HandleSILAttsUpdated(const string &host,
 //   Justin Privitera, Wed Jul 13 15:24:42 PDT 2022
 //   Added `setColorTableAttributes` call for the QvisColorTableButton and
 //   QvisNoDefaultColorTableButton.
+// 
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Added the missing logic from the ctObserver. Now we check if a CT is 
+//   "active" before trying to put it in the buttons.
 //
 // ****************************************************************************
 

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -5105,10 +5105,14 @@ ViewerSubject::HandleColorTable()
 
             int nNames = colorAtts->GetNumColorTables();
             const stringVector &names = colorAtts->GetNames();
+            const intVector &active = colorAtts->GetActive();
             for(int i = 0; i < nNames; ++i)
             {
-                QvisColorTableButton::addColorTable(names[i].c_str());
-                QvisNoDefaultColorTableButton::addColorTable(names[i].c_str());
+                if (active[i])
+                {
+                    QvisColorTableButton::addColorTable(names[i].c_str());
+                    QvisNoDefaultColorTableButton::addColorTable(names[i].c_str());
+                }
             }
 
             // Update all of the QvisColorTableButton widgets.

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -239,6 +239,10 @@ debug1 <<"    ctName: " << ctName.toStdString() << endl;
         // if this color table was deleted
         if (colorTableAtts->GetColorTableIndex(ctName.toStdString()) == -1)
         {
+            if (buttonType == CONT)
+                colorTableAtts->SetDefaultContinuous(colorTableNames[buttonType][0].toStdString());
+            else
+                colorTableAtts->SetDefaultDiscrete(colorTableNames[buttonType][0].toStdString());
             colorTable = colorTableNames[buttonType][0];
             setText(colorTable);
             setToolTip(colorTable);
@@ -522,8 +526,12 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
                         // Does this color table match the type of this button?
                         if (colorTableAtts->GetColorTables(i).GetDiscreteFlag() == myButtonType)
                         {
-                            QString myColorTable{colorTableAtts->GetNames()[i].c_str()};
-                            buttons[i]->setColorTable(myColorTable);
+                            std::string myColorTable{colorTableAtts->GetNames()[i]};
+                            if (myButtonType == CONT)
+                                colorTableAtts->SetDefaultContinuous(myColorTable);
+                            else
+                                colorTableAtts->SetDefaultDiscrete(myColorTable);
+                            buttons[i]->setColorTable(QString(myColorTable.c_str()));
                             break;
                         }
                     }
@@ -531,7 +539,14 @@ QvisNoDefaultColorTableButton::updateColorTableButtons()
                 // Else there are CTs here of the correct type
                 else
                 {
+                    // This code might *seem* redundant, but it ensures `setColorTable`
+                    // hits the first case, instead of it having to go through
+                    // 3 conditions to get to the right behavior.
                     QString myColorTable{colorTableNames[myButtonType][0]};
+                    if (myButtonType == CONT)
+                        colorTableAtts->SetDefaultContinuous(myColorTable.toStdString());
+                    else
+                        colorTableAtts->SetDefaultDiscrete(myColorTable.toStdString());
                     buttons[i]->setColorTable(myColorTable);
                 }
             }

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -217,6 +217,10 @@ QvisNoDefaultColorTableButton::sizePolicy() const
 //    Justin Privitera, Wed Aug  3 19:46:13 PDT 2022
 //    Added logic to prevent CT from being changed when CT passed out of the 
 //    tag filtering selection.
+// 
+//    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//    Logic was added to ensure no desync with the color table atts and to
+//    react to color tables outside the filtering selection.
 //
 // ****************************************************************************
 
@@ -498,6 +502,11 @@ QvisNoDefaultColorTableButton::addColorTable(const QString &ctName)
 // 
 //   Justin Privitera, Wed Jul 13 15:19:47 PDT 2022
 //   Added call to getbuttontype() to specify which button.
+// 
+//   Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
+//   Guards are in place now to protect the buttons from falling out of sync
+//   with the color table attributes and to ensure that they always represent
+//   valid color table choices.
 //   
 // ****************************************************************************
 


### PR DESCRIPTION
### Description

Resolves #17921 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
It's that time again... This PR deals with a number of color table fixes and features for 3.3.1:

Features:
 - Tags are now deleted once no more color tables are associated with them.
 - There is no longer a limit to the number of tags visit supports.
 - There has been a refactor of the tag data structures into a unified structure.

Bugfixes:
 - Fixed a bug where the default continuous and default discrete color table buttons no longer reflected accurate information when large numbers of color tables were deleted.
 - Fixed a bug where if a user deleted the final continuous/discrete color table in a filtering selection, the default continuous/discrete button did not update to a fall-back color table.
 - Fixed a desync between what the default discrete and continuous CT buttons believe the default discrete and continuous color tables are and what the color table attributes object thinks they are.
 - Added a guard so it is impossible to delete the last continuous or last discrete color table.
 - Fixed a bug where it was possible to select a color table that was not in the filtered list of color tables.
 - Fixed a crash caused by deleting a color table that was not in the filtered list of color tables.
 - Fixed a crash caused by clicking the delete button when no more color tables were in the filtered list.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
