### PR TITLE
Fix Find module for Nektar++ to support version 5.0.0 built from build_visit

### DIFF
--- a/src/CMake/FindNektar++.cmake
+++ b/src/CMake/FindNektar++.cmake
@@ -7,6 +7,12 @@
 #   Kathleen Biagas, Fri Mar 17 10:27:23 PDT 2017
 #   Set HAVE_NETKAR_PP if NEKTAR++_FOUND.
 #
+#   Kathleen Biagas, Mon Sep 12, 2022
+#   Support Nektar 5.0.0 (version used in build_visit).
+#   There are fewer libraries built.
+#   Cleaned up find_package call that is necessary to pick up the nektar++
+#   defined CMakeVariables. 
+#
 #****************************************************************************/
 
 # Use the NEKTAR++_DIR hint from the config-site .cmake file 
@@ -14,49 +20,45 @@
 #MESSAGE(STATUS "  NEKTAR++_VERSION=${NEKTAR++_VERSION}")
 #MESSAGE(STATUS "  VISIT_NEKTAR++_DIR=${VISIT_NEKTAR++_DIR}")
 
-# The libraries as of Nektar++ 4.4
-SET(NEKTAR++_LIBRARIES LibUtilities
-		       StdRegions
-		       SpatialDomains
-		       LocalRegions
-		       MultiRegions 
-		       Collections
-		       GlobalMapping
-		       FieldUtils)
+set(NEKTAR++_LIBRARIES
+       Collections
+       LibUtilities
+       LocalRegions
+       MultiRegions
+       SpatialDomains
+       StdRegions)
 
-If( EXISTS ${VISIT_NEKTAR++_DIR} )
+# if NEKTAR++_VERSION not defined, will assume latest from build_visit, which is 5.0.0
+# otherwise check the version number
+if(DEFINED NEKTAR++_VERSION AND NEKTAR++_VERSION VERSION_LESS "5.0.0")
+    # Additional libraries for Nektar++ 4.4
+    list(APPEND NEKTAR++_LIBRARIES
+            FieldUtils
+            GlobalMapping)
+endif()
 
-    IF(EXISTS ${VISIT_NEKTAR++_DIR}/${LIB}/nektar++/cmake/NEKTAR++Config.cmake)
-        SET(NEKTAR++_DIR ${VISIT_NEKTAR++_DIR})
-    ENDIF()
+if(EXISTS ${VISIT_NEKTAR++_DIR})
+    # need to call find_package to pick up CMake vars defined in Nektar++'s config .cmake files
+    find_package(Nektar++ NO_MODULE PATHS ${VISIT_NEKTAR++_DIR})
 
-    MESSAGE(STATUS "Checking for Nektar++ in ${NEKTAR++_DIR}/${LIB}/nektar++/cmake")
+    # message(STATUS "  NEKTAR++_INCLUDE_DIRS=${NEKTAR++_INCLUDE_DIRS}")
+    # message(STATUS "  NEKTAR++_TP_INCLUDE_DIRS=${NEKTAR++_TP_INCLUDE_DIRS}")
+    # message(STATUS "  NEKTAR++_LIBRARY_DIRS=${NEKTAR++_LIBRARY_DIRS}")
+    # message(STATUS "  NEKTAR++_TP_LIBRARY_DIRS=${NEKTAR++_TP_LIBRARY_DIRS}")
+    # message(STATUS "  NEKTAR++_DEFINITIONS=${NEKTAR++_DEFINITIONS}")
+endif()
 
-    #  Find Nektar++
-    set(CMAKE_PREFIX_PATH ${VISIT_NEKTAR++_DIR}/${LIB}/nektar++/cmake ${CMAKE_PREFIX_PATH})
-    set(CMAKE_LIBRARY_PATH ${VISIT_NEKTAR++_DIR}/${LIB}/nektar++ ${CMAKE_LIBRARY_PATH})
+include(${VISIT_SOURCE_DIR}/CMake/SetUpThirdParty.cmake)
 
-    FIND_PACKAGE(Nektar++)
-#    FIND_PACKAGE(NEKTAR++ 5.0.0 REQUIRED PATHS ${NEKTAR++_DIR})
-
-#    MESSAGE(STATUS "  NEKTAR++_INCLUDE_DIRS=${NEKTAR++_INCLUDE_DIRS}")
-#    MESSAGE(STATUS "  NEKTAR++_TP_INCLUDE_DIRS=${NEKTAR++_TP_INCLUDE_DIRS}")
-#    MESSAGE(STATUS "  NEKTAR++_LIBRARY_DIRS=${NEKTAR++_LIBRARY_DIRS}")
-#    MESSAGE(STATUS "  NEKTAR++_TP_LIBRARY_DIRS=${NEKTAR++_TP_LIBRARY_DIRS}")
-
-#    MESSAGE(STATUS "  NEKTAR++_DEFINITIONS=${NEKTAR++_DEFINITIONS}")
-ENDIF()
-
-INCLUDE(${VISIT_SOURCE_DIR}/CMake/SetUpThirdParty.cmake)
-
+# this will 'find' the Nektar++ libraries and also set them up for installation
 SET_UP_THIRD_PARTY(NEKTAR++
     INCDIR include/nektar++
     LIBS ${NEKTAR++_LIBRARIES}
     )
 
-IF(NEKTAR++_FOUND)
-    SET(HAVE_NEKTAR_PP true CACHE BOOL "Have Nektar++ lib")
+if(NEKTAR++_FOUND)
+    set(HAVE_NEKTAR_PP true CACHE BOOL "Have Nektar++ lib")
 else()
     unset(NEKTAR++_LIBRARIES)
-ENDIF(NEKTAR++_FOUND)
+endif(NEKTAR++_FOUND)
 

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -61,6 +61,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with <code>FindVTKh.cmake</code> where it wouldn't install the shared libraries when VTK-h was built with <code>spack</code>.</li>
   <li>Fixed build errors where avtqueries need '-lrt' on Linux, and visitpy needed thread libs.</li>
   <li>Removed --hdf4 as an option from build_visit.</li>
+  <li>Fixed VisIt's find module for Nektar++ so it will correctly find the 5.0.0 version built by build_visit.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Resolves #18056.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I ran build_visit with --all-io, then built visit 3.3RC against the libraries that were built, nektar was found successfully and VisIt's compilation succeeded.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
