### PR TITLE
Fix OpenDatabase call in quickrecipes/expressions so the test can run on Windows.

### DIFF
--- a/src/test/tests/quickrecipes/expressions.py
+++ b/src/test/tests/quickrecipes/expressions.py
@@ -7,6 +7,9 @@
 #  Date:       August 26, 2022
 #
 #  Modificatons:
+#    Kathleen Biagas, Mon Sep 12, 2022
+#    Change OpenDatabase call to use 'silo_data_path' so that the test can
+#    run on Windows.
 #
 # ----------------------------------------------------------------------------
 
@@ -48,7 +51,7 @@ mat_val_pairs = [(1, 0.75), (3, 1.2), (6, 0.2), (7, 1.6), (8, 1.8), (11, 2.2), (
 create_mat_value_expr("myvar", "mat1", "quadmesh2d", mat_val_pairs)
 
 # Create a pseudocolor plot of the expression.
-OpenDatabase("/usr/gapps/visit/data/rect2d.silo")
+OpenDatabase(silo_data_path("rect2d.silo"))
 AddPlot("Pseudocolor", "myvar")
 DrawPlots()
 # mapMaterialsToValues }


### PR DESCRIPTION
### Description
Use 'silo_data_path' instead of '/user/gapps/visit/data/'

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?
Ran the test successfully on Windows.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
