### PR TITLE
Add qt patch to fix compile error on Arch Linux.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -63,6 +63,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed build errors where avtqueries need '-lrt' on Linux, and visitpy needed thread libs.</li>
   <li>Removed --hdf4 as an option from build_visit.</li>
   <li>Fixed VisIt's find module for Nektar++ so it will correctly find the 5.0.0 version built by build_visit.</li>
+  <li>Added a patch to build_visit so that Qt 5.14.2 will build on Arch Linux systems using gcc 12.2.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -278,6 +278,10 @@ function apply_qt_patch
         if [[ $? != 0 ]] ; then
             return 1
         fi
+        apply_qt_5142_cmath_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
         if [[ "$OPSYS" == "Linux" ]]; then
             if [[ "$DO_MESAGL" == "yes" ]] ; then
                 apply_qt_5142_linux_mesagl_patch
@@ -537,6 +541,32 @@ diff -c qtbase/src/corelib/text/qbytearraymatcher.h.orig c qtbase/src/corelib/te
 EOF
     if [[ $? != 0 ]] ; then
         warn "qt 5.14.2 for numeric-limits patch3 failed"
+        return 1
+    fi
+
+    return 0
+}
+
+function apply_qt_5142_cmath_patch
+{
+    info "Patching qt 5.14.2 for qjp2handler cmath include"
+    patch -p0 <<EOF
+diff -c qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp.orig qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp
+*** qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp.orig
+--- qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp
+***************
+*** 45,50 ****
+--- 45,51 ----
+  #include "qcolor.h"
+
+  #include <jasper/jasper.h>
++ #include <cmath>
+
+  QT_BEGIN_NAMESPACE
+
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.14.2 for qjp2handler cmath include"
         return 1
     fi
 


### PR DESCRIPTION
### Description
qjp2handler.cpp needs `#include <cmath>`.
Resolves #17841.


### Type of change

<!-- Please check one of the boxes below -->

~~* [ ] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
* [X] Other~~ <!-- please explain with a note below -->
  Fix build error.

### How Has This Been Tested?

I ran build_visit and ensure the patch was applied correctly.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
