### PR TITLE
uncomment xrayquery conduit error test (fix bad baseline) (#18078) (#18079)

### DIFF
--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -460,6 +460,9 @@ DrawPlots()
 
 Query("XRay Image", "hdf5", outdir_bad, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
 s = GetQueryOutputString()
+# strip out two lines that make the test machine dependent
+s = '\n'.join([line if line[:4] != "file" else '' for line in s.split('\n')])
+s = '\n'.join([line if line[:4] != "line" else '' for line in s.split('\n')])
 TestText("xrayimage36", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))

--- a/test/baseline/queries/xrayimage/xrayimage36.txt
+++ b/test/baseline/queries/xrayimage/xrayimage36.txt
@@ -1,6 +1,6 @@
 engine_ser: Conduit Exception in X Ray Image Query Execute: 
 
-file: /usr/workspace/justin/build_containers/3.3RC/conduit-v0.8.3/src/libs/relay/conduit_relay_io_hdf5.cpp
-line: 3002
+
+
 message: 
 HDF5 Error code-1 Error opening HDF5 file for writing: /tmp/baddir/output.cycle_000048.root


### PR DESCRIPTION
### Description

Resolves #17970 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

Same description as #18078 but I fixed the bad baseline and slightly modified the test to reflect that.

The test only passed on my system before, now it should pass everywhere.

These changes are already on develop as I found it there and fixed it there.
