### PR TITLE
Add qt patch to fix compile error on Arch Linux. (#18082)

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -63,6 +63,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed build errors where avtqueries need '-lrt' on Linux, and visitpy needed thread libs.</li>
   <li>Removed --hdf4 as an option from build_visit.</li>
   <li>Fixed VisIt's find module for Nektar++ so it will correctly find the 5.0.0 version built by build_visit.</li>
+  <li>Added a patch to build_visit so that Qt 5.14.2 will build on Arch Linux systems using gcc 12.2.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -278,6 +278,10 @@ function apply_qt_patch
         if [[ $? != 0 ]] ; then
             return 1
         fi
+        apply_qt_5142_cmath_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
         if [[ "$OPSYS" == "Linux" ]]; then
             if [[ "$DO_MESAGL" == "yes" ]] ; then
                 apply_qt_5142_linux_mesagl_patch
@@ -537,6 +541,32 @@ diff -c qtbase/src/corelib/text/qbytearraymatcher.h.orig c qtbase/src/corelib/te
 EOF
     if [[ $? != 0 ]] ; then
         warn "qt 5.14.2 for numeric-limits patch3 failed"
+        return 1
+    fi
+
+    return 0
+}
+
+function apply_qt_5142_cmath_patch
+{
+    info "Patching qt 5.14.2 for qjp2handler cmath include"
+    patch -p0 <<EOF
+diff -c qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp.orig qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp
+*** qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp.orig
+--- qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp
+***************
+*** 45,50 ****
+--- 45,51 ----
+  #include "qcolor.h"
+
+  #include <jasper/jasper.h>
++ #include <cmath>
+
+  QT_BEGIN_NAMESPACE
+
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.14.2 for qjp2handler cmath include"
         return 1
     fi
 


### PR DESCRIPTION
### Description

qjp2handler.cpp needs to #include <cmath>.
Resolves #17841.

Merge from 3.3RC.