### PR TITLE
Get init coords from mc_load_nodes

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2621,6 +2621,7 @@ avtMiliFileFormat::AddMiliVariableToMetaData(avtDatabaseMetaData *avtMD,
 //      Only add pressure for stress.
 //
 //      Mark C. Miller, Wed Sep 14 23:28:17 PDT 2022
+//      Handle displacements only on main mesh.
 //      Just define the existence of init_mesh_coords vector variable here.
 // ****************************************************************************
 
@@ -2644,11 +2645,12 @@ avtMiliFileFormat::AddMiliDerivedVariables(avtDatabaseMetaData *md,
 
     //
     // First, check if node displacement exists. If not, add it now.
+    // Do this only for the main mesh, not the sand mesh.
     //
     MiliVariableMetaData *noddisp = miliMetaData[meshId]->
         GetVarMDByShortName("noddisp", "node");
 
-    if (noddisp == NULL)
+    if (meshPath == "" && noddisp == NULL)
     {
         //
         // Node displacement is the difference between the node positions

--- a/src/resources/help/en_US/relnotes3.3.1.html
+++ b/src/resources/help/en_US/relnotes3.3.1.html
@@ -39,6 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed an issue with the x ray image query that caused rays to sometimes be cast incorrectly when specifying non-square output.</li>
   <li>Added a patch for the Mili plugin that increases the maximum path length for input files from 300 to 4096 characters.</li>
   <li>The widget for displaying Blueprint export options was improved to use a fixed-width font and ensure newlines are preserved.</li>
+  <li>Mili plugin correctly computes displacements from the initial coordinates (via <code>mc_load_nodes()</code> from the Mili A file). Previously, it was computing displacements relative to the nodal positions (<code>nodpos</code> variable) at the initial timestep.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #18091 

In Mili files, there are two possible sources for coordinate data; the *initial* coordinates and the `nodpos` results subrecord. The *initial* coords are not read as a Mili subrecord. Instead, they are read via `mc_load_nodes`. 

Some Mili files contain only the *initial* coordinates. Others contain both. Typically, the *only* reason for ever using the *initial* coordinates in a Mili file is for computing *displacements*. When computed that way, it is `nodpos - initial_coords`. As an aside, some Mili data producers can also compute and write explicit displacements to the file as `noddisp` results subrecord.

Previously, the plugin was defining `init_mesh_coords` as `conn_cmfe(<[0]i:coords>,<mesh1>)` where `coords` was defined as `coord(mesh1)` and is wrong because it then uses `nodpos` at time zero as `init_mesh_coords`. This update corrects that and simply *announces* `init_mesh_coords` exists as a *vector* variable in `avtMiliFileFormat::PopulateDatabaseMetadata` and then adds special-case logic to `avtMiliFileFormat::GetVectorVar` to use the data obtained from `mc_load_nodes` if the requested variable is `init_mesh_coords`.

Note that because of the way Mili handles this, a Mili file with *only* initial coordinates and no `nodpos` subrecord as well as a Mili file *with* initial coordinates and a `nodpos` subrecord of size 1 (e.g. only 1 time instance of that field) are both single timestep databases. The only difference between the two is that in the former, *displacements* are non-sensical...there are no displacements...only initial coordinates.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Manually in my checkout

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
