### PR TITLE
init coords on sand mesh (#18105)

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -1778,6 +1778,8 @@ avtMiliFileFormat::GetVar(int timestep,
 //  Mark C. Miller, Wed Sep 14 23:29:22 PDT 2022
 //  Add logic to handle get for init_mesh_coords.
 //
+//  Mark C. Miller, Fri Sep 16 11:28:10 PDT 2022
+//  Support init_mesh_coords on main mesh and sand mesh.
 // ****************************************************************************
 
 vtkDataArray *
@@ -1788,7 +1790,7 @@ avtMiliFileFormat::GetVectorVar(int timestep,
     int gvvTimer = visitTimer->StartTimer();
     int meshId   = ExtractMeshIdFromPath(varPath);
 
-    if (string(varPath) == "Primal/node/init_mesh_coords")
+    if (string(varPath).find("Primal/node/init_mesh_coords") != std::string::npos)
     {
         if (!datasets[dom][meshId] && datasets[dom][meshId]->GetPoints() == NULL)
         {
@@ -2629,6 +2631,9 @@ avtMiliFileFormat::AddMiliVariableToMetaData(avtDatabaseMetaData *avtMD,
 //      Mark C. Miller, Wed Sep 14 23:28:17 PDT 2022
 //      Handle displacements only on main mesh.
 //      Just define the existence of init_mesh_coords vector variable here.
+//
+//      Mark C. Miller, Fri Sep 16 11:26:22 PDT 2022
+//      Handle displacements on sand mesh too...they are same as main mesh.
 // ****************************************************************************
 
 void
@@ -2656,7 +2661,7 @@ avtMiliFileFormat::AddMiliDerivedVariables(avtDatabaseMetaData *md,
     MiliVariableMetaData *noddisp = miliMetaData[meshId]->
         GetVarMDByShortName("noddisp", "node");
 
-    if (meshPath == "" && noddisp == NULL)
+    if (noddisp == NULL)
     {
         //
         // Node displacement is the difference between the node positions


### PR DESCRIPTION
Fix test suite...handle displacements on sand mesh too. In Mili, the sand mesh is just the main mesh but possibly with some elements ghosted out. So, we serve the same data for initial coordinates in either case. In prev. update, I restricted initial mesh coordinates to only the main mesh and that was incorrect.