### PR TITLE
add parallel baselines for x ray query tests

### DIFF
--- a/test/baseline/queries/xrayimage/parallel/xrayimage36.txt
+++ b/test/baseline/queries/xrayimage/parallel/xrayimage36.txt
@@ -1,0 +1,6 @@
+engine_par: Conduit Exception in X Ray Image Query Execute: 
+
+
+
+message: 
+HDF5 Error code-1 Error opening HDF5 file for writing: /tmp/baddir/output.cycle_000048.root

--- a/test/baseline/queries/xrayimage/scalable_parallel_icet/xrayimage36.txt
+++ b/test/baseline/queries/xrayimage/scalable_parallel_icet/xrayimage36.txt
@@ -1,0 +1,6 @@
+engine_par: Conduit Exception in X Ray Image Query Execute: 
+
+
+
+message: 
+HDF5 Error code-1 Error opening HDF5 file for writing: /tmp/baddir/output.cycle_000048.root


### PR DESCRIPTION
This should fix the failing parallel tests.

I have added new baselines that match the output from the test suite run last night.