### PR TITLE
Fix regression skip path

### DIFF
--- a/src/test/py_src/visit_test_suite.py
+++ b/src/test/py_src/visit_test_suite.py
@@ -508,12 +508,17 @@ def finalize_options(opts):
     if isinstance(opts["classes"],str):
         opts["classes"]  = opts["classes"].split(",")
     opts["skip_list"]    = None
-    if not opts["skip_file"] is None and os.path.isfile(opts["skip_file"]):
-        try:
-            if opts["no_skip"] == False:
-                opts["skip_list"] = json_load(opts["skip_file"])
-        except:
-            opts["skip_list"] = None
+
+    if not opts["skip_file"] is None:
+        if not os.path.isfile(opts["skip_file"]):
+            opts["skip_file"] = abs_path(opts["tests_dir"], "../", "skip.json")
+        if os.path.isfile(opts["skip_file"]):
+            try:
+                if opts["no_skip"] == False:
+                    opts["skip_list"] = json_load(opts["skip_file"])
+            except:
+                opts["skip_list"] = None
+
 
 # ----------------------------------------------------------------------------
 #  Method: parse_args
@@ -1079,6 +1084,7 @@ def main(opts,tests):
     """
     Main entry point for the test suite.
     """
+    print("visit_test_suite.py :main")
     finalize_options(opts)
     Log("[[VisIt Test Suite]]")
     if opts["check_data"]:

--- a/src/test/skip.json
+++ b/src/test/skip.json
@@ -16,6 +16,8 @@
                     {"platform":"win", "category":"hybrid","file":"field_operators.py","cases":["field_op_04"]},
                     {"platform":"win", "category":"hybrid","file":"selection_pp.py"},
                     {"platform":"win", "category":"plugins"},
+                    {"platform":"win", "category":"queries","file":"flatten.py","cases":["multi_rect2d_box_nodes","multi_rect2d_box_zones"]},
+                    {"platform":"win", "category":"queries","file":"xrayimage.py"},
                     {"platform":"win", "category":"simulation","file":"batch.py"},
                     {"platform":"win", "category":"simulation","file":"csg.py"},
                     {"platform":"win", "category":"simulation","file":"curve.py"},


### PR DESCRIPTION
### Description

skip_file is set based on a skip_def (default skip path), which isn't being set correctly. Added a kludge that if skip_file doesn't exist, try a path relative to opts["tests_dir"], which should be set correctly by the time we try to read skip_file.

Also modified skip.json to add xrayimage test, and a few flatten cases to Windows skip list until the issues with those tests can be resolved.

I tried running a single test that is part of the skip list, and the test didn't run.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~
