### PR TITLE
Fix regression skip_file path. (#18138)

### DIFF
--- a/src/test/py_src/visit_test_suite.py
+++ b/src/test/py_src/visit_test_suite.py
@@ -508,12 +508,17 @@ def finalize_options(opts):
     if isinstance(opts["classes"],str):
         opts["classes"]  = opts["classes"].split(",")
     opts["skip_list"]    = None
-    if not opts["skip_file"] is None and os.path.isfile(opts["skip_file"]):
-        try:
-            if opts["no_skip"] == False:
-                opts["skip_list"] = json_load(opts["skip_file"])
-        except:
-            opts["skip_list"] = None
+
+    if not opts["skip_file"] is None:
+        if not os.path.isfile(opts["skip_file"]):
+            opts["skip_file"] = abs_path(opts["tests_dir"], "../", "skip.json")
+        if os.path.isfile(opts["skip_file"]):
+            try:
+                if opts["no_skip"] == False:
+                    opts["skip_list"] = json_load(opts["skip_file"])
+            except:
+                opts["skip_list"] = None
+
 
 # ----------------------------------------------------------------------------
 #  Method: parse_args
@@ -1079,6 +1084,7 @@ def main(opts,tests):
     """
     Main entry point for the test suite.
     """
+    print("visit_test_suite.py :main")
     finalize_options(opts)
     Log("[[VisIt Test Suite]]")
     if opts["check_data"]:

--- a/src/test/py_src/visit_test_suite.py
+++ b/src/test/py_src/visit_test_suite.py
@@ -1084,7 +1084,6 @@ def main(opts,tests):
     """
     Main entry point for the test suite.
     """
-    print("visit_test_suite.py :main")
     finalize_options(opts)
     Log("[[VisIt Test Suite]]")
     if opts["check_data"]:

--- a/src/test/skip.json
+++ b/src/test/skip.json
@@ -16,6 +16,8 @@
                     {"platform":"win", "category":"hybrid","file":"field_operators.py","cases":["field_op_04"]},
                     {"platform":"win", "category":"hybrid","file":"selection_pp.py"},
                     {"platform":"win", "category":"plugins"},
+                    {"platform":"win", "category":"queries","file":"flatten.py","cases":["multi_rect2d_box_nodes","multi_rect2d_box_zones"]},
+                    {"platform":"win", "category":"queries","file":"xrayimage.py"},
                     {"platform":"win", "category":"simulation","file":"batch.py"},
                     {"platform":"win", "category":"simulation","file":"csg.py"},
                     {"platform":"win", "category":"simulation","file":"curve.py"},


### PR DESCRIPTION
### Description
skip_file is set based on a skip_def (default skip path), which isn't being set correctly. Added a kludge that if skip_file isn't found, to use a path relative to tests_dir, which should be set correctly by the time we try to read skip_file.

Modified skip.json to add xrayimage test, and a few flatten cases to Windows skip list until the issues with those tests can be resolved.


Merge from 3.3RC