### PR TITLE
Change test_root_path to test_baseline_path in silo_datatypes.py test.

### DIFF
--- a/src/test/tests/databases/silo_datatypes.py
+++ b/src/test/tests/databases/silo_datatypes.py
@@ -34,6 +34,10 @@
 #
 #    Mark C. Miller, Thu Sep 23 21:23:42 PDT 2010
 #    Remove override of pass/fail for long long data since now using silo-4.8
+#
+#    Eric Brugger, Mon Sep 26 11:35:01 PDT 2022
+#    Changed use of test_root_path to more appropriate test_baseline_path.
+#
 # ----------------------------------------------------------------------------
 TurnOffAllAnnotations() # defines global object 'a'
 
@@ -131,9 +135,9 @@ for smode in ("hdf5", "pdb"):
                          file=filename
                          cur  = pjoin("silo_datatypes","current","%s.png" % filename)
                          diff = pjoin("silo_datatypes","diff","%s.png" % filename)
-                         base = test_root_path("baseline","databases",
-                                               "silo_datatypes",
-                                               "silo_datatypes_%s_%s.png"%(mt,fvarname))
+                         base = test_baseline_path("databases",
+                                                   "silo_datatypes",
+                                                   "silo_datatypes_%s_%s.png"%(mt,fvarname))
                          (tPixs, pPixs, dPixs, davg) = DiffUsingPIL(file, cur, diff, base, "")
                          result = "PASSED"
                          if (dPixs > 0 and davg > 1):


### PR DESCRIPTION
### Description

This fixes the test suite failures in `silo_datatypes.py` by changing uses of `test_root_path` to the more appropriate `test_baseline_path` function.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I copied the file to the test suite directory and ran that particular test and the test passed, whereas it didn't without the change.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
