### PR TITLE
Change /usr/workspace/wsa to /usr/WS1 in regressiontest_pascal.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -107,6 +107,12 @@
 #   Cyrus Harrison, Thu Sep  8 12:42:42 PDT 2022
 #   Use new entry point for visit testing module.
 #
+#   Eric Brugger, Wed Sep 28 10:11:32 PDT 2022
+#   Changed all paths using /usr/workspace/wsa to /usr/WS1 so that the
+#   launcher test would pass. They are both the same directory, but the
+#   current directory when running the tests needs to start with /usr/WS1
+#   for the launcher test to work properly.
+#
 
 # Determine the users name and e-mail address.
 #
@@ -174,7 +180,7 @@ branch="trunk"
 revision="latest"
 serial="false"
 testHost="pascal"
-testDir="/usr/workspace/wsa/visit"
+testDir="/usr/WS1/visit"
 post="true"
 nerscHost="cori.nersc.gov"
 
@@ -218,7 +224,7 @@ done
 
 if test "$branch" = "trunk" ; then
     workingDir="test_trunk"
-    cmakeCmd="/usr/workspace/wsa/visit/visit/thirdparty_shared/3.3.0/toss3/cmake/3.18.2/linux-x86_64_gcc-7.3/bin/cmake"
+    cmakeCmd="/usr/WS1/visit/visit/thirdparty_shared/3.3.0/toss3/cmake/3.18.2/linux-x86_64_gcc-7.3/bin/cmake"
 else
     workingDir="test_branch"
     cmakeCmd="/usr/gapps/visit/thirdparty_shared/3.2.0/cmake/3.14.7/linux-x86_64_gcc-6.1/bin/cmake"
@@ -509,7 +515,7 @@ if test "$post" = "true" ; then
     # Check the results into github.
     cd src/test
     newResults=\`ls -d *22:00\`
-    cd /usr/workspace/wsa/visit/dashboard/dashboard
+    cd /usr/WS1/visit/dashboard/dashboard
     git add \$newResults baselines index.html
     git commit -m "Add new results to the dashboard."
     git pull


### PR DESCRIPTION
### Description

Changed paths using `/usr/workspace/wsa` to `/usr/WS1` in `regressiontest_pascal`. The should fix the failures in the `launcher.py` test.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I manually ran the `launcher.py` test when using the /usr/workspace/wsa path and it failed and then when I changed it to /usr/WS1 and it worked. I haven't actually tested the modified script. That will get tested tonight when the test suite runs.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
