### PR TITLE
fix for bv_opsray vtk9 check and missing dependencies

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -64,6 +64,7 @@ function bv_ospray_depends_on
 
         depends_on="cmake"
    else
+        depends_on="cmake ispc embree"
         if [[ "$DO_TBB" == "yes" ]]; then
             depends_on="${depends_on} tbb"
         else

--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -169,7 +169,7 @@ function bv_ospray_is_enabled
 function bv_ospray_ensure
 {
     if [[ "$DO_OSPRAY" == "yes" && "$USE_SYSTEM_OSPRAY" == "no" ]]; then
-        if [[ "$DO_VTK9" ]]; then
+        if [[ "$DO_VTK9" == "yes" ]]; then
            ensure_built_or_ready "ospray" $OSPRAY_VERSION $OSPRAY_BUILD_DIR $OSPRAY_FILE $OSPRAY_URL
             if [[ $? != 0 ]] ; then
                 ANY_ERRORS="yes"


### PR DESCRIPTION
### Description

Resolves #18154 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
 - fixes a test in an if-statement that caused `bv_opsray` to use vtk9 logic when vtk9 was disabled.
 - adds back in missing dependencies for ospray when vtk9 is off.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
opsray downloads successfully with this change.
it also builds successfully with this change.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
