### PR TITLE
Fix auto + initializer list potential problem

### DIFF
--- a/src/avt/Expressions/Derivations/avtRelativeVolumeExpression.C
+++ b/src/avt/Expressions/Derivations/avtRelativeVolumeExpression.C
@@ -63,6 +63,6 @@ vtkDataArray *
 avtRelativeVolumeExpression::DeriveVariable (vtkDataSet *in_ds, 
                                              int currentDomainsIndex)
 {
-    auto do_vol_strain{false};
+    bool do_vol_strain{false};
     return avtStrainExpression::CalculateEvolOrRelvol(in_ds, do_vol_strain);
 }

--- a/src/avt/Expressions/Derivations/avtRelativeVolumeExpression.C
+++ b/src/avt/Expressions/Derivations/avtRelativeVolumeExpression.C
@@ -56,6 +56,8 @@ avtRelativeVolumeExpression::~avtRelativeVolumeExpression()
 //  Creation:   Fri Sep  9 10:37:12 PDT 2022
 //
 //  Modifications:
+//     Justin Privitera, Thu Sep 29 15:22:38 PDT 2022
+//     Replaced auto with bool.
 //
 // ****************************************************************************
 

--- a/src/avt/Expressions/Derivations/avtStrainVolumetricExpression.C
+++ b/src/avt/Expressions/Derivations/avtStrainVolumetricExpression.C
@@ -56,6 +56,8 @@ avtStrainVolumetricExpression::~avtStrainVolumetricExpression()
 //  Creation:   Fri Sep  9 10:37:12 PDT 2022
 //
 //  Modifications:
+//     Justin Privitera, Thu Sep 29 15:22:38 PDT 2022
+//     Replaced auto with bool.
 //
 // ****************************************************************************
 

--- a/src/avt/Expressions/Derivations/avtStrainVolumetricExpression.C
+++ b/src/avt/Expressions/Derivations/avtStrainVolumetricExpression.C
@@ -63,6 +63,6 @@ vtkDataArray *
 avtStrainVolumetricExpression::DeriveVariable (vtkDataSet *in_ds, 
                                              int currentDomainsIndex)
 {
-    auto do_vol_strain{true};
+    bool do_vol_strain{true};
     return avtStrainExpression::CalculateEvolOrRelvol(in_ds, do_vol_strain);
 }

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -907,6 +907,9 @@ QvisColorTableWindow::AddGlobalTag(std::string currtag, bool first_time)
 //    Justin Privitera, Fri Sep  2 16:46:21 PDT 2022
 //    Run the tag table generation the first time so we can set up the tagInfo
 //    map. Purge tagList and tagTable entries that have 0 refcount.
+// 
+//     Justin Privitera, Thu Sep 29 15:22:38 PDT 2022
+//     Replaced braces w/ equals to avoid init list behavior.
 //
 // ****************************************************************************
 
@@ -2166,6 +2169,8 @@ QvisColorTableWindow::addColorTable()
 //    Error when attempting to delete the last continuous or discrete CT.
 //    Update tag refcount before deleting CT.
 // 
+//     Justin Privitera, Thu Sep 29 15:22:38 PDT 2022
+//     Replaced braces w/ parens to avoid init list behavior.
 // ****************************************************************************
 
 void
@@ -2194,7 +2199,6 @@ QvisColorTableWindow::deleteColorTable()
     if (QTreeWidgetItem *item = nameListBox->currentItem())
     {
         std::string ctName = item->text(0).toStdString();
-        // TODO remove the `const_cast` on develop; this issue has been solved there.
         auto ccpl(const_cast<ColorControlPointList *>(colorAtts->GetColorControlPoints(ctName)));
         if (tagList["Continuous"].numrefs == 1 && ccpl->HasTag("Continuous"))
         {

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -942,7 +942,7 @@ QvisColorTableWindow::UpdateTags()
         first_time = false;
 
         // Purge tagList/tagTable entries that have 0 refcount.
-        for (auto itr{tagList.begin()}; itr != tagList.end();)
+        for (auto itr = tagList.begin(); itr != tagList.end();)
         {
             if (itr->second.numrefs <= 0)
             {
@@ -2195,7 +2195,7 @@ QvisColorTableWindow::deleteColorTable()
     {
         std::string ctName = item->text(0).toStdString();
         // TODO remove the `const_cast` on develop; this issue has been solved there.
-        auto ccpl{const_cast<ColorControlPointList *>(colorAtts->GetColorControlPoints(ctName))};
+        auto ccpl(const_cast<ColorControlPointList *>(colorAtts->GetColorControlPoints(ctName)));
         if (tagList["Continuous"].numrefs == 1 && ccpl->HasTag("Continuous"))
         {
             QString tmp;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
I've gotten myself into trouble with C++ again. TLDR, if you use `auto myvar{myval}`, `myvar` might end up as an array, depending on the compiler and the version of C++. This is a well-known idiosyncrasy of `auto` and initializer lists. I have addressed each instance of this on the RC (all of them added by me in the past) so that there is no more ambiguity.

No errors have been reported thus far with any instance of this, and all tests pass without making any changes, but the syntax _is_ ambiguous, so each should be changed just in case.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz.
mili tests pass which test expressions
CT window areas affected by this change also work as expected.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
