### PR TITLE
fix xray query test crash on windows

### DIFF
--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -449,7 +449,7 @@ CloseDatabase(silo_data_path("curv3d.silo"))
 
 # write to dir w/ read only permissions
 
-outdir_bad = "/tmp/baddir"
+outdir_bad = outdir_set + "/baddir"
 if not os.path.isdir(outdir_bad):
     os.mkdir(outdir_bad)
 os.chmod(outdir_bad, 0o444)

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -387,7 +387,7 @@ DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
 # test opening the bp output and visualizing in visit
-conduit_db = out_path(outdir_set + "/hdf5", "output.cycle_000048.root")
+conduit_db = pjoin(outdir_set , "hdf5", "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -308,14 +308,15 @@ CloseDatabase(silo_data_path("curv3d.silo"))
 # test blueprint output
 #
 
-conduit_db = out_path(outdir_set, "output.cycle_000048.root")
-
-def setup_bp_test():
+def setup_bp_test(outdir_set, subdir):
+    conduit_dir = outdir_set + "/" + subdir
+    if not os.path.isdir(conduit_dir):
+        os.mkdir(conduit_dir)
     OpenDatabase(silo_data_path("curv3d.silo"))
     AddPlot("Pseudocolor", "d")
     DrawPlots()
 
-def test_bp_state(testname):
+def test_bp_state(testname, conduit_db):
     xrayout = conduit.Node()
     conduit.relay.io.blueprint.load_mesh(xrayout, conduit_db)
     
@@ -370,16 +371,17 @@ def test_bp_state(testname):
 # hdf5
 #
 
-setup_bp_test()
+setup_bp_test(outdir_set, "hdf5")
 
 # run query and test the output message
-Query("XRay Image", "hdf5", outdir_set, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+Query("XRay Image", "hdf5", outdir_set + "/hdf5", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
 s = GetQueryOutputString()
 TestText("xrayimage32", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
 # test opening the bp output and visualizing in visit
+conduit_db = out_path(outdir_set + "/hdf5", "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
@@ -387,20 +389,19 @@ Test("Blueprint_HDF5_X_Ray_Output")
 DeleteAllPlots()
 CloseDatabase(conduit_db)
 
-test_bp_state("Blueprint_HDF5_X_Ray_Output")
-
-os.remove(conduit_db)
+test_bp_state("Blueprint_HDF5_X_Ray_Output", conduit_db)
 
 # json
 
-setup_bp_test()
+setup_bp_test(outdir_set, "json")
 
-Query("XRay Image", "json", outdir_set, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+Query("XRay Image", "json", outdir_set + "/json", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
 s = GetQueryOutputString()
 TestText("xrayimage33", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
+conduit_db = out_path(outdir_set + "/json", "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
@@ -408,26 +409,23 @@ Test("Blueprint_JSON_X_Ray_Output")
 DeleteAllPlots()
 CloseDatabase(conduit_db)
 
-os.remove(conduit_db)
+# yaml
 
-# conduit_json
+setup_bp_test(outdir_set, "yaml")
 
-setup_bp_test()
-
-Query("XRay Image", "yaml", outdir_set, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+Query("XRay Image", "yaml", outdir_set + "/yaml", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
 s = GetQueryOutputString()
 TestText("xrayimage34", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
-OpenDatabase(conduit_db)
 
+conduit_db = out_path(outdir_set + "/yaml", "output.cycle_000048.root")
+OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
 Test("Blueprint_YAML_X_Ray_Output")
 DeleteAllPlots()
 CloseDatabase(conduit_db)
-
-os.remove(conduit_db)
 
 # 
 # test catching failures
@@ -439,7 +437,9 @@ dir_dne = outdir_set + "/doesnotexist"
 if os.path.isdir(dir_dne):
     os.rmdir(dir_dne)
 
-setup_bp_test()
+OpenDatabase(silo_data_path("curv3d.silo"))
+AddPlot("Pseudocolor", "d")
+DrawPlots()
 
 Query("XRay Image", "hdf5", dir_dne, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
 s = GetQueryOutputString()

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -455,7 +455,7 @@ CloseDatabase(silo_data_path("curv3d.silo"))
 
 # write to dir w/ read only permissions
 
-outdir_bad = outdir_set + "/baddir"
+outdir_bad = pjoin(outdir_set, "baddir")
 if not os.path.isdir(outdir_bad):
     os.mkdir(outdir_bad)
 os.chmod(outdir_bad, 0o444)

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -291,7 +291,7 @@ DeleteAllPlots()
 # 
 # test setting output directory
 # 
-outdir_set = TestEnv.params["run_dir"] + "/testdir"
+outdir_set = pjoin(TestEnv.params["run_dir"], "testdir")
 if not os.path.isdir(outdir_set):
     os.mkdir(outdir_set)
 

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -407,7 +407,7 @@ TestText("xrayimage33", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
-conduit_db = out_path(outdir_set + "/json", "output.cycle_000048.root")
+conduit_db = pjoin(outdir_set, "json", "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -314,10 +314,17 @@ CloseDatabase(silo_data_path("curv3d.silo"))
 # test blueprint output
 #
 
-def setup_bp_test(outdir_set, subdir):
-    conduit_dir = pjoin(outdir_set, subdir)
-    if not os.path.isdir(conduit_dir):
-        os.mkdir(conduit_dir)
+conduit_dir_hdf5 = pjoin(outdir_set, "hdf5")
+if not os.path.isdir(conduit_dir_hdf5):
+    os.mkdir(conduit_dir_hdf5)
+conduit_dir_json = pjoin(outdir_set, "json")
+if not os.path.isdir(conduit_dir_json):
+    os.mkdir(conduit_dir_json)
+conduit_dir_yaml = pjoin(outdir_set, "yaml")
+if not os.path.isdir(conduit_dir_yaml):
+    os.mkdir(conduit_dir_yaml)
+
+def setup_bp_test():
     OpenDatabase(silo_data_path("curv3d.silo"))
     AddPlot("Pseudocolor", "d")
     DrawPlots()
@@ -377,17 +384,17 @@ def test_bp_state(testname, conduit_db):
 # hdf5
 #
 
-setup_bp_test(outdir_set, "hdf5")
+setup_bp_test()
 
 # run query and test the output message
-Query("XRay Image", "hdf5", outdir_set + "/hdf5", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+Query("XRay Image", "hdf5", conduit_dir_hdf5, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
 s = GetQueryOutputString()
 TestText("xrayimage32", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
 # test opening the bp output and visualizing in visit
-conduit_db = pjoin(outdir_set , "hdf5", "output.cycle_000048.root")
+conduit_db = pjoin(conduit_dir_hdf5, "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
@@ -399,15 +406,15 @@ test_bp_state("Blueprint_HDF5_X_Ray_Output", conduit_db)
 
 # json
 
-setup_bp_test(outdir_set, "json")
+setup_bp_test()
 
-Query("XRay Image", "json", outdir_set + "/json", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+Query("XRay Image", "json", conduit_dir_json, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
 s = GetQueryOutputString()
 TestText("xrayimage33", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
-conduit_db = pjoin(outdir_set, "json", "output.cycle_000048.root")
+conduit_db = pjoin(conduit_dir_json, "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
@@ -417,15 +424,15 @@ CloseDatabase(conduit_db)
 
 # yaml
 
-setup_bp_test(outdir_set, "yaml")
+setup_bp_test()
 
-Query("XRay Image", "yaml", outdir_set + "/yaml", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+Query("XRay Image", "yaml", conduit_dir_yaml, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
 s = GetQueryOutputString()
 TestText("xrayimage34", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
-conduit_db = pjoin(outdir_set, "yaml", "output.cycle_000048.root")
+conduit_db = pjoin(conduit_dir_yaml, "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
@@ -443,9 +450,7 @@ dir_dne = outdir_set + "/doesnotexist"
 if os.path.isdir(dir_dne):
     os.rmdir(dir_dne)
 
-OpenDatabase(silo_data_path("curv3d.silo"))
-AddPlot("Pseudocolor", "d")
-DrawPlots()
+setup_bp_test()
 
 Query("XRay Image", "hdf5", dir_dne, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
 s = GetQueryOutputString()

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -285,7 +285,7 @@ DeleteAllPlots()
 # 
 # test setting output directory
 # 
-outdir_set = out_base + "/testdir"
+outdir_set = TestEnv.params["run_dir"] + "/testdir"
 if not os.path.isdir(outdir_set):
     os.mkdir(outdir_set)
 

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -458,25 +458,27 @@ TestText("xrayimage35", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
-# write to dir w/ read only permissions
+# os.chmod does not work on windows
+if not platform.system() == "Windows":
+    # write to dir w/ read only permissions
 
-outdir_bad = pjoin(outdir_set, "baddir")
-if not os.path.isdir(outdir_bad):
-    os.mkdir(outdir_bad)
-os.chmod(outdir_bad, 0o444)
+    outdir_bad = pjoin(outdir_set, "baddir")
+    if not os.path.isdir(outdir_bad):
+        os.mkdir(outdir_bad)
+    os.chmod(outdir_bad, 0o444)
 
-OpenDatabase(silo_data_path("curv3d.silo"))
-AddPlot("Pseudocolor", "d")
-DrawPlots()
+    OpenDatabase(silo_data_path("curv3d.silo"))
+    AddPlot("Pseudocolor", "d")
+    DrawPlots()
 
-Query("XRay Image", "hdf5", outdir_bad, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
-s = GetQueryOutputString()
-# strip out two lines that make the test machine dependent
-s = '\n'.join([line if line[:4] != "file" else '' for line in s.split('\n')])
-s = '\n'.join([line if line[:4] != "line" else '' for line in s.split('\n')])
-TestText("xrayimage36", s)
-DeleteAllPlots()
-CloseDatabase(silo_data_path("curv3d.silo"))
+    Query("XRay Image", "hdf5", outdir_bad, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))
+    s = GetQueryOutputString()
+    # strip out two lines that make the test machine dependent
+    s = '\n'.join([line if line[:4] != "file" else '' for line in s.split('\n')])
+    s = '\n'.join([line if line[:4] != "line" else '' for line in s.split('\n')])
+    TestText("xrayimage36", s)
+    DeleteAllPlots()
+    CloseDatabase(silo_data_path("curv3d.silo"))
 
 #
 # Test that we get decent error messages for common cases

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -315,7 +315,7 @@ CloseDatabase(silo_data_path("curv3d.silo"))
 #
 
 def setup_bp_test(outdir_set, subdir):
-    conduit_dir = outdir_set + "/" + subdir
+    conduit_dir = pjoin(outdir_set, subdir)
     if not os.path.isdir(conduit_dir):
         os.mkdir(conduit_dir)
     OpenDatabase(silo_data_path("curv3d.silo"))

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -425,7 +425,7 @@ TestText("xrayimage34", s)
 DeleteAllPlots()
 CloseDatabase(silo_data_path("curv3d.silo"))
 
-conduit_db = out_path(outdir_set + "/yaml", "output.cycle_000048.root")
+conduit_db = pjoin(outdir_set, "yaml", "output.cycle_000048.root")
 OpenDatabase(conduit_db)
 AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -30,6 +30,12 @@
 # 
 #    Justin Privitera, Thu Sep  8 16:29:06 PDT 2022
 #    Added new tests for blueprint output metadata.
+# 
+#    Justin Privitera, Fri Sep 30 15:54:40 PDT 2022
+#    Changed location of temp output files.
+#    os.remove is gone.
+#    tmp/baddir is gone, replaced.
+#    These changes were made so the tests no longer crash on windows.
 #
 # ----------------------------------------------------------------------------
 

--- a/test/baseline/queries/xrayimage/parallel/xrayimage35.txt
+++ b/test/baseline/queries/xrayimage/parallel/xrayimage35.txt
@@ -1,1 +1,1 @@
-engine_par: Directory VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/doesnotexist does not exist.
+engine_par: Directory VISIT_TOP_DIR/test/testdir/doesnotexist does not exist.

--- a/test/baseline/queries/xrayimage/parallel/xrayimage36.txt
+++ b/test/baseline/queries/xrayimage/parallel/xrayimage36.txt
@@ -3,4 +3,4 @@ engine_par: Conduit Exception in X Ray Image Query Execute:
 
 
 message: 
-HDF5 Error code-1 Error opening HDF5 file for writing: /tmp/baddir/output.cycle_000048.root
+HDF5 Error code-1 Error opening HDF5 file for writing: VISIT_TOP_DIR/test/testdir/baddir/output.cycle_000048.root

--- a/test/baseline/queries/xrayimage/scalable_parallel_icet/xrayimage35.txt
+++ b/test/baseline/queries/xrayimage/scalable_parallel_icet/xrayimage35.txt
@@ -1,1 +1,1 @@
-engine_par: Directory VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/doesnotexist does not exist.
+engine_par: Directory VISIT_TOP_DIR/test/testdir/doesnotexist does not exist.

--- a/test/baseline/queries/xrayimage/scalable_parallel_icet/xrayimage36.txt
+++ b/test/baseline/queries/xrayimage/scalable_parallel_icet/xrayimage36.txt
@@ -3,4 +3,4 @@ engine_par: Conduit Exception in X Ray Image Query Execute:
 
 
 message: 
-HDF5 Error code-1 Error opening HDF5 file for writing: /tmp/baddir/output.cycle_000048.root
+HDF5 Error code-1 Error opening HDF5 file for writing: VISIT_TOP_DIR/test/testdir/baddir/output.cycle_000048.root

--- a/test/baseline/queries/xrayimage/xrayimage31.txt
+++ b/test/baseline/queries/xrayimage/xrayimage31.txt
@@ -1,1 +1,1 @@
-The x ray image query results were written to the file VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/output00.png
+The x ray image query results were written to the file VISIT_TOP_DIR/test/testdir/output00.png

--- a/test/baseline/queries/xrayimage/xrayimage32.txt
+++ b/test/baseline/queries/xrayimage/xrayimage32.txt
@@ -1,1 +1,1 @@
-The x ray image query results were written to the file VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/output.cycle_000048.root
+The x ray image query results were written to the file VISIT_TOP_DIR/test/testdir/hdf5/output.cycle_000048.root

--- a/test/baseline/queries/xrayimage/xrayimage33.txt
+++ b/test/baseline/queries/xrayimage/xrayimage33.txt
@@ -1,1 +1,1 @@
-The x ray image query results were written to the file VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/output.cycle_000048.root
+The x ray image query results were written to the file VISIT_TOP_DIR/test/testdir/json/output.cycle_000048.root

--- a/test/baseline/queries/xrayimage/xrayimage34.txt
+++ b/test/baseline/queries/xrayimage/xrayimage34.txt
@@ -1,1 +1,1 @@
-The x ray image query results were written to the file VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/output.cycle_000048.root
+The x ray image query results were written to the file VISIT_TOP_DIR/test/testdir/yaml/output.cycle_000048.root

--- a/test/baseline/queries/xrayimage/xrayimage35.txt
+++ b/test/baseline/queries/xrayimage/xrayimage35.txt
@@ -1,1 +1,1 @@
-engine_ser: Directory VISIT_TOP_DIR/test/current/queries/xrayimage/testdir/doesnotexist does not exist.
+engine_ser: Directory VISIT_TOP_DIR/test/testdir/doesnotexist does not exist.

--- a/test/baseline/queries/xrayimage/xrayimage36.txt
+++ b/test/baseline/queries/xrayimage/xrayimage36.txt
@@ -3,4 +3,4 @@ engine_ser: Conduit Exception in X Ray Image Query Execute:
 
 
 message: 
-HDF5 Error code-1 Error opening HDF5 file for writing: /tmp/baddir/output.cycle_000048.root
+HDF5 Error code-1 Error opening HDF5 file for writing: VISIT_TOP_DIR/test/testdir/baddir/output.cycle_000048.root


### PR DESCRIPTION
### Description

Resolves #18004 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Fix x ray image query test crashing on windows.
I have addressed the concerns in the ticket. Specifically:
1) I have changed the location of temporary output files
2) `os.remove` is gone
3) `tmp/baddir` is gone, replaced by something better
4) baselines have been updated

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz. All x ray query tests pass.
We need to see if this passes on windows.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
