### PR TITLE
Bug in freeing resources in moab plugin (#17915)

### DIFF
--- a/src/databases/MOAB/avtMOABFileFormat.C
+++ b/src/databases/MOAB/avtMOABFileFormat.C
@@ -86,26 +86,28 @@ avtMOABFileFormat::avtMOABFileFormat(const char *filename, const DBOptionsAttrib
 //
 // ****************************************************************************
 
-avtMOABFileFormat::~avtMOABFileFormat()
-{
-	debug1 << " avtMOABFileFormat::~avtMOABFileFormat: freeing file descriptor\n";
-	if (file_descriptor)
-	{
-		free(file_descriptor);
-		file_descriptor=NULL;
-	}
-	delete mbCore;
+avtMOABFileFormat::~avtMOABFileFormat() {
+    debug1 << " avtMOABFileFormat::~avtMOABFileFormat \n";
+    FreeUpResources();
 }
 void
-avtMOABFileFormat::FreeUpResources(void)
-{
-	debug1 << " avtMOABFileFormat::FreeUpResources: freeing file descriptor\n";
-    free  (file_descriptor);
-    file_descriptor = NULL;
+avtMOABFileFormat::FreeUpResources(void) {
+    debug1 << " avtMOABFileFormat::FreeUpResources: freeing file descriptor\n";
+    if (file_descriptor) {
+        free(file_descriptor);
+        file_descriptor = NULL;
+    }
 #ifdef PARALLEL
-    delete pcomm;
+	if (pcomm)
+	{
+		delete pcomm;
+		pcomm = NULL;
+	}
 #endif
-    delete mbCore;
+    if (mbCore) {
+        delete mbCore;
+        mbCore = NULL;
+    }
 }
 
 void
@@ -166,13 +168,21 @@ avtMOABFileFormat::gatherMhdfInformation()
     debug1 << "Nodes: " << num_nodes << " dense tags: " <<  number_node_tags << "\n";
     for (int i=0; i< number_node_tags; i++)
     {
-        const char * tag_name = file_descriptor->tags[file_descriptor->nodes.dense_tag_indices[i]].name;
+        MHDF_TagDesc & tagStr = file_descriptor->tags[file_descriptor->nodes.dense_tag_indices[i]];
+        const char * tag_name = tagStr.name;
 
-        int sizeTag = file_descriptor->tags[file_descriptor->nodes.dense_tag_indices[i]].size;
+        int sizeTag = tagStr.size;
         debug1 << "   tag "<< i << " "  << tag_name << " size:" << sizeTag << "\n";
         struct tagBasic  tag1;
         tag1.nameTag=string(tag_name);
         tag1.size=sizeTag;
+        if (tagStr.default_value && ( sizeTag == 1 ) &&
+                ( (tagStr.type == mhdf_INTEGER) || (tagStr.type == mhdf_FLOAT )) )
+        {
+            tag1.defValue = tagStr.default_value;
+            tag1.type = tagStr.type;
+        }
+
         debug1 << "  node     tag "<< i << " "  << tag_name <<" size:" << sizeTag << "\n";
         nodeTags.push_back(tag1);
     }
@@ -189,12 +199,19 @@ avtMOABFileFormat::gatherMhdfInformation()
             << number_elem_tags <<"\n";
         for (int j=0; j<number_elem_tags; j++)
         {
-            const char * tag_name = file_descriptor->tags[edesc.dense_tag_indices[j]].name;
-            int sizeTag = file_descriptor->tags[edesc.dense_tag_indices[j]].size;
+            MHDF_TagDesc & tagStr = file_descriptor->tags[edesc.dense_tag_indices[j]];
+            const char * tag_name = tagStr.name;
+            int sizeTag = tagStr.size;
             struct tagBasic  tag1;
 
             tag1.nameTag=string(tag_name);
             tag1.size=sizeTag;
+            if (tagStr.default_value && ( sizeTag == 1 ) &&
+                            ( (tagStr.type == mhdf_INTEGER) || (tagStr.type == mhdf_FLOAT )) )
+            {
+                tag1.defValue = tagStr.default_value;
+                tag1.type = tagStr.type;
+            }
 
             debug2 << " elem   tag "<< j << " "  << tag_name <<" size:" << sizeTag << "\n";
             elemTags.insert(tag1);
@@ -286,7 +303,25 @@ avtMOABFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
             struct tagBasic tag = *setIter;
             nameDisplay += tag.nameTag;
             if (tag.size == 1)
-              AddScalarVarToMetaData(md, nameDisplay.c_str(), meshname, AVT_ZONECENT);
+            {
+                avtScalarMetaData *smd = new avtScalarMetaData;
+                smd->name = nameDisplay.c_str();
+                smd->meshName = meshname;
+                smd->centering = AVT_ZONECENT;
+                double defValDouble = 0;
+                if (tag.defValue && tag.type == 1) // integer
+                {
+                    defValDouble = *((int*)(tag.defValue));
+                }
+                if (tag.defValue && tag.type == 2) // double
+                {
+                    defValDouble = *((double*)(tag.defValue));
+                }
+                double values[2] = {defValDouble, defValDouble};
+                smd->SetMissingData(values);
+                smd->SetMissingDataType(avtScalarMetaData::MissingData_Value);
+                md->Add(smd);
+            }
             else if (tag.size == 2 || tag.size == 3)
               AddVectorVarToMetaData(md, nameDisplay.c_str(), meshname, AVT_ZONECENT, tag.size);
             else
@@ -298,7 +333,26 @@ avtMOABFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
             struct tagBasic tag = nodeTags[i];
             nameDisplay +=tag.nameTag;
             if (tag.size == 1)
-              AddScalarVarToMetaData(md, nameDisplay.c_str(), meshname, AVT_NODECENT);
+            {
+                avtScalarMetaData *smd = new avtScalarMetaData;
+                smd->name = nameDisplay.c_str();
+                smd->meshName = meshname;
+                smd->centering = AVT_NODECENT;
+                double defValDouble = 0;
+                if (tag.defValue && tag.type == 1) // integer
+                {
+                    defValDouble = *((int*)(tag.defValue));
+                }
+                if (tag.defValue && tag.type == 2) // double
+                {
+                    defValDouble = *((double*)(tag.defValue));
+                }
+                double values[2] = {defValDouble, defValDouble};
+                smd->SetMissingData(values);
+                smd->SetMissingDataType(avtScalarMetaData::MissingData_Value);
+                md->Add(smd);
+            }
+              // AddScalarVarToMetaData(md, nameDisplay.c_str(), meshname, AVT_NODECENT);
             else if (tag.size == 2 || tag.size == 3)
               AddVectorVarToMetaData(md, nameDisplay.c_str(), meshname, AVT_NODECENT, tag.size);
             else
@@ -585,7 +639,7 @@ avtMOABFileFormat::GetMesh(int domain, const char *meshname)
         //
         // Create the unstructured mesh
         //
-        vtkUnstructuredGrid *ugrid = vtkUnstructuredGrid::New(); 
+        vtkUnstructuredGrid *ugrid = vtkUnstructuredGrid::New();
 
         {
             // Get the list of vertices
@@ -607,7 +661,7 @@ avtMOABFileFormat::GetMesh(int domain, const char *meshname)
                 pts[i] = static_cast<float> (coords[i]);
             }
             coords.clear();
-            
+
             ugrid->SetPoints(points);
             points->Delete();
         }

--- a/src/databases/MOAB/avtMOABFileFormat.h
+++ b/src/databases/MOAB/avtMOABFileFormat.h
@@ -68,6 +68,9 @@ class avtMOABFileFormat : public avtSTMDFileFormat
     struct tagBasic {
       std::string nameTag;
       int size;
+      void * defValue; // size 4 or 8 usually
+      int type; // mhdf_INTEGER = 1,    /**< Integer type */
+                // mhdf_FLOAT = 2,      /**< Floating point value */ (double)
     };
     struct compare1 {
       bool operator () (const tagBasic& lhs, const tagBasic& rhs) const


### PR DESCRIPTION
* do not double free resources

* delete pcomm too

it cannot exist without moab core, anyway

* simplify destructor, just call freeupresources

* add missing value logic

when a scalar, dense tag has a default value for an entity, it is ignored with missing_value logic

### Description

Resolves # <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have followed the [style guidelines][1] of this project.~~
- [ ] I have performed a self-review of my own code.~~
- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [ ] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
