### PR TITLE
Fix signal debug message typo by microizing

### DIFF
--- a/src/common/misc/DebugStreamFull.C
+++ b/src/common/misc/DebugStreamFull.C
@@ -134,6 +134,20 @@ close_streams()
 //
 // ****************************************************************************
 
+#if !defined(_WIN32)
+#define SIG_CASE(Sig) \
+    case Sig: \
+          debug1 << "signalhandler_core: " << #Sig << "! (" << strsignal(Sig) << ")" << endl; \
+          close_streams(); abort(); \
+          break
+#else
+#define SIG_CASE(Sig) \
+    case Sig: \
+          debug1 << "signalhandler_core: " << #Sig << "!" << endl; \
+          close_streams(); abort(); \
+          break
+#endif
+
 static void
 signalhandler_core(int sig)
 {
@@ -145,39 +159,15 @@ signalhandler_core(int sig)
 
     switch (sig)
     {
-      case SIGILL:
-          debug1 << "signalhandler_core: SIG!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
-      case SIGABRT:
-          debug1 << "signalhandler_core: SIGABRT!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
-      case SIGFPE:
-          debug1 << "signalhandler_core: SIGFPE!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
-      case SIGSEGV:
-          debug1 << "signalhandler_core: SIGSEGV!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
+      SIG_CASE(SIGILL);
+      SIG_CASE(SIGABRT);
+      SIG_CASE(SIGFPE);
+      SIG_CASE(SIGSEGV);
 #if !defined(_WIN32)
-      case SIGBUS:
-          debug1 << "signalhandler_core: SIGBUS!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
-      case SIGQUIT:
-          debug1 << "signalhandler_core: SIGQUIT!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
-      case SIGTRAP:
-          debug1 << "signalhandler_core: SIGTRAP!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
-      case SIGSYS:
-          debug1 << "signalhandler_core: SIGSYS!" << endl;
-          close_streams(); abort(); // HOOKS_IGNORE
-          break;
+      SIG_CASE(SIGBUS);
+      SIG_CASE(SIGQUIT);
+      SIG_CASE(SIGTRAP);
+      SIG_CASE(SIGSYS);
 #endif
     }
 }

--- a/src/common/misc/DebugStreamFull.C
+++ b/src/common/misc/DebugStreamFull.C
@@ -150,7 +150,7 @@ signalhandler_core(int sig)
           close_streams(); abort(); // HOOKS_IGNORE
           break;
       case SIGABRT:
-          debug1 << "signalhandler_core: SIGBRT!" << endl;
+          debug1 << "signalhandler_core: SIGABRT!" << endl;
           close_streams(); abort(); // HOOKS_IGNORE
           break;
       case SIGFPE:

--- a/src/common/misc/DebugStreamFull.C
+++ b/src/common/misc/DebugStreamFull.C
@@ -132,6 +132,9 @@ close_streams()
 //    I made it print the name of the signal to the debug log so we have
 //    an idea of whether or not VisIt quit due to handling a signal.
 //
+//    Mark C. Miller, Fri Oct  7 16:12:22 PDT 2022
+//    Macroize case statements to avoid misspelled signal ids and reduce
+//    code duplication.
 // ****************************************************************************
 
 #if !defined(_WIN32)


### PR DESCRIPTION
### Description

Fix typo in signal `SIGBRT` printed to debug logs. It should be `SIGABRT`. I noticed a `SIGILL` and for a moment thought that too was a typo missing the `K` for `SIGKILL` but those two are indeed two different signals.

To correct, I macroized the code printing signals to debug logs. Now, no way to misspell it. I also added logic to `strsignal()` the description to debug logs too (but not on Windows).


### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
