### PR TITLE
Fix a bug reading Mili material variables.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -22,6 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.3.2</font></b></p>
 <ul>
   <li>On macOS, VisIt launched by double-clicking the icon now allows users who give VisIt permission to browse files and folders in the Desktop, Documents, or Downloads folders. </li>
+  <li>Fixed a bug reading Mili material variables.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -22,7 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.3.2</font></b></p>
 <ul>
   <li>On macOS, VisIt launched by double-clicking the icon now allows users who give VisIt permission to browse files and folders in the Desktop, Documents, or Downloads folders. </li>
-  <li>Fixed a bug reading Mili material variables.</li>
+  <li>Fixed a bug reading Mili material variables when the mesh had multiple domains.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Fixed a bug reading Mili material variables when the mesh had multiple domains. The material variables are only defined on domain 0, so I added special logic to always read the material variables from domain 0.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I had a Mili file from a user that demonstrated the bug. I verified that the material variable displayed properly after the fix with a Pseudocolor plot of a material variable. The data is much too large to add to the ticket or our test suite.

I ran the test suite on `tests/databases/mili.py` and verified that the tests all still pass.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
