### PR TITLE
Fix a couple windows testing issues.

### DIFF
--- a/src/bin/visit.c
+++ b/src/bin/visit.c
@@ -734,10 +734,13 @@ VisItLauncherMain(int argc, char *argv[])
     {
         FreeConsole();
         AllocConsole();
-#ifdef VISIT_WINDOWS_APPLICATION
-        // If we're running a parallel engine then let's hide the console window.
         if(component == "engine_par")
+#ifdef VISIT_WINDOWS_APPLICATION
+            // Hide the parallel engine console window.
             ShowWindow(GetConsoleWindow(), SW_HIDE);
+#else
+            // Prevent parallel engine console window from stealing focus.
+            ShowWindow(GetConsoleWindow(), SW_SHOWMINNOACTIVE);
 #endif
     }
 

--- a/src/test/run_visit_test_suite.bat.in
+++ b/src/test/run_visit_test_suite.bat.in
@@ -6,6 +6,6 @@ SET PYTHONPATH=@CMAKE_BINARY_DIR@/lib/@CMAKE_BUILD_TYPE@/site-packages/
    -t @VISIT_SOURCE_DIR@/test/tests ^
    -s @VISIT_SOURCE_DIR@/test/skip.json ^
    --src @VISIT_SOURCE_DIR@ ^
-   --cmake @CMAKE_COMMAND@ ^
+   --cmake "@CMAKE_COMMAND@" ^
    -o testing_output ^
    -e @CMAKE_RUNTIME_OUTPUT_DIRECTORY@/@CMAKE_BUILD_TYPE@/visit.exe %*


### PR DESCRIPTION
Wrap CMAKE_COMMAND in quotes in case there are spaces in the path.

Prevent engine_par engine console window from stealing focus.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Run regression testing on Windows successfully, and parallel tests no longer inhibit other work being done since the parallel engine console window no longer steals focus.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
