### PR TITLE
Fix bug reading .visit file that contained a comment for each file.

### DIFF
--- a/src/avt/Database/Database/avtDatabase.C
+++ b/src/avt/Database/Database/avtDatabase.C
@@ -2387,6 +2387,10 @@ avtDatabase::NumStagesForFetch(avtDataRequest_p)
 //    Eric Brugger, Fri May  1 12:39:32 PDT 2020
 //    Added logic to skip lines that start with !TIME and !ENSEMBLE.
 //
+//    Kathleen Biagas, Thu Oct 27 11:45:24 PDT 2022
+//    Removed badCount, it prevented .visit files from having comments
+//    associated with each file when fileCount >= 10000.
+//
 // ****************************************************************************
 
 bool
@@ -2412,11 +2416,10 @@ avtDatabase::GetFileListFromTextFile(const char *textfile,
     char  str_auto[1024];
     char  str_with_dir[2048];
     int   goodCount = 0; // number of valid lines, keywords and files
-    int   badCount = 0; // number of empty and comment lines
     int   fileCount = 0; // number of non empty, non comment, non keyword, lines
     int   bang_nBlocks = -1;
     bool failed = false;
-    while (!ifile.eof() && !failed && badCount < 10000)
+    while (!ifile.eof() && !failed)
     {
         str_auto[0] = '\0';
         ifile.getline(str_auto, 1024, '\n');
@@ -2499,8 +2502,6 @@ avtDatabase::GetFileListFromTextFile(const char *textfile,
             if (str_auto[0] != '!')
                 ++fileCount;
         }
-        else
-            ++badCount;
     }
 
     if (bang_nBlocks > 0 && !failed)

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -24,7 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>On macOS, VisIt launched by double-clicking the icon now allows users who give VisIt permission to browse files and folders in the Desktop, Documents, or Downloads folders. </li>
   <li>Fixed a bug reading Mili material variables when the mesh had multiple domains.</li>
   <li>Fixed a bug causing the blueprint plugin to incorrectly assign a zonal association to mfem grid functions that were neither H1 nor L2.</li>
-  <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.<li>
+  <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -24,6 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>On macOS, VisIt launched by double-clicking the icon now allows users who give VisIt permission to browse files and folders in the Desktop, Documents, or Downloads folders. </li>
   <li>Fixed a bug reading Mili material variables when the mesh had multiple domains.</li>
   <li>Fixed a bug causing the blueprint plugin to incorrectly assign a zonal association to mfem grid functions that were neither H1 nor L2.</li>
+  <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.<li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

There were > 10000 files and also then > 10000 comments, which triggered logic to stop processing the file after 10000 comments had been read.

I removed the counting logic for comments, allowing the whole file to be processed.

Resolves #18236

### Type of change

<!-- Please check one of the boxes below -->

~~* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I opened customer's data and was able to plot all time states.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
