### PR TITLE
Patch VTK in build_visit to fix an engine off screen rendering crash.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug reading Mili material variables when the mesh had multiple domains.</li>
   <li>Fixed a bug causing the blueprint plugin to incorrectly assign a zonal association to mfem grid functions that were neither H1 nor L2.</li>
   <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.</li>
+  <li>Fixed a bug that caused the compute engine to crash when in scalable rendering mode. The specific bug involved saving non screen capture images, but the crash could occur whenever doing scalable rendering.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1429,6 +1429,42 @@ EOF
     return 0;
 }
 
+function apply_vtk_osmesa_render_patch
+{
+    # Apply a patch where the OSMesaMakeCurrent could sometimes pass the
+    # wrong window size for the buffer.
+    patch -p0 << \EOF
+diff -u Rendering/OpenGL2/vtkOSOpenGLRenderWindow.cxx.orig Rendering/OpenGL2/vtkOSOpenGLRenderWindow.cxx
+--- Rendering/OpenGL2/vtkOSOpenGLRenderWindow.cxx.orig  2022-10-31 14:53:21.228362000 -0700
++++ Rendering/OpenGL2/vtkOSOpenGLRenderWindow.cxx       2022-10-31 14:55:24.072140000 -0700
+@@ -201,7 +201,6 @@
+       this->Internal->OffScreenContextId = OSMesaCreateContext(GL_RGBA, nullptr);
+     }
+   }
+-  this->MakeCurrent();
+ 
+   this->Mapped = 0;
+   this->Size[0] = width;
+@@ -330,8 +329,8 @@
+ {
+   if ((this->Size[0] != width)||(this->Size[1] != height))
+   {
+-    this->Superclass::SetSize(width, height);
+     this->ResizeOffScreenWindow(width, height);
++    this->Superclass::SetSize(width, height);
+     this->Modified();
+   }
+ }
+EOF
+
+    if [[ $? != 0 ]] ; then
+      warn "vtk patch for compiler version check failed."
+      return 1
+    fi
+
+    return 0;
+}
+
 
 function apply_vtk_patch
 {
@@ -1480,6 +1516,10 @@ function apply_vtk_patch
         return 1
     fi
 
+    apply_vtk_osmesa_render_patch
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
     return 0
 }
 


### PR DESCRIPTION
### Description

Resolves #18177 

I added a patch to `build_visit` for VTK that fixes a crash doing an offscreen render in the engine.

The patch was to `vtkOSOpenGLRenderWindow.cxx` and involved 2 changes.

1) I switched the order of the calls `this->ResizeOffScreenWindow` and `this->Superclass::SetSize` in `vtkOSOpenGLRenderWindow::SetSize`. The problem was `Superclass::SetSize` updated the class member `Size` and `ResizeOffScreenWindow` eventually called `ReleaseGraphicsResources` on the OSMesa context. This eventually resulted in a call to `MakeCurrent`, which called `OSMesaMakeCurrent` passing the old unresized image buffer and the new `Size`. In the case of the crash the new `Size` was larger than the old buffer associated with the OSMesa context causing a memory overwrite, which eventually caused a crash with a `free` failing.

Switching the order fixed the issue of passing the new `Size` with the old unresized image buffer.

2) I removed a superflous `MakeCurrent` call in `vtkOSOpenGLRenderWindwo::CreateOffScreenWindow`. The code consisted of:
```
  this->MakeCurrent();

  this->Mapped = 0;
  this->Size[0] = width;
  this->Size[1] = height;

  this->MakeCurrent();
```
The first `MakeCurrent` call resulted in calling `OSMesaMakeCurrent` with the new image buffer and the old `Size`. It didn't appear to cause a problem in the case I was testing but it is wrong. Since there is another `MakeCurrent` call after the `Size` is updated there isn't any reason for the first call to `MakeCurrent`.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I created a unified `build_visit` script with the additional VTK patch and ran it to build VTK. I verified that the changes were correctly made to the VTK source.

I then built the current 3.3RC against the new VTK and ran through the scenario described in the ticket and VisIt no longer crashed. I also went back and forth, panning and zooming between the 2 windows, changing the window sizes and saving images in between. The images were all correct and there were no crashes.

### Checklist:

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
