### PR TITLE
Patch VTK in build_visit to fix an engine off screen rendering crash. (#18259)

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug reading Mili material variables when the mesh had multiple domains.</li>
   <li>Fixed a bug causing the blueprint plugin to incorrectly assign a zonal association to mfem grid functions that were neither H1 nor L2.</li>
   <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.</li>
+  <li>Fixed a bug that caused the compute engine to crash when in scalable rendering mode. The specific bug involved saving non screen capture images, but the crash could occur whenever doing scalable rendering.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Resolves #18177 
Merge from the 3.3RC to develop.