### PR TITLE
add blt submodule and ci check 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/blt"]
+	path = src/blt
+	url = https://github.com/llnl/blt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
   jobs:
   - job: Main_Build
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-latest'
     timeoutInMinutes: 0
     container: ${{ variables.container_tag }}
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,13 +21,13 @@ pr:
     include:
     - develop
 
-# add fast fail checks here
+# fast fail sanity checks
 stages:
-- stage: Quick
+- stage: Sanity
   jobs:
-  - job: Fast_Check
+  - job: BLT_Time_Travel_Check
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
         clean: boolean
@@ -35,12 +35,12 @@ stages:
 
       - script: |
           #######################################
-          # run our quick check
+          # run our sanity check script
           #######################################
-          echo "OK"
-          # NOTE FOR AZURE:
-          # only return code of the command is checked!
-        displayName: 'Example Fast Check'
+          git fetch
+          python scripts/ci/check_blt_time_travel.py
+        displayName: 'BLT Time Travel Check'
+
 
 # main checks build using docker containers that
 # include tpls built with build_visit

--- a/hashes.txt
+++ b/hashes.txt
@@ -1,1 +1,1 @@
-blt  branch='develop' commit='97ea54d892b4b1d56736830575c3db62e3d7674d-TEST FOR FAILURE'
+blt  branch='develop' commit='97ea54d892b4b1d56736830575c3db62e3d7674d'

--- a/hashes.txt
+++ b/hashes.txt
@@ -1,0 +1,1 @@
+blt  branch='develop' commit='97ea54d892b4b1d56736830575c3db62e3d7674d-TEST FOR FAILURE'

--- a/scripts/ci/check_blt_time_travel.py
+++ b/scripts/ci/check_blt_time_travel.py
@@ -1,0 +1,63 @@
+import sys
+import subprocess
+
+# parse hashes.txt file to check which BLT we should be using 
+def shexe(cmd,ret_output=False,echo = False):
+    """ Helper for executing shell commands. """
+    if echo:
+        print("[exe: {}]".format(cmd))
+    if ret_output:
+        p = subprocess.Popen(cmd,
+                             shell=True,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        res = p.communicate()[0]
+        res = res.decode('utf8')
+        return p.returncode,res
+    else:
+        return subprocess.call(cmd,shell=True)
+
+def read_blt_hash():
+    with open("hashes.txt") as f:
+       for txt in f.readlines():
+           if txt.count("blt") > 0:
+               key = "commit='"
+               cmt_start = txt.find(key) + len(key)
+               # find commit
+               commit = txt[cmt_start:].strip()
+               # remove trailing '
+               return commit[:-1]
+    # hard fail
+    print("[ERROR: could not read blt info from hashes.txt]")
+    sys.exit(-1)
+
+def read_last_blt_commit():
+    cmd = 'git ls-files -s src/blt'
+    rcode, rout = shexe(cmd,ret_output=True)
+    # the commit id is the second token
+    toks = rout.split()
+    if rcode != 0 or len(toks) < 2:
+        print("[ERROR: could not git ls-files -s src/blt]")
+        sys.exit(-1)
+    return toks[1]
+
+def main():
+    expected = read_blt_hash()
+    current  = read_last_blt_commit()
+    print("[blt sanity check]")
+    print("[ Expected sha (hashes.txt): {0}]".format(expected))
+    print("[ Current  sha (from git):   {0}]".format(current))
+    if expected != current:
+        print("[ERROR: sha mismatch!]")
+        print("[If you wanted to update blt - did you update hashes.txt?]")
+        sys.exit(-1)
+    else:
+        print("[PASS: sanity is preserved]")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+    
+    
+

--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -71,6 +71,9 @@
 #   Kathleen Biagas, Thu Mar 24, 2022
 #   Use CMake-style path for installs of python-include on Windows.
 #
+#   Cyrus Harrison, Fri Nov  4 14:35:16 PDT 2022
+#   More status messages.
+#
 #****************************************************************************/
 
 INCLUDE(${VISIT_SOURCE_DIR}/CMake/ThirdPartyInstallLibrary.cmake)
@@ -88,7 +91,6 @@ INCLUDE(${VISIT_SOURCE_DIR}/CMake/ThirdPartyInstallLibrary.cmake)
 #
 
 MESSAGE(STATUS "Looking for Python")
-
 ###
 # CODE FROM CONDUIT TO FIND PYTHON INTERP AND LIBS
 ###
@@ -104,7 +106,11 @@ if(PYTHON_DIR AND NOT PYTHON_EXECUTABLE)
     elseif(WIN32)
         set(PYTHON_EXECUTABLE ${PYTHON_DIR}/python.exe)
     endif()
+    message(STATUS "Using PYTHON_EXECUTABLE from PYTHON_DIR:")
+    message(STATUS "PYTHON_DIR: ${PYTHON_DIR}")
+    message(STATUS "PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
 endif()
+
 
 find_package(PythonInterp REQUIRED)
 if(PYTHONINTERP_FOUND)

--- a/src/CMake/SetupBLT.cmake
+++ b/src/CMake/SetupBLT.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+# Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Conduit.
+
+################################################################
+# if BLT_SOURCE_DIR is not set - use "blt" as default
+################################################################
+# Note: this is relative to the root CMakeLists.txt file
+# so relative to the git repo root, this is actually `src/blt`
+if(NOT BLT_SOURCE_DIR)
+    set(BLT_SOURCE_DIR "blt")
+endif()
+
+################################################################
+# if not set, prefer c++11 lang standard
+################################################################
+if(NOT BLT_CXX_STD)
+    set(BLT_CXX_STD "c++11" CACHE STRING "")
+endif()
+
+################################################################
+# don't use BLT's all warnings feature
+set(ENABLE_ALL_WARNINGS OFF CACHE BOOL "")
+################################################################
+
+################################################################
+################################################################
+# Google Test will look or python
+# If PYTHON_EXECUTABLE is not set, it will go on to find
+# the wrong python, so this logic protects us when using
+# PYTHON_DIR, as VisIt has for some time
+################################################################
+################################################################
+set(CMAKE_DISABLE_FIND_PACKAGE_PythonInterp ON)
+
+message(STATUS "Setting up BLT")
+################################################################
+# init blt using BLT_SOURCE_DIR
+################################################################
+include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
+
+# allow us to find python again
+set(CMAKE_DISABLE_FIND_PACKAGE_PythonInterp OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1017,7 +1017,7 @@ unset(v_list)
 #-----------------------------------------------------------------------------
 # This also includes 
 # VisIt's BLT defaults
-include(cmake/SetupBLT.cmake)
+include(CMake/SetupBLT.cmake)
 
 #-----------------------------------------------------------------------------
 # Set up some installation related value and macros (needs version).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -523,6 +523,9 @@
 #    Kathleen Biagas, Mon Sep 26, 2022
 #    Remove HDF4 support.
 #
+#    Cyrus Harrison, Fri Nov  4 13:38:24 PDT 2022
+#    Wire up BLT CMake Build System Helpers.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
@@ -541,6 +544,7 @@ if(COMMAND cmake_policy)
         endif()
     endif()
 endif()
+
 
 #
 # Try to capture the initial set of cmake command line args passed by
@@ -721,12 +725,14 @@ SET(CMAKE_C_COMPILER ${VISIT_C_COMPILER})
 SET(CMAKE_CXX_COMPILER ${VISIT_CXX_COMPILER})
 SET(CMAKE_Fortran_COMPILER ${VISIT_FORTRAN_COMPILER})
 
+
 #-----------------------------------------------------------------------------
 # VisIt project. Declare the project after including the input because
 #                this lets us set up defaults in the config-site.
 #-----------------------------------------------------------------------------
 
 PROJECT(VISIT)
+
 
 include(${VISIT_SOURCE_DIR}/CMake/CheckMinimumCompilerVersion.cmake)
 
@@ -1005,6 +1011,13 @@ list(GET v_list 0 VISIT_VERSION_MAJOR)
 list(GET v_list 1 VISIT_VERSION_MINOR)
 list(GET v_list 2 VISIT_VERSION_PATCH)
 unset(v_list)
+
+#-----------------------------------------------------------------------------
+# Init BLT
+#-----------------------------------------------------------------------------
+# This also includes 
+# VisIt's BLT defaults
+include(cmake/SetupBLT.cmake)
 
 #-----------------------------------------------------------------------------
 # Set up some installation related value and macros (needs version).

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -70,9 +70,8 @@ if(VISIT_PYTHON_DIR AND VISIT_ENABLE_MANUALS AND NOT VISIT_STATIC)
         ${VISIT_BINARY_DIR}/resources/help/en_US/manual -a)
 
     #
-    # Allow `make docs` to be an alais for `make manuals`
+    # Allow `make docs` to be an alias for `make manuals`
     #
-    add_custom_target(docs)
     add_dependencies(docs manuals)
 
 

--- a/src/doc/building_visit/Building_Directly_With_CMake.rst
+++ b/src/doc/building_visit/Building_Directly_With_CMake.rst
@@ -6,7 +6,7 @@ If a *config site file* is available for the platform you wish to build on, VisI
 
 .. code:: bash
 
-  git clone git@github.com:visit-dav/visit.git
+  git clone --recursive git@github.com:visit-dav/visit.git
   mkdir visit/build
   cd visit/build
 

--- a/src/doc/dev_manual/GitHub.rst
+++ b/src/doc/dev_manual/GitHub.rst
@@ -20,6 +20,7 @@ The following top level directories exist in the visit repository.
 * `src <https://github.com/visit-dav/visit/tree/develop/src/>`_ - The VisIt_ source code. It includes the Read the Docs documentation and the regression test suite.
 * `test/baseline <https://github.com/visit-dav/visit/tree/develop/test/baseline/>`_ - The baseline results for the regression test suite.
 
+
 Setting Up Git LFS
 ------------------
 
@@ -74,10 +75,11 @@ To setup our hooks::
     cd visit
     ./scripts/git-hooks/install-hooks.sh 
 
+
 Creating a Branch
 -----------------
 
-Developement for VisIt_ is done off of two main branches, the ``develop`` branch and the current release candidate branch, which was ``3.2RC`` when this content was written. The ``develop`` branch is used for development that will go into the next major or minor release. Major releases are releases where the first digit of the release number is incremented, Minor releases are releases where the second digit of the release number is incremented. The release candidate branch is used for development that will go into the next patch release. Patch releases are releases where the third digit of the release number is incremented.
+Development for VisIt_ is done off of two main branches, the ``develop`` branch and the current release candidate branch, which was ``3.2RC`` when this content was written. The ``develop`` branch is used for development that will go into the next major or minor release. Major releases are releases where the first digit of the release number is incremented, Minor releases are releases where the second digit of the release number is incremented. The release candidate branch is used for development that will go into the next patch release. Patch releases are releases where the third digit of the release number is incremented.
 
 There is no convention on the names of a branch. One commonly used convention is ``task\Username\YYYY_MM_DD_Description`` where ``Username`` is your GitHub user name, ``YYYY`` is the current year, ``MM`` is the current month, ``DD`` is the current day, and ``Description`` is a short description of the task to be performed. Since branches only exist while you are doing the development, the name isn't critical, but it should be sufficiently descriptive so that someone can have some idea what the development on the branch is about.
 
@@ -92,6 +94,12 @@ To create a branch off of the current release candidate::
     git checkout 3.2RC
     git pull
     git checkout -b task/user/2021_05_07_bug_fix
+
+
+When you switch branches, you may also need to update submodules so they match your branch::
+
+    git submodule update 
+
 
 Doing Development
 -----------------
@@ -117,3 +125,25 @@ Once you have finished all your changes you can push the change to GitHub. To pu
     git push --set-upstream origin task/user/2021_05_07_bug_fix
 
 Once you have pushed your changes to GitHub, you can submit a :ref:`pull request <Creating a Pull Request>`.
+
+
+CMake Build System 
+-------------------
+
+VisIt's build system uses `BLT <https://github.com/llnl/blt/>`_ CMake helpers.
+BLT is included in VisIt's git repo as a git submodule.
+To obtain the submodule, use `git clone --recursive ` when cloning, or manually setup the submodule after cloning using:
+
+    git submodule init
+    git submodule update 
+
+When you switch branches, you may also need to update submodules so they match your branch::
+
+    git submodule update 
+
+Branch development with git submodules can lead to unintended submodule commits.
+To avoid this, we have an CI check that ensures the active submodule commits match
+a version explicitly listed in a `hashes.txt` file at the root of the git repo.
+
+
+

--- a/src/doc/dev_manual/GitHub.rst
+++ b/src/doc/dev_manual/GitHub.rst
@@ -63,11 +63,11 @@ You can access GitHub either through https or ssh. If you use https you will be 
 
 To clone the repository::
 
-    git clone https://github.com/visit-dav/visit.git
+    git clone --recursive https://github.com/visit-dav/visit.git
 
 or::
 
-    git clone ssh://git@github.com/visit-dav/visit.git
+    git clone  --recursive ssh://git@github.com/visit-dav/visit.git
 
 To setup our hooks::
 

--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -257,7 +257,7 @@ rm -f buildlog installlog
 
 # Clone the repository if necessary.
 if test ! -e $testDir/$workingDir/visit; then
-    git clone ssh://git@github.com/visit-dav/visit.git >> buildlog 2>&1
+    git clone  --recursive ssh://git@github.com/visit-dav/visit.git >> buildlog 2>&1
 fi
 
 # Update the repository.


### PR DESCRIPTION
### Description

Adds:
- BLT CMake helpers as submodule.
- CI Check for blt time travel

Updates:
- ci/build scripts to use `git clone --recursive` to make sure they have access to BLT
- docs to mention `git clone --recursive`  and alternative to init submodules after a clone.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [x] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->
build system

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
