### PR TITLE
Add multiple-expression Defer example.

### DIFF
--- a/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
+++ b/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
@@ -4,10 +4,9 @@ DeferExpression operator
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The DeferExpression operator is a special-purpose operator that defers 
-expression execution until later in VisIt's pipeline execution cycle. This 
-means that instead of expression execution taking place before any operators 
-are applied, expression execution can instead take place after operators have 
-been applied.
+expression execution until later in VisIt's pipeline execution cycle.
+This means that instead of expression evaluation taking place before any operators are applied, expression evaluation can instead take place after operators have been applied, at whatever point in the pipeline the DeferOperator exists.
+This may be necessary in cases where an expression involves the *output* of an operator, or the operator behaves in such a way as to change the outcome of an expression.
 
 Plotting surface normals
 """"""""""""""""""""""""

--- a/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
+++ b/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
@@ -32,3 +32,14 @@ evaluated until after the ExternalSurface operator has been applied.
 
    DeferExpression operator example
 
+
+Deferring multiple expressions
+""""""""""""""""""""""""""""""
+
+What if you want to color a surface by a new variable equal to **(1.0 - X)^2** where **X** is the x-component of the surface's normal?
+Starting with the previous example, and supposing the surface normal expression was defined as **surfn=point_surface_normal("mesh")**.
+You would create a new expression to grab the x-component of the normal: **X=(1.0-surfn[0])^2**.
+Add a :ref:`Pseudocolor plot` of **X**.
+Apply the :ref:`ExternalSurface operator`.
+Apply the DeferExpression operator and add both **surfn** and **X** to the list of variables being deferred.
+

--- a/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
+++ b/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
@@ -39,7 +39,7 @@ Deferring multiple expressions
 What if you want to color a surface by a new variable equal to **(1.0 - X)^2** where **X** is the x-component of the surface's normal?
 Starting with the previous example, and supposing the surface normal expression was defined as **surfn=point_surface_normal("mesh")**.
 You would create a new expression to grab the x-component of the normal: **X=(1.0-surfn[0])^2**.
-Add a :ref:`Pseudocolor plot` of **X**.
+Add a :ref:`pseudocolor_plot_head` of **X**.
 Apply the :ref:`ExternalSurface operator`.
 Apply the DeferExpression operator and add both **surfn** and **X** to the list of variables being deferred.
 

--- a/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
+++ b/src/doc/using_visit/Operators/OperatorTypes/DeferExpression_operator.rst
@@ -36,10 +36,10 @@ evaluated until after the ExternalSurface operator has been applied.
 Deferring multiple expressions
 """"""""""""""""""""""""""""""
 
-What if you want to color a surface by a new variable equal to **(1.0 - X)^2** where **X** is the x-component of the surface's normal?
-Starting with the previous example, and supposing the surface normal expression was defined as **surfn=point_surface_normal("mesh")**.
-You would create a new expression to grab the x-component of the normal: **X=(1.0-surfn[0])^2**.
-Add a :ref:`pseudocolor_plot_head` of **X**.
+What if you want to color a surface by a new variable equal to ``(1.0 - X)^2`` where ``X`` is the x-component of the surface's normal?
+Starting with the previous example, and supposing the surface normal expression was defined as ``surfn=point_surface_normal("mesh")``.
+You would create a new expression to grab the x-component of the normal: ``X=(1.0-surfn[0])^2``.
+Add a :ref:`pseudocolor_plot_head` of ``X``.
 Apply the :ref:`ExternalSurface operator`.
-Apply the DeferExpression operator and add both **surfn** and **X** to the list of variables being deferred.
+Apply the DeferExpression operator and add both ``surfn`` and ``X`` to the list of variables being deferred.
 

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1965,7 +1965,6 @@ resrad Function: ``resrad()`` : ``resrad(expr0)``
 .. _CrackWidth_Expression_Function:
 
 crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
-
     Calculates crack width using the following formula:
 
         | crackwidth = L * (1 - (exp(-delta))  

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -2258,7 +2258,7 @@ Deferring expression evaluation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Expressions are generally evaluated before any operators are applied to the data.
-There are instances where one may want to defer the evaluation until after other filters have been applied.
+In cases where an expression involves the *output* of an operator, or the operator behaves in such a way as to change the outcome of an expression,  then it is necessary to *defer*  evaluation of such an expression until *after* operators have been applied.
 The :ref:`DeferExpression operator` is designed for this purpose.
 It will cause expressions in its list to be evaluated at the time of it's own execution in the pipeline.
 

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1048,14 +1048,12 @@ Material Error Function: ``materror()`` : ``materror(<Mat>,[Const,Const...])``
     as an integer. If multiple materials are to be selected from the 
     *material variable*, enclose them in square brackets as a list.
 
-    Examples...
+    Examples... ::
 
-::
-
-    materror(materials, 1)
-    materror(materials, [1,3])
-    materror(materials, "copper")
-    materror(materials, ["copper", "steel"])
+     materror(materials, 1)
+     materror(materials, [1,3])
+     materror(materials, "copper")
+     materror(materials, ["copper", "steel"])
 
 .. _Matvf_Expression_Function:
 
@@ -1066,14 +1064,12 @@ Material Volume Fractions Function: ``matvf()`` : ``matvf(<Mat>,[Const,Const,...
     the ``Const`` argument(s) identify one or more materials within the
     *material variable*. 
     
-    Examples...
+    Examples... ::
 
-::
-
-    matvf(materials, 1)
-    matvf(materials, [1,3])
-    matvf(materials, "copper")
-    matvf(materials, ["copper", "steel"])
+     matvf(materials, 1)
+     matvf(materials, [1,3])
+     matvf(materials, "copper")
+     matvf(materials, ["copper", "steel"])
 
 .. _NMats_Expression_Function:
 
@@ -1091,13 +1087,11 @@ Specmf Function: ``specmf()`` : ``specmf(<Spec>,<MConst>,[Const,Const,...])``
     The ``<Const>`` argument(s) identify which species within the
     *species variable* to select.
 
-    Examples:
+    Examples: ::
 
-::
-
-    specmf(species, 1, 1)
-    specmf(species, "copper", 1)
-    specmf(species, "copper", [1,3])
+     specmf(species, 1, 1)
+     specmf(species, "copper", 1)
+     specmf(species, "copper", [1,3])
 
 .. _Value_For_Material_Expression_Function:
 
@@ -1203,18 +1197,15 @@ Global Nodeid Function: ``global_nodeid()`` : ``global_nodeid(expr0)``
 .. _Ghost_Zoneid_Expression_Function:
 
 Ghost Zoneid Function: ``ghost_zoneid()`` : ``ghost_zoneid(<Mesh>)``
-    Returns the ghost zone id of each zone in the mesh. The ghost zone id could be any combination of the following:
+    Returns the ghost zone id of each zone in the mesh. The ghost zone id could be any combination of the following: ::
 
-::
+     DUPLICATED_ZONE_INTERNAL_TO_PROBLEM = 0,
+     ENHANCED_CONNECTIVITY_ZONE = 1,
+     REDUCED_CONNECTIVITY_ZONE = 2,
+     REFINED_ZONE_IN_AMR_GRID = 3,
+     ZONE_EXTERIOR_TO_PROBLEM = 4,
+     ZONE_NOT_APPLICABLE_TO_PROBLEM = 5
 
-    DUPLICATED_ZONE_INTERNAL_TO_PROBLEM = 0,
-    ENHANCED_CONNECTIVITY_ZONE = 1,
-    REDUCED_CONNECTIVITY_ZONE = 2,
-    REFINED_ZONE_IN_AMR_GRID = 3,
-    ZONE_EXTERIOR_TO_PROBLEM = 4,
-    ZONE_NOT_APPLICABLE_TO_PROBLEM = 5
-
-:
     where each flag represents a bit shift by the specified number of bits. So if a zone is not a ghost zone, the value returned would be 0, while if it was a ``DUPLICATED_ZONE_INTERNAL_TO_PROBLEM`` and a ``REFINED_ZONE_IN_AMR_GRID``, the value returned would be 1001 in binary, or 9 in decimal.
 
 .. _Volume_Function:
@@ -1582,9 +1573,7 @@ Position-Based CMFE Function: ``pos_cmfe()`` : ``pos_cmfe(<Donor Variable>,<Targ
    the expression properly identifies the different states of the donor
    variable instead of always mapping a fixed state.
 
-   Examples...
-   
-::
+   Examples... ::
 
     # Case A: Donor variable, "pressure" in same database as mesh, "ucdmesh"
     # Note that due to a limitation in Expression parsing, the '[0]id:' is
@@ -1965,18 +1954,18 @@ resrad Function: ``resrad()`` : ``resrad(expr0)``
 .. _CrackWidth_Expression_Function:
 
 crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
-    Calculates crack width using the following formula:
+    Calculates crack width using the following formula: ::
 
-        | crackwidth = L * (1 - (exp(-delta))  
-        | where: 
-        |  L = ZoneVol / (Area perpendicular to crack_dir)
-        |     find Area by slicing the cell by plane with origin == cell center
-        |     and Normal == crack_dir.  Take area of that slice.
-        | 
-        |  delta =
-        |     T11 for crack dir1 = component 0 of strain_tensor 
-        |     T22 for crack dir2 = component 4 of strain_tensor
-        |     T33 for crack dir3 = component 8 of strain_tensor
+     crackwidth = L * (1 - (exp(-delta))  
+     where: 
+        L = ZoneVol / (Area perpendicular to crack_dir)
+            find Area by slicing the cell by plane with origin == cell center
+            and Normal == crack_dir.  Take area of that slice.
+         
+        delta =
+            T11 for crack dir1 = component 0 of strain_tensor 
+            T22 for crack dir2 = component 4 of strain_tensor
+            T33 for crack dir3 = component 8 of strain_tensor
    
 Time Iteration Expressions
 """"""""""""""""""""""""""
@@ -2219,9 +2208,7 @@ for the result. If this is not the desired result, the
 :ref:`recenter() <Recenter_Expression_Function>` expression function should be
 used, where appropriate, to adjust centering of some of the
 terms in the expression.  Note that ordering of operations will probably be
-important. For example
-
-::
+important. For example ::
 
     node_var + recenter(zone_var)
     recenter(zone_var + node_var)

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1967,6 +1967,7 @@ resrad Function: ``resrad()`` : ``resrad(expr0)``
 crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
 
     Calculates crack width using the following formula:
+
         | crackwidth = L * (1 - (exp(-delta))  
         | where: 
         |  L = ZoneVol / (Area perpendicular to crack_dir)

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1967,15 +1967,16 @@ resrad Function: ``resrad()`` : ``resrad(expr0)``
 crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
 
     Calculates crack width using the following formula:
-        crackwidth = L * (1 - (exp(-delta))  
-        where: 
-          L = ZoneVol / (Area perpendicular to crack_dir)
-            find Area by slicing the cell by plane with origin == cell center
-            and Normal == crack_dir.  Take area of that slice.
-    
-          delta = T11 for crack dir1 = component 0 of strain_tensor 
-                  T22 for crack dir2 = component 4 of strain_tensor
-                  T33 for crack dir3 = component 8 of strain_tensor
+        | crackwidth = L * (1 - (exp(-delta))  
+        | where: 
+        |  L = ZoneVol / (Area perpendicular to crack_dir)
+        |     find Area by slicing the cell by plane with origin == cell center
+        |     and Normal == crack_dir.  Take area of that slice.
+        | 
+        |  delta =
+        |     T11 for crack dir1 = component 0 of strain_tensor 
+        |     T22 for crack dir2 = component 4 of strain_tensor
+        |     T33 for crack dir3 = component 8 of strain_tensor
    
 Time Iteration Expressions
 """"""""""""""""""""""""""
@@ -2252,6 +2253,15 @@ elsewhere.
 Just as for centering, we have two options when dealing with variables from
 two different meshes. Each of which involves *mapping* one of the variables
 onto the other variable's mesh using one of the CMFE expression functions.
+
+Deferring expression evaluation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Expressions are generally evaluated before any operators are applied to the data.
+There are instances where one may want to defer the evaluation until after other filters have been applied.
+The :ref:`DeferExpression operator` is designed for this purpose.
+It will cause expressions in its list to be evaluated at the time of it's own execution in the pipeline.
+
 
 Automatic expressions
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Description
Add note about Defer Expression to the Expressions page.
Resolves #4565.

Also, fix readability of crack_width expression by using line blocks to preserve indentation.


### Type of change

<!-- Please check one of the boxes below -->

~~* [ ] Bug fix~~
~~* [ ] New feature~~
* [X] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I built the 'manual's without errors or warnings.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
