### PR TITLE
Use initial mesh coords for strain

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2642,6 +2642,9 @@ avtMiliFileFormat::AddMiliVariableToMetaData(avtDatabaseMetaData *avtMD,
 //
 //      Mark C. Miller, Fri Sep 16 11:26:22 PDT 2022
 //      Handle displacements on sand mesh too...they are same as main mesh.
+//
+//      Mark C. Miller, Tue Nov  8 18:11:00 PST 2022
+//      Ensure correct initial mesh coords are used for strain exprs.
 // ****************************************************************************
 
 void
@@ -2789,15 +2792,7 @@ avtMiliFileFormat::AddMiliDerivedVariables(avtDatabaseMetaData *md,
     std::string varPath;
     std::string varPathBase = "Derived/Shared/";
 
-    std::string initCoordsName = meshPath +
-        "Derived/Shared/strain/initial_strain_coords";
-    Expression initCoordsExpr;
-    initCoordsExpr.SetName(initCoordsName);
-    initCoordsExpr.SetDefinition("conn_cmfe(coord(<[0]i:" +
-        meshName + ">)," + meshName + ")");
-    initCoordsExpr.SetType(Expression::VectorMeshVar);
-    initCoordsExpr.SetHidden(true);
-    md->AddExpression(&initCoordsExpr);
+    std::string initCoordsName = meshPath + "Primal/node/init_mesh_coords"
 
     //
     // Relative volume.

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug causing the blueprint plugin to incorrectly assign a zonal association to mfem grid functions that were neither H1 nor L2.</li>
   <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.</li>
   <li>Fixed a bug that caused the compute engine to crash when in scalable rendering mode. The specific bug involved saving non screen capture images, but the crash could occur whenever doing scalable rendering.</li>
+  <li>Fixed bug in Mili plugin where Green Lagrange strain was using incorrect initial coordintes.</li> 
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves an issue reported by Mili user on Teams where Green Lagrange strain was using a cmfe of coordinates of mesh from state 0. Instead, it should be using `init_mesh_coords`. 

In Mili, there is a difference between what *iniital* means and what state 0 means. Initial means what is stored in the A file and read via `mc_load_nodes` whereas state 0 means the first computed state from the data producer and is read with `mc_read_results` (the data is a Mili results record).

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
