### PR TITLE
use init_mesh_coords for strain (#18276)

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2648,6 +2648,9 @@ avtMiliFileFormat::AddMiliVariableToMetaData(avtDatabaseMetaData *avtMD,
 //
 //      Mark C. Miller, Fri Sep 16 11:26:22 PDT 2022
 //      Handle displacements on sand mesh too...they are same as main mesh.
+//
+//      Mark C. Miller, Tue Nov  8 18:11:00 PST 2022
+//      Ensure correct initial mesh coords are used for strain exprs.
 // ****************************************************************************
 
 void
@@ -2795,15 +2798,7 @@ avtMiliFileFormat::AddMiliDerivedVariables(avtDatabaseMetaData *md,
     std::string varPath;
     std::string varPathBase = "Derived/Shared/";
 
-    std::string initCoordsName = meshPath +
-        "Derived/Shared/strain/initial_strain_coords";
-    Expression initCoordsExpr;
-    initCoordsExpr.SetName(initCoordsName);
-    initCoordsExpr.SetDefinition("conn_cmfe(coord(<[0]i:" +
-        meshName + ">)," + meshName + ")");
-    initCoordsExpr.SetType(Expression::VectorMeshVar);
-    initCoordsExpr.SetHidden(true);
-    md->AddExpression(&initCoordsExpr);
+    std::string initCoordsName = meshPath + "Primal/node/init_mesh_coords"
 
     //
     // Relative volume.

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug causing the blueprint plugin to incorrectly assign a zonal association to mfem grid functions that were neither H1 nor L2.</li>
   <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.</li>
   <li>Fixed a bug that caused the compute engine to crash when in scalable rendering mode. The specific bug involved saving non screen capture images, but the crash could occur whenever doing scalable rendering.</li>
+  <li>Fixed bug in Mili plugin where Green Lagrange strain was using incorrect initial coordintes.</li> 
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Cherry-pick merge of 121767f169a92ad297779aa8139c6aadeba73bf8 from `3.3RC` to `develop`
