### PR TITLE
X Ray Image Query Blueprint Output Imaging Plane topologies and extra metadata

### DIFF
--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -91,6 +91,27 @@ inline bool outputTypeIsBlueprint(int otype)
         otype == BLUEPRINT_YAML_OUT;
 }
 
+inline void Cross(double result[3], const double v1[3], const double v2[3])
+{
+    result[0] = (v1[1] * v2[2]) - (v1[2] * v2[1]);
+    result[1] = (v1[2] * v2[0]) - (v1[0] * v2[2]);
+    result[2] = (v1[0] * v2[1]) - (v1[1] * v2[0]);
+}
+
+inline void Add(double result[3], const double v1[3], const double v2[3])
+{
+    result[0] = v1[0] + v2[0];
+    result[1] = v1[1] + v2[1];
+    result[2] = v1[2] + v2[2];
+}
+
+inline void Scale(double result[3], const double v[3], const double s)
+{
+    result[0] = v[0] * s;
+    result[1] = v[1] * s;
+    result[2] = v[2] * s;
+}
+
 // ****************************************************************************
 //  Method: avtXRayImageQuery::avtXRayImageQuery
 //
@@ -1332,6 +1353,9 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             data_out["state/xray_view/imagePan/y"] = imagePan[1];
             data_out["state/xray_view/imageZoom"] = imageZoom;
             data_out["state/xray_view/perspective"] = perspective;
+            data_out["state/xray_view/numXPixels"] = nx;
+            data_out["state/xray_view/numYPixels"] = ny;
+            data_out["state/xray_view/numBins"] = numBins;
 
             // calculate spatial extent coords
             // (the physical extents of the image projected on the near plane)
@@ -1364,6 +1388,78 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             data_out["state/xray_view/image_coords/y"].set(conduit::DataType::float32(y_coords_dim));
             float *spatial_yvals = data_out["state/xray_view/image_coords/y"].value();
             for (int i = 0; i < y_coords_dim; i ++) { spatial_yvals[i] = i * nearDy; }
+
+            data_out["state/xray_view/detectorWidth"] = 2. * nearWidth;
+            data_out["state/xray_view/detectorHeight"] = 2. * nearHeight;
+
+            // VIEW PLANE
+
+            // set up view plane coords
+            data_out["coordsets/view_plane_coords/type"] = "explicit";
+            data_out["coordsets/view_plane_coords/values/x"].set(conduit::DataType::float64(4));
+            data_out["coordsets/view_plane_coords/values/y"].set(conduit::DataType::float64(4));
+            data_out["coordsets/view_plane_coords/values/z"].set(conduit::DataType::float64(4));
+            double *xvals_view = data_out["coordsets/view_plane_coords/values/x"].value();
+            double *yvals_view = data_out["coordsets/view_plane_coords/values/y"].value();
+            double *zvals_view = data_out["coordsets/view_plane_coords/values/z"].value();
+            
+            // calculate left vector by crossing normal with up vector
+            double left[3];
+            Cross(left, viewUp, normal);
+            
+            // lower left corner, lower right corner, etc.
+            double llc[3], lrc[3], ulc[3], urc[3];
+            
+            // a couple containers for intermediate vector math results
+            double temp1[3], temp2[3], temp3[3];
+
+            // calc llc
+            Scale(temp1, viewUp, -1. * viewHeight);
+            Scale(temp2, left, viewWidth);
+            Add(temp3, temp1, temp2);
+            Add(llc, temp3, focus);
+            
+            // calc lrc
+            Scale(temp1, viewUp, -1. * viewHeight);
+            Scale(temp2, left, -1. * viewWidth);
+            Add(temp3, temp1, temp2);
+            Add(lrc, temp3, focus);            
+            
+            // calc ulc
+            Scale(temp1, viewUp, viewHeight);
+            Scale(temp2, left, viewWidth);
+            Add(temp3, temp1, temp2);
+            Add(ulc, temp3, focus);            
+            
+            // calc urc
+            Scale(temp1, viewUp, viewHeight);
+            Scale(temp2, left, -1. * viewWidth);
+            Add(temp3, temp1, temp2);
+            Add(urc, temp3, focus);
+            
+            // set x values          // set y values          // set z values
+            xvals_view[0] = llc[0];  yvals_view[0] = llc[1];  zvals_view[0] = llc[2];
+            xvals_view[1] = lrc[0];  yvals_view[1] = lrc[1];  zvals_view[1] = lrc[2];
+            xvals_view[2] = urc[0];  yvals_view[2] = urc[1];  zvals_view[2] = urc[2];
+            xvals_view[3] = ulc[0];  yvals_view[3] = ulc[1];  zvals_view[3] = ulc[2];
+
+            // set up view plane topo
+            data_out["topologies/view_plane_topo/type"] = "unstructured";
+            data_out["topologies/view_plane_topo/coordset"] = "view_plane_coords";
+            data_out["topologies/view_plane_topo/elements/shape"] = "quad";
+            data_out["topologies/view_plane_topo/elements/connectivity"].set(conduit::DataType::int32(4));
+            int *view_plane_conn = data_out["topologies/view_plane_topo/elements/connectivity"].value();
+            for (int i = 0; i < 4; i ++) { view_plane_conn[i] = i; }
+
+            // set up view plane trivial field
+            data_out["fields/view_plane_field/topology"] = "view_plane_topo";
+            data_out["fields/view_plane_field/association"] = "element";
+            data_out["fields/view_plane_field/volume_dependent"] = "false";
+            data_out["fields/view_plane_field/values"].set(conduit::DataType::float64(1));
+            conduit::float64 *view_plane_field_vals = data_out["fields/view_plane_field/values"].value();
+            view_plane_field_vals[0] = 0;
+
+            data_out.print();
 
             // verify
             conduit::Node verify_info;

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -984,6 +984,12 @@ avtXRayImageQuery::GetSecondaryVars(std::vector<std::string> &outVars)
 // 
 //    Justin Privitera, Thu Sep 29 17:35:07 PDT 2022
 //    Added warning message for bmp output in result message and to debug1.
+// 
+//    Justin Privitera, Tue Nov 15 11:44:01 PST 2022
+//    Various changes to the blueprint output:
+//     - Reorganized metadata into categories
+//     - Added new metadata outputs: query parameters and extra data
+//     - Added imaging plane topologies
 //
 // ****************************************************************************
 
@@ -1442,15 +1448,15 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             double center[3], temp[3];
             Scale(temp, normal, nearPlane);
             Add(center, temp, focus);
-            WriteImagingPlane(data_out, "near_plane", nearWidth, nearHeight, center);
+            WriteBlueprintImagingPlane(data_out, "near_plane", nearWidth, nearHeight, center);
 
             // write view plane
-            WriteImagingPlane(data_out, "view_plane", viewWidth, viewHeight, focus);
+            WriteBlueprintImagingPlane(data_out, "view_plane", viewWidth, viewHeight, focus);
 
             // write far plane
             Scale(temp, normal, farPlane);
             Add(center, temp, focus);
-            WriteImagingPlane(data_out, "far_plane", farWidth, farHeight, center);
+            WriteBlueprintImagingPlane(data_out, "far_plane", farWidth, farHeight, center);
 
             // verify
             conduit::Node verify_info;
@@ -1927,10 +1933,10 @@ avtXRayImageQuery::WriteArrays(vtkDataSet **leaves,
 }
 
 // ****************************************************************************
-//  Method: avtXRayImageQuery::WriteImagingPlane
+//  Method: avtXRayImageQuery::WriteBlueprintImagingPlane
 //
 //  Purpose:
-//    TODO
+//    Calculates imaging plane coords and writes them to blueprint output.
 //
 //  Programmer: Justin Privitera
 //  Creation:   November 14, 2022
@@ -1938,11 +1944,11 @@ avtXRayImageQuery::WriteArrays(vtkDataSet **leaves,
 // ****************************************************************************
 
 void
-avtXRayImageQuery::WriteImagingPlane(conduit::Node &data_out,
-                                     const std::string plane_name,
-                                     const double width,
-                                     const double height,
-                                     const double center[3])
+avtXRayImageQuery::WriteBlueprintImagingPlane(conduit::Node &data_out,
+                                              const std::string plane_name,
+                                              const double width,
+                                              const double height,
+                                              const double center[3])
 {
     // set up imaging plane coords
     data_out["coordsets/" + plane_name + "_coords/type"] = "explicit";
@@ -1960,7 +1966,7 @@ avtXRayImageQuery::WriteImagingPlane(conduit::Node &data_out,
     // lower left corner, lower right corner, etc.
     double llc[3], lrc[3], ulc[3], urc[3];
     
-    // a couple containers for intermediate vector math results
+    // containers for intermediate vector math results
     double temp1[3], temp2[3], temp3[3];
 
     // calc llc

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -155,7 +155,7 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
     double                    width, height;
     int                       nx, ny;
 
-    std::string               absVarName;  //e.g. "absorbtivity"
+    std::string               absVarName;  //e.g. "absorptivity"
     std::string               emisVarName; //e.g. "emissivity"
 
     int                       numPixels;

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -158,7 +158,7 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
     double                    width, height;
     int                       nx, ny;
 
-    std::string               absVarName;  //e.g. "absorptivity"
+    std::string               absVarName;  //e.g. "absorbtivity"
     std::string               emisVarName; //e.g. "emissivity"
 
     int                       numPixels;

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -179,6 +179,11 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
                                           conduit::float64 *intensity_vals,
                                           conduit::float64 *depth_vals,
                                           int numBins);
+    void                      WriteImagingPlane(conduit::Node &data_out,
+                                                const std::string plane_name,
+                                                const double width,
+                                                const double height,
+                                                const double center[3]);
 #endif
     void                      ConvertOldImagePropertiesToNew();
     void                      CheckData(vtkDataSet **, const int);

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -85,6 +85,9 @@
 //    Justin Privitera, Tue Jun 14 10:21:03 PDT 2022
 //    Added conduit include here, added output dir field + setter, 
 //    added write arrays method for writing conduit blueprint output.
+// 
+//    Justin Privitera, Tue Nov 15 11:44:01 PST 2022
+//    Added WriteBlueprintImagingPlane function if conduit is defined
 //
 // ****************************************************************************
 
@@ -179,11 +182,11 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
                                           conduit::float64 *intensity_vals,
                                           conduit::float64 *depth_vals,
                                           int numBins);
-    void                      WriteImagingPlane(conduit::Node &data_out,
-                                                const std::string plane_name,
-                                                const double width,
-                                                const double height,
-                                                const double center[3]);
+    void                      WriteBlueprintImagingPlane(conduit::Node &data_out,
+                                                         const std::string plane_name,
+                                                         const double width,
+                                                         const double height,
+                                                         const double center[3]);
 #endif
     void                      ConvertOldImagePropertiesToNew();
     void                      CheckData(vtkDataSet **, const int);

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Enhancements in version 3.3.2</font></b></p>
 <ul>
   <li>In the X Ray Image Query, a warning was added for the BMP output type, saying it may not function properly. This output type will be removed in the next major release of VisIt.</li>
+  <li>For Blueprint output types from the X Ray Image Query, a host of new metadata has been added, as well as imaging plane topologies.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -323,6 +323,9 @@ if not os.path.isdir(conduit_dir_json):
 conduit_dir_yaml = pjoin(outdir_set, "yaml")
 if not os.path.isdir(conduit_dir_yaml):
     os.mkdir(conduit_dir_yaml)
+conduit_dir_imaging_planes = pjoin(outdir_set, "imaging_planes")
+if not os.path.isdir(conduit_dir_imaging_planes):
+    os.mkdir(conduit_dir_imaging_planes)
 
 def setup_bp_test():
     OpenDatabase(silo_data_path("curv3d.silo"))
@@ -431,12 +434,8 @@ def test_bp_state(testname, conduit_db):
     test_bp_state_xray_view(testname, xrayout)
     test_bp_state_xray_query(testname, xrayout)
     test_bp_state_xray_data(testname, xrayout)
-    
-    
 
-#
 # hdf5
-#
 
 setup_bp_test()
 
@@ -492,6 +491,61 @@ AddPlot("Pseudocolor", "mesh_image_topo/intensities")
 DrawPlots()
 Test("Blueprint_YAML_X_Ray_Output")
 DeleteAllPlots()
+CloseDatabase(conduit_db)
+
+# test imaging plane topos
+
+setup_bp_test()
+
+params = dict()
+params["image_size"] = (400, 300)
+params["output_dir"] = conduit_dir_imaging_planes
+params["output_type"] = "hdf5"
+params["focus"] = (0., 2.5, 10.)
+params["perspective"] = 1
+params["near_plane"] = -50.
+params["far_plane"] = 50.
+params["vars"] = ("d", "p")
+params["parallel_scale"] = 5.
+Query("XRay Image", params)
+
+conduit_db = pjoin(conduit_dir_imaging_planes, "output.cycle_000048.root")
+
+OpenDatabase(conduit_db)
+
+AddPlot("Pseudocolor", "mesh_far_plane_topo/far_plane_field", 1, 1)
+AddPlot("Pseudocolor", "mesh_view_plane_topo/view_plane_field", 1, 1)
+AddPlot("Pseudocolor", "mesh_near_plane_topo/near_plane_field", 1, 1)
+DrawPlots()
+
+SetActivePlots(4)
+PseudocolorAtts = PseudocolorAttributes()
+PseudocolorAtts.invertColorTable = 1
+PseudocolorAtts.opacityType = PseudocolorAtts.FullyOpaque  # ColorTable, FullyOpaque, Constant, Ramp, VariableRange
+SetPlotOptions(PseudocolorAtts)
+
+# SetActivePlots(2)
+# PseudocolorAtts = PseudocolorAttributes()
+# PseudocolorAtts.colorTableName = "Oranges"
+# PseudocolorAtts.invertColorTable = 1
+# PseudocolorAtts.opacityType = PseudocolorAtts.Constant  # ColorTable, FullyOpaque, Constant, Ramp, VariableRange
+# PseudocolorAtts.opacity = 0.7
+# SetPlotOptions(PseudocolorAtts)
+
+View3DAtts = View3DAttributes()
+View3DAtts.viewNormal = (-0.519145, 0.199692, -0.831031)
+View3DAtts.focus = (0, 2.5, 10)
+View3DAtts.viewUp = (-0.0954901, 0.952683, 0.288577)
+View3DAtts.viewAngle = 30
+View3DAtts.parallelScale = 58.6531
+View3DAtts.nearPlane = -117.306
+View3DAtts.farPlane = 117.306
+SetView3D(View3DAtts)
+
+Test("Blueprint_HDF5_Imaging_Planes")
+
+DeleteAllPlots()
+CloseDatabase(silo_data_path("curv3d.silo"))
 CloseDatabase(conduit_db)
 
 # 

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -36,6 +36,10 @@
 #    os.remove is gone.
 #    tmp/baddir is gone, replaced.
 #    These changes were made so the tests no longer crash on windows.
+# 
+#    Justin Privitera, Tue Nov 15 14:54:35 PST 2022
+#    Added new tests for additional blueprint output metadata as well as
+#    imaging plane topologies.
 #
 # ----------------------------------------------------------------------------
 
@@ -523,14 +527,6 @@ PseudocolorAtts = PseudocolorAttributes()
 PseudocolorAtts.invertColorTable = 1
 PseudocolorAtts.opacityType = PseudocolorAtts.FullyOpaque  # ColorTable, FullyOpaque, Constant, Ramp, VariableRange
 SetPlotOptions(PseudocolorAtts)
-
-# SetActivePlots(2)
-# PseudocolorAtts = PseudocolorAttributes()
-# PseudocolorAtts.colorTableName = "Oranges"
-# PseudocolorAtts.invertColorTable = 1
-# PseudocolorAtts.opacityType = PseudocolorAtts.Constant  # ColorTable, FullyOpaque, Constant, Ramp, VariableRange
-# PseudocolorAtts.opacity = 0.7
-# SetPlotOptions(PseudocolorAtts)
 
 View3DAtts = View3DAttributes()
 View3DAtts.viewNormal = (-0.519145, 0.199692, -0.831031)

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -329,13 +329,7 @@ def setup_bp_test():
     AddPlot("Pseudocolor", "d")
     DrawPlots()
 
-def test_bp_state(testname, conduit_db):
-    xrayout = conduit.Node()
-    conduit.relay.io.blueprint.load_mesh(xrayout, conduit_db)
-    
-    cycle = xrayout["domain_000000/state/cycle"]
-    TestValueEQ(testname + "_Cycle", cycle, 48)
-
+def test_bp_state_xray_view(testname, xrayout):
     normalx = xrayout["domain_000000/state/xray_view/normal/x"]
     normaly = xrayout["domain_000000/state/xray_view/normal/y"]
     normalz = xrayout["domain_000000/state/xray_view/normal/z"]
@@ -372,13 +366,73 @@ def test_bp_state(testname, conduit_db):
     
     perspective = xrayout["domain_000000/state/xray_view/perspective"]
     TestValueEQ(testname + "_Perspective", perspective, 0)
+
+    perspectiveStr = xrayout["domain_000000/state/xray_view/perspectiveStr"]
+    TestValueEQ(testname + "_PerspectiveStr", perspectiveStr, "parallel")
+
+def test_bp_state_xray_query(testname, xrayout):
+    divideEmisByAbsorb = xrayout["domain_000000/state/xray_query/divideEmisByAbsorb"]
+    TestValueEQ(testname + "_DivideEmisByAbsorb", divideEmisByAbsorb, 1)
     
-    spatial_coords_x = xrayout["domain_000000/state/xray_view/image_coords/x"]
-    spatial_coords_y = xrayout["domain_000000/state/xray_view/image_coords/y"]
+    divideEmisByAbsorbStr = xrayout["domain_000000/state/xray_query/divideEmisByAbsorbStr"]
+    TestValueEQ(testname + "_DivideEmisByAbsorbStr", divideEmisByAbsorbStr, "yes")
+    
+    numXPixels = xrayout["domain_000000/state/xray_query/numXPixels"]
+    TestValueEQ(testname + "_NumXPixels", numXPixels, 300)
+    
+    numYPixels = xrayout["domain_000000/state/xray_query/numYPixels"]
+    TestValueEQ(testname + "_NumYPixels", numYPixels, 200)
+    
+    numBins = xrayout["domain_000000/state/xray_query/numBins"]
+    TestValueEQ(testname + "_NumBins", numBins, 1)
+    
+    absVarName = xrayout["domain_000000/state/xray_query/absVarName"]
+    TestValueEQ(testname + "_AbsVarName", absVarName, "d")
+    
+    emisVarName = xrayout["domain_000000/state/xray_query/emisVarName"]
+    TestValueEQ(testname + "_EmisVarName", emisVarName, "p")
+
+def test_bp_state_xray_data(testname, xrayout):
+    spatial_coords_x = xrayout["domain_000000/state/xray_data/image_coords/x"]
+    spatial_coords_y = xrayout["domain_000000/state/xray_data/image_coords/y"]
     TestValueEQ(testname + "_SpatialExtents0", [spatial_coords_x[0], spatial_coords_y[0]], [0.0, 0.0])
     TestValueEQ(testname + "_SpatialExtents1", [spatial_coords_x[1], spatial_coords_y[1]], [0.05, 0.05])
     TestValueEQ(testname + "_SpatialExtents2", [spatial_coords_x[2], spatial_coords_y[2]], [0.1, 0.1])
     TestValueEQ(testname + "_SpatialExtents3", [spatial_coords_x[-1], spatial_coords_y[-1]], [15.0, 10.0])
+    
+    detectorWidth = xrayout["domain_000000/state/xray_data/detectorWidth"]
+    TestValueEQ(testname + "_DetectorWidth", detectorWidth, 15)
+
+    detectorHeight = xrayout["domain_000000/state/xray_data/detectorHeight"]
+    TestValueEQ(testname + "_DetectorHeight", detectorHeight, 10)
+    
+    intensityMax = xrayout["domain_000000/state/xray_data/intensityMax"]
+    TestValueEQ(testname + "_IntensityMax", intensityMax, 0.24153)
+    
+    intensityMin = xrayout["domain_000000/state/xray_data/intensityMin"]
+    TestValueEQ(testname + "_IntensityMin", intensityMin, 0)
+    
+    pathLengthMax = xrayout["domain_000000/state/xray_data/pathLengthMax"]
+    TestValueEQ(testname + "_PathLengthMax", pathLengthMax, 148.67099)
+    
+    pathLengthMin = xrayout["domain_000000/state/xray_data/pathLengthMin"]
+    TestValueEQ(testname + "_PathLengthMin", pathLengthMin, 0)
+
+def test_bp_state(testname, conduit_db):
+    xrayout = conduit.Node()
+    conduit.relay.io.blueprint.load_mesh(xrayout, conduit_db)
+
+    time = xrayout["domain_000000/state/time"]
+    TestValueEQ(testname + "_Time", time, 4.8)
+    
+    cycle = xrayout["domain_000000/state/cycle"]
+    TestValueEQ(testname + "_Cycle", cycle, 48)
+
+    test_bp_state_xray_view(testname, xrayout)
+    test_bp_state_xray_query(testname, xrayout)
+    test_bp_state_xray_data(testname, xrayout)
+    
+    
 
 #
 # hdf5

--- a/test/baseline/queries/xrayimage/Blueprint_HDF5_Imaging_Planes.png
+++ b/test/baseline/queries/xrayimage/Blueprint_HDF5_Imaging_Planes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:998eab0924aa0ffaa0f27a2f5fd48377eaaecd46f79bf256bce4165b07044971
+size 2379


### PR DESCRIPTION
### Description

Addresses multiple bullets in #17791 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Added inline vector math functions.
Changes to blueprint output:
 - reorganized metadata into 4 categories: top level, view params, query params, and other metadata. This organization is reflected in the structure of the output conduit tree
 - Added new metadata output: perspectiveStr, divideEmisByAbsorb, divideEmisByAbsorbStr, numXPixels, numYPixels, numBins, absVarName, emisVarName, detectorWidth, detectorHeight, intensityMax, intensityMin, pathLengthMax, pathLengthMin
 - Added imaging plane topologies. This enables users to visualize the near plane, view plane, and far plane on top of their data, allowing them greater understanding of the orientation and position of the simulated x ray detector.

I will update the docs when I merge with develop.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Added tests for new metadata and for imaging topos
built and ran on rztopaz
all tests pass

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
