### PR TITLE
Fix color table window resize offscreen bug

### DIFF
--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -192,6 +192,7 @@ void
 QvisColorTableWindow::CreateWindowContents()
 {
     central->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    central->setMaximumHeight(800);
     // Create the widgets needed to set the default color tables.
     topLayout->setMargin(2);
     // topLayout->setSizeConstraint(QLayout::SetFixedSize);

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -191,14 +191,14 @@ QvisColorTableWindow::~QvisColorTableWindow()
 void
 QvisColorTableWindow::CreateWindowContents()
 {
-    // central->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    central->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     // Create the widgets needed to set the default color tables.
     topLayout->setMargin(2);
-    topLayout->setSizeConstraint(QLayout::SetFixedSize);
+    // topLayout->setSizeConstraint(QLayout::SetFixedSize);
     defaultGroup = new QGroupBox(central);
     defaultGroup->setTitle(tr("Default Color Table"));
-    QSizePolicy *sizePolicy = new QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum, QSizePolicy::GroupBox);
-    // defaultGroup->setSizePolicy(*sizePolicy);
+    // QSizePolicy *sizePolicy = new QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum, QSizePolicy::GroupBox);
+    defaultGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(defaultGroup, 5);
     
     QVBoxLayout *innerDefaultTopLayout = new QVBoxLayout(defaultGroup);
@@ -226,7 +226,7 @@ QvisColorTableWindow::CreateWindowContents()
     // management stuff.
     colorTableWidgetGroup = new QGroupBox(central);
     colorTableWidgetGroup->setTitle(tr("Manager"));
-    // colorTableWidgetGroup->setSizePolicy(*sizePolicy);
+    colorTableWidgetGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(colorTableWidgetGroup, 5);
     QVBoxLayout *innerColorTableLayout = new QVBoxLayout(colorTableWidgetGroup);
     // innerColorTableLayout->setSizeConstraint(QLayout::SetFixedSize);
@@ -266,6 +266,7 @@ QvisColorTableWindow::CreateWindowContents()
 
     nameListBox = new QTreeWidget(colorTableWidgetGroup);
     nameListBox->setMinimumHeight(100);
+    nameListBox->setMaximumHeight(100);
     nameListBox->setColumnCount(1);
     // don't want the header
     nameListBox->header()->close();
@@ -284,6 +285,7 @@ QvisColorTableWindow::CreateWindowContents()
     tagTable->clear();
     tagTable->setSortingEnabled(true);
     tagTable->setMinimumHeight(100);
+    tagTable->setMaximumHeight(100);
     tagTable->setMinimumWidth(250);
     tagTable->setColumnCount(2);
     mgLayout->addWidget(tagTable, 3, 0, 1, 3);
@@ -308,7 +310,8 @@ QvisColorTableWindow::CreateWindowContents()
     // Add the group box that will contain the color-related widgets.
     colorWidgetGroup = new QGroupBox(central);
     colorWidgetGroup->setTitle(tr("Editor"));
-    // colorWidgetGroup->setSizePolicy(*sizePolicy);
+    colorWidgetGroup->setMaximumHeight(350);
+    // colorWidgetGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(colorWidgetGroup, 100);
     QVBoxLayout *innerColorLayout = new QVBoxLayout(colorWidgetGroup);
     // innerColorLayout->setSizeConstraint(QLayout::SetFixedSize);
@@ -321,21 +324,22 @@ QvisColorTableWindow::CreateWindowContents()
     colorNumColors->setKeyboardTracking(false);
     colorNumColors->setRange(2,256);
     colorNumColors->setSingleStep(1);
+    colorNumColors->setMaximumWidth(75);
     connect(colorNumColors, SIGNAL(valueChanged(int)),
             this, SLOT(resizeColorTable(int)));
-    colorInfoLayout->addWidget(colorNumColors, 0, 1, 1, 2);
+    colorInfoLayout->addWidget(colorNumColors, 1, 3, 1, 1);
     colorInfoLayout->addWidget(new QLabel(tr("Number of colors"),
-                                          colorWidgetGroup), 0, 0);
+                                          colorWidgetGroup), 1, 0, 1, 3);
 
     // Create radio buttons to convert the color table between color table types.
-    colorInfoLayout->addWidget(new QLabel(tr("Color table type")), 1, 0);
+    colorInfoLayout->addWidget(new QLabel(tr("Color table type")), 0, 0, 1, 3);
     colorTableTypeGroup = new QButtonGroup(colorWidgetGroup);
     QRadioButton *rb = new QRadioButton(tr("Continuous"),colorWidgetGroup);
     colorTableTypeGroup->addButton(rb,0);
-    colorInfoLayout->addWidget(rb, 1, 1);
+    colorInfoLayout->addWidget(rb, 0, 3, 1, 2);
     rb = new QRadioButton(tr("Discrete"),colorWidgetGroup);
     colorTableTypeGroup->addButton(rb,1);
-    colorInfoLayout->addWidget(rb, 1, 2);
+    colorInfoLayout->addWidget(rb, 0, 5, 1, 2);
     connect(colorTableTypeGroup, SIGNAL(buttonClicked(int)),
             this, SLOT(setColorTableType(int)));
 
@@ -346,12 +350,15 @@ QvisColorTableWindow::CreateWindowContents()
     innerColorLayout->addLayout(seLayout);
 
     alignPointButton = new QPushButton(tr("Align"), colorWidgetGroup);
+    alignPointButton->setMaximumWidth(60);
     connect(alignPointButton, SIGNAL(clicked()),
             this, SLOT(alignControlPoints()));
+    // seLayout->addWidget(alignPointButton, 0, 0);
     seLayout->addWidget(alignPointButton);
     seLayout->addStretch(10);
 
     smoothLabel = new QLabel(tr("Smoothing"), colorWidgetGroup);
+    // seLayout->addWidget(smoothLabel, 0, 1);
     seLayout->addWidget(smoothLabel);
     smoothingMethod = new QComboBox(colorWidgetGroup);
     smoothingMethod->addItem(tr("None"));
@@ -359,11 +366,13 @@ QvisColorTableWindow::CreateWindowContents()
     smoothingMethod->addItem(tr("Cubic Spline"));
     connect(smoothingMethod, SIGNAL(activated(int)),
             this, SLOT(smoothingMethodChanged(int)));
+    // seLayout->addWidget(smoothingMethod, 0, 2);
     seLayout->addWidget(smoothingMethod);
 
     equalCheckBox = new QCheckBox(tr("Equal"), colorWidgetGroup);
     connect(equalCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(equalSpacingToggled(bool)));
+    // seLayout->addWidget(equalCheckBox, 0, 3);
     seLayout->addWidget(equalCheckBox);
 
     // Create the spectrum bar.
@@ -412,12 +421,13 @@ QvisColorTableWindow::CreateWindowContents()
     showIndexHintsCheckBox->setChecked(false);
     connect(showIndexHintsCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(showIndexHintsToggled(bool)));
-    innerColorLayout->addWidget(showIndexHintsCheckBox);
+    // innerColorLayout->addWidget(showIndexHintsCheckBox);
+    colorInfoLayout->addWidget(showIndexHintsCheckBox, 1, 4, 1, 3);
 
 
     // Create the discrete color table sliders, text fields.
     QGridLayout *discreteLayout = new QGridLayout();
-    // seLayout->setSizeConstraint(QLayout::SetFixedSize);
+    // discreteLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(discreteLayout);
     QString cnames[4];
     cnames[0] = tr("Red");

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -191,14 +191,20 @@ QvisColorTableWindow::~QvisColorTableWindow()
 void
 QvisColorTableWindow::CreateWindowContents()
 {
+    // central->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     // Create the widgets needed to set the default color tables.
     topLayout->setMargin(2);
+    topLayout->setSizeConstraint(QLayout::SetFixedSize);
     defaultGroup = new QGroupBox(central);
     defaultGroup->setTitle(tr("Default Color Table"));
+    QSizePolicy *sizePolicy = new QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum, QSizePolicy::GroupBox);
+    // defaultGroup->setSizePolicy(*sizePolicy);
     topLayout->addWidget(defaultGroup, 5);
     
     QVBoxLayout *innerDefaultTopLayout = new QVBoxLayout(defaultGroup);
+    // innerDefaultTopLayout->setSizeConstraint(QLayout::SetFixedSize);
     QGridLayout *innerDefaultLayout = new QGridLayout();
+    // innerDefaultLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerDefaultTopLayout->addLayout(innerDefaultLayout);
     innerDefaultLayout->setColumnMinimumWidth(1, 10);
 
@@ -220,11 +226,14 @@ QvisColorTableWindow::CreateWindowContents()
     // management stuff.
     colorTableWidgetGroup = new QGroupBox(central);
     colorTableWidgetGroup->setTitle(tr("Manager"));
+    // colorTableWidgetGroup->setSizePolicy(*sizePolicy);
     topLayout->addWidget(colorTableWidgetGroup, 5);
     QVBoxLayout *innerColorTableLayout = new QVBoxLayout(colorTableWidgetGroup);
+    // innerColorTableLayout->setSizeConstraint(QLayout::SetFixedSize);
 
     // Create the color management widgets.
     mgLayout = new QGridLayout();
+    // mgLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorTableLayout->addLayout(mgLayout);
 
     newButton = new QPushButton(tr("New"), colorTableWidgetGroup);
@@ -299,11 +308,14 @@ QvisColorTableWindow::CreateWindowContents()
     // Add the group box that will contain the color-related widgets.
     colorWidgetGroup = new QGroupBox(central);
     colorWidgetGroup->setTitle(tr("Editor"));
+    // colorWidgetGroup->setSizePolicy(*sizePolicy);
     topLayout->addWidget(colorWidgetGroup, 100);
     QVBoxLayout *innerColorLayout = new QVBoxLayout(colorWidgetGroup);
+    // innerColorLayout->setSizeConstraint(QLayout::SetFixedSize);
 
     // Create controls to set the number of colors in the color table.
     QGridLayout *colorInfoLayout = new QGridLayout();
+    // colorInfoLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(colorInfoLayout);
     colorNumColors = new QSpinBox(colorWidgetGroup);
     colorNumColors->setKeyboardTracking(false);
@@ -330,6 +342,7 @@ QvisColorTableWindow::CreateWindowContents()
 
     // Create the buttons that help manipulate the spectrum bar.
     QHBoxLayout *seLayout = new QHBoxLayout();
+    // seLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(seLayout);
 
     alignPointButton = new QPushButton(tr("Align"), colorWidgetGroup);
@@ -404,6 +417,7 @@ QvisColorTableWindow::CreateWindowContents()
 
     // Create the discrete color table sliders, text fields.
     QGridLayout *discreteLayout = new QGridLayout();
+    // seLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(discreteLayout);
     QString cnames[4];
     cnames[0] = tr("Red");

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -185,6 +185,9 @@ QvisColorTableWindow::~QvisColorTableWindow()
 //
 //   Justin Privitera, Thu Jul 14 16:57:42 PDT 2022
 //   Added searchbox gui element and hooked up signals and slots for searching.
+// 
+//   Justin Privitera, Thu Nov 17 12:28:10 PST 2022
+//   Resolved window resizing off the screen issue by limiting maximum height.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -191,6 +191,7 @@ QvisColorTableWindow::~QvisColorTableWindow()
 void
 QvisColorTableWindow::CreateWindowContents()
 {
+    // Want more buttons in the window? Increase this value.
     central->setMaximumHeight(800);
     // Create the widgets needed to set the default color tables.
     topLayout->setMargin(2);
@@ -200,9 +201,7 @@ QvisColorTableWindow::CreateWindowContents()
     topLayout->addWidget(defaultGroup, 5);
     
     QVBoxLayout *innerDefaultTopLayout = new QVBoxLayout(defaultGroup);
-    // innerDefaultTopLayout->setSizeConstraint(QLayout::SetFixedSize);
     QGridLayout *innerDefaultLayout = new QGridLayout();
-    // innerDefaultLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerDefaultTopLayout->addLayout(innerDefaultLayout);
     innerDefaultLayout->setColumnMinimumWidth(1, 10);
 
@@ -227,11 +226,9 @@ QvisColorTableWindow::CreateWindowContents()
     colorTableWidgetGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(colorTableWidgetGroup, 5);
     QVBoxLayout *innerColorTableLayout = new QVBoxLayout(colorTableWidgetGroup);
-    // innerColorTableLayout->setSizeConstraint(QLayout::SetFixedSize);
 
     // Create the color management widgets.
     mgLayout = new QGridLayout();
-    // mgLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorTableLayout->addLayout(mgLayout);
 
     newButton = new QPushButton(tr("New"), colorTableWidgetGroup);
@@ -263,6 +260,7 @@ QvisColorTableWindow::CreateWindowContents()
     mgLayout->addWidget(tagCombiningBehaviorChoice, 1, 2, 1, 4);
 
     nameListBox = new QTreeWidget(colorTableWidgetGroup);
+    // fixed name list box size
     nameListBox->setMinimumHeight(100);
     nameListBox->setMaximumHeight(100);
     nameListBox->setColumnCount(1);
@@ -282,6 +280,7 @@ QvisColorTableWindow::CreateWindowContents()
             this, SLOT(tagTableItemSelected(QTreeWidgetItem *, int)));
     tagTable->clear();
     tagTable->setSortingEnabled(true);
+    // fixed tag table size
     tagTable->setMinimumHeight(100);
     tagTable->setMaximumHeight(100);
     tagTable->setMinimumWidth(250);
@@ -308,15 +307,13 @@ QvisColorTableWindow::CreateWindowContents()
     // Add the group box that will contain the color-related widgets.
     colorWidgetGroup = new QGroupBox(central);
     colorWidgetGroup->setTitle(tr("Editor"));
+    // Note: if new buttons are added to the editor, this value must be adjusted.
     colorWidgetGroup->setMaximumHeight(350);
-    // colorWidgetGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(colorWidgetGroup, 100);
     QVBoxLayout *innerColorLayout = new QVBoxLayout(colorWidgetGroup);
-    // innerColorLayout->setSizeConstraint(QLayout::SetFixedSize);
 
     // Create controls to set the number of colors in the color table.
     QGridLayout *colorInfoLayout = new QGridLayout();
-    // colorInfoLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(colorInfoLayout);
     colorNumColors = new QSpinBox(colorWidgetGroup);
     colorNumColors->setKeyboardTracking(false);
@@ -343,18 +340,13 @@ QvisColorTableWindow::CreateWindowContents()
 
 
     // Create the buttons that help manipulate the spectrum bar.
-    // QHBoxLayout *seLayout = new QHBoxLayout();
     QGridLayout *seLayout = new QGridLayout();
-    // seLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(seLayout);
 
     alignPointButton = new QPushButton(tr("Align"), colorWidgetGroup);
-    // alignPointButton->setMaximumWidth(60);
     connect(alignPointButton, SIGNAL(clicked()),
             this, SLOT(alignControlPoints()));
     seLayout->addWidget(alignPointButton, 0, 0, 1, 1);
-    // seLayout->addWidget(alignPointButton);
-    // seLayout->addStretch(10);
 
     smoothLabel = new QLabel(tr("Smoothing"), colorWidgetGroup);
     smoothLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -188,6 +188,7 @@ QvisColorTableWindow::~QvisColorTableWindow()
 // 
 //   Justin Privitera, Thu Nov 17 12:28:10 PST 2022
 //   Resolved window resizing off the screen issue by limiting maximum height.
+//   Adjusted location of several buttons and labels to use less screen space.
 //
 // ****************************************************************************
 

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -191,14 +191,11 @@ QvisColorTableWindow::~QvisColorTableWindow()
 void
 QvisColorTableWindow::CreateWindowContents()
 {
-    central->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     central->setMaximumHeight(800);
     // Create the widgets needed to set the default color tables.
     topLayout->setMargin(2);
-    // topLayout->setSizeConstraint(QLayout::SetFixedSize);
     defaultGroup = new QGroupBox(central);
     defaultGroup->setTitle(tr("Default Color Table"));
-    // QSizePolicy *sizePolicy = new QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum, QSizePolicy::GroupBox);
     defaultGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(defaultGroup, 5);
     

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -343,35 +343,34 @@ QvisColorTableWindow::CreateWindowContents()
 
 
     // Create the buttons that help manipulate the spectrum bar.
-    QHBoxLayout *seLayout = new QHBoxLayout();
+    // QHBoxLayout *seLayout = new QHBoxLayout();
+    QGridLayout *seLayout = new QGridLayout();
     // seLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(seLayout);
 
     alignPointButton = new QPushButton(tr("Align"), colorWidgetGroup);
-    alignPointButton->setMaximumWidth(60);
+    // alignPointButton->setMaximumWidth(60);
     connect(alignPointButton, SIGNAL(clicked()),
             this, SLOT(alignControlPoints()));
-    // seLayout->addWidget(alignPointButton, 0, 0);
-    seLayout->addWidget(alignPointButton);
-    seLayout->addStretch(10);
+    seLayout->addWidget(alignPointButton, 0, 0, 1, 1);
+    // seLayout->addWidget(alignPointButton);
+    // seLayout->addStretch(10);
 
     smoothLabel = new QLabel(tr("Smoothing"), colorWidgetGroup);
-    // seLayout->addWidget(smoothLabel, 0, 1);
-    seLayout->addWidget(smoothLabel);
+    smoothLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    seLayout->addWidget(smoothLabel, 0, 1, 1, 1);
     smoothingMethod = new QComboBox(colorWidgetGroup);
     smoothingMethod->addItem(tr("None"));
     smoothingMethod->addItem(tr("Linear"));
     smoothingMethod->addItem(tr("Cubic Spline"));
     connect(smoothingMethod, SIGNAL(activated(int)),
             this, SLOT(smoothingMethodChanged(int)));
-    // seLayout->addWidget(smoothingMethod, 0, 2);
-    seLayout->addWidget(smoothingMethod);
+    seLayout->addWidget(smoothingMethod, 0, 2, 1, 1);
 
     equalCheckBox = new QCheckBox(tr("Equal"), colorWidgetGroup);
     connect(equalCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(equalSpacingToggled(bool)));
-    // seLayout->addWidget(equalCheckBox, 0, 3);
-    seLayout->addWidget(equalCheckBox);
+    seLayout->addWidget(equalCheckBox, 0, 3, 1, 1);
 
     // Create the spectrum bar.
     spectrumBar = new QvisSpectrumBar(colorWidgetGroup);
@@ -419,13 +418,11 @@ QvisColorTableWindow::CreateWindowContents()
     showIndexHintsCheckBox->setChecked(false);
     connect(showIndexHintsCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(showIndexHintsToggled(bool)));
-    // innerColorLayout->addWidget(showIndexHintsCheckBox);
     colorInfoLayout->addWidget(showIndexHintsCheckBox, 1, 4, 1, 3);
 
 
     // Create the discrete color table sliders, text fields.
     QGridLayout *discreteLayout = new QGridLayout();
-    // discreteLayout->setSizeConstraint(QLayout::SetFixedSize);
     innerColorLayout->addLayout(discreteLayout);
     QString cnames[4];
     cnames[0] = tr("Red");

--- a/src/gui/QvisColorTableWindow.C
+++ b/src/gui/QvisColorTableWindow.C
@@ -197,7 +197,6 @@ QvisColorTableWindow::CreateWindowContents()
     topLayout->setMargin(2);
     defaultGroup = new QGroupBox(central);
     defaultGroup->setTitle(tr("Default Color Table"));
-    defaultGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(defaultGroup, 5);
     
     QVBoxLayout *innerDefaultTopLayout = new QVBoxLayout(defaultGroup);
@@ -223,7 +222,6 @@ QvisColorTableWindow::CreateWindowContents()
     // management stuff.
     colorTableWidgetGroup = new QGroupBox(central);
     colorTableWidgetGroup->setTitle(tr("Manager"));
-    colorTableWidgetGroup->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     topLayout->addWidget(colorTableWidgetGroup, 5);
     QVBoxLayout *innerColorTableLayout = new QVBoxLayout(colorTableWidgetGroup);
 

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -27,7 +27,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug reading .visit file with more than 10,000 files and comments for each file.</li>
   <li>Fixed a bug that caused the compute engine to crash when in scalable rendering mode. The specific bug involved saving non screen capture images, but the crash could occur whenever doing scalable rendering.</li>
   <li>Fixed bug in Mili plugin where Green Lagrange strain was using incorrect initial coordintes.</li> 
-</ul>
+  <li>Fixed a rare issue with the color table window that caused it to resize horizontally larger than the screen, causing buttons to be off the screen.</li>
+  </ul>
 
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.3.2</font></b></p>

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -28,7 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug that caused the compute engine to crash when in scalable rendering mode. The specific bug involved saving non screen capture images, but the crash could occur whenever doing scalable rendering.</li>
   <li>Fixed bug in Mili plugin where Green Lagrange strain was using incorrect initial coordintes.</li> 
   <li>Fixed a rare issue with the color table window that caused it to resize horizontally larger than the screen, causing buttons to be off the screen.</li>
-  </ul>
+</ul>
 
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.3.2</font></b></p>


### PR DESCRIPTION
### Description

Resolves #17801 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
The color table window now has a maximum height, so it can no longer resize off the screen. I also moved some gui elements around to use the screen space more efficiently.

This was a real chore... I went down many a Qt rabbit hole before arriving at this much simpler solution.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz. The gui looks and functions as I expect.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
