### PR TITLE
Fix obsolete code refs in test suite.

### DIFF
--- a/src/plots/Boundary/BoundaryAttributes.code
+++ b/src/plots/Boundary/BoundaryAttributes.code
@@ -30,7 +30,7 @@ BoundaryAttributes::VarChangeRequiresReset()
     return true;
 }
 
-
+Target: xml2python
 Function: PyBoundaryAttributes_SetDefaults
 Declaration: PyBoundaryAttributes_SetDefaults
 Definition:

--- a/src/plots/Boundary/PyBoundaryAttributes.C
+++ b/src/plots/Boundary/PyBoundaryAttributes.C
@@ -1344,12 +1344,15 @@ PyBoundaryAttributes_SetParent(PyObject *obj, PyObject *parent)
     obj2->parent = parent;
 }
 
+// ****************************************************************************
+//  Modifications:
+//    Kathleen Bonnell, Mon Dec  2 18:06:04 PST 2002
+//    Make defaultAtts point to the passed atts directly.
+//
+// ****************************************************************************
 void
 PyBoundaryAttributes_SetDefaults(const BoundaryAttributes *atts)
 {
-    if(defaultAtts)
-        delete defaultAtts;
-
-    defaultAtts = new BoundaryAttributes(*atts);
+    defaultAtts = const_cast<BoundaryAttributes*>(atts);
 }
 

--- a/src/test/tests/databases/ProteinDataBank.py
+++ b/src/test/tests/databases/ProteinDataBank.py
@@ -16,6 +16,9 @@
 #    Brad Whitlock, Thu Mar 12 11:04:32 PDT 2009
 #    I restructured the test into functions.
 #
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
+#
 # ----------------------------------------------------------------------------
 
 def LabelTest(testname, var, zoomview):
@@ -28,12 +31,12 @@ def LabelTest(testname, var, zoomview):
     LabelAtts.drawLabelsFacing = LabelAtts.Front  # Front, Back, FrontAndBack
     LabelAtts.labelDisplayFormat = LabelAtts.Natural  # Natural, LogicalIndex, Index
     LabelAtts.numberOfLabels = 200
-    LabelAtts.specifyTextColor1 = 1
-    LabelAtts.textColor1 = (0, 255, 0, 255)
-    LabelAtts.textHeight1 = 0.03
-    LabelAtts.specifyTextColor2 = 0
-    LabelAtts.textColor2 = (0, 0, 255, 0)
-    LabelAtts.textHeight2 = 0.02
+    LabelAtts.textFont1.useForegroundColor = 0
+    LabelAtts.textFont1.color = (0, 255, 0, 255)
+    LabelAtts.textFont1.scale = 5
+    LabelAtts.textFont2.useForegroundColor = 1
+    LabelAtts.textFont2.color = (0, 0, 255, 0)
+    LabelAtts.textFont2.scale = 4
     LabelAtts.horizontalJustification = LabelAtts.HCenter  # HCenter, Left, Right
     LabelAtts.verticalJustification = LabelAtts.VCenter  # VCenter, Top, Bottom
     LabelAtts.depthTestMode = LabelAtts.LABEL_DT_AUTO  # LABEL_DT_AUTO, LABEL_DT_ALWAYS, LABEL_DT_NEVER
@@ -70,7 +73,6 @@ def AddMoleculePlot(db, var):
     MoleculeAtts.bondCylinderQuality = MoleculeAtts.Medium  # Low, Medium, High, Super
     MoleculeAtts.bondRadius = 0.12
     MoleculeAtts.bondLineWidth = 0
-    MoleculeAtts.bondLineStyle = 0
     MoleculeAtts.elementColorTable = "cpk_jmol"
     MoleculeAtts.residueTypeColorTable = "amino_shapely"
     MoleculeAtts.residueSequenceColorTable = "Default"

--- a/src/test/tests/databases/bov.py
+++ b/src/test/tests/databases/bov.py
@@ -14,6 +14,9 @@
 #    Brad Whitlock, Thu May 4 14:02:29 PST 2006
 #    Added testing of INT and DOUBLE BOV files.
 #
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
+#
 # ----------------------------------------------------------------------------
 
 def SaveTestImage(name):
@@ -66,8 +69,8 @@ def TestBOVDivide(prefix, db, doSubset):
     AddPlot("Mesh", "mesh")
     AddPlot("Label", "myvar")
     L = LabelAttributes()
-    L.textHeight1 = 0.03
-    L.textHeight2 = 0.03
+    L.textFont1.scale = 5
+    L.textFont2.scale = 5
     SetPlotOptions(L)
     SetActivePlots((0,1,2))
     AddOperator("Slice")

--- a/src/test/tests/databases/chgcar.py
+++ b/src/test/tests/databases/chgcar.py
@@ -23,6 +23,9 @@
 #    Added call(s) to DrawPlots() b/c of changes to the default plot state
 #    behavior when an operator is added.
 #
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
+#
 # ----------------------------------------------------------------------------
 
 
@@ -79,7 +82,7 @@ SetOperatorOptions(IndexSelectAtts)
 
 AddPlot("Label", "charge")
 LabelAtts = LabelAttributes()
-LabelAtts.textHeight1 = 0.05
+LabelAtts.textFont1.scale = 7
 LabelAtts.restrictNumberOfLabels = 0
 SetPlotOptions(LabelAtts)
 DrawPlots()

--- a/src/test/tests/databases/netcdf.py
+++ b/src/test/tests/databases/netcdf.py
@@ -28,12 +28,15 @@
 #    Brad Whitlock, Thu Sep  9 11:03:30 PDT 2010
 #    I added tests for time-varying curves, FVCOM.
 #
-#    Kathleen Biagas, Fri Sep 21 10:12:15 MST 2012 
+#    Kathleen Biagas, Fri Sep 21 10:12:15 MST 2012
 #    Removed pjoin so that tests can run on Windows.
 #
 #    Kathleen Biagas, Wed Aug 28 09:04:00 MST 2019
 #    Turn off cycling of colors for all Curve plot tests.  Set the colors
 #    individually to match current baseline results.
+#
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
 #
 # ----------------------------------------------------------------------------
 RequiredDatabasePlugin("NETCDF")
@@ -87,7 +90,7 @@ def test0():
     SetView3D(v1)
     Test("netcdf_0_01")
 
-    # Plot the terrain by stripping away most of the air. 
+    # Plot the terrain by stripping away most of the air.
     SetActivePlots(1)
     DeleteActivePlots()
     AddOperator("IndexSelect")
@@ -172,7 +175,7 @@ def test1():
     SetOperatorOptions(t)
     L = LabelAttributes()
     L.restrictNumberOfLabels = 0
-    L.textHeight1 = 0.04
+    L.textFont1.scale = 6
     SetPlotOptions(L)
     DrawPlots()
     SetActivePlots(1)
@@ -334,7 +337,7 @@ def test3():
 
     TestSection("Basic NETCDF reader with zone-centered data")
     swa = SaveWindowAttributes()
-    swa.width = 1000 
+    swa.width = 1000
     swa.height = 1000
     swa.screenCapture = 0
     db = "netcdf_test_data/oase-mapdata.nc"

--- a/src/test/tests/databases/pdbdatabase.py
+++ b/src/test/tests/databases/pdbdatabase.py
@@ -29,6 +29,9 @@
 #    Kathleen Biagas, Mon Dec 19 15:45:38 PST 2016
 #    Use FilledBoundary plot for materials instead of Subset.
 #
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
+#
 # ----------------------------------------------------------------------------
 RequiredDatabasePlugin("PDB")
 
@@ -110,7 +113,7 @@ def TestWithDatabase(db, testName):
     DrawPlots();
     vec = VectorAttributes()
     vec.nVectors = 1200
-    vec.colorByMag = 0
+    vec.colorByMagnitude = 0
     SetPlotOptions(vec)
     v.windowCoords = (-9.51217, -0.289482, 0.983025, 10.6717)
     v.viewportCoords = (0.2, 0.95, 0.15, 0.95)
@@ -203,7 +206,7 @@ def TestMixvars(db):
     v = View2DAttributes()
     v.windowCoords = (-9.51866, 3.29394, 13.9258, 26.4126)
     v.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v.fullFrameActivationMode = v.Off 
+    v.fullFrameActivationMode = v.Off
     SetView2D(v)
     Test("pdb_nomix")
 

--- a/src/test/tests/databases/silo.py
+++ b/src/test/tests/databases/silo.py
@@ -1,15 +1,15 @@
 # ----------------------------------------------------------------------------
 #  CLASSES: nightly
 #
-#  Test Case:  silo.py 
+#  Test Case:  silo.py
 #
 #  Tests:      multi-part silo files
 #              operators - slice
 #              operators - onion peel
-#              selection - by domains 
+#              selection - by domains
 #
-#  Programmer: Mark C. Miller 
-#  Date:       March 8, 2004 
+#  Programmer: Mark C. Miller
+#  Date:       March 8, 2004
 #
 #  Defects:    4335/4337.
 #
@@ -17,7 +17,7 @@
 #    Kathleen Bonnell, Tue Mar  9 08:48:14 PST 2004
 #    Turned off databaseInfo annotation, Used TurnOffDomains instead of
 #    SIL sets to get correct domain turned off, reordered DrawPlots for
-#    test 3 so that we get same results in parallel.  For OnionPeel, use 
+#    test 3 so that we get same results in parallel.  For OnionPeel, use
 #    SetDefaultOperatorOptions so that options are applied.
 #
 #    Hank Childs, Thu Jun 24 09:59:12 PDT 2004
@@ -33,7 +33,7 @@
 #    Added time invariant mesh tests
 #
 #    Mark C. Miller, Wed Feb  7 20:23:22 PST 2007
-#    Modified code to set SIL Restriction for mesh1_dup to be independent 
+#    Modified code to set SIL Restriction for mesh1_dup to be independent
 #    of the file structure. Added test for multivar that spans multiple
 #    multimeshes; it should fail.
 #
@@ -69,11 +69,11 @@
 #    Mark C. Miller, Tue Feb 28 00:36:09 PST 2012
 #    Added a slew of tests for hybrid zoo and arbitrary polygonal/polyhedral
 #    meshes and variables defined upon them.
-# 
-#    Kathleen Biagas, Thurs May 23 14:09:15 MST 2013 
+#
+#    Kathleen Biagas, Thurs May 23 14:09:15 MST 2013
 #    Don't run certain tests on Windows that cause a crash.
 #
-#    Kathleen Biagas, Thurs Jun 6 11:04:13 PDT 2013 
+#    Kathleen Biagas, Thurs Jun 6 11:04:13 PDT 2013
 #    Re-enable tests 42,44, and 45 on Windows, now that crash has been fixed.
 #
 #    Edward Rusu, Tues Oct 2 8:20:24 PDT 2018
@@ -82,6 +82,9 @@
 #    Kathleen Biagas, Wed Aug 28 09:04:00 MST 2019
 #    Turn off cycling of colors for all Curve plot tests.  Set the colors
 #    individually to match current baseline results.
+#
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Remove obsolete 'colorByMag' vector att with 'colorByMagnitude'.
 #
 # ----------------------------------------------------------------------------
 TurnOffAllAnnotations() # defines global object 'a'
@@ -102,7 +105,7 @@ OpenDatabase(silo_data_path("multipart_multi_ucd3d.silo"))
 
 
 #
-# Test simple read and display of a variable 
+# Test simple read and display of a variable
 #
 AddPlot("Pseudocolor","d")
 DrawPlots()
@@ -144,7 +147,7 @@ AddPlot("Pseudocolor","p")
 op = OnionPeelAttributes()
 op.categoryName = "domains"
 op.subsetName = "domain11"
-op.index = (5) 
+op.index = (5)
 op.logical = 0
 op.adjacencyType = op.Face
 op.requestedLayer = 3
@@ -160,7 +163,7 @@ HideActivePlots()
 
 
 #
-# Do some os work to create what VisIt will see as a 
+# Do some os work to create what VisIt will see as a
 # 'virtual' database of multi-part silo files by
 # creating appropriately named links
 #
@@ -169,7 +172,7 @@ HideActivePlots()
 # Cyrus: I tried to change this, from prev code
 # b/c symlinks won't work on Windows.
 #
-# also silo paths in multipart_multi_ucd3d, don't point to 
+# also silo paths in multipart_multi_ucd3d, don't point to
 # gorfo files,they won't work out of the data dir
 # (and we shouldn't be modifying the data dir !)
 
@@ -178,7 +181,7 @@ HideActivePlots()
 # All the copies are made into the run_dir by default, which gets cleaned
 # up unless --no-cleanup is used.
 
-# remove any gorfos 
+# remove any gorfos
 for f in glob.glob("gorfo_*"):
     os.remove(f)
 
@@ -187,7 +190,7 @@ i = 0
 
 for filename in glob.glob(silo_data_path("multipart_multi_ucd3d*.silo")):
     # copy the original file because the silo files have relatives paths
-    shutil.copy(filename, os.path.basename(filename)) 
+    shutil.copy(filename, os.path.basename(filename))
     if filename.endswith("multipart_multi_ucd3d.silo"):
         shutil.copy(filename,"gorfo_1000")
         shutil.copy(filename,"gorfo_2000")
@@ -271,7 +274,7 @@ AddPlot("Vector","vec")
 vec = VectorAttributes()
 vec.useStride = 1
 vec.stride = 41
-vec.colorByMag = 0
+vec.colorByMagnitude = 0
 SetPlotOptions(vec)
 DrawPlots()
 Test("silo_21")

--- a/src/test/tests/hybrid/field_operators.py
+++ b/src/test/tests/hybrid/field_operators.py
@@ -39,6 +39,10 @@
 #
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #    Added ability to swtich between Silo's HDF5 and PDB data.
+#
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Remove obsolete 'colorByMag' vector att with 'colorByMagnitude'.
+#
 # ----------------------------------------------------------------------------
 
 
@@ -73,7 +77,7 @@ OpenDatabase(silo_data_path("rect2d.silo"))
 DefineVectorExpression("grad_d", "gradient(d)")
 AddPlot("Vector", "grad_d")
 v = VectorAttributes()
-v.colorByMag = 1
+v.colorByMagnitude = 1
 v.vectorOrigin = v.Middle
 SetPlotOptions(v)
 DrawPlots()
@@ -84,7 +88,7 @@ DeleteAllPlots()
 
 AddPlot("Vector", "grad_u")
 v = VectorAttributes()
-v.colorByMag = 1
+v.colorByMagnitude = 1
 v.vectorOrigin = v.Middle
 SetPlotOptions(v)
 DrawPlots()

--- a/src/test/tests/operators/defer_expr.py
+++ b/src/test/tests/operators/defer_expr.py
@@ -18,7 +18,7 @@
 #    Explicitly specify the color table for the vector plot.  This is an issue
 #    because this test runs with "-config" (*not* "-noconfig") and the default
 #    color table can get confused if the user has a color table in his .visit
-#    directory that collides with the normal default ("hot").  So we're 
+#    directory that collides with the normal default ("hot").  So we're
 #    skirting that issue by explicitly specifying the color table.
 #
 #    Jeremy Meredith, Mon Jul 14 12:28:50 EDT 2008
@@ -37,6 +37,9 @@
 #
 #    Brad Whitlock, Wed Apr 18 15:40:47 PDT 2012
 #    Make vectors constant color for test 8.
+#
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Remove obsolete 'colorByMag' vector att with 'colorByMagnitude'.
 #
 # ----------------------------------------------------------------------------
 
@@ -172,7 +175,7 @@ SetPlotOptions(c)
 AddPlot("Vector", "normals")
 v = VectorAttributes()
 v.origOnly = 0
-v.colorByMag = 0
+v.colorByMagnitude = 0
 v.vectorColor = (255,255,0,255)
 SetPlotOptions(v)
 AddOperator("Isosurface")

--- a/src/test/tests/plots/label.py
+++ b/src/test/tests/plots/label.py
@@ -2,7 +2,7 @@
 #  MODES: serial
 #  CLASSES: nightly
 #
-#  Test Case:  label.py 
+#  Test Case:  label.py
 #
 #  Tests:      Tests the label plot
 #
@@ -44,7 +44,10 @@
 #    behavior when an operator is added.
 #
 #    Alister Maguire, Mon Feb 26 10:22:04 PST 2018
-#    Added TestMixedVariables for testing datasets with mixed variables. 
+#    Added TestMixedVariables for testing datasets with mixed variables.
+#
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
 #
 # ----------------------------------------------------------------------------
 RequiredDatabasePlugin(("Boxlib2D", "SAMRAI", "VTK"))
@@ -53,8 +56,8 @@ RequiredDatabasePlugin(("Boxlib2D", "SAMRAI", "VTK"))
 # Create label attributes with somewhat larger text.
 def CreateLabelAttributes():
     L = LabelAttributes()
-    L.textHeight1 = 0.03
-    L.textHeight2 = 0.03
+    L.textFont1.scale = 5
+    L.textFont2.scale = 5
     return L
 
 def SaveTestImage(name):
@@ -78,21 +81,21 @@ def TestGeneralFeatures():
     v0 = View2DAttributes()
     v0.windowCoords = (-11.6154, 11.8294, -3.18886, 8.33075)
     v0.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v0.fullFrameActivationMode = v0.Off 
+    v0.fullFrameActivationMode = v0.Off
     SetView2D(v0)
     SaveTestImage("label_0_01")
 
     v1 = View2DAttributes()
     v1.windowCoords = (-1.0815, 1.29556, 1.98696, 3.15493)
     v1.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v1.fullFrameActivationMode = v1.Off 
+    v1.fullFrameActivationMode = v1.Off
     SetView2D(v1)
     SaveTestImage("label_0_02")
 
     v2 = View2DAttributes()
     v2.windowCoords = (1.78125, 3.00819, 0.209532, 0.812385)
     v2.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v2.fullFrameActivationMode = v2.Off 
+    v2.fullFrameActivationMode = v2.Off
     AddPlot("Mesh", "curvmesh2d")
     DrawPlots()
     SetActivePlots(0)
@@ -113,42 +116,42 @@ def TestGeneralFeatures():
     # Try showing nodes and cells and alter their respective sizes
     L.showCells = 1
     L.showNodes = 1
-    L.textHeight1 = 0.04
-    L.textHeight2 = 0.03  
+    L.textFont1.scale = 6
+    L.textFont2.scale = 5
     SetPlotOptions(L)
     SaveTestImage("label_0_06")
 
     # Change the cell color.
-    L.textColor1 = (0,255,0,255)
-    L.specifyTextColor1 = 1
+    L.textFont1.color = (0,255,0,255)
+    L.textFont1.useForegroundColor = 0
     SetPlotOptions(L)
     SaveTestImage("label_0_07")
 
     # Change the node color
-    L.textColor2 = (100,10,255,255)
-    L.specifyTextColor2 = 1
+    L.textFont2.color = (100,10,255,255)
+    L.textFont2.useForegroundColor = 0
     SetPlotOptions(L)
     SaveTestImage("label_0_08")
-    L.textColor1 = (0,255,0,255)
-    L.textColor2 = (0,255,0,255)
+    L.textFont1.color = (0,255,0,255)
+    L.textFont2.color = (0,255,0,255)
 
     # Change the structured indices to regular indices
     L.showCells = 1
     L.labelDisplayFormat = L.Index
-    L.textHeight1 = 0.03
+    L.textFont1.scale = 5
     SetPlotOptions(L)
     SaveTestImage("label_0_09")
 
     # Make the text a little bigger
-    L.textHeight1 = 0.06
-    L.textHeight2 = 0.06
+    L.textFont1.scale = 8
+    L.textFont2.scale = 8
     L.showCells = 0
     SetPlotOptions(L)
     SaveTestImage("label_0_10")
 
     # Test different text alignments
-    L.textHeight1 = 0.04
-    L.textHeight2 = 0.04
+    L.textFont1.scale = 6
+    L.textFont2.scale = 6
     L.horizontalJustification = L.Left
     SetPlotOptions(L)
     SaveTestImage("label_0_11")
@@ -220,11 +223,11 @@ def TestCurvilinear2D():
     v0 = View2DAttributes()
     v0.windowCoords = (-0.632297, 0.483674, 3.38963, 4.57713)
     v0.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v0.fullFrameActivationMode = v0.Off 
+    v0.fullFrameActivationMode = v0.Off
     SetView2D(v0)
     L = CreateLabelAttributes()
-    L.textHeight1 = 0.03
-    L.textHeight2 = 0.03
+    L.textFont1.scale = 5
+    L.textFont2.scale = 5
     SetPlotOptions(L)
     SaveTestImage("label_1_01")
 
@@ -268,11 +271,11 @@ def TestRectilinear2D():
     v0 = View2DAttributes()
     v0.windowCoords = (0.425121, 0.574879, 0.566829, 0.766505)
     v0.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v0.fullFrameActivationMode = v0.Off 
+    v0.fullFrameActivationMode = v0.Off
     SetView2D(v0)
     L = CreateLabelAttributes()
-    L.textHeight1 = 0.03
-    L.textHeight2 = 0.03
+    L.textFont1.scale = 5
+    L.textFont2.scale = 5
     SetPlotOptions(L)
     SaveTestImage("label_2_00")
 
@@ -298,8 +301,8 @@ def TestRectilinear2D():
     AddPlot("Label", "quadmesh2d")
     DrawPlots()
     L.showNodes = 1
-    L.textHeight1 = 0.03
-    L.textHeight2 = 0.03
+    L.textFont1.scale = 5
+    L.textFont2.scale = 5
     SetPlotOptions(L)
     SaveTestImage("label_2_04")
 
@@ -321,19 +324,19 @@ def TestUnstructured2D():
     AddPlot("Label", "ucdmesh2d")
     L = CreateLabelAttributes()
     L.showNodes = 1
-    L.textHeight1 = 0.04
-    L.textHeight2 = 0.04
-    L.textColor1 = (255,0,0,255)
-    L.textColor2 = (255,0,0,255)
-    L.specifyTextColor1 = 1
-    L.specifyTextColor2 = 1
+    L.textFont1.scale = 6
+    L.textFont2.scale = 6
+    L.textFont1.color = (255,0,0,255)
+    L.textFont2.color = (255,0,0,255)
+    L.textFont1.useForegroundColor = 0
+    L.textFont2.useForegroundColor = 0
     L.restrictNumberOfLabels = 0
     SetPlotOptions(L)
     DrawPlots()
     v0 = View2DAttributes()
     v0.windowCoords = (-0.154956, 4.15496, -0.154956, 4.15496)
     v0.viewportCoords = (0.2, 0.95, 0.15, 0.95)
-    v0.fullFrameActivationMode = v0.Off 
+    v0.fullFrameActivationMode = v0.Off
     SetView2D(v0)
     SaveTestImage("label_3_00")
 
@@ -349,8 +352,8 @@ def TestUnstructured2D():
     ChangeActivePlotsVar("ucdmesh2d")
     AddPlot("FilledBoundary", "mat1")
     DrawPlots()
-    L.specifyTextColor1 = 0
-    L.specifyTextColor2 = 0
+    L.textFont1.useForegroundColor = 1
+    L.textFont2.useForegroundColor = 1
     SetPlotOptions(L)
     SetActivePlots((0,1,2))
     TurnMaterialsOff("2")
@@ -377,8 +380,8 @@ def TestSlice():
     SetOperatorOptions(s)
     # Make the labels a little bigger
     L = CreateLabelAttributes()
-    L.textHeight1 = 0.05
-    L.textHeight2 = 0.05
+    L.textFont1.scale = 7
+    L.textFont2.scale = 7
     L.depthTestMode = L.LABEL_DT_NEVER
     SetPlotOptions(L)
     DrawPlots()
@@ -444,13 +447,13 @@ def TestLabeledVTK():
     DrawPlots()
     SetActivePlots((1, 2))
     l = LabelAttributes()
-    l.textHeight1 = 0.06
-    l.textHeight2 = 0.06
+    l.textFont1.scale = 8
+    l.textFont2.scale = 8
     l.depthTestMode = l.LABEL_DT_NEVER
     SetPlotOptions(l)
 
     v = GetView3D()
-    v.viewNormal = (-0.826308, 0.365749, 0.428303) 
+    v.viewNormal = (-0.826308, 0.365749, 0.428303)
     v.focus = (0, 0, 0)
     v.viewUp = (0.262408, 0.92288, -0.28184)
     v.parallelScale = 1.55885
@@ -458,7 +461,7 @@ def TestLabeledVTK():
     v.farPlane  =  3.11769
     v.imageZoom = 0.941919
     SetView3D(v)
-    
+
     SaveTestImage("label_5_01")
     DeleteAllPlots()
 
@@ -471,7 +474,7 @@ def TestLabellingSubsets():
     AddPlot("Label", "blocks")
     l = LabelAttributes()
     l.restrictNumberOfLabels = 0
-    l.textHeight1 = 0.03
+    l.textFont1.scale = 5
     l.depthTestMode = l.LABEL_DT_NEVER
     SetPlotOptions(l)
     SetActivePlots((0,1,2))
@@ -520,7 +523,7 @@ def TestLabellingSubsets():
     AddPlot("Label", "patches")
     l = LabelAttributes()
     l.restrictNumberOfLabels = 0
-    l.textHeight1 = 0.027
+    l.textFont1.scale = 4.7
     SetPlotOptions(l)
     DrawPlots()
     v = View2DAttributes()
@@ -540,7 +543,7 @@ def TestLabellingSubsets():
     v.fullFrameAutoThreshold = 100
     SetView2D(v)
     SetActivePlots(2)
-    l.textHeight1 = 0.02
+    l.textFont1.scale = 4
     SetPlotOptions(l)
     SaveTestImage("label_6_04")
     DeleteAllPlots()
@@ -552,7 +555,7 @@ def TestLabellingSubsets():
     AddPlot("FilledBoundary", "mat1")
     AddPlot("Label", "mat1")
     l = LabelAttributes()
-    l.textHeight1 = 0.03
+    l.textFont1.scale = 5
     SetPlotOptions(l)
     SetActivePlots((0,1,2))
     AddOperator("Slice")
@@ -601,12 +604,12 @@ def TestLabellingTensors():
     # Now see how changing the text height affects binning
     ResetView()
     l = LabelAttributes()
-    l.textHeight1 = 0.01
+    l.textFont1.scale = 3
     SetActivePlots(2)
     SetPlotOptions(l)
     SaveTestImage("label_7_03")
 
-    l.textHeight1 = 0.04
+    l.textFont1.scale = 6
     SetPlotOptions(l)
     SaveTestImage("label_7_04")
 
@@ -712,7 +715,7 @@ def TestLabelling3D():
     L.showNodes = 1
     SetPlotOptions(L)
     SaveTestImage("label_8_05")
-    
+
     # Label a variable that would normally have labels that protrude into
     # the dataset
     ChangeActivePlotsVar("speed")
@@ -830,9 +833,9 @@ def TestSlicedVectors():
     AddPlot("Mesh", "quadmesh3d")
     AddPlot("Label", "vel")
     L = LabelAttributes()
-    L.textHeight1 = 0.04
-    L.textColor1 = (255,0,0,255)
-    L.specifyTextColor1 = 1
+    L.textFont1.scale = 6
+    L.textFont1.color = (255,0,0,255)
+    L.textFont1.useForegroundColor = 0
     SetPlotOptions(L)
     SetActivePlots((0,1))
     AddOperator("Slice")

--- a/src/test/tests/plots/mesh.py
+++ b/src/test/tests/plots/mesh.py
@@ -58,6 +58,9 @@
 #    Replace use of meshatts 'foregroundFlag', 'backgroundFlag' with
 #    'meshColorSource' and 'opaqueColorSource' respectively.
 #
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Remove obsolete mesh att 'lineStyle'.
+#
 # ----------------------------------------------------------------------------
 
 
@@ -78,10 +81,9 @@ def TestCurve():
 
     Test("mesh_curve_01")
 
-    #Change line style, line width and color
+    # Change color
     # and add a PC Plot.
     m = MeshAttributes()
-    m.lineStyle = 3
     m.opaqueColorSource = m.OpaqueCustom
     m.opaqueColor = (0, 122, 200, 255)
     SetPlotOptions(m)
@@ -90,7 +92,6 @@ def TestCurve():
     Test("mesh_curve_02")
 
     SetActivePlots(0)
-    m.lineStyle = 2
     SetPlotOptions(m)
     SetActivePlots(1)
     HideActivePlots()

--- a/src/test/tests/simulation/scalar.py
+++ b/src/test/tests/simulation/scalar.py
@@ -5,10 +5,12 @@
 #
 #  Tests:      libsim - connecting to simulation and retrieving data from it.
 #
-#  Programmer: Kathleen Biagas 
-#  Date:       June 18, 2014 
+#  Programmer: Kathleen Biagas
+#  Date:       June 18, 2014
 #
 #  Modifications:
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
 #
 # ----------------------------------------------------------------------------
 
@@ -28,7 +30,7 @@ if connected:
     AddPlot("Pseudocolor", "zonal")
     AddPlot("Label", "zonal")
     LabelAtts = LabelAttributes()
-    LabelAtts.textHeight1 = 0.05
+    LabelAtts.textFont1.scale = 7
     SetPlotOptions(LabelAtts)
     DrawPlots()
     Test("scalar02")
@@ -40,7 +42,7 @@ if connected:
     AddPlot("Pseudocolor", "nodal")
     AddPlot("Label", "nodal")
     LabelAtts = LabelAttributes()
-    LabelAtts.textHeight1 = 0.05
+    LabelAtts.textFont1.scale = 7
     LabelAtts.depthTestMode = LabelAtts.LABEL_DT_NEVER
     SetPlotOptions(LabelAtts)
 
@@ -48,7 +50,7 @@ if connected:
     Test("scalar03")
 
 # Close down the simulation.
-if started:        
+if started:
     sim.endsim()
 
 Exit()

--- a/src/test/tests/simulation/var.py
+++ b/src/test/tests/simulation/var.py
@@ -5,10 +5,12 @@
 #
 #  Tests:      libsim - connecting to simulation and retrieving data from it.
 #
-#  Programmer: Kathleen Biagas 
-#  Date:       June 6, 2014 
+#  Programmer: Kathleen Biagas
+#  Date:       June 6, 2014
 #
 #  Modifications:
+#    Kathleen Biagas, Mon Nov 28, 2022
+#    Replace obsolete Label text attributes with new versions.
 #
 # ----------------------------------------------------------------------------
 
@@ -29,12 +31,12 @@ if connected:
     AddPlot("Vector", "zonal_vector")
     VectorAtts = VectorAttributes()
     VectorAtts.scale = 0.5
-    VectorAtts.colorByMag = 0
+    VectorAtts.colorByMagnitude = 0
     VectorAtts.vectorColor = (255, 255, 255, 255)
     SetPlotOptions(VectorAtts)
     AddPlot("Label", "zonal_label")
     LabelAtts = LabelAttributes()
-    LabelAtts.textHeight1 = 0.04
+    LabelAtts.textFont1.scale = 6
     SetPlotOptions(LabelAtts)
     DrawPlots()
     Test("var02")
@@ -53,7 +55,7 @@ if connected:
     Test("var03")
 
 # Close down the simulation.
-if started:        
+if started:
     sim.endsim()
 
 Exit()


### PR DESCRIPTION
### Description

This should fix the nightly regressions.
Replace obsolete atts references with new versions.
Also fixed BoundaryAttributes::SetDefaults python method, it needed an xml2python Target line in the .code file.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the failing tests with success in serial.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
