### PR TITLE
X Ray Image Query: change "Energy Group Bins" to "Energy Group Bounds"

### DIFF
--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -163,6 +163,9 @@ inline void Scale(double result[3], const double v[3], const double s)
 // 
 //    Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //    Set default values for energy group bin variables.
+// 
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds.
 //
 // ****************************************************************************
 
@@ -240,6 +243,9 @@ avtXRayImageQuery::avtXRayImageQuery():
 // 
 //    Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //    Make sure the energy group bins are deleted.
+// 
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds.
 //
 // ****************************************************************************
 
@@ -299,6 +305,9 @@ avtXRayImageQuery::~avtXRayImageQuery()
 // 
 //    Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //    Logic for energy group bins.
+// 
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds.
 //
 // ****************************************************************************
 
@@ -335,7 +344,7 @@ avtXRayImageQuery::SetInputParams(const MapNode &params)
         SetEnergyGroupBounds(v);
     }
 
-    // Are you ever going to have just one energy group bin? No.
+    // Are you ever going to have just one energy group bound? No.
     // But this is here for helpful error messaging. It is possible
     // to pass just one number in under energy_group_bounds, so with
     // this logic here VisIt will give users sensible error messages
@@ -754,6 +763,11 @@ avtXRayImageQuery::SetBackgroundIntensities(const doubleVector &intensities)
 //
 //  Programmer: Justin Privitera
 //  Creation:   November 18, 2022
+// 
+//  Modifications:
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds. Changed the function 
+//    name.
 //
 // ****************************************************************************
 
@@ -1049,6 +1063,9 @@ avtXRayImageQuery::GetSecondaryVars(std::vector<std::string> &outVars)
 //    Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //    Added logic to output energy group bounds in blueprint output if they are
 //    provided; include an info message if not.
+// 
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -174,8 +174,8 @@ avtXRayImageQuery::avtXRayImageQuery():
     backgroundIntensity = 0.0;
     backgroundIntensities = NULL;
     nBackgroundIntensities = 0;
-    energyGroupBins = NULL;
-    nEnergyGroupBins = 0;
+    energyGroupBounds = NULL;
+    nEnergyGroupBounds = 0;
     debugRay = -1;
     familyFiles = false;
     outputType = PNG_OUT;
@@ -247,8 +247,8 @@ avtXRayImageQuery::~avtXRayImageQuery()
 {
     if (backgroundIntensities != NULL)
         delete [] backgroundIntensities;
-    if (energyGroupBins != NULL)
-        delete [] energyGroupBins;
+    if (energyGroupBounds != NULL)
+        delete [] energyGroupBounds;
 }
 
 // ****************************************************************************
@@ -328,23 +328,23 @@ avtXRayImageQuery::SetInputParams(const MapNode &params)
         SetBackgroundIntensities(v);
     }
 
-    if (params.HasNumericVectorEntry("energy_group_bins"))
+    if (params.HasNumericVectorEntry("energy_group_bounds"))
     {
         doubleVector v;
-        params.GetEntry("energy_group_bins")->ToDoubleVector(v);
-        SetEnergyGroupBins(v);
+        params.GetEntry("energy_group_bounds")->ToDoubleVector(v);
+        SetEnergyGroupBounds(v);
     }
 
     // Are you ever going to have just one energy group bin? No.
     // But this is here for helpful error messaging. It is possible
-    // to pass just one number in under energy_group_bins, so with
+    // to pass just one number in under energy_group_bounds, so with
     // this logic here VisIt will give users sensible error messages
     // embedded within the blueprint metadata.
-    if (params.HasNumericEntry("energy_group_bins"))
+    if (params.HasNumericEntry("energy_group_bounds"))
     {
         doubleVector v;
-        v.push_back(params.GetEntry("energy_group_bins")->ToDouble());
-        SetEnergyGroupBins(v);
+        v.push_back(params.GetEntry("energy_group_bounds")->ToDouble());
+        SetEnergyGroupBounds(v);
     }
 
     if (params.HasNumericEntry("debug_ray"))
@@ -747,7 +747,7 @@ avtXRayImageQuery::SetBackgroundIntensities(const doubleVector &intensities)
 }
 
 // ****************************************************************************
-//  Method: avtXRayImageQuery::SetEnergyGroupBins
+//  Method: avtXRayImageQuery::SetEnergyGroupBounds
 //
 //  Purpose:
 //    Set the energy group bins.
@@ -758,15 +758,15 @@ avtXRayImageQuery::SetBackgroundIntensities(const doubleVector &intensities)
 // ****************************************************************************
 
 void
-avtXRayImageQuery::SetEnergyGroupBins(const doubleVector &bins)
+avtXRayImageQuery::SetEnergyGroupBounds(const doubleVector &bins)
 {
-    if (energyGroupBins != NULL)
-        delete [] energyGroupBins;
+    if (energyGroupBounds != NULL)
+        delete [] energyGroupBounds;
 
-    energyGroupBins = new double[bins.size()];
+    energyGroupBounds = new double[bins.size()];
     for (int i = 0; i < bins.size(); i++)
-        energyGroupBins[i] = bins[i];
-    nEnergyGroupBins = bins.size();
+        energyGroupBounds[i] = bins[i];
+    nEnergyGroupBounds = bins.size();
 }
 
 // ****************************************************************************
@@ -1474,26 +1474,26 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             for (int i = 0; i < y_coords_dim; i ++) { spatial_yvals[i] = i * nearDy; }
 
             // include energy group bins in blueprint output if they are provided
-            if (energyGroupBins)
+            if (energyGroupBounds)
             {
-                if (z_coords_dim == nEnergyGroupBins) // only pass them thru if it makes sense to do so
+                if (z_coords_dim == nEnergyGroupBounds) // only pass them thru if it makes sense to do so
                 {
-                    data_out["state/xray_data/image_coords/z"].set(conduit::DataType::float64(nEnergyGroupBins));
+                    data_out["state/xray_data/image_coords/z"].set(conduit::DataType::float64(nEnergyGroupBounds));
                     double *spatial_zvals = data_out["state/xray_data/image_coords/z"].value();
-                    for (int i = 0; i < nEnergyGroupBins; i ++) { spatial_zvals[i] = energyGroupBins[i]; }                    
+                    for (int i = 0; i < nEnergyGroupBounds; i ++) { spatial_zvals[i] = energyGroupBounds[i]; }                    
                 }
                 else
                 {
                     std::stringstream out;
-                    out << "Energy group bins size mismatch: provided " 
-                        << nEnergyGroupBins << " bins, but " 
+                    out << "Energy group bounds size mismatch: provided " 
+                        << nEnergyGroupBounds << " bounds, but " 
                         << z_coords_dim << " in query results.";
                     data_out["state/xray_data/image_coords/z"] = out.str();
                 }
             }
             else
             {
-                data_out["state/xray_data/image_coords/z"] = "Energy group bins not provided.";
+                data_out["state/xray_data/image_coords/z"] = "Energy group bounds not provided.";
             }
 
             data_out["state/xray_data/detectorWidth"] = 2. * nearWidth;

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -122,7 +122,7 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
     void                      SetBackgroundIntensity(const double &intensity);
     void                      SetBackgroundIntensities(
                                   const doubleVector &intensities);
-    void                      SetEnergyGroupBins(
+    void                      SetEnergyGroupBounds(
                                   const doubleVector &bins);
     void                      SetDebugRay(const int &ray);
     void                      SetOutputRayBounds(const bool &flag);
@@ -136,8 +136,8 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
     double                    backgroundIntensity;
     double                   *backgroundIntensities;
     int                       nBackgroundIntensities;
-    double                   *energyGroupBins;
-    int                       nEnergyGroupBins;
+    double                   *energyGroupBounds;
+    int                       nEnergyGroupBounds;
     int                       debugRay;
     bool                      outputRayBounds;
     bool                      familyFiles;

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -91,6 +91,9 @@
 // 
 //    Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //    Added energy group bin variables and a setter.
+// 
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -36,7 +36,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>In the X Ray Image Query, a warning was added for the BMP output type, saying it may not function properly. This output type will be removed in the next major release of VisIt.</li>
   <li>For Blueprint output types from the X Ray Image Query, a host of new metadata has been added, as well as imaging plane topologies.</li>
-  <li>In the X Ray Image Query, users may optionally pass energy group bin values to the query, which will appear as part of the metadata in the Blueprint output types.</li>
+  <li>In the X Ray Image Query, users may optionally pass energy group bounds to the query, which will appear as part of the metadata in the Blueprint output types.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -46,6 +46,9 @@
 #    Reorganized blueprint tests so they use a function. That function also
 #    uses new and old query calls, doubling the number of blueprint tests.
 #    It also tests energy group bin output for hdf5.
+# 
+#    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+#    Renamed energy group bins to energy group bounds.
 #
 # ----------------------------------------------------------------------------
 

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -405,25 +405,25 @@ def test_bp_state_xray_query(testname, xrayout):
     emisVarName = xrayout["domain_000000/state/xray_query/emisVarName"]
     TestValueEQ(testname + "_EmisVarName", emisVarName, "p")
 
-NO_BINS = 0
-BIN_MISMATCH = 1
-BINS = 2
+NO_ENERGY_GROUP_BOUNDS = 0
+ENERGY_GROUP_BOUNDS_MISMATCH = 1
+ENERGY_GROUP_BOUNDS = 2
 
-def test_bp_state_xray_data(testname, xrayout, bin_state = NO_BINS):
+def test_bp_state_xray_data(testname, xrayout, bin_state = NO_ENERGY_GROUP_BOUNDS):
     spatial_coords_x = xrayout["domain_000000/state/xray_data/image_coords/x"]
     spatial_coords_y = xrayout["domain_000000/state/xray_data/image_coords/y"]
-    energy_group_bins = xrayout["domain_000000/state/xray_data/image_coords/z"]
+    energy_group_bounds = xrayout["domain_000000/state/xray_data/image_coords/z"]
     TestValueEQ(testname + "_SpatialExtents0", [spatial_coords_x[0], spatial_coords_y[0]], [0.0, 0.0])
     TestValueEQ(testname + "_SpatialExtents1", [spatial_coords_x[1], spatial_coords_y[1]], [0.05, 0.05])
     TestValueEQ(testname + "_SpatialExtents2", [spatial_coords_x[2], spatial_coords_y[2]], [0.1, 0.1])
     TestValueEQ(testname + "_SpatialExtents3", [spatial_coords_x[-1], spatial_coords_y[-1]], [15.0, 10.0])
-    if (bin_state == NO_BINS):
-        TestValueEQ(testname + "_EnergyGroupBins", energy_group_bins, "Energy group bins not provided.")
-    elif (bin_state == BIN_MISMATCH):
-        baseline_string = "Energy group bins size mismatch: provided 3 bins, but 2 in query results."
-        TestValueEQ(testname + "_EnergyGroupBins", energy_group_bins, baseline_string)
-    elif (bin_state == BINS):
-        TestValueEQ(testname + "_EnergyGroupBins", [energy_group_bins[0], energy_group_bins[1]], [3.7, 4.2])
+    if (bin_state == NO_ENERGY_GROUP_BOUNDS):
+        TestValueEQ(testname + "_EnergyGroupBounds", energy_group_bounds, "Energy group bounds not provided.")
+    elif (bin_state == ENERGY_GROUP_BOUNDS_MISMATCH):
+        baseline_string = "Energy group bounds size mismatch: provided 3 bounds, but 2 in query results."
+        TestValueEQ(testname + "_EnergyGroupBounds", energy_group_bounds, baseline_string)
+    elif (bin_state == ENERGY_GROUP_BOUNDS):
+        TestValueEQ(testname + "_EnergyGroupBounds", [energy_group_bounds[0], energy_group_bounds[1]], [3.7, 4.2])
     
     detectorWidth = xrayout["domain_000000/state/xray_data/detectorWidth"]
     TestValueEQ(testname + "_DetectorWidth", detectorWidth, 15)
@@ -443,7 +443,7 @@ def test_bp_state_xray_data(testname, xrayout, bin_state = NO_BINS):
     pathLengthMin = xrayout["domain_000000/state/xray_data/pathLengthMin"]
     TestValueEQ(testname + "_PathLengthMin", pathLengthMin, 0)
 
-def test_bp_state(testname, conduit_db, bin_state = NO_BINS):
+def test_bp_state(testname, conduit_db, bin_state = NO_ENERGY_GROUP_BOUNDS):
     xrayout = conduit.Node()
     conduit.relay.io.blueprint.load_mesh(xrayout, conduit_db)
 
@@ -492,12 +492,12 @@ def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
         CloseDatabase(conduit_db)
 
     if (hdf5):
-        test_bp_state(testname + str(i), conduit_db) # no bins
+        test_bp_state(testname + str(i), conduit_db) # no bounds
         setup_bp_test()
         Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"), [1,2,3])
-        test_bp_state(testname + str(i), conduit_db, BIN_MISMATCH) # no bins
+        test_bp_state(testname + str(i), conduit_db, ENERGY_GROUP_BOUNDS_MISMATCH) # bounds mismatch
         Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"), [3.7, 4.2])
-        test_bp_state(testname + str(i), conduit_db, BINS) # no bins
+        test_bp_state(testname + str(i), conduit_db, ENERGY_GROUP_BOUNDS) # bounds
         DeleteAllPlots()
         CloseDatabase(silo_data_path("curv3d.silo"))
 

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -11897,6 +11897,9 @@ visit_GetQueryParameters(PyObject *self, PyObject *args)
 //   Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //   Added another tuple (tuple2) to store double vector info.
 //   This one is used for the x ray image query to store energy group bins.
+// 
+//    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
+//    Renamed energy group bins to energy group bounds.
 //
 // ****************************************************************************
 

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -12196,7 +12196,7 @@ visit_Query_deprecated(PyObject *self, PyObject *args)
     GetDoubleVectorFromPyObject(tuple2, vals);
 
     if (!vals.empty())
-        params["energy_group_bins"] = vals;
+        params["energy_group_bounds"] = vals;
 
     debug3 << mn << " sending query params: " << params.ToXML() << endl;
 


### PR DESCRIPTION
### Description

Addresses a bullet in #17791 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Steve asked me to change the name `energy_group_bins` to `energy_group_bounds` so I changed this everywhere to avoid any ambiguity.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz all tests pass

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
