### PR TITLE
Replace use of obsolete atts with new versions.

### DIFF
--- a/src/test/tests/operators/onionpeel.py
+++ b/src/test/tests/operators/onionpeel.py
@@ -53,6 +53,9 @@
 #    Modified AMR test to include the default Subset plot, now that it
 #    is fixed.
 #
+#    Kathleen Biagas, Tue Nov 29 10:40:50 PST 2022
+#    Change use of obosolete text settings to new textFont settings.
+#
 # ----------------------------------------------------------------------------
 
 def TestBigSil():
@@ -450,10 +453,10 @@ def TestBigSilMesh():
     label.showCells = 1
     label.drawLabelsFacing = label.FrontAndBack
     label.labelDisplayFormat = label.Index
-    label.specifyTextColor1 = 1
-    label.textColor1 = (255, 0, 0, 0)
-    label.specifyTextColor2 = 1
-    label.textColor2 = (0, 0, 255, 0)
+    label.textFont1.useForegroundColor = 0
+    label.textFont1.color = (255, 0, 0, 0)
+    label.textFont2.useForegroundColor = 0
+    label.textFont2.color = (0, 0, 255, 0)
     label.depthTestMode = label.LABEL_DT_NEVER
     SetPlotOptions(label)
 
@@ -514,10 +517,10 @@ def TestAMR():
     label.showCells = 1
     label.drawLabelsFacing = label.FrontAndBack
     label.labelDisplayFormat = label.Index
-    label.specifyTextColor1 = 1
-    label.textColor1 = (255, 0, 0, 0)
-    label.specifyTextColor2 = 1
-    label.textColor2 = (0, 0, 255, 0)
+    label.textFont1.useForegroundColor = 0
+    label.textFont1.color = (255, 0, 0, 0)
+    label.textFont2.useForegroundColor = 0
+    label.textFont2.color = (0, 0, 255, 0)
     label.depthTestMode = label.LABEL_DT_NEVER
     SetPlotOptions(label)
 
@@ -602,10 +605,10 @@ def TestAMR():
     label.showCells = 1
     label.drawLabelsFacing = label.FrontAndBack
     label.labelDisplayFormat = label.Index
-    label.specifyTextColor1 = 1
-    label.textColor1 = (255, 0, 0, 0)
-    label.specifyTextColor2 = 1
-    label.textColor2 = (0, 0, 255, 0)
+    label.textFont1.useForegroundColor = 0
+    label.textFont1.color = (255, 0, 0, 0)
+    label.textFont2.useForegroundColor = 0
+    label.textFont2.color = (0, 0, 255, 0)
     label.depthTestMode = label.LABEL_DT_NEVER
     SetPlotOptions(label)
 

--- a/src/test/tests/plots/vector.py
+++ b/src/test/tests/plots/vector.py
@@ -26,6 +26,9 @@
 #    Added call(s) to DrawPlots() b/c of changes to the default plot state 
 #    behavior when an operator is added.
 #
+#    Kathleen Biagas, Tue Nov 29 10:41:39 PST 2022
+#    Replace obsolte 'colorByMag' vector att with 'colorByMagnitude'.
+#
 # ----------------------------------------------------------------------------
 
 
@@ -95,7 +98,7 @@ SetPlotOptions(vector_atts)
 Test("vector_08")
 
 vector_atts.headOn = 1
-vector_atts.colorByMag = 0
+vector_atts.colorByMagnitude = 0
 vector_atts.vectorColor = (255, 0, 255, 255)
 SetPlotOptions(vector_atts)
 Test("vector_09")
@@ -104,7 +107,7 @@ Test("vector_09")
 #
 # Test zonal vectors.
 #
-vector_atts.colorByMag = 1
+vector_atts.colorByMagnitude = 1
 SetPlotOptions(vector_atts)
 ChangeActivePlotsVar("disp")
 Test("vector_10")


### PR DESCRIPTION
### Description

Fix remaining regression errors due to removal of obsolete atts settings.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
