### PR TITLE
XRayQuery fix detector height and width metadata

### DIFF
--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1066,6 +1066,10 @@ avtXRayImageQuery::GetSecondaryVars(std::vector<std::string> &outVars)
 // 
 //    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 //    Renamed energy group bins to energy group bounds.
+// 
+//    Justin Privitera, Wed Nov 30 10:41:17 PST 2022
+//    Absolute value is applied to detector height and width to ensure
+//    sensible values come out of the query.
 //
 // ****************************************************************************
 
@@ -1513,8 +1517,11 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
                 data_out["state/xray_data/image_coords/z"] = "Energy group bounds not provided.";
             }
 
-            data_out["state/xray_data/detectorWidth"] = 2. * nearWidth;
-            data_out["state/xray_data/detectorHeight"] = 2. * nearHeight;
+            // If the near plane is too far back, it can cause the near width
+            // and height to be negative. However, the detector height and 
+            // width ought to be positive values, hence the absolute value.
+            data_out["state/xray_data/detectorWidth"] = fabs(2. * nearWidth);
+            data_out["state/xray_data/detectorHeight"] = fabs(2. * nearHeight);
 
             if (numfieldvals > 0)
             {

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -49,6 +49,10 @@
 # 
 #    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 #    Renamed energy group bins to energy group bounds.
+# 
+#    Justin Privitera, Wed Nov 30 10:41:17 PST 2022
+#    Added tests for always positive detector height and width in blueprint
+#    metadata.
 #
 # ----------------------------------------------------------------------------
 
@@ -339,6 +343,9 @@ if not os.path.isdir(conduit_dir_yaml):
 conduit_dir_imaging_planes = pjoin(outdir_set, "imaging_planes")
 if not os.path.isdir(conduit_dir_imaging_planes):
     os.mkdir(conduit_dir_imaging_planes)
+conduit_dir_detector_dims = pjoin(outdir_set, "detector_dims")
+if not os.path.isdir(conduit_dir_detector_dims):
+    os.mkdir(conduit_dir_detector_dims)
 
 def setup_bp_test():
     OpenDatabase(silo_data_path("curv3d.silo"))
@@ -507,6 +514,36 @@ def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
 blueprint_test("hdf5", conduit_dir_hdf5, 32, "Blueprint_HDF5_X_Ray_Output", True)
 blueprint_test("json", conduit_dir_json, 34, "Blueprint_JSON_X_Ray_Output", False)
 blueprint_test("yaml", conduit_dir_yaml, 36, "Blueprint_YAML_X_Ray_Output", False)
+
+# test detector height and width are always positive in blueprint output
+
+setup_bp_test()
+
+params = dict()
+params["image_size"] = (400, 300)
+params["output_type"] = "hdf5"
+params["output_dir"] = conduit_dir_detector_dims
+params["focus"] = (0., 2.5, 10.)
+params["perspective"] = 1
+params["near_plane"] = -50.
+params["far_plane"] = 50.
+params["vars"] = ("d", "p")
+params["energy_group_bounds"] = [3.7, 4.2];
+params["parallel_scale"] = 5.
+Query("XRay Image", params)
+
+DeleteAllPlots()
+CloseDatabase(silo_data_path("curv3d.silo"))
+
+conduit_db = pjoin(conduit_dir_detector_dims, "output.cycle_000048.root")
+xrayout = conduit.Node()
+conduit.relay.io.blueprint.load_mesh(xrayout, conduit_db)
+
+detectorWidth = xrayout["domain_000000/state/xray_data/detectorWidth"]
+TestValueEQ("Blueprint_Positive_DetectorWidth", detectorWidth, 22.3932263237838)
+
+detectorHeight = xrayout["domain_000000/state/xray_data/detectorHeight"]
+TestValueEQ("Blueprint_Positive_DetectorHeight", detectorHeight, 16.7949192423103)
 
 # test imaging plane topos
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
I noticed that it was possible the the detector height and width to come out of the query as negative values. This doesn't make any sense so here is a small fix and some tests. I'll make the change in the docs example when I merge this w/ develop.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
added new tests. built and ran on rztopaz all tests pass.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~ - no release notes update since this bug was added very recently and was never out in the wild.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
