### PR TITLE
X Ray Image Query pipe units through the query

### DIFF
--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -191,6 +191,7 @@ avtXRayImageQuery::avtXRayImageQuery():
     absUnits = "no units provided";
     emisUnits = "no units provided";
     intensityUnits = "no units provided";
+    pathLengthUnits = "no info provided";
 
     //
     // The new view specification
@@ -373,6 +374,8 @@ avtXRayImageQuery::SetInputParams(const MapNode &params)
         unitsmap["emisUnits"] = params.GetEntry("emis_units")->AsString();
     if (params.HasEntry("intensity_units"))
         unitsmap["intensityUnits"] = params.GetEntry("intensity_units")->AsString();
+    if (params.HasEntry("path_length_units"))
+        unitsmap["pathLengthUnits"] = params.GetEntry("path_length_units")->AsString();
     SetUnits(unitsmap);
 
     if (params.HasNumericEntry("debug_ray"))
@@ -832,6 +835,8 @@ avtXRayImageQuery::SetUnits(const std::map<std::string, std::string> &unitsmap)
             emisUnits = unitsmap.at("emisUnits");
         if (unitsmap.count("intensityUnits") > 0)
             intensityUnits = unitsmap.at("intensityUnits");
+        if (unitsmap.count("pathLengthUnits") > 0)
+            pathLengthUnits = unitsmap.at("pathLengthUnits");
     }
 }
 
@@ -1440,6 +1445,7 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
 
             data_out["fields/path_length/topology"] = "image_topo";
             data_out["fields/path_length/association"] = "element";
+            data_out["fields/path_length/units"] = pathLengthUnits;
             // set to float64 regardless of vtk data types
             data_out["fields/path_length/values"].set(conduit::DataType::float64(numfieldvals));
             conduit::float64 *depth_vals = data_out["fields/path_length/values"].value();

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -166,6 +166,9 @@ inline void Scale(double result[3], const double v[3], const double s)
 // 
 //    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 //    Renamed energy group bins to energy group bounds.
+// 
+//    Justin Privitera, Wed Nov 30 17:43:48 PST 2022
+//    Added default values for units.
 //
 // ****************************************************************************
 
@@ -315,6 +318,9 @@ avtXRayImageQuery::~avtXRayImageQuery()
 // 
 //    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 //    Renamed energy group bins to energy group bounds.
+// 
+//    Justin Privitera, Wed Nov 30 17:43:48 PST 2022
+//    Added logic to handle passing through the units.
 //
 // ****************************************************************************
 
@@ -1123,6 +1129,10 @@ avtXRayImageQuery::GetSecondaryVars(std::vector<std::string> &outVars)
 // 
 //    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 //    Renamed energy group bins to energy group bounds.
+// 
+//    Justin Privitera, Wed Nov 30 17:43:48 PST 2022
+//    The units are propagated to the output metadata for blueprint output 
+//    types.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -2200,6 +2200,11 @@ avtXRayImageQuery::WriteBlueprintImagingPlane(conduit::Node &data_out,
 //
 //  Purpose:
 //    Retrieves default values for input variables. 
+// 
+//  Note:
+//    If someone uses this function to get the default parameters, modifies
+//    them, and runs the query, the query will default to using the simplified
+//    view specification even if the user only modified the new view params.
 //
 //  Programmer: Kathleen Biagas 
 //  Creation:   July 15, 2011
@@ -2214,6 +2219,9 @@ avtXRayImageQuery::WriteBlueprintImagingPlane(conduit::Node &data_out,
 //
 //    Eric Brugger, Thu May 21 12:15:59 PDT 2015
 //    I added support for debugging a ray.
+// 
+//    Justin Privitera, Thu Dec  1 11:39:12 PST 2022
+//    Added all missing default input parameters.
 //
 // ****************************************************************************
 
@@ -2225,20 +2233,57 @@ avtXRayImageQuery::GetDefaultInputParams(MapNode &params)
     v.push_back("emissivity");
     params["vars"] = v;
 
-    params["divide_emis_by_absorb"] = 0;
     params["background_intensity"] = 0.0;
-    params["debug_ray"] = -1;
+    params["background_intensities"] = 0.0;
+    params["divide_emis_by_absorb"] = 0;
     params["output_type"] = std::string("png");
+    params["output_dir"] = std::string(".");
+    params["family_files"] = 0;
+
+    intVector is;
+    is.push_back(200);
+    is.push_back(200);
+    params["image_size"] = is;
+
+    params["debug_ray"] = -1;
+    params["output_ray_bounds"] = 0;
+
+    doubleVector egb;
+    egb.push_back(0.0);
+    egb.push_back(1.0);
+    params["energy_group_bounds"] = egb;
+
+    params["spatial_units"] = std::string("spatial units");
+    params["energy_units"] = std::string("energy units");
+    params["abs_units"] = std::string("abs units");
+    params["emis_units"] = std::string("emis units");
+    params["intensity_units"] = std::string("intensity units");
+    params["path_length_units"] = std::string("path length info");
+
+    //
+    // The old view parameters.
+    //
+    params["width"] = 1.0;
+    params["height"] = 1.0;
+
+    doubleVector o;
+    o.push_back(0.0);
+    o.push_back(0.0);
+    o.push_back(0.0);
+    params["origin"] = o;
+
+    params["theta"] = 0.0;
+    params["phi"] = 0.0;
+
+    doubleVector uv;
+    uv.push_back(0.0);
+    uv.push_back(1.0);
+    uv.push_back(0.0);
+    params["up_vector"] = uv;
 
     //
     // The new view parameters.
     //
-    doubleVector n;
-    n.push_back(0.0);
-    n.push_back(0.0);
-    n.push_back(1.0);
-    params["normal"] = n;
-
     doubleVector f;
     f.push_back(0.0);
     f.push_back(0.0);
@@ -2250,6 +2295,12 @@ avtXRayImageQuery::GetDefaultInputParams(MapNode &params)
     vu.push_back(1.0);
     vu.push_back(0.0);
     params["view_up"] = vu;
+
+    doubleVector n;
+    n.push_back(0.0);
+    n.push_back(0.0);
+    n.push_back(1.0);
+    params["normal"] = n;
 
     params["view_angle"] = 30.;
     params["parallel_scale"] = 0.5;
@@ -2263,32 +2314,6 @@ avtXRayImageQuery::GetDefaultInputParams(MapNode &params)
 
     params["image_zoom"] = 1.;
     params["perspective"] = 1;
-
-    intVector is;
-    is.push_back(200);
-    is.push_back(200);
-    params["image_size"] = is;
-
-    //
-    // The old view parameters.
-    //
-    doubleVector o;
-    o.push_back(0.0);
-    o.push_back(0.0);
-    o.push_back(0.0);
-    params["origin"] = o;
-
-    doubleVector uv;
-    uv.push_back(0.0);
-    uv.push_back(1.0);
-    uv.push_back(0.0);
-    params["up_vector"] = uv;
-
-    params["theta"] = 0.0;
-    params["phi"] = 0.0;
-
-    params["width"] = 1.0;
-    params["height"] = 1.0;
 }
 
 // ****************************************************************************

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -191,7 +191,6 @@ avtXRayImageQuery::avtXRayImageQuery():
     absUnits = "no units provided";
     emisUnits = "no units provided";
     intensityUnits = "no units provided";
-    pathLengthUnits = "no units provided";
 
     //
     // The new view specification
@@ -374,8 +373,6 @@ avtXRayImageQuery::SetInputParams(const MapNode &params)
         unitsmap["emisUnits"] = params.GetEntry("emis_units")->AsString();
     if (params.HasEntry("intensity_units"))
         unitsmap["intensityUnits"] = params.GetEntry("intensity_units")->AsString();
-    if (params.HasEntry("path_length_units"))
-        unitsmap["pathLengthUnits"] = params.GetEntry("path_length_units")->AsString();
     SetUnits(unitsmap);
 
     if (params.HasNumericEntry("debug_ray"))
@@ -835,8 +832,6 @@ avtXRayImageQuery::SetUnits(const std::map<std::string, std::string> &unitsmap)
             emisUnits = unitsmap.at("emisUnits");
         if (unitsmap.count("intensityUnits") > 0)
             intensityUnits = unitsmap.at("intensityUnits");
-        if (unitsmap.count("pathLengthUnits") > 0)
-            pathLengthUnits = unitsmap.at("pathLengthUnits");
     }
 }
 
@@ -1445,7 +1440,6 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
 
             data_out["fields/path_length/topology"] = "image_topo";
             data_out["fields/path_length/association"] = "element";
-            data_out["fields/path_length/units"] = pathLengthUnits;
             // set to float64 regardless of vtk data types
             data_out["fields/path_length/values"].set(conduit::DataType::float64(numfieldvals));
             conduit::float64 *depth_vals = data_out["fields/path_length/values"].value();

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -178,6 +178,7 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
     std::string               absUnits;
     std::string               emisUnits;
     std::string               intensityUnits;
+    std::string               pathLengthUnits;
 
     int                       numPixels;
 

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -94,6 +94,9 @@
 // 
 //    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 //    Renamed energy group bins to energy group bounds.
+// 
+//    Justin Privitera, Wed Nov 30 17:43:48 PST 2022
+//    Adds variables for units and one setter for all of them.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -127,6 +127,7 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
                                   const doubleVector &intensities);
     void                      SetEnergyGroupBounds(
                                   const doubleVector &bins);
+    void                      SetUnits(const std::map<std::string, std::string> &unitsmap);
     void                      SetDebugRay(const int &ray);
     void                      SetOutputRayBounds(const bool &flag);
     void                      SetFamilyFiles(const bool &flag);
@@ -170,6 +171,14 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
 
     std::string               absVarName;  //e.g. "absorbtivity"
     std::string               emisVarName; //e.g. "emissivity"
+
+    // units, to be output in blueprint metadata
+    std::string               spatialUnits;
+    std::string               energyUnits;
+    std::string               absUnits;
+    std::string               emisUnits;
+    std::string               intensityUnits;
+    std::string               pathLengthUnits;
 
     int                       numPixels;
 

--- a/src/avt/Queries/Queries/avtXRayImageQuery.h
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.h
@@ -178,7 +178,6 @@ class QUERY_API avtXRayImageQuery : public avtDatasetQuery
     std::string               absUnits;
     std::string               emisUnits;
     std::string               intensityUnits;
-    std::string               pathLengthUnits;
 
     int                       numPixels;
 

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>In the X Ray Image Query, a warning was added for the BMP output type, saying it may not function properly. This output type will be removed in the next major release of VisIt.</li>
   <li>For Blueprint output types from the X Ray Image Query, a host of new metadata has been added, as well as imaging plane topologies.</li>
   <li>In the X Ray Image Query, users may optionally pass energy group bounds to the query, which will appear as part of the metadata in the Blueprint output types.</li>
+  <li>In the X Ray Image Query, users may optionally pass the units for various input and output values through the query. These units will be propagated in the Blueprint output metadata.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -349,64 +349,77 @@ def test_bp_state_xray_view(testname, xrayout):
     normalx = xrayout["domain_000000/state/xray_view/normal/x"]
     normaly = xrayout["domain_000000/state/xray_view/normal/y"]
     normalz = xrayout["domain_000000/state/xray_view/normal/z"]
-    TestValueEQ(testname + "_Normal", [normalx, normaly, normalz], [0,0,1])
+    TestValueEQ(testname + "_view_Normal", [normalx, normaly, normalz], [0,0,1])
     
     focusx = xrayout["domain_000000/state/xray_view/focus/x"]
     focusy = xrayout["domain_000000/state/xray_view/focus/y"]
     focusz = xrayout["domain_000000/state/xray_view/focus/z"]
-    TestValueEQ(testname + "_Focus", [focusx, focusy, focusz], [0,2.5,10])
+    TestValueEQ(testname + "_view_Focus", [focusx, focusy, focusz], [0,2.5,10])
     
     viewUpx = xrayout["domain_000000/state/xray_view/viewUp/x"]
     viewUpy = xrayout["domain_000000/state/xray_view/viewUp/y"]
     viewUpz = xrayout["domain_000000/state/xray_view/viewUp/z"]
-    TestValueEQ(testname + "_ViewUp", [viewUpx, viewUpy, viewUpz], [0,1,0])
+    TestValueEQ(testname + "_view_ViewUp", [viewUpx, viewUpy, viewUpz], [0,1,0])
     
     viewAngle = xrayout["domain_000000/state/xray_view/viewAngle"]
-    TestValueEQ(testname + "_ViewAngle", viewAngle, 30)
+    TestValueEQ(testname + "_view_ViewAngle", viewAngle, 30)
     
     parallelScale = xrayout["domain_000000/state/xray_view/parallelScale"]
-    TestValueEQ(testname + "_ParallelScale", parallelScale, 5)
+    TestValueEQ(testname + "_view_ParallelScale", parallelScale, 5)
     
     nearPlane = xrayout["domain_000000/state/xray_view/nearPlane"]
-    TestValueEQ(testname + "_NearPlane", nearPlane, -100)
+    TestValueEQ(testname + "_view_NearPlane", nearPlane, -100)
     
     farPlane = xrayout["domain_000000/state/xray_view/farPlane"]
-    TestValueEQ(testname + "_FarPlane", farPlane, 100)
+    TestValueEQ(testname + "_view_FarPlane", farPlane, 100)
     
     imagePanx = xrayout["domain_000000/state/xray_view/imagePan/x"]
     imagePany = xrayout["domain_000000/state/xray_view/imagePan/y"]
-    TestValueEQ(testname + "_ImagePan", [imagePanx, imagePany], [0,0])
+    TestValueEQ(testname + "_view_ImagePan", [imagePanx, imagePany], [0,0])
     
     imageZoom = xrayout["domain_000000/state/xray_view/imageZoom"]
-    TestValueEQ(testname + "_ImageZoom", imageZoom, 1)
+    TestValueEQ(testname + "_view_ImageZoom", imageZoom, 1)
     
     perspective = xrayout["domain_000000/state/xray_view/perspective"]
-    TestValueEQ(testname + "_Perspective", perspective, 0)
+    TestValueEQ(testname + "_view_Perspective", perspective, 0)
 
     perspectiveStr = xrayout["domain_000000/state/xray_view/perspectiveStr"]
-    TestValueEQ(testname + "_PerspectiveStr", perspectiveStr, "parallel")
+    TestValueEQ(testname + "_view_PerspectiveStr", perspectiveStr, "parallel")
 
-def test_bp_state_xray_query(testname, xrayout):
+UNITS_OFF = 0
+UNITS_ON = 1
+
+def test_bp_state_xray_query(testname, xrayout, units):
     divideEmisByAbsorb = xrayout["domain_000000/state/xray_query/divideEmisByAbsorb"]
-    TestValueEQ(testname + "_DivideEmisByAbsorb", divideEmisByAbsorb, 1)
+    TestValueEQ(testname + "_query_DivideEmisByAbsorb", divideEmisByAbsorb, 1)
     
     divideEmisByAbsorbStr = xrayout["domain_000000/state/xray_query/divideEmisByAbsorbStr"]
-    TestValueEQ(testname + "_DivideEmisByAbsorbStr", divideEmisByAbsorbStr, "yes")
+    TestValueEQ(testname + "_query_DivideEmisByAbsorbStr", divideEmisByAbsorbStr, "yes")
     
     numXPixels = xrayout["domain_000000/state/xray_query/numXPixels"]
-    TestValueEQ(testname + "_NumXPixels", numXPixels, 300)
+    TestValueEQ(testname + "_query_NumXPixels", numXPixels, 300)
     
     numYPixels = xrayout["domain_000000/state/xray_query/numYPixels"]
-    TestValueEQ(testname + "_NumYPixels", numYPixels, 200)
+    TestValueEQ(testname + "_query_NumYPixels", numYPixels, 200)
     
     numBins = xrayout["domain_000000/state/xray_query/numBins"]
-    TestValueEQ(testname + "_NumBins", numBins, 1)
+    TestValueEQ(testname + "_query_NumBins", numBins, 1)
     
     absVarName = xrayout["domain_000000/state/xray_query/absVarName"]
-    TestValueEQ(testname + "_AbsVarName", absVarName, "d")
+    TestValueEQ(testname + "_query_AbsVarName", absVarName, "d")
     
     emisVarName = xrayout["domain_000000/state/xray_query/emisVarName"]
-    TestValueEQ(testname + "_EmisVarName", emisVarName, "p")
+    TestValueEQ(testname + "_query_EmisVarName", emisVarName, "p")
+
+    absUnits = xrayout["domain_000000/state/xray_query/absUnits"]
+    emisUnits = xrayout["domain_000000/state/xray_query/emisUnits"]
+
+    if (units == UNITS_ON):
+        TestValueEQ(testname + "_query_AbsUnits", absUnits, "abs units")
+        TestValueEQ(testname + "_query_EmisUnits", emisUnits, "emis units")
+    else:
+        TestValueEQ(testname + "_query_AbsUnits", absUnits, "no units provided")
+        TestValueEQ(testname + "_query_EmisUnits", emisUnits, "no units provided")
 
 NO_ENERGY_GROUP_BOUNDS = 0
 ENERGY_GROUP_BOUNDS_MISMATCH = 1
@@ -416,37 +429,37 @@ def test_bp_state_xray_data(testname, xrayout, bin_state = NO_ENERGY_GROUP_BOUND
     spatial_coords_x = xrayout["domain_000000/state/xray_data/image_coords/x"]
     spatial_coords_y = xrayout["domain_000000/state/xray_data/image_coords/y"]
     energy_group_bounds = xrayout["domain_000000/state/xray_data/image_coords/z"]
-    TestValueEQ(testname + "_SpatialExtents0", [spatial_coords_x[0], spatial_coords_y[0]], [0.0, 0.0])
-    TestValueEQ(testname + "_SpatialExtents1", [spatial_coords_x[1], spatial_coords_y[1]], [0.05, 0.05])
-    TestValueEQ(testname + "_SpatialExtents2", [spatial_coords_x[2], spatial_coords_y[2]], [0.1, 0.1])
-    TestValueEQ(testname + "_SpatialExtents3", [spatial_coords_x[-1], spatial_coords_y[-1]], [15.0, 10.0])
+    TestValueEQ(testname + "_data_SpatialExtents0", [spatial_coords_x[0], spatial_coords_y[0]], [0.0, 0.0])
+    TestValueEQ(testname + "_data_SpatialExtents1", [spatial_coords_x[1], spatial_coords_y[1]], [0.05, 0.05])
+    TestValueEQ(testname + "_data_SpatialExtents2", [spatial_coords_x[2], spatial_coords_y[2]], [0.1, 0.1])
+    TestValueEQ(testname + "_data_SpatialExtents3", [spatial_coords_x[-1], spatial_coords_y[-1]], [15.0, 10.0])
     if (bin_state == NO_ENERGY_GROUP_BOUNDS):
-        TestValueEQ(testname + "_EnergyGroupBounds", energy_group_bounds, "Energy group bounds not provided.")
+        TestValueEQ(testname + "_data_EnergyGroupBounds", energy_group_bounds, "Energy group bounds not provided.")
     elif (bin_state == ENERGY_GROUP_BOUNDS_MISMATCH):
         baseline_string = "Energy group bounds size mismatch: provided 3 bounds, but 2 in query results."
-        TestValueEQ(testname + "_EnergyGroupBounds", energy_group_bounds, baseline_string)
+        TestValueEQ(testname + "_data_EnergyGroupBounds", energy_group_bounds, baseline_string)
     elif (bin_state == ENERGY_GROUP_BOUNDS):
-        TestValueEQ(testname + "_EnergyGroupBounds", [energy_group_bounds[0], energy_group_bounds[1]], [3.7, 4.2])
+        TestValueEQ(testname + "_data_EnergyGroupBounds", [energy_group_bounds[0], energy_group_bounds[1]], [3.7, 4.2])
     
     detectorWidth = xrayout["domain_000000/state/xray_data/detectorWidth"]
-    TestValueEQ(testname + "_DetectorWidth", detectorWidth, 15)
+    TestValueEQ(testname + "_data_DetectorWidth", detectorWidth, 15)
 
     detectorHeight = xrayout["domain_000000/state/xray_data/detectorHeight"]
-    TestValueEQ(testname + "_DetectorHeight", detectorHeight, 10)
+    TestValueEQ(testname + "_data_DetectorHeight", detectorHeight, 10)
     
     intensityMax = xrayout["domain_000000/state/xray_data/intensityMax"]
-    TestValueEQ(testname + "_IntensityMax", intensityMax, 0.24153)
+    TestValueEQ(testname + "_data_IntensityMax", intensityMax, 0.24153)
     
     intensityMin = xrayout["domain_000000/state/xray_data/intensityMin"]
-    TestValueEQ(testname + "_IntensityMin", intensityMin, 0)
+    TestValueEQ(testname + "_data_IntensityMin", intensityMin, 0)
     
     pathLengthMax = xrayout["domain_000000/state/xray_data/pathLengthMax"]
-    TestValueEQ(testname + "_PathLengthMax", pathLengthMax, 148.67099)
+    TestValueEQ(testname + "_data_PathLengthMax", pathLengthMax, 148.67099)
     
     pathLengthMin = xrayout["domain_000000/state/xray_data/pathLengthMin"]
-    TestValueEQ(testname + "_PathLengthMin", pathLengthMin, 0)
+    TestValueEQ(testname + "_data_PathLengthMin", pathLengthMin, 0)
 
-def test_bp_state(testname, conduit_db, bin_state = NO_ENERGY_GROUP_BOUNDS):
+def test_bp_state(testname, conduit_db, bin_state = NO_ENERGY_GROUP_BOUNDS, units = UNITS_OFF):
     xrayout = conduit.Node()
     conduit.relay.io.blueprint.load_mesh(xrayout, conduit_db)
 
@@ -457,8 +470,30 @@ def test_bp_state(testname, conduit_db, bin_state = NO_ENERGY_GROUP_BOUNDS):
     TestValueEQ(testname + "_Cycle", cycle, 48)
 
     test_bp_state_xray_view(testname, xrayout)
-    test_bp_state_xray_query(testname, xrayout)
+    test_bp_state_xray_query(testname, xrayout, units)
     test_bp_state_xray_data(testname, xrayout, bin_state)
+
+    xunits = xrayout["domain_000000/coordsets/image_coords/units/x"]
+    yunits = xrayout["domain_000000/coordsets/image_coords/units/y"]
+    zunits = xrayout["domain_000000/coordsets/image_coords/units/z"]
+
+    intensityUnits = xrayout["domain_000000/fields/intensities/units"]
+    pathLengthUnits = xrayout["domain_000000/fields/path_length/units"]
+
+    if (units == UNITS_ON):
+        TestValueEQ(testname + "_XUnits", xunits, "cm")
+        TestValueEQ(testname + "_YUnits", yunits, "cm")
+        TestValueEQ(testname + "_ZUnits", zunits, "kev")
+        
+        TestValueEQ(testname + "_IntensityUnits", intensityUnits, "intensity units")
+        TestValueEQ(testname + "_PathLengthUnits", pathLengthUnits, "path length metadata")
+    else:
+        TestValueEQ(testname + "_XUnits", xunits, "no units provided")
+        TestValueEQ(testname + "_YUnits", yunits, "no units provided")
+        TestValueEQ(testname + "_ZUnits", zunits, "no units provided")
+        
+        TestValueEQ(testname + "_IntensityUnits", intensityUnits, "no units provided")
+        TestValueEQ(testname + "_PathLengthUnits", pathLengthUnits, "no info provided")
 
 def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
     for i in range(0, 2):
@@ -479,6 +514,12 @@ def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
             params["height"] = 10.;
             params["image_size"] = (300, 200)
             params["vars"] = ("d", "p")
+            params["spatial_units"] = "cm";
+            params["energy_units"] = "kev";
+            params["abs_units"] = "abs units";
+            params["emis_units"] = "emis units";
+            params["intensity_units"] = "intensity units";
+            params["path_length_units"] = "path length metadata";
             Query("XRay Image", params)
         s = GetQueryOutputString()
         TestText("xrayimage" + str(testtextnumber + i), s)
@@ -495,12 +536,13 @@ def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
         CloseDatabase(conduit_db)
 
     if (hdf5):
-        test_bp_state(testname + str(i), conduit_db) # no bounds
+        units = UNITS_OFF if i == 0 else UNITS_ON
+        test_bp_state(testname + str(i), conduit_db, NO_ENERGY_GROUP_BOUNDS, units) # no bounds
         setup_bp_test()
         Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"), [1,2,3])
-        test_bp_state(testname + str(i), conduit_db, ENERGY_GROUP_BOUNDS_MISMATCH) # bounds mismatch
+        test_bp_state(testname + str(i), conduit_db, ENERGY_GROUP_BOUNDS_MISMATCH, UNITS_OFF) # bounds mismatch
         Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"), [3.7, 4.2])
-        test_bp_state(testname + str(i), conduit_db, ENERGY_GROUP_BOUNDS) # bounds
+        test_bp_state(testname + str(i), conduit_db, ENERGY_GROUP_BOUNDS, UNITS_OFF) # bounds
         DeleteAllPlots()
         CloseDatabase(silo_data_path("curv3d.silo"))
 

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -49,6 +49,9 @@
 # 
 #    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 #    Renamed energy group bins to energy group bounds.
+# 
+#    Justin Privitera, Wed Nov 30 17:43:48 PST 2022
+#    Added tests for piping the units through the query.
 #
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

Addresses a bullet in #17791 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Adds units to the blueprint output and arguments for each type of unit to the query.
Also adds tests for this feature.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rztopaz all new and old tests pass

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have followed the [style guidelines][1] of this project.~~
- [x] I have performed a self-review of my own code.~~
- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [x] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
