### PR TITLE
Fix ubuntu22 docker

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu22
+++ b/scripts/docker/Dockerfile-ubuntu22
@@ -60,9 +60,9 @@ WORKDIR /home/visit
 RUN mkdir third-party
 # Copy build_visit and the script to run it
 COPY build_visit3_3_1 /home/visit
-COPY run_build_visit_fedora31.sh /home/visit
+COPY run_build_visit_ubuntu22.sh /home/visit
 COPY build_visit_docker_cleanup.py /home/visit
 COPY build_test_visit.sh /home/visit
 COPY test_visit.py /home/visit
 # Build the third party libraries.
-RUN /bin/bash run_build_visit_fedora31.sh
+RUN /bin/bash run_build_visit_ubuntu22.sh

--- a/scripts/docker/run_build_visit_ubuntu22.sh
+++ b/scripts/docker/run_build_visit_ubuntu22.sh
@@ -1,0 +1,1 @@
+echo "yes" | ./build_visit3_3_1 --required --optional --mesagl --mpich --uintah --no-moab --no-pidx --no-vtkm --no-vtkh --no-ospray --no-visit --thirdparty-path /home/visit/third-party --makeflags -j4 --cxxflags -std=c++11; python build_visit_docker_cleanup.py


### PR DESCRIPTION
### Description

Created run_build_visit_ubuntu22.sh from the fedora31 version and added -std=c++11 to build_visit command line. Allows Uintah and OpenEXR to build. Add --no-ospray as it doesn't build with gcc11 (needs a patch).

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I used the dockerfile to build the container with success.  Ran the build_visit_test with success.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have followed the [style guidelines][1] of this project.~~
- [X] I have performed a self-review of my own code.~~
~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
- [X] I have assigned reviewers (see [VisIt's PR procedures][2] for more information).~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
