### PR TITLE
Fix ubuntu22 dockerfile.

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu22
+++ b/scripts/docker/Dockerfile-ubuntu22
@@ -60,9 +60,9 @@ WORKDIR /home/visit
 RUN mkdir third-party
 # Copy build_visit and the script to run it
 COPY build_visit3_3_1 /home/visit
-COPY run_build_visit_fedora31.sh /home/visit
+COPY run_build_visit_ubuntu22.sh /home/visit
 COPY build_visit_docker_cleanup.py /home/visit
 COPY build_test_visit.sh /home/visit
 COPY test_visit.py /home/visit
 # Build the third party libraries.
-RUN /bin/bash run_build_visit_fedora31.sh
+RUN /bin/bash run_build_visit_ubuntu22.sh

--- a/scripts/docker/run_build_visit_ubuntu22.sh
+++ b/scripts/docker/run_build_visit_ubuntu22.sh
@@ -1,0 +1,1 @@
+echo "yes" | ./build_visit3_3_1 --required --optional --mesagl --mpich --uintah --no-moab --no-pidx --no-vtkm --no-vtkh --no-ospray --no-visit --thirdparty-path /home/visit/third-party --makeflags -j4 --cxxflags -std=c++11; python build_visit_docker_cleanup.py


### PR DESCRIPTION
Merge from 3.3RC.
Created run_build_visit_ubuntu22.sh from the fedora31 version and added -std=c++11 to build_visit command line. Allows Uintah and OpenEXR to build. Add --no-ospray as it doesn't build with gcc11 (needs a patch).
