### PR TITLE
Rm bizarre last line

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -211,4 +211,3 @@ else
     # Pass "-u" to python to turn off buffering
     exec python -u $frontendlauncherpy $0 ${1+"$@"}
 fi
-$0 = shift @ARGV;


### PR DESCRIPTION
The last line had no effect because the `exec` statements in both branches of the `if-else` block meant it was never executed. On top of that, there is no clear idea what that line was *intended* to do. What it did do was call `frontendlauncher` (`$0`) recursively with three args, `=`, `shift` and `@ARGV;` which I think was not intentional.
