### PR TITLE
Add archive3 target for option to explicitly python3

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -148,11 +148,18 @@ SET(ARCHIVE_NAME {ANAME})
 SET(ARCHIVE_FILES {AFILES})
 
 #-----------------------------------------------------------------------------
-# Define convenience command/target to create an archive...optimized variant
+# Define convenience commands/targets to create an archive...optimized variant
 # using python tarfile module. This gives optimal compression (due to preset=9)
 # but might fail. If it does, it prints an error message informing user to
 # use `fbarchive` target instead
 #-----------------------------------------------------------------------------
+ADD_CUSTOM_COMMAND(
+    OUTPUT _archive3_create
+    COMMAND python3 -c \"import sys,tarfile\try:\  tf=tarfile.open\(sys.argv[1],'w:xz',preset=9\)\  [tf.add\(x\) for x in sys.argv[2:]]\except:\  print\('\\n\\n\\n***archive target failed, try archive target***\\n\\n\\n'\)\" ${CMAKE_CURRENT_SOURCE_DIR}/$${ARCHIVE_NAME} $${ARCHIVE_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+ADD_CUSTOM_TARGET(archive3 DEPENDS _archive3_create)
+
+# Try same with normal python
 ADD_CUSTOM_COMMAND(
     OUTPUT _archive_create
     COMMAND python -c \"import sys,tarfile\try:\  tf=tarfile.open\(sys.argv[1],'w:xz',preset=9\)\  [tf.add\(x\) for x in sys.argv[2:]]\except:\  print\('\\n\\n\\n***archive target failed, use fbarchive target***\\n\\n\\n'\)\" ${CMAKE_CURRENT_SOURCE_DIR}/$${ARCHIVE_NAME} $${ARCHIVE_FILES}
@@ -193,7 +200,10 @@ ADD_CUSTOM_TARGET(
     COMMAND ${CMAKE_COMMAND} -E echo ""
     COMMAND ${CMAKE_COMMAND} -E echo "               Conveninent make targets:"
     COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "To create an optimally compressed archive..."
+    COMMAND ${CMAKE_COMMAND} -E echo "To create an optimally compressed archive (using python3)..."
+    COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=<arname> AFILES=\"dir1 dir2 file1...\" archive3"
+    COMMAND ${CMAKE_COMMAND} -E echo ""
+    COMMAND ${CMAKE_COMMAND} -E echo "To create an optimally compressed archive (using python)..."
     COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=<arname> AFILES=\"dir1 dir2 file1...\" archive"
     COMMAND ${CMAKE_COMMAND} -E echo ""
     COMMAND ${CMAKE_COMMAND} -E echo "To create a fallback archive if optimal compression fails..."
@@ -212,7 +222,7 @@ ADD_CUSTOM_TARGET(
     COMMAND ${CMAKE_COMMAND} -E echo "Examples..."
     COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=silo_hdf5_test_data.tar.xz expand"
     COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=silo_hdf5_test_data.tar.xz list"
-    COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=my_test_data.tar.xz AFILES=my_test_data archive"
+    COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=my_test_data.tar.xz AFILES=my_test_data archive3"
     COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=foo.tar.xz AFILES=\"dir1 file1 dir2\" archive"
     COMMAND ${CMAKE_COMMAND} -E echo "  make ANAME=foo.tar.xz AFILES=foo fbarchive"
     COMMAND ${CMAKE_COMMAND} -E echo ""


### PR DESCRIPTION
### Description

The `data` dir's `CMakeLists.txt` file already has `archive` and `fbarchive` targets to help create archives. The `archive` target tries to use Python's `tarfile` module to produce maximally compressed XZ tar file. It uses `python` (not `python3`) to do it and can sometimes fail. When it fails, the only answer is to use the *fall-back* target, `fbarchive` which results in poorly compressed files.

It fails on my macOS machine because `python` there is Python 2 and the `tarfile` module there doesn't have the necessary features. But, my macOS machine does have a `python3` for which it does work.

So, I just added an `archive3` target which explicitly requests it use `python3` to do its work. So, you can try `archive` target first, maybe then try `archive3` and otherwise `fbarchive`.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
