### PR TITLE
Fix warnings when generating  manuals.

### DIFF
--- a/src/doc/dev_manual/UpdatingPlugins.rst
+++ b/src/doc/dev_manual/UpdatingPlugins.rst
@@ -54,16 +54,19 @@ Conditionals must be specified in the *.code* file with *Target* specified as *x
 These conditionals create these lines in the CMakeLists.txt:
 
 .. literalinclude:: ../../plots/Volume/CMakeLists.txt
-    :lines: 96-102
+    :lines: 65-67
 
 .. literalinclude:: ../../plots/Volume/CMakeLists.txt
-    :lines: 118-120
+    :lines: 61-63
 
 .. literalinclude:: ../../plots/Volume/CMakeLists.txt
-    :lines: 150-152
+    :lines: 83-85
 
 .. literalinclude:: ../../plots/Volume/CMakeLists.txt
-    :lines: 160-162
+    :lines: 115-117
+
+.. literalinclude:: ../../plots/Volume/CMakeLists.txt
+    :lines: 125-127
 
 
 Info files
@@ -97,15 +100,126 @@ The arguments for a renamed field: the old field name, the new field name, the v
 
 Here is an example from the WellBore plot, which had a field removed in version 3.0.0
 
-Here's code file for the cpp change:
+Here's code file for the cpp change::
 
-.. literalinclude:: ../../plots/WellBore/WellBoreAttributes.code
-    :lines: 265-312
+    Target: xml2atts
+    Function: ProcessOldVersions
+    Declaration: virtual void ProcessOldVersions(DataNode *parentNode, const char *configVersion);
+    Definition:
+    // ****************************************************************************
+    // Method: WellBoreAttributes::ProcessOldVersions
+    //
+    // Purpose:
+    //   This method allows handling of older config/session files that may
+    //   contain fields that are no longer present or have been modified/renamed.
+    //
+    // Programmer: Kathleen Biagas
+    // Creation:   April 4, 2018
+    //
+    // Modifications:
+    //
+    // ****************************************************************************
+    #include <visit-config.h>
+    #ifdef VIEWER
+    #include <avtCallback.h>
+    #endif
+    
+    void
+    WellBoreAttributes::ProcessOldVersions(DataNode *parentNode,
+                                    const char *configVersion)
+    {
+    #if VISIT_OBSOLETE_AT_VERSION(3,3,2)
+    #error This code is obsolete in this version. Please remove it.
+    #else
+        if(parentNode == 0)
+        return;
 
-Now for the python getattr and setattr methods:
+        DataNode *searchNode = parentNode->GetNode("WellBoreAttributes");
+        if(searchNode == 0)
+            return;
 
-.. literalinclude:: ../../plots/WellBore/WellBoreAttributes.code
-    :lines: 315-380 
+        if (VersionLessThan(configVersion, "3.0.0"))
+        {
+            if (searchNode->GetNode("wellLineStyle") != 0)
+            {
+    #ifdef VIEWER
+                avtCallback::IssueWarning(DeprecationMessage("wellLineStyle", "3.3.2"));
+    #endif
+                searchNode->RemoveNode("wellLineStyle");
+            }
+        }
+    #endif
+    }
+
+Now for the python getattr and setattr methods::
+
+    Target: xml2python
+    Code: PyWellBoreAttributes_getattr
+    Prefix:
+    Postfix:
+    #if VISIT_OBSOLETE_AT_VERSION(3,3,2)
+    #error This code is obsolete in this version. Please remove it.
+    #else
+        // Try and handle legacy fields
+
+        //
+        //  Removed in 3.0.0
+        //
+        // wellLineStyle and it's possible enumerations
+        bool wellLineStyleFound = false;
+        if (strcmp(name, "wellLineStyle") == 0)
+        {
+            wellLineStyleFound = true;
+        }
+        else if (strcmp(name, "SOLID") == 0)
+        {
+            wellLineStyleFound = true;
+        }
+        else if (strcmp(name, "DASH") == 0)
+        {
+            wellLineStyleFound = true;
+        }
+        else if (strcmp(name, "DOT") == 0)
+        {
+            wellLineStyleFound = true;
+        }
+        else if (strcmp(name, "DOTDASH") == 0)
+        {
+            wellLineStyleFound = true;
+        }
+
+        if (wellLineStyleFound)
+        {
+            PyErr_WarnEx(NULL,
+                "wellLineStyle is no longer a valid WellBore "
+                "attribute.\nIt's value is being ignored, please remove "
+                "it from your script.\n", 3);
+            return PyInt_FromLong(0L);
+        }
+    #endif
+    
+    
+    Code: PyWellBoreAttributes_setattr
+    Prefix:
+    Postfix:
+    #if VISIT_OBSOLETE_AT_VERSION(3,3,2)
+    #error This code is obsolete in this version. Please remove it.
+    #else
+        // Try and handle legacy fields
+        if(obj == &NULL_PY_OBJ)
+        {
+            //
+            //  Removed in 3.0.0
+            //
+            if(strcmp(name, "wellLineStyle") == 0)
+            {
+                PyErr_WarnEx(NULL, "'wellLineStyle' is obsolete. It is being ignored.", 3);
+                Py_INCREF(Py_None);
+                obj = Py_None;
+            }
+        }
+    #endif
+
 
 **Important**: Changes to fields in the Attributes are not allowed in patch releases, as it may cause incompatibility between client and server running different patches of the same major.minor release.
 

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -1960,17 +1960,20 @@ resrad Function: ``resrad()`` : ``resrad(expr0)``
 
 crack width Function: ``crack_width()`` : ``crack_width(crack_num, <crack1_dir>, <crack2_dir>, <crack3_dir>, <strain_tensor>, volume2(<mesh_name>))``
 
-    Calculates crack width using the following formula:
-        crackwidth = L * (1 - (exp(-delta))  
-        where: 
+    Calculates crack width using the following formula::
+
+        crackwidth = L * (1 - (exp(-delta))
+        where:
           L = ZoneVol / (Area perpendicular to crack_dir)
             find Area by slicing the cell by plane with origin == cell center
             and Normal == crack_dir.  Take area of that slice.
-    
-          delta = T11 for crack dir1 = component 0 of strain_tensor 
-                  T22 for crack dir2 = component 4 of strain_tensor
-                  T33 for crack dir3 = component 8 of strain_tensor
-   
+         
+        delta =
+            T11 for crack dir1 = component 0 of strain_tensor
+            T22 for crack dir2 = component 4 of strain_tensor
+            T33 for crack dir3 = component 8 of strain_tensor
+
+
 Time Iteration Expressions
 """"""""""""""""""""""""""
 


### PR DESCRIPTION
Some warnings were for literal-included sections of source files that had changed, so the line references were no longer valid.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [X] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I built the 'manuals' target without warnings and looked at the changed sections of the generated docs to ensure they are correct.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
