### PR TITLE
Enable clearing of last error message in CLI

### DIFF
--- a/src/doc/python_scripting/functions.rst
+++ b/src/doc/python_scripting/functions.rst
@@ -3658,8 +3658,8 @@ GetLastError
 
 return type : string
     GetLastError returns a string containing the last error message that VisIt
-    issued since being cleared. If int-clr arg, if present, is non-zero, once
-    the message is retrieved, it is also cleared.
+    issued since being cleared. If int-clr is present and is non-zero, once
+    the message is retrieved it is also cleared.
 
 
 **Description:**

--- a/src/doc/python_scripting/functions.rst
+++ b/src/doc/python_scripting/functions.rst
@@ -3654,16 +3654,19 @@ GetLastError
 ::
 
   GetLastError() -> string
+  GetLastError(int-clr) -> string
 
 return type : string
     GetLastError returns a string containing the last error message that VisIt
-    issued.
+    issued since being cleared. If int-clr arg, if present, is non-zero, once
+    the message is retrieved, it is also cleared.
 
 
 **Description:**
 
     The GetLastError function returns a string containing the last error
-    message that VisIt issued.
+    message that VisIt issued since being cleared. If int-clr arg, if present,
+    is non-zero, once the message is retrieved, it is also cleared.
 
 
 **Example:**
@@ -3673,6 +3676,8 @@ return type : string
   #% visit -cli
   OpenDatabase("/this/database/does/not/exist")
   print("VisIt Error: %s" % GetLastError())
+  # Get last message into msg and then clear last error message to ""
+  msg = GetLastError(1)
 
 
 GetLight

--- a/src/doc/python_scripting/functions.rst
+++ b/src/doc/python_scripting/functions.rst
@@ -3657,16 +3657,14 @@ GetLastError
   GetLastError(int-clr) -> string
 
 return type : string
-    GetLastError returns a string containing the last error message that VisIt
-    issued since being cleared. If int-clr is present and is non-zero, once
-    the message is retrieved it is also cleared.
+    GetLastError returns a string containing the last error message that VisIt issued since being cleared.
+    If int-clr is present and is non-zero, once the message is retrieved it is also cleared.
 
 
 **Description:**
 
-    The GetLastError function returns a string containing the last error
-    message that VisIt issued since being cleared. If int-clr arg, if present,
-    is non-zero, once the message is retrieved, it is also cleared.
+    The GetLastError function returns a string containing the last error message that VisIt issued since being cleared.
+    If int-clr is present and is non-zero, once the message is retrieved it is also cleared.
 
 
 **Example:**

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -39,6 +39,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>For Blueprint output types from the X Ray Image Query, a host of new metadata has been added, as well as imaging plane topologies.</li>
   <li>In the X Ray Image Query, users may optionally pass energy group bounds to the query, which will appear as part of the metadata in the Blueprint output types.</li>
   <li>In the X Ray Image Query, users may optionally pass the units for various input and output values through the query. These units will be propagated in the Blueprint output metadata.</li>
+  <li>The <code>GetLastError()</code> CLI method now accepts an optional integer argument indicating whether to clear out the last error message after retrieving it.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/test/tests/unit/default_methods.py
+++ b/src/test/tests/unit/default_methods.py
@@ -22,6 +22,10 @@ TestValueEQ("GetDebugLevel()", GetDebugLevel(), 0)
 DeleteWindow()
 TestValueEQ("GetLastError()", GetLastError(), "Can't delete the last window.")
 
+# Test that we can clear the last error too
+GetLastError(1)
+TestValueEQ("Clearing GetLastError()", GetLastError(), "")
+
 # This version number test assumes 3, single digits
 TestValueGE("Version()", int(Version().replace('.','')), 321)
 

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -312,6 +312,7 @@ public:
     void ClearError()
     {
         errorFlag = 0;
+        lastError = "";
     };
     int SetSuppressLevel(int newLevel)
     {
@@ -322,7 +323,7 @@ public:
 
     int GetSuppressLevel() const { return suppressLevel; };
     int ErrorFlag() const { return errorFlag; };
-    const std::string &GetLastError() const { return lastError; };
+    const std::string &GetLastError() const { return lastError; }
 
     virtual void Update(Subject *s)
     {
@@ -1808,17 +1809,24 @@ visit_GetDebugLevel(PyObject *self, PyObject *args)
 // Creation:   Fri Jul 26 12:15:57 PDT 2002
 //
 // Modifications:
+//   Mark C. Miller, Tue Dec  6 18:02:38 PST 2022
+//   Allow for option to clear the error after retrieving it.
 //
 // ****************************************************************************
 
 STATIC PyObject *
 visit_GetLastError(PyObject *self, PyObject *args)
 {
-    NO_ARGUMENTS();
-    const char *str = "";
-    if(messageObserver)
-        str = messageObserver->GetLastError().c_str();
-    return PyString_FromString(str);
+    int clear = 0;
+    std::string retval;
+    if (!PyArg_ParseTuple(args, "|i", &clear)) return NULL;
+    if (messageObserver)
+    {
+        retval = messageObserver->GetLastError();
+        if (clear != 0)
+            messageObserver->ClearError();
+    }
+    return PyString_FromString(retval.c_str());
 }
 
 // ****************************************************************************

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -323,7 +323,7 @@ public:
 
     int GetSuppressLevel() const { return suppressLevel; };
     int ErrorFlag() const { return errorFlag; };
-    const std::string &GetLastError() const { return lastError; }
+    const std::string &GetLastError() const { return lastError; };
 
     virtual void Update(Subject *s)
     {


### PR DESCRIPTION
### Description

The CLI method, `GetLastError()` returns the last error message. But, there was no way to clear it out to `""`. So, once an error happened, it would forever be some string until a new error happened. There is also an associated `errorFlag` in the supporting class and there was already a `ClearError()` method in that class but it only reset the `errorFlag` and left the `lastError` unchanged.

I made `ClearError()` also reset `lastError` to `""` and then added an optional integer arg to `GetLastError(int-clr)` so that it can accept an integer argument, `int-clr`. If `int-clr` is a non-zero integer, then after obtaining whatever string is in `lastError`, it will also reset `lastError` to `""`. If `int-clr` is zero, it behaves the same as `GetLastError()`. Any other argument will cause `GetLastError()` to fail.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
