### PR TITLE
Remove reference to SNPRINTF macro as it no longer exists.

### DIFF
--- a/src/doc/dev_manual/StyleGuide.rst
+++ b/src/doc/dev_manual/StyleGuide.rst
@@ -536,31 +536,15 @@ MyClass.C file contents: ::
     MyClass::MyClass() { }
     MyClass::~MyClass() { }
 
-Include snprintf.h
-~~~~~~~~~~~~~~~~~~
+Do not use 'sprintf'
+~~~~~~~~~~~~~~~~~~~~
 
 VisIt_ source code should not use *sprintf* into a static sized buffer
 due to the possibility of buffer overruns, which introduce memory
 problems and possible security threats. To combat this, the use of
 *sprintf* is deprecated and all new code should use *snprintf*, which
 behaves the same but also takes the size of the buffer as an argument
-so buffer overruns are not possible. The *snprintf* function is not
-supported in any of the Windows header files but there is a *\_snprintf*
-function. Since some platforms can use *snprintf* and Windows must use
-*\_snprintf*, there is an snprintf.h header file that defines an
-*SNPRINTF* macro which evaluates to the proper symbol based on the
-compiler being used. ::
-
-    // Don't do this
-    const char *s = "This is a very long message "
-    "intended to overrun the buffer.";
-    char buf[20];
-    sprintf(buf, "Message: %s", s);
-
-    // Do this instead
-    #include <snprintf.h>
-    SNPRINTF(buf, 20, "Message: %s", s);
-
+so buffer overruns are not possible.
 
 Do not use variables called near or far
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Description

I noticed this section while browsing through the Style guide.
The SNPRINTF macro was removed in #3752.


### Type of change

<!-- Please check one of the boxes below -->

~~* [ ] Bug fix~~
~~* [ ] New feature~~
* [X] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
