### PR TITLE
new silo decomp info case enh for 3.3.2

### DIFF
--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -5470,8 +5470,10 @@ avtSiloFileFormat::FindStandardConnectivity(DBfile *dbfile, int &ndomains,
         debug1 << "avtSiloFileFormat: using standard connectivity info" <<endl;
 
         // Look for absence of `Domain_0/BlockNum` along with the
-        // existence of `Domains_BlockNums` & `Domains_Extents`
+        // existence of `Domains_BlockNums` & `Domain_Extents`
         // to identify the rare "6th" silo decomp format.
+        //
+        // (yes, Domain_Extents is singular not plural form)
         //
         // This case is a blend of some of the arrays used for the mmadj and
         // "standard" format flavors.
@@ -5488,7 +5490,7 @@ avtSiloFileFormat::FindStandardConnectivity(DBfile *dbfile, int &ndomains,
         //
         if( !DBInqVarExists(dbfile,"Domain_0/BlockNum") &&
              DBInqVarExists(dbfile,"Domains_BlockNums") &&
-             DBInqVarExists(dbfile,"Domains_Extents") )
+             DBInqVarExists(dbfile,"Domain_Extents") )
         {
             debug1 << "avtSiloFileFormat: using the `6th` connectivity info "
                    << "format variant" <<endl;
@@ -5500,7 +5502,7 @@ avtSiloFileFormat::FindStandardConnectivity(DBfile *dbfile, int &ndomains,
 
             if(needConnectivityInfo)
             {
-                err |= DBReadVar(dbfile, "Domains_Extents", extents) != 0;
+                err |= DBReadVar(dbfile, "Domain_Extents", extents) != 0;
             }
 
             if (err)
@@ -5510,14 +5512,16 @@ avtSiloFileFormat::FindStandardConnectivity(DBfile *dbfile, int &ndomains,
                 return;
             }
 
-            // NOTE: The 6th format only appears during a full moon,
-            // and there will be no neighbors willing to connect.
-            for (int j = 0 ; j < ndomains ; j++)
+            if(needConnectivityInfo)
             {
-                nneighbors[j] = 0;
+                // NOTE: The 6th format only appears during a full moon,
+                // and there will be no neighbors willing to connect.
+                for (int j = 0 ; j < ndomains ; j++)
+                {
+                    nneighbors[j] = 0;
+                }
+                lneighbors = 0;
             }
-
-            lneighbors = 0;
         }
         else
         {

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -5211,6 +5211,10 @@ avtSiloFileFormat::GetConnectivityAndGroupInformation(DBfile *dbfile,
 //    Mark C. Miller, Wed Jun 15 09:22:14 PDT 2016
 //    Read the Domains_BlockNums data to support adding block decompposition
 //    as a variable.
+//
+//    Cyrus Harrison, Fri Dec  9 14:45:57 PST 2022
+//    Add support for the rare `6th` decomp format discovered in the wild.
+//
 // ****************************************************************************
 
 void
@@ -5464,25 +5468,39 @@ avtSiloFileFormat::FindStandardConnectivity(DBfile *dbfile, int &ndomains,
     if (!packed_conn_info) // use standard connectivity info
     {
         debug1 << "avtSiloFileFormat: using standard connectivity info" <<endl;
-        for (int j = 0 ; j < ndomains ; j++)
+
+        // Look for absence of `Domain_0/BlockNum` along with the
+        // existence of `Domains_BlockNums` & `Domains_Extents`
+        // to identify the rare "6th" silo decomp format.
+        //
+        // This case is a blend of some of the arrays used for the mmadj and
+        // "standard" format flavors.
+        //
+        // It came to town in a file that has decomp dirs but the blocks
+        // are all independent and neighborless.
+        // 
+        // mmadj can't represent this case (all relationships can't be empty,
+        // in a mmadj -- its simply too dire of a state for the mmadj to face.)
+        //
+        // CYRUS NOTE: This might not actually be the "6th" format
+        // (it's at least the 5th :-), but the name conveys multitude of
+        // formats, and helps us reflect on our collective decomp decisions.
+        //
+        if( !DBInqVarExists(dbfile,"Domain_0/BlockNum") &&
+             DBInqVarExists(dbfile,"Domains_BlockNums") &&
+             DBInqVarExists(dbfile,"Domains_Extents") )
         {
+            debug1 << "avtSiloFileFormat: using the `6th` connectivity info "
+                   << "format variant" <<endl;
             bool err = false;
-            char varname[256];
-            if (needConnectivityInfo)
-            {
-                sprintf(varname, "Domain_%d/Extents", j);
-                err |= DBReadVar(dbfile, varname, &extents[j*6]) != 0;
-
-                sprintf(varname, "Domain_%d/NumNeighbors", j);
-                err |= DBReadVar(dbfile, varname, &nneighbors[j]) != 0;
-
-                lneighbors += nneighbors[j] * 11;
-            }
-
             if (needGroupInfo)
             {
-                sprintf(varname, "Domain_%d/BlockNum", j);
-                err |= DBReadVar(dbfile, varname, &(groupIds[j])) != 0;
+                err |= DBReadVar(dbfile,"Domains_BlockNums", groupIds) != 0;
+            }
+
+            if(needConnectivityInfo)
+            {
+                err |= DBReadVar(dbfile, "Domains_Extents", extents) != 0;
             }
 
             if (err)
@@ -5490,6 +5508,47 @@ avtSiloFileFormat::FindStandardConnectivity(DBfile *dbfile, int &ndomains,
                 ndomains = -1;
                 numGroups = -1;
                 return;
+            }
+
+            // NOTE: The 6th format only appears during a full moon,
+            // and there will be no neighbors willing to connect.
+            for (int j = 0 ; j < ndomains ; j++)
+            {
+                nneighbors[j] = 0;
+            }
+
+            lneighbors = 0;
+        }
+        else
+        {
+            // the original std connectivity info 
+            for (int j = 0 ; j < ndomains ; j++)
+            {
+                bool err = false;
+                char varname[256];
+                if (needConnectivityInfo)
+                {
+                    sprintf(varname, "Domain_%d/Extents", j);
+                    err |= DBReadVar(dbfile, varname, &extents[j*6]) != 0;
+
+                    sprintf(varname, "Domain_%d/NumNeighbors", j);
+                    err |= DBReadVar(dbfile, varname, &nneighbors[j]) != 0;
+
+                    lneighbors += nneighbors[j] * 11;
+                }
+
+                if (needGroupInfo)
+                {
+                    sprintf(varname, "Domain_%d/BlockNum", j);
+                    err |= DBReadVar(dbfile, varname, &(groupIds[j])) != 0;
+                }
+
+                if (err)
+                {
+                    ndomains = -1;
+                    numGroups = -1;
+                    return;
+                }
             }
         }
 

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -41,6 +41,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>In the X Ray Image Query, users may optionally pass the units for various input and output values through the query. These units will be propagated in the Blueprint output metadata.</li>
   <li>Added support to export PolyData with a single cell type to the Blueprint Database plugin writer.</li>
   <li>The X Ray Image Query now outputs Blueprint meshes representing the rays used in the raytrace if a Blueprint output type is selected.</li>
+  <li>The Silo Database plugin was updated to support a rare decomposition format discovered in the wild.</li>
+  
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Adds support for a discovered-in-the-wild corner case of a new Silo Decomposition format. 


### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [x] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I am working on building on HPC platform to test the exemplar file.

- [x] finish test with exemplar file

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
