### PR TITLE
Rebase a couple of silo results due to regen of data files

### DIFF
--- a/test/baseline/databases/silo/silo_15.png
+++ b/test/baseline/databases/silo/silo_15.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:923f04b2af7e0994fc6d5f0673cd08d0019d396b9d549190a44769a0fe320f1a
-size 10693
+oid sha256:0295bfcf9ccd761ecd8612242a400037d5c2ef94162a014e0a44b37588855fc2
+size 10695

--- a/test/baseline/databases/silo/silo_32.png
+++ b/test/baseline/databases/silo/silo_32.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ae0b38b82cd81dcb0fa3b5c601f9b071dac09f05007a25e555acc3d9c168921
-size 12176
+oid sha256:6fbb1acc7d480a3d7005c91ffd1c3f18a55b9ed34793c27563233c139912222f
+size 12174


### PR DESCRIPTION
I found and fixed some problems with material objects in Silo files. But, I regenerated the files on macOS and I think original was on Linux. This lead to subtle (single pixel) diffs in some cases.