### PR TITLE
Modify makemovie.py to adjust the number of digits in filenames.

### DIFF
--- a/src/bin/makemovie.py
+++ b/src/bin/makemovie.py
@@ -517,8 +517,7 @@ class MakeMovie(object):
     #
     #   Eric Brugger, Mon Dec 19 13:06:50 PST 2022
     #   I added code to set the number of digits in the movie file names
-    #   based on the number needed rather than always four. Note that it
-    #   uses a minimum of four digits to maintain backawards compatability.
+    #   based on the number needed rather than always four.
     #
     ###########################################################################
 
@@ -2058,8 +2057,7 @@ class MakeMovie(object):
     #
     #   Eric Brugger, Mon Dec 19 13:06:50 PST 2022
     #   I added code to set the number of digits in the movie file names
-    #   based on the number needed rather than always four. Note that it
-    #   uses a minimum of four digits to maintain backawards compatability.
+    #   based on the number needed rather than always four.
     #
     ###########################################################################
     def IterateAndSaveFrames(self):
@@ -2140,7 +2138,8 @@ class MakeMovie(object):
     #
     # Purpose:    This method generates the movie format names.
     #             This code was extracted from GenerateFrames and then
-    #             modified to first set the digitFormat.
+    #             modified to set the digitFormat. Note that it generates
+    #             between four and seven digits.
     #
     # Programmer: Eric Brugger
     # Date:       Mon Dec 19 13:06:50 PST 2022
@@ -2151,6 +2150,9 @@ class MakeMovie(object):
 
     def GenerateFileNames(self):
 
+        # Calculate the number of frames in the movie. This may over estimate
+        # the total number in a few rare cases, but overestimating isn't an
+        # issue.
         nTotalFrames = (self.frameEnd - self.frameStart + 1) / self.frameStep
         if nTotalFrames > 999999:
             self.digitFormat = "%07d"
@@ -2273,8 +2275,7 @@ class MakeMovie(object):
     #
     #   Eric Brugger, Mon Dec 19 13:06:50 PST 2022
     #   I added code to set the number of digits in the movie file names
-    #   based on the number needed rather than always four. Note that it
-    #   uses a minimum of four digits to maintain backawards compatability.
+    #   based on the number needed rather than always four.
     #
     ###########################################################################
 
@@ -2613,8 +2614,7 @@ class MakeMovie(object):
     #
     #   Eric Brugger, Mon Dec 19 13:06:50 PST 2022
     #   I added code to set the number of digits in the movie file names
-    #   based on the number needed rather than always four. Note that it
-    #   uses a minimum of four digits to maintain backawards compatability.
+    #   based on the number needed rather than always four.
     #
     ###########################################################################
 

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -43,7 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The X Ray Image Query now outputs Blueprint meshes representing the rays used in the raytrace if a Blueprint output type is selected.</li>
   <li>The Blueprint output from the X Ray Image Query previously included coordinates for the spatial extents of the output image. These coordinates have been promoted to a valid blueprint mesh.</li>
   <li>The Silo Database plugin was updated to support a rare decomposition format discovered in the wild.</li>
-  <li>Enhanced the make movie script so that it sets the number of digits in the output file names based on the number needed rather than always using four. Note that it uses a minimum of four digits to maintain backwards compatability and a maximum of seven digits on the assumption you will not create a movie longer than 92 hours.</li>
+  <li>Enhanced the make movie script so that it sets the number of digits in the output file names based on the number needed rather than always using four. Note that it uses a minimum of four digits to maintain backwards compatibility and a maximum of seven digits on the assumption you will not create a movie longer than 92 hours.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -43,6 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The X Ray Image Query now outputs Blueprint meshes representing the rays used in the raytrace if a Blueprint output type is selected.</li>
   <li>The Blueprint output from the X Ray Image Query previously included coordinates for the spatial extents of the output image. These coordinates have been promoted to a valid blueprint mesh.</li>
   <li>The Silo Database plugin was updated to support a rare decomposition format discovered in the wild.</li>
+  <li>Enhanced the make movie script so that it sets the number of digits in the output file names based on the number needed rather than always using four. Note that it uses a minimum of four digits to maintain backwards compatability and a maximum of seven digits on the assumption you will not create a movie longer than 92 hours.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Enhanced the make movie script so that it sets the number of digits in the output file names based on the number needed rather than always using four. Note that it uses a minimum of four digits to maintain backwards compatibility and a maximum of seven digits on the assumption you will not create a movie longer than 92 hours.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I manually set values for the frameStart, frameEnd, and frameStep in the script to generate 4 digits, 5 digits, 6 digits and 7 digits in the file names.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
