### PR TITLE
Fix the makemovie.py script for the template and script file cases.

### DIFF
--- a/src/bin/makemovie.py
+++ b/src/bin/makemovie.py
@@ -2080,8 +2080,13 @@ class MakeMovie(object):
 
         self.Debug(1, "*** frameStart=%d, frameEnd=%d" % (self.frameStart, self.frameEnd))
 
+        # Calculate the number of frames in the movie. This may over estimate
+        # the total number in a few rare cases, but overestimating isn't an
+        # issue.
+        nTotalFrames = (self.frameEnd - self.frameStart + 1) / self.frameStep
+
         # Generate the file names.
-        self.GenerateFileNames()
+        self.GenerateFileNames(nTotalFrames)
 
         # Save the old rendering mode.
         old_ra = GetRenderingAttributes()
@@ -2148,12 +2153,8 @@ class MakeMovie(object):
     #
     ###########################################################################
 
-    def GenerateFileNames(self):
+    def GenerateFileNames(self, nTotalFrames):
 
-        # Calculate the number of frames in the movie. This may over estimate
-        # the total number in a few rare cases, but overestimating isn't an
-        # issue.
-        nTotalFrames = (self.frameEnd - self.frameStart + 1) / self.frameStep
         if nTotalFrames > 999999:
             self.digitFormat = "%07d"
         elif nTotalFrames > 99999:
@@ -2315,6 +2316,11 @@ class MakeMovie(object):
             index = index + 1
 
         if(self.usesTemplateFile):
+            # Generate the file names. Pass 1 as the number of files so
+            # that the number of digits in the family index is four to
+            # match legacy behavior.
+            self.GenerateFileNames(1)
+
             # Determine the name of the movie template base class's file.
             prefix = ""
             if os.name == "nt":
@@ -2479,6 +2485,10 @@ class MakeMovie(object):
             globals()['classSaveWindowObj'] = self
             # Create a modified version of the user's script.
             name = self.CreateMangledSource(self.scriptFile)
+            # Generate the file names. Pass 1 as the number of files so
+            # that the number of digits in the family index is four to
+            # match legacy behavior.
+            self.GenerateFileNames(1)
             # Try executing the modified version of the user's script.
             Source(name)
             # Remove the modified script.

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -46,7 +46,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the Silo reader to support a rare decomposition format discovered in the wild.</li>
   <li>Added support for reading Blueprint data with blueprint_index per-mesh partition maps to the Blueprint reader.</li>
   <li>Extended support for reading sparsely populated Blueprint trees in the Blueprint reader.</li>
-  <li>Enhanced the make movie script so that it sets the number of digits in the output file names based on the number needed rather than always using four. Note that it uses a minimum of four digits to maintain backwards compatibility and a maximum of seven digits on the assumption you will not create a movie longer than 92 hours.</li>
+  <li>Enhanced the make movie script so that it sets the number of digits in the output file names based on the number needed rather than always using four when the number of frames in the movie is known ahead of time, which is when a session file or the current plot is used. Note that it uses a minimum of four digits to maintain backwards compatibility and a maximum of seven digits on the assumption you will not create a movie longer than 92 hours.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

Fixed the makemovie.py script for the template and script file cases. When using a template or script file, the number of frames is not known ahead of time so it defaults to generating names with four digits for the family number to maintain legacy behavior.

This should also fix the hybrid/movie.py test suite failures.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran the hybrid/movie.py test script in serial on quartz and it passed.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [ X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
