### PR TITLE
Task/brugger1/2023 01 06 mili reader

### DIFF
--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -1659,11 +1659,11 @@ avtMiliFileFormat::GetVar(int timestep,
     int nVals = 0;
     if (varMD->GetCentering() == AVT_NODECENT)
     {
-        int nVals = miliMetaData[meshId]->GetNumNodes(dom);
+        nVals = miliMetaData[meshId]->GetNumNodes(dom);
     }
     else
     {
-        int nVals = miliMetaData[meshId]->GetNumCells(dom);
+        nVals = miliMetaData[meshId]->GetNumCells(dom);
     }
 
     //

--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -1645,7 +1645,6 @@ avtMiliFileFormat::GetVar(int timestep,
     }
 
     intVector SRIds    = varMD->GetSubrecIds(domVar);
-    int nSRs           = SRIds.size();
     int vType          = varMD->GetNumType();
     string vShortName  = varMD->GetShortName();
 
@@ -2213,7 +2212,7 @@ avtMiliFileFormat::GetElementSetVar(int timestep,
         // Element sets are specialized vectors such that each
         // element in the vector is a list of integration points.
         //
-        for (int j = 0; j < compIdxs.size(); ++j)
+        for (size_t j = 0; j < compIdxs.size(); ++j)
         {
             int idx = (i * dataSize) + (compIdxs[j] * compDims);
             idx += targetIP;
@@ -2288,7 +2287,7 @@ avtMiliFileFormat::ReadMiliVarToBuffer(char *varName,
     // Loop over the subrecords, and retrieve the variable
     // data from mili.
     //
-    for (int i = 0 ; i < SRIds.size(); i++)
+    for (size_t i = 0 ; i < SRIds.size(); i++)
     {
         int nTargetEl = 0;
         int nBlocks   = 0;
@@ -3056,7 +3055,7 @@ avtMiliFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md,
                 // that are treated as distinct variables. We need to
                 // check for this and add them individually.
                 //
-                for (int j = 0; j < groupShared.size(); ++j)
+                for (size_t j = 0; j < groupShared.size(); ++j)
                 {
                     bool addVarNow = true;
                     SharedVariableInfo *sharedInfo = NULL;
@@ -3698,7 +3697,6 @@ avtMiliFileFormat::ExtractJsonClasses(rapidjson::Document &jDoc,
 
             string lName = "";
             int scID     = -1;
-            int elCount  = 0;
 
             if (val.HasMember("LongName"))
             {
@@ -4095,6 +4093,8 @@ avtMiliFileFormat::RetrieveZoneLabelInfo(const int meshId,
     }
     delete [] elemList;
     delete [] labelIds;
+
+    visitTimer->StopTimer(loadZoneLabels, "MILI: Loading zone labels");
 }
 
 
@@ -4127,7 +4127,6 @@ avtMiliFileFormat::RetrieveNodeLabelInfo(const int meshId,
                                          char *shortName,
                                          const int dom)
 {
-    int nLabeledNodes = 0;
     int nNodes        = miliMetaData[meshId]->GetNumNodes(dom);
     int numBlocks     = 0;
     int *blockRanges  = NULL;

--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -1609,7 +1609,7 @@ avtMiliFileFormat::GetVar(int timestep,
 //    Eric Brugger, Thu Jan  5 15:25:33 PST 2023
 //    I fixed a bug where variables that were only defined on a portion of
 //    the nodes weren't being placed on the correct nodes. This was handled
-//    properly for zonal variables. I fixed the bug by unifiying the handling
+//    properly for zonal variables. I fixed the bug by unifying the handling
 //    of nodal and zonal variables.
 //
 // ****************************************************************************

--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -2318,16 +2318,8 @@ avtMiliFileFormat::ReadMiliVarToBuffer(char *varName,
         }
         else if (nBlocks > 1)
         {
-            int totalBlocksSize = 0;
-            for (int b = 0; b < nBlocks; ++b)
-            {
-                int curStart = blockRanges[b * 2];
-                int stop     = blockRanges[b * 2 + 1];
-                totalBlocksSize += stop - curStart + 1;
-            }
-
-            float *MBBuffer = new float[totalBlocksSize * varSize];
-            int resultSize = totalBlocksSize * varSize;
+            int resultSize = nTargetEl * varSize;
+            float *MBBuffer = new float[resultSize];
 
             ReadMiliResults(dbid[dom], ts, SRId,
                 1, &varName, vType, resultSize, MBBuffer);

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a rare issue with the color table window that caused it to resize horizontally larger than the screen, causing buttons to be off the screen.</li>
   <li>Fixed a bug with Pick where it incorrectly used the node origin.</li>
   <li>Fixed a bug where "atan2" did not show up in the list of expressions in the Expressions window.</li>
+  <li>Fixed a bug with the Mili reader where variables that were only defined on a portion of the nodes weren't being placed on the correct nodes.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #17729

I fixed a bug where variables that were only defined on a portion of the nodes weren't being placed on the correct nodes. This was handled properly for zonal variables. I fixed the bug by unifying the handling of nodal and zonal variables.

I also eliminated some warning variables from unused variables and comparisons between ints and unsigned ints.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I compared pen1s - pen7s for the first and last time step with what griz shows.
I ran tests/databases/mili.py in the test suite and it passed, so no errors were introduced.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
