### PR TITLE
bp struct strided bugfix (resolve issues reading xray image query results)

### DIFF
--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
@@ -504,8 +504,15 @@ ExplicitCoordsToVTKPoints(const Node &n_coords, const Node &n_topo)
     int  pts_strides[3] = {0,0,0};
     int  pts_offsets[3] = {0,0,0};
 
-    if(n_topo.has_path("elements/dims/offsets") || 
-       n_topo.has_path("elements/dims/strides"))
+    //
+    // only support offsets, strides for "structured" topos
+    //
+    // NOTE: we could also support this uniform or rectilinear
+    // but we need more / different logic to detect the logical
+    // point dims from the coordset
+    if( n_topo["type"].as_string() == "structured" &&
+        ( n_topo.has_path("elements/dims/offsets") ||
+          n_topo.has_path("elements/dims/strides") ) )
     {
         AVT_CONDUIT_BP_INFO("ExplicitCoordsToVTKPoints:: structured strided case ");
         // for this case, we need to apply 
@@ -1141,7 +1148,15 @@ avtConduitBlueprintDataAdaptor::BlueprintToVTK::FieldToVTK(
 {
     vtkDataArray * res = nullptr;
     // Handle optional offsets and strides ()
-    if(field.has_path("offsets") || field.has_path("strides") )
+    //
+    // only support offsets, strides for fields on  "structured" topos
+    //
+    // NOTE: we could also support this uniform or rectilinear
+    // but we need more / different logic to detect the logical
+    // point dims from the coordset
+    //
+    if( topo["type"].as_string() == "structured" && 
+        (field.has_path("offsets") || field.has_path("strides")) )
     {
         AVT_CONDUIT_BP_INFO("FieldToVTK:: structured strided case: ");
         


### PR DESCRIPTION
### Description

Limits the strided structured support in the blueprint plugin to only `structured` typologies. 

Resolves issues with x ray blueprint output.

X ray blueprint output provides extra offset and stride info for fields on a rectilinear grid, 
This info is for post processing and is not needed to produce the right dataset in visit,
so we can safely limit the strided structured logic to  `structured` typologies.



### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I built and ran on macOS, everything this resolves the test suite issues with `tests/queries/xrayimage.py`

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
