### PR TITLE
 python atts repr fix for 3.3RC

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -39,6 +39,10 @@
 #   version string to use "expr" instead of the bash built-in "[[ ]]", which
 #   doesn't work with bourne shell.
 #
+#   Cyrus Harrison, Fri Jan 27 09:12:15 PST 2023
+#   Added logic to use system `python3` if `python` is not available.
+#   (Installed use finds and calls our python, this helps with developer use)
+#
 ###############################################################################
 
 # Determine VisIt architecture
@@ -138,6 +142,7 @@ do
         lang=$arg
         export LANG="$lang"
         export LANGUAGE="$lang"
+	export LC_NUMERIC="C"
         break
     fi
     if test "$arg" = "-lang"; then
@@ -207,7 +212,14 @@ if test -n "$visitpython"; then
     exec "$visitpython" -u $frontendlauncherpy $0 ${1+"$@"}
 else
     #echo "System python $frontendlauncherpy $0 ${1+"$@"}"
-
-    # Pass "-u" to python to turn off buffering
-    exec python -u $frontendlauncherpy $0 ${1+"$@"}
+    # check if system python is called `python`,
+    # if not we assume it is called `python3`, since that is the way of the world
+    type python >/dev/null 2>&1
+    testValue=$?
+    if [ $testValue -ne 0 ]; then
+        exec python3 -u $frontendlauncherpy $0 ${1+"$@"}
+    else
+        # Pass "-u" to python to turn off buffering
+        exec python -u $frontendlauncherpy $0 ${1+"$@"}
+    fi
 fi

--- a/src/resources/help/en_US/relnotes3.3.2.html
+++ b/src/resources/help/en_US/relnotes3.3.2.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with Pick where it incorrectly used the node origin.</li>
   <li>Fixed a bug where "atan2" did not show up in the list of expressions in the Expressions window.</li>
   <li>Fixed a bug with the Mili reader where variables that were only defined on a portion of the nodes weren't being placed on the correct nodes.</li>
+  <li>Fixed the default attributes repr() behavior in the CLI to again print attribute details. This was unintended change introduced with Python 3 support.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/visitpy/common/Py2and3Support.h
+++ b/src/visitpy/common/Py2and3Support.h
@@ -286,6 +286,14 @@ PyUnicode_From_UTF32_Unicode_Buffer(const char *unicode_buffer,
 #define PyVarObject_TAIL
 #endif
 
+// 2023/01/27 CYRUSH Note:
+// tp_print / tp_vectorcall_offset slot is not used by python 3.0 - 3.7
+// it should not be used for python 3.8 > unless Py_TPFLAGS_HAVE_VECTORCALL
+// is passed, but we choose to always set to 0
+//
+// Also we use VPY_STR to implement both str() and repr(), as this
+// preserves the Python 2 cli behavior to echo object contents via repr()
+//
 
 #define VISIT_PY_TYPE_OBJ( VPY_TYPE,      \
                            VPY_NAME,      \
@@ -305,11 +313,11 @@ static PyTypeObject VPY_TYPE = \
     sizeof(VPY_OBJECT),        /* tp_basicsize */ \
     0,                         /* tp_itemsize */ \
     (destructor)VPY_DEALLOC,   /* tp_dealloc */ \
-    (printfunc)VPY_PRINT,      /* tp_print */ \
+    0,                         /* tp_print (python 2) or tp_vectorcall_offset (python3.8 > ) */ \
     (getattrfunc)VPY_GETATTR,  /* tp_getattr */ \
     (setattrfunc)VPY_SETATTR,  /* tp_setattr */ \
     0,                         /* tp_reserved */ \
-    0,                         /* tp_repr */ \
+    (reprfunc)VPY_STR,         /* tp_repr */ \
     VPY_AS_NUMBER,             /* tp_as_number */ \
     0,                         /* tp_as_sequence */ \
     0,                         /* tp_as_mapping */ \


### PR DESCRIPTION
### Description

* Restores default printing of attributes in cli by setting repr() implementation to str()

Fixes an unintended behavior change between python 2 and python 3.

```
>>> pc = PseudocolorAttributes()
>>> pc

>>> print(pc)
```

Again produce the same output.

* Fix for frontend launcher to uses system `python3`, when system `python` does not exist



### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on macOS w/ and w/o changes to verify desired repr() output. 
### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
