### PR TITLE
Fix name of error function in error checks

### DIFF
--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -1645,7 +1645,7 @@ avtExodusFileFormat::GetTimesteps(int *ntimes, vector<double> *times)
             double *atimes = &(times->operator[](0));
             float *vals = new float[len];
             VisItNCErr = nc_get_var_float(ncExIIId, timesVarId, vals);
-            CheckNCError(nc_inq_dimid);
+            CheckNCError(nc_get_var_float);
             for (size_t i = 0; i < len; i++)
                 atimes[i] = vals[i];
             delete [] vals;
@@ -1653,7 +1653,7 @@ avtExodusFileFormat::GetTimesteps(int *ntimes, vector<double> *times)
         else if (vtype == NC_DOUBLE)
         {
             VisItNCErr = nc_get_var_double(ncExIIId, timesVarId, &(times->operator[](0)));
-            CheckNCError(nc_inq_dimid);
+            CheckNCError(nc_get_var_double);
         }
         else
         {


### PR DESCRIPTION
### Description

In #18477 we noticed a cut-n-paste bug where the name of a function passed in error checking macro was not the name of the function most recently called.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
