### PR TITLE
Fix Exodus bug reading a file a zero length time array.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.3.html
+++ b/src/resources/help/en_US/relnotes3.3.3.html
@@ -1,0 +1,37 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Language" content="en-us">
+  <title>VisIt 3.3.3 Release Notes</title>
+</head>
+<body>
+<center><b><font size="6">VisIt 3.3.3 Release Notes</font></b></center>
+
+<p>Welcome to VisIt's release notes page. This page describes the important
+enhancements and bug-fixes that were added to this release.</p>
+
+<p><b>Sections</b></p>
+<ul>
+  <li><a href="#Bugs_fixed">Bug Fixes</a></li>
+  <li><a href="#Enhancements">Enhancements</a></li>
+</ul>
+
+<a name="Bugs_fixed"></a>
+<p><b><font size="4">Bugs fixed in version 3.3.3</font></b></p>
+<ul>
+  <li>Fixed a bug in the Exodus reader where it would display an erroneous error message when the array with the simulation times had zero length.</li>
+  <li>Fix 2.</li>
+</ul>
+
+<a name="Enhancements"></a>
+<p><b><font size="4">Enhancements in version 3.3.3</font></b></p>
+<ul>
+  <li>Enhancement 1.</li>
+  <li>Enhancement 2.</li>
+</ul>
+
+<p>Click the following link to view the release notes for the previous version
+of VisIt: <a href=relnotes3.3.2.html>3.3.2</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
### Description

Resolves #18477

Fixed a bug with the Exodus reader where it would output an erroneous error message with the array with the simulation times had zero length. Now it just returns a single time state with a time of zero.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran VisIt 3.3.1 on the Exodus file that demonstrated the bug and the error message appeared. I then did the same thing after the change and the error message was gone.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
