### PR TITLE
Correct the path to the pascal config site file in the regression test script.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -113,6 +113,10 @@
 #   current directory when running the tests needs to start with /usr/WS1
 #   for the launcher test to work properly.
 #
+#   Eric Brugger, Wed Feb 15 16:29:23 PST 2023
+#   I corrected the path to the pascal config site file to take into account
+#   that we were now doing out of source builds.
+#
 
 # Determine the users name and e-mail address.
 #
@@ -337,7 +341,7 @@ if test "$serial" = "true" ; then
 fi
 if test "$branch" = "trunk" ; then
     $cmakeCmd \
-        -DVISIT_CONFIG_SITE=config-site/pascal83.cmake \
+        -DVISIT_CONFIG_SITE=../src/config-site/pascal83.cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DVISIT_BUILD_ALL_PLUGINS=1 \
         -DVISIT_ENABLE_DATA_MANUAL_EXAMPLES:BOOL=ON \
@@ -348,7 +352,7 @@ if test "$branch" = "trunk" ; then
         ../src >> ../../buildlog 2>&1
 else
     $cmakeCmd \
-        -DVISIT_CONFIG_SITE=config-site/pascal83.cmake \
+        -DVISIT_CONFIG_SITE=../src/config-site/pascal83.cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DVISIT_BUILD_ALL_PLUGINS=1 \
         -DVISIT_ENABLE_DATA_MANUAL_EXAMPLES:BOOL=ON \


### PR DESCRIPTION
### Description

Corrected the path the the pascal config site file in the regression test suite script.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran `recmake_vist.sh` on pascal from a failed build. It couldn't find the config-site file and failed. I changed the path to the config site file in the same manner as this change and ran `recmake_visit.sh` again and it succeeded.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
