### PR TITLE
Fix destination of copied resources folders on Windows.

### DIFF
--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -25,6 +25,9 @@
 #   Kathleen Biagas, Tue Jan 31, 2023
 #   Use custom target with custom commands to copy resources on Windows.
 #
+#   Kathleen Biagas, Tue Feb 21, 2023
+#   Fix destination of copied resources folders on Windows.
+#
 #*****************************************************************************
 
 # Do a little extra in the hosts directory.
@@ -40,30 +43,30 @@ if(WIN32)
     add_custom_target(copy_resources ALL
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/clients
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/clients
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/colortables
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/colortables
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/help
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/help
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/hosts
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/hosts
             COMMAND ${CMAKE_COMMAND} -E rm -f
                     ${VISIT_EXECUTABLE_DIR}/resources/hosts/CMakeLists.txt
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/images
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/images
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/movietemplates
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/movietemplates
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/translations
-                    ${VISIT_EXECUTABLE_DIR}/resources
+                    ${VISIT_EXECUTABLE_DIR}/resources/translations
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/usage
-                    ${VISIT_EXECUTABLE_DIR}/resources)
+                    ${VISIT_EXECUTABLE_DIR}/resources/usage)
     visit_add_to_util_builds(copy_resources)
 else()
 


### PR DESCRIPTION
### Description

Address issue of resources not being in expected location.

### Type of change

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran regression suite successfully on Windows.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
