### PR TITLE
Comment out docs build fails on warning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: src/doc/conf.py
-  fail_on_warning: true
+  # fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all


### PR DESCRIPTION
### Description

Related to #18513

Just a temporary change until we decide what the best path forward is. This should allow the docs to update successfully.