### PR TITLE
Preserve the file name passed in constructor

### DIFF
--- a/src/databases/MOAB/avtMOABFileFormat.C
+++ b/src/databases/MOAB/avtMOABFileFormat.C
@@ -67,7 +67,7 @@ avtMOABFileFormat::avtMOABFileFormat(const char *filename, const DBOptionsAttrib
     // INITIALIZE DATA MEMBERS
 
 	debug1<< " constructor called, file " << filename << "\n";
-    fileName = filename;
+    fileName = strdup(filename);
     mbCore = new moab::Core();
 }
 
@@ -96,6 +96,11 @@ avtMOABFileFormat::FreeUpResources(void) {
     if (file_descriptor) {
         free(file_descriptor);
         file_descriptor = NULL;
+    }
+    if (fileName != NULL)
+    {
+        free(fileName);
+        fileName = NULL;
     }
 #ifdef PARALLEL
 	if (pcomm)

--- a/src/databases/MOAB/avtMOABFileFormat.h
+++ b/src/databases/MOAB/avtMOABFileFormat.h
@@ -92,7 +92,7 @@ class avtMOABFileFormat : public avtSTMDFileFormat
     vtkDataArray*          GetDirichletSetsVar();
     vtkDataArray*          GetGeometrySetsVar();
     moab::Core*            mbCore;
-    const char*            fileName;
+    char*                  fileName;
     const DBOptionsAttributes *  readOptions;
     bool                   fileLoaded;
     struct mhdf_FileDesc *       file_descriptor;


### PR DESCRIPTION
just simply setting the fileName pointer to
the passed file name in constructor does not guarantee that the value of the fileName member data will remain valid; we need to duplicate/deep copy the passed string (char *) 
Use strdup method for that, it is now part of ISO standard (since 2019)

Observed only when we tried animating a list of h5m files Until now, we were lucky that the string was not destroyed at some point

### Description

Resolves # <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
