### PR TITLE
Fix bash redirection syntax error

### DIFF
--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -1276,7 +1276,7 @@ function build_hostconf
     # First line of config-site file provides a hint to the location
     # of cmake.
 
-    THIRD_PARTY_ABS_PATH=$(pushd $THIRD_PARTY_PATH 1,2>/dev/null; pwd; popd 1,2>/dev/null)
+    THIRD_PARTY_ABS_PATH=$(pushd $THIRD_PARTY_PATH >/dev/null 2>&1; pwd; popd >/dev/null 2>&1)
     if [[ "$CMAKE_INSTALL" != "" ]]; then
         echo "#$CMAKE_INSTALL/cmake" > $HOSTCONF
     else


### PR DESCRIPTION
### Description

I happened to see these errors running `build_visit`...

```
./visit/src/tools/dev/scripts/bv_support//helper_funcs.sh: line 1279: pushd: too many arguments
./visit/src/tools/dev/scripts/bv_support//helper_funcs.sh: line 1279: popd: 1,2: invalid argument
```

The problem was that line 1279 was using csh redirction syntax when it should have been using sh/bash syntax...

```
-    THIRD_PARTY_ABS_PATH=$(pushd $THIRD_PARTY_PATH 1,2>/dev/null; pwd; popd 1,2>/dev/null)
+    THIRD_PARTY_ABS_PATH=$(pushd $THIRD_PARTY_PATH >/dev/null 2>&1; pwd; popd >/dev/null 2>&1)
```

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
