### PR TITLE
Fix a couple of bugs with picking with swivel focus enabled.

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.3.html
+++ b/src/resources/help/en_US/relnotes3.3.3.html
@@ -21,7 +21,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.3.3</font></b></p>
 <ul>
   <li>Fixed a bug in the Exodus reader where it would display an erroneous error message when the array with the simulation times had zero length.</li>
-  <li>Fix 2.</li>
+  <li>Fixed a bug with Swivel focus where it didn't properly center the picked point in the window when the image was panned.</li>
+  <li>Fixed a bug with Swivel focus where the view in locked windows didn't get updated.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/queries/pick.py
+++ b/src/test/tests/queries/pick.py
@@ -3060,6 +3060,42 @@ def TestRemoveLabeledPicks():
     DeleteAllPlots()
     ResetPickLetter()
 
+def TestSwivelFocus():
+    ResetPickAttributes()
+    ClearPickPoints()
+    DeleteAllPlots()
+    ResetPickLetter()
+    ResetView()
+
+    OpenDatabase(silo_data_path("globe.silo"))
+    TurnOffAllAnnotations()
+    AddPlot("Mesh", "mesh1")
+    DrawPlots()
+    v = GetView3D()
+    v.viewNormal = (-0.461806, -0.673199, 0.577526)
+    v.focus = (0., 0., 0.)
+    v.viewUp = (-0.243052, 0.722237, 0.647532)
+    v.viewAngle = 30
+    v.parallelScale = 17.3205
+    v.nearPlane = -34.641
+    v.farPlane = 34.641
+    v.imagePan = (0.341463, 0.234840)
+    v.imageZoom = 1.21
+    SetView3D(v)
+
+    orig_atts = GetPickAttributes()
+    fh_atts   = GetPickAttributes()
+    fh_atts.swivelFocusToPick = 1
+    SetPickAttributes(fh_atts)
+
+    PickByNode(element=707)
+    Test("SwivelFocus_00")
+
+    SetPickAttributes(orig_atts)
+    ClearPickPoints()
+    DeleteAllPlots()
+    ResetPickLetter()
+
 def TestSwivelHighlight():
     ResetPickAttributes()
     ClearPickPoints()
@@ -3219,6 +3255,7 @@ def PickMain():
     PickZoneLabel()
     PickNodeLabel()
     PickRangeLabel()
+    TestSwivelFocus()
     TestSwivelHighlight()
     TestNodeHighlight()
     TestTranslatedHighlight()

--- a/src/viewer/core/ViewerWindow.C
+++ b/src/viewer/core/ViewerWindow.C
@@ -6128,6 +6128,11 @@ ViewerWindow::ChooseCenterOfRotation(double sx, double sy)
 // Creation:   Wed Aug  8 15:06:17 PDT 2018 
 //
 // Modifications:
+//   Eric Brugger, Wed Mar  8 10:26:17 PST 2023
+//   Set the imagePan to zero so that plot is centered on the pick point
+//   even if the image is panned. Added a call to UpdateViewAtts so that
+//   the view attributes displayed in the GUI are updated as well as
+//   handling locked views. 
 //   
 // ****************************************************************************
 
@@ -6139,8 +6144,12 @@ ViewerWindow::SwivelFocus3D(double x, double y, double z)
     view.focus[0] = x;
     view.focus[1] = y;
     view.focus[2] = z;
+    view.imagePan[0] = 0.;
+    view.imagePan[1] = 0.;
 
     SetView3D(view);
+
+    ViewerWindowManager::Instance()->UpdateViewAtts(windowId, false, false, true, false);
 }
 
 // ****************************************************************************

--- a/test/baseline/queries/pick/SwivelFocus_00.png
+++ b/test/baseline/queries/pick/SwivelFocus_00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5bf063ee606291268a5681e94acfbcb8265f808cfc62421807022eb1e1ef93d
+size 5356


### PR DESCRIPTION
### Description

Resolves #17943 
Resolves #18232 

Fixed a couple of bugs with swivel focus. It didn't properly center the pick point if the image was zoomed. The view attributes weren't updated in the GUI and it didn't handle locked windows correctly.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I panned and zoomed a mesh plot of globe.silo and then did a node pick with swivel focus on. The picked point was centered in the window. Also, the 3d view attributes were updated properly in the GUI. Swivel focus is enabled in the "Pick" window. 

I created mesh plots of globe.silo in 2 windows. I then panned, zoomed and rotated the image in the second window, locked the view in the second window and then the first window and then both windows had the view from the second window. I then did a pick in window 2 with swivel focus on and the image in window 2 centered on the picked node and then the same happened in window 1.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
