### PR TITLE
Generate email if test results not produced

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -477,8 +477,10 @@ fi
 
 cd $testDir/$workingDir/visit/src/test
 
+# if we don't have a test results directory, exit with failure now
 if test ! -d "\$dateTag"; then
     echo "\$dateTag doesn't exist."
+    src/tools/dev/scripts/visit-notify-test-failure -host $testHost
     exit
 fi
 


### PR DESCRIPTION
Minor change to testing scripting to ensure an email is generated, minimally to anyone on the `logRecipients` variable...

https://github.com/visit-dav/visit/blob/5b21f888cba034570cd9a71224db152953197aa7/src/tools/dev/scripts/visit-notify-test-failure#L8-L9

If the test suite doesn't appear to have generated results for any reason.

