### PR TITLE
Fix pluginVsInstall errors related to VTKm version update.

### DIFF
--- a/src/CMake/FilterDependencies.cmake.in
+++ b/src/CMake/FilterDependencies.cmake.in
@@ -20,6 +20,9 @@
 #    Fixed the Qt and qwt frameworks path for OSX and the syntax error produced from
 #    filtering the right parenthesis in certain cases.
 #
+#    Kathleen Biagas, Fri March 10, 2023
+#    Filter out vtkm_* libraries as they are static.
+#
 #****************************************************************************/
 cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0057 NEW)
@@ -126,6 +129,7 @@ function(FILTER_VISIT_LIB_DEPENDENCIES filename)
         # The line is tokenized to make filtering easier (albeit slower).
         #   * Replace vtk<lib> with vtk<lib>-<vtk_small_version>
         #   * Replace Qt5::<lib> with Qt5<lib>
+        #   * Remove vtkm_*
         #   * Remove quotes surrounding 'xxx_LIB_DEPENDS'
         set(skip_next_token FALSE)
         foreach(token ${line})
@@ -191,6 +195,9 @@ function(FILTER_VISIT_LIB_DEPENDENCIES filename)
               set(skip_next_token TRUE) 
               continue()
             elseif(${token} MATCHES "icet")
+              # Static libs, not necessary to be listed as a dependency here
+              continue()
+            elseif(${token} MATCHES "vtkm_")
               # Static libs, not necessary to be listed as a dependency here
               continue()
             elseif(${token} MATCHES "OSMesa")

--- a/src/CMake/PluginVsInstallHelpers.cmake
+++ b/src/CMake/PluginVsInstallHelpers.cmake
@@ -18,8 +18,11 @@
 #   Add PYTHON_FOUND guard for python path related logic to avoid
 #   error with empty path passed to get_filename_component
 #
-#   Kathleen Biagas, Wed Jun  8 2023
+#   Kathleen Biagas, Wed Jun  8 2022
 #   Install VisItIncludeVars.cmake.
+#
+#   Kathleen Biagas, Fri Mar 10, 2023
+#   Replaced VTKh logic with VTKm.
 #
 #******************************************************************************
 
@@ -100,7 +103,7 @@ if(VISIT_MESAGL_DIR)
                    "${OPENGL_LIBRARIES}")
 endif()
 
-if(VTKH_FOUND)
+if(VTKM_FOUND)
     # VTKm_INCLUDE_DIRS isn't enough for use with our PluginVsInstall stucture,
     # because there are some includes related to vtkm interface libraries
     # that get automagically added by CMake when the vtkh library is used as a
@@ -120,8 +123,7 @@ if(VTKH_FOUND)
                 if(TARGET ${ll_dep})
                     string(SUBSTRING "${ll_dep}" 0 4 ll_dep_prefix)
                     # only process libraries that start with vtkh or vtkm
-                    if ("${ll_dep_prefix}" STREQUAL "vtkh" OR
-                        "${ll_dep_prefix}" STREQUAL "vtkm")
+                    if ("${ll_dep_prefix}" STREQUAL "vtkm")
                         list(FIND ${deplist} ${ll_dep} havetarg)
                         if(${havetarg} EQUAL -1)
                             list(APPEND ${deplist} ${ll_dep})
@@ -156,17 +158,17 @@ if(VTKH_FOUND)
         endif()
     endmacro()
 
-    # find the link dependencies for vtkh
-    list(APPEND vtkh_deps vtkh)
-    get_lib_dep(vtkh vtkh_deps)
+    # find the link dependencies for vtkm
+    list(APPEND vtkm_deps vtkm_filter)
+    get_lib_dep(vtkm_filter vtkm_deps)
 
-    # find the interface includes for all vtkh link dependencies
+    # find the interface includes for all vtkm link dependencies
     set(ii_inc_dep "")
-    foreach(vtkhll ${vtkh_deps})
-        string(SUBSTRING "${vtkhll}" 0 4 ll_dep_prefix)
+    foreach(vtkmll ${vtkm_deps})
+        string(SUBSTRING "${vtkmll}" 0 4 ll_dep_prefix)
         # only process libraries that start with vtkm
         if("${ll_dep_prefix}" STREQUAL "vtkm")
-           get_inc_dep(${vtkhll} ii_inc_dep)
+           get_inc_dep(${vtkmll} ii_inc_dep)
         endif()
     endforeach()
 
@@ -304,7 +306,7 @@ if(UNIX)
    set(exodusii_include_relative_path "/exodusii/inc")
    set(vtk_include_relative_path "/vtk/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}")
 else(UNIX)
-   set(python_include_relative_path "/python")
+   set(python_include_relative_path "/python/include")
    set(exodusii_include_relative_path "/exodusii/include")
    set(vtk_include_relative_path "/vtk/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}")
 endif(UNIX)


### PR DESCRIPTION
### Description
Filter out vtkm_* libraries from dependencies as they are static.
Replace VTKh logic with VTKm.

### Type of change

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I compiled and ran the tests locally with success.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
