### PR TITLE
X Ray Image Query: Move line from 3.4 Release Notes to 3.3.3 Release Notes

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.3.html
+++ b/src/resources/help/en_US/relnotes3.3.3.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added support to directly open ".mesh" files with MFEM Plugin.</li>
   <li>Updated the VTKm library from version 1.7.0 to 1.9.0 to add support for AMD GPUs.</li>
   <li>Added original cell id support for MFEM Meshes in the Blueprint Plugin. With this change the Mesh plot will now plot outlines of high order elements, instead of the elements of the low order refined mesh.</li>
+  <li>The X Ray Image Query now includes a new topology in the Conduit Blueprint output types, the Spatial Energy Reduced Mesh.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.4.0.html
+++ b/src/resources/help/en_US/relnotes3.4.0.html
@@ -78,7 +78,6 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The X Ray Image Query now supports three different file naming "schemes". The default is "none", which will attempt to keep the filename as simple as possible. There is an option to "family" output files, which has nearly the same behavior as the old "family_files" option. The final option is to have "cycle" information in filenames. The "family_files" option has not been removed to preserve backwards compatibility. If both options are present, "filename_scheme" will be used instead.</li>
   <li>Output filenaming conventions have been updated and standardized for X Ray Image Query outputs.</li>
   <li>The BMP output type for the X Ray Image Query has been removed.</li>
-  <li>The X Ray Image Query now includes a new topology in the Conduit Blueprint output types, the Spatial Energy Reduced Mesh.</li>
 </ul>
 
 <a name="Bugs_fixed"></a>


### PR DESCRIPTION
Now that the work from #18557 is being backported to the RC (#18564) in time for the 3.3.3 release, it makes sense to update the release notes so that the changes are correctly listed under the 3.3.3 release notes and not the 3.4 release notes.