### PR TITLE
escape paths in mfem json to avoid parsing issues

### DIFF
--- a/src/common/misc/FileFunctions.C
+++ b/src/common/misc/FileFunctions.C
@@ -914,12 +914,33 @@ FileFunctions::Normalize(const std::string &path, const std::string &pathSep)
 //    Kathleen Biagas, Thu Jan 29 15:53:12 MST 2015
 //    Some tweaks on windows to hanlde cwd_context of '.'.
 //
+//    Cyrus Harrison, Thu Mar 16 10:07:17 PDT 2023
+//    Fix for windows case where path could be appended itself.
+//
 // ****************************************************************************
 
 const char *
 FileFunctions::Absname(const char *cwd_context, const char *path, 
     const char *pathSep)
 {
+    // if we already have an abs path, return it!
+#ifdef _WIN32
+    // if non null,
+    // use  windows api check for relative path to determine
+    // if we have abs path
+    if(path && !PathIsRelative(path))
+    {
+        return path;
+    }
+#else
+    // if non-null and starts with `/`
+    // we already have an abs on *nix systems
+    if(path && path[0] == '/')
+    {
+        return path;
+    }
+#endif
+
     // Clear our temporary array for handling char * return values.
     StaticStringBuf[0] = '\0';
 

--- a/src/common/utility/StringHelpers.C
+++ b/src/common/utility/StringHelpers.C
@@ -1441,7 +1441,6 @@ StringHelpers::EscapeSpecialChars(const std::string &input)
         }
 
         return res;
-    }
 }
 
 // ****************************************************************************

--- a/src/common/utility/StringHelpers.C
+++ b/src/common/utility/StringHelpers.C
@@ -916,7 +916,7 @@ StringHelpers::append(std::vector<std::string> &argv,
 //
 // ****************************************************************************
 std::vector<std::string>
-StringHelpers::split(const std::string input, const char separator)
+StringHelpers::split(const std::string &input, const char separator)
 {
     std::istringstream iss(input);
     std::string cur;
@@ -1292,7 +1292,7 @@ StringHelpers::StringToInt(const string &input, int &output)
 //
 // ****************************************************************************
 bool
-StringHelpers::ParseRange(const string range, std::vector<int> &list)
+StringHelpers::ParseRange(const string &range, std::vector<int> &list)
 {
     std::vector<std::string> rangeTokens = StringHelpers::split(range, ',');
 
@@ -1366,6 +1366,83 @@ StringHelpers::ParseRange(const string range, std::vector<int> &list)
     return parseError;
 }
 
+// ****************************************************************************
+//  Method:  StringHelpers::EscapeString
+//
+//  Purpose:
+//   Escapes any special chars in a string. Need when you want to
+//   prepare a string that can later be parsed by JSON.
+//
+//  Logic from:
+//   conduit::utils::escape_special_chars in:
+//  https://github.com/LLNL/conduit/blob/develop/src/libs/conduit/conduit_utils.cpp
+//
+//
+//  Programmer:  Cyrus Harrison
+//  Creation:    Wed Mar 15 10:28:03 PDT 2023
+//
+//  Modifications:
+//
+// ****************************************************************************
+std::string
+StringHelpers::EscapeSpecialChars(const std::string &input)
+{
+        std::string res;
+        for(size_t i = 0; i < input.size(); ++i)
+        {
+            char val = input[i];
+            // supported special chars
+            switch(val)
+            {
+                // quotes and slashes
+                case '\"':
+                case '\\':
+                {
+                    res += '\\';
+                    res += val;
+                    break;
+                }
+                // newline
+                case '\n':
+                {
+                    res += "\\n";
+                    break;
+                }
+                // tab
+                case '\t':
+                {
+                    res += "\\t";
+                    break;
+                }
+                // backspace
+                case '\b':
+                {
+                    res += "\\b";
+                    break;
+                }
+                // formfeed
+                case '\f':
+                {
+                    res += "\\f";
+                    break;
+                }
+                // carriage return
+                case '\r':
+                {
+                    res += "\\r";
+                    break;
+                }
+
+                default:
+                {
+                    res += val;
+                }
+            }
+        }
+
+        return res;
+    }
+}
 
 // ****************************************************************************
 //  Method:  StringHelpers::ends_with

--- a/src/common/utility/StringHelpers.h
+++ b/src/common/utility/StringHelpers.h
@@ -70,8 +70,10 @@ namespace StringHelpers
     std::string UTILITY_API cdr(const std::string, const char separator);
     void UTILITY_API append(std::vector<std::string> &,
                             std::vector<std::string>);
-    std::vector<std::string> UTILITY_API split(const std::string,
+
+    std::vector<std::string> UTILITY_API split(const std::string &input,
                                                const char separator);
+
     void UTILITY_API rtrim(std::string &var);
     void UTILITY_API ltrim(std::string &var);
     void UTILITY_API  trim(std::string &var);
@@ -91,7 +93,10 @@ namespace StringHelpers
     std::string UTILITY_API UpperCase(const std::string &src);
 
     bool UTILITY_API StringToInt(const std::string &, int &);
-    bool UTILITY_API ParseRange(const std::string , std::vector<int> &);
+    bool UTILITY_API ParseRange(const std::string &, std::vector<int> &);
+
+    std::string UTILITY_API  EscapeSpecialChars(const std::string &str);
+
 // ****************************************************************************
 //  Function: str_to_u_numeric
 //

--- a/src/databases/MFEM/JSONRoot.C
+++ b/src/databases/MFEM/JSONRoot.C
@@ -912,11 +912,10 @@ JSONRoot::ToJson(ostringstream &oss)
     // loop over data sets
     for(int i=0;i<(int)dset_names.size();i++)
     {
-        std::string mesh_path = StringHelpers::EscapeSpecialChars(dset.Mesh().Path().Expand());
-
         // domain and mesh data
         oss << "   \"" << dset_names[i] << "\":{\n";
         JSONRootDataSet &dset =  DataSet(dset_names[i]);
+        std::string mesh_path = StringHelpers::EscapeSpecialChars(dset.Mesh().Path().Expand());
         oss << "     \"domains\": " << dset.NumberOfDomains() <<",\n";
         oss << "     \"mesh\": {\"path\": \"" << mesh_path << "\"},\n";
         oss << "     \"fields\": {\n";

--- a/src/databases/MFEM/JSONRoot.C
+++ b/src/databases/MFEM/JSONRoot.C
@@ -927,7 +927,7 @@ JSONRoot::ToJson(ostringstream &oss)
         {
 
             JSONRootEntry &field = dset.Field(field_names[j]);
-            std::string field_path = StringHelpers::EscapeSpecialChars(field.Path().Expand())
+            std::string field_path = StringHelpers::EscapeSpecialChars(field.Path().Expand());
             oss << "        \"" << field_names[j] << " \": {";
             oss << "\"path\": \"" << field_path << "\", \"tags\":{";
             vector<string>tag_names;

--- a/src/databases/MFEM/JSONRoot.C
+++ b/src/databases/MFEM/JSONRoot.C
@@ -41,6 +41,9 @@ void  RapidJSONParseErrorDetails(const std::string &json,
     int  doc_line   = 0;
     int  doc_char   = 0;
 
+    // remove any `\r` that may linger so we can split on `\n`
+    json_curr = StringHelpers::Replace(json_curr,"\r","");
+
     std::vector<std::string> lines = StringHelpers::split(json_curr,'\n');
 
     if(lines.size() > 0)
@@ -50,12 +53,12 @@ void  RapidJSONParseErrorDetails(const std::string &json,
         doc_char = lines[lines.size()-1].size();
     }
 
-    os << " parse error message:\n"
-       << GetParseError_En(document.GetParseError()) << "\n"
-       << " offset: "    << doc_offset << "\n"
-       << " line: "      << doc_line << "\n"
-       << " character: " << doc_char << "\n"
-       << " json:\n"     << json << "\n"; 
+    os << " parse error message: " << std::endl
+       << GetParseError_En(document.GetParseError()) << std::endl
+       << " offset: "    << doc_offset << std::endl
+       << " line: "      << doc_line << std::endl
+       << " character: " << doc_char << std::endl
+       << " json:\n"     << json << std::endl; 
 }
 
 }; // end detail
@@ -820,6 +823,9 @@ JSONRoot::ParseJSONString(const std::string &json,
 //  Creation:    Fri Mar  3 10:50:30 PST 2023
 //
 //  Modifications:
+//    Cyrus Harrison, Wed Mar 15 12:25:13 PDT 2023
+//    Escape file system paths to avoid issues with JSON parsing
+//    vs windows paths.
 //
 // **************************************************************************** 
 std::string  
@@ -841,12 +847,14 @@ JSONRoot::GenerateMocRootJSON(const std::string &mfem_mesh_file)
     int topo_dim = mesh.Dimension();
 
     std::ostringstream moc_json;
+    
+    std::string mfem_mesh_file_escaped = StringHelpers::EscapeSpecialChars(mfem_mesh_file);
 
     moc_json << "{" << std::endl
              << "\"dsets\":{" << std::endl
              << "   \"main\":{" << std::endl
              << "       \"domains\": 1" << "," << std::endl 
-             << "       \"mesh\": { \"path\": \"" << mfem_mesh_file << "\"," <<  std::endl
+             << "       \"mesh\": { \"path\": \"" << mfem_mesh_file_escaped << "\"," <<  std::endl
              << "                   \"tags\": { \"spatial_dim\":" 
                                              << "\"" << spatial_dim  << "\" ,"
                                              << "\"topo_dim\":" 
@@ -889,6 +897,11 @@ JSONRoot::ToJson()
 //  Modifications
 //    Mark C. Miller, Tue Sep 20 18:07:42 PDT 2016
 //    Add support for expressions
+//
+//    Cyrus Harrison, Wed Mar 15 12:25:13 PDT 2023
+//    Escape file system paths to avoid issues with JSON parsing
+//    vs windows paths.
+//
 // **************************************************************************** 
 void
 JSONRoot::ToJson(ostringstream &oss) 
@@ -899,20 +912,24 @@ JSONRoot::ToJson(ostringstream &oss)
     // loop over data sets
     for(int i=0;i<(int)dset_names.size();i++)
     {
+        std::string mesh_path = StringHelpers::EscapeSpecialChars(dset.Mesh().Path().Expand());
+
         // domain and mesh data
         oss << "   \"" << dset_names[i] << "\":{\n";
         JSONRootDataSet &dset =  DataSet(dset_names[i]);
         oss << "     \"domains\": " << dset.NumberOfDomains() <<",\n";
-        oss << "     \"mesh\": {\"path\": \"" << dset.Mesh().Path().Expand() << "\"},\n";
+        oss << "     \"mesh\": {\"path\": \"" << mesh_path << "\"},\n";
         oss << "     \"fields\": {\n";
         // loop over fields
         vector<string>field_names;
         dset.Fields(field_names);
         for(int j=0;j<(int)field_names.size();j++)
         {
+
             JSONRootEntry &field = dset.Field(field_names[j]);
-                oss << "        \"" << field_names[j] << " \": {";
-                oss << "\"path\": \"" << field.Path().Expand() << "\", \"tags\":{";
+            std::string field_path = StringHelpers::EscapeSpecialChars(field.Path().Expand())
+            oss << "        \"" << field_names[j] << " \": {";
+            oss << "\"path\": \"" << field_path << "\", \"tags\":{";
             vector<string>tag_names;
             field.Tags(tag_names);
             for(int k=0;k<(int)tag_names.size();k++)


### PR DESCRIPTION
### Description

Resolves #18570  by escaping path strings so when they are parsed as JSON we avoid issues.

### Type of change

* [x] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I need Kathleen to verify this resolves on windows :-)

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
