### PR TITLE
Fix ffp.py failure in the regression suite.

### DIFF
--- a/src/test/skip.json
+++ b/src/test/skip.json
@@ -2,7 +2,6 @@
  {"mode":"serial","tests":[
                     {"category":"databases","file":"diff.py"},
                     {"category":"databases","file":"exodus.py","cases":["exodus_13a","exodus_13b"]},
-                    {"category":"databases","file":"ffp.py", "cases":["ffp_03"]},
                     {"category":"databases","file":"silo.py","cases":["silo_curvilinear_3d_surface_3"]},
                     {"category":"hybrid","file":"clonecopy.py"},
                     {"category":"hybrid","file":"ddf_vs_dbinning.py"},
@@ -37,7 +36,6 @@
  {"mode":"parallel","tests":[
                     {"category":"databases","file":"diff.py"},
                     {"category":"databases","file":"exodus.py","cases":["exodus_13a","exodus_13b"]},
-                    {"category":"databases","file":"ffp.py", "cases":["ffp_03"]},
                     {"category":"databases","file":"pixie.py","cases":["pixie_04"]},
                     {"category":"databases","file":"silo.py","cases":["silo_curvilinear_3d_surface_3"]},
                     {"category":"databases","file":"zipwrapper.py"},
@@ -81,7 +79,6 @@
  {"mode":"scalable,parallel,icet","tests":[
                     {"category":"databases","file":"diff.py"},
                     {"category":"databases","file":"exodus.py","cases":["exodus_13a","exodus_13b"]},
-                    {"category":"databases","file":"ffp.py", "cases":["ffp_03"]},
                     {"category":"databases","file":"pixie.py","cases":["pixie_04"]},
                     {"category":"databases","file":"silo.py","cases":["silo_curvilinear_3d_surface_3"]},
                     {"category":"databases","file":"zipwrapper.py"},

--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -150,6 +150,9 @@
 #   Install git lfs before updating the repository. Added more logging
 #   to the git repository update.
 #
+#   Eric Brugger, Wed Mar 15 13:41:38 PDT 2023
+#   Update the location of where libstripack is copied from.
+#
 
 # Determine the users name and e-mail address.
 #
@@ -411,7 +414,7 @@ cat ../make.err >> ../../buildlog
 echo "Source build completed at: \`date\`"
 
 # Copy stripack lib for ffp plugin tests
-cp /usr/workspace/visit/miller86/stripack/libstripack.so ./lib/.
+cp /usr/workspace/wsa/visit/visit/thirdparty_shared/3.3.2/toss4/stripack/libstripack.so ./lib/.
 
 # Update the test baselines
 cd ../test

--- a/src/tools/dev/scripts/run-build-visit
+++ b/src/tools/dev/scripts/run-build-visit
@@ -24,6 +24,9 @@
 #    Eric Brugger, Fri Feb 17 09:36:29 PST 2023
 #    Added support for building on poodle.
 #
+#    Eric Brugger, Wed Mar 15 13:45:39 PDT 2023
+#    Added support for building libstripack on poodle.
+#
 #-----------------------------------------------------------------------
 
 #
@@ -235,10 +238,18 @@ then
    then
       mkdir /usr/workspace/wsa/visit/visit/thirdparty_shared/$version/toss4
    fi
+   if [ ! -d /usr/workspace/wsa/visit/visit/thirdparty_shared/$version/toss4/stripack ]
+   then
+      mkdir /usr/workspace/wsa/visit/visit/thirdparty_shared/$version/toss4/stripack
+   fi
    env PAR_COMPILER=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/include \
        ./$build_visit_script --required --optional --mesagl --uintah --parallel --qt510 --no-pyside --no-visit --thirdparty-path /usr/workspace/wsa/visit/visit/thirdparty_shared/$version/toss4 --makeflags -j16
+   env FC_COMPILER=/usr/tce/bin/gfortran \
+       FCFLAGS="-fdefault-real-8 -fdefault-double-8 -shared -fPIC" \
+       STRIPACK_INSTALL_DIR=/usr/workspace/wsa/visit/visit/thirdparty_shared/$version/toss4/stripack \
+       ./$build_visit_script --fortran --no-visit --no-thirdparty --no-zlib --stripack --thirdparty-path /usr/workspace/wsa/visit/visit/thirdparty_shared/$version/toss4
    mv ${build_visit_script}_log ${build_visit_script}_log.poodle
 fi
 


### PR DESCRIPTION
### Description

The `databases/ffp.py` test was failing because the ffp reader dynamically links libstripack at runtime and that library hadn't been built for toss4.

I modified `run-build-visit` to also build `libstripack` on poodle. I then modified the location where it copied `libstripack` from to the location that `run-build-visit` installed it.

Finally, I removed `ffp.py` from the skip list.

As an FYI, this [section](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/using_visit/WorkingWithFiles/Read_Write_Options.html#ffp) in the users manual has a good description of why the ffp reader is implemented the way it is along with instructions on using `build_visit` to build libstripack.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I used `run-build-visit` to build and install libstripack. I then ran the `ffp.py` regression test on pascal and got a pass.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
