### PR TITLE
Add /usr/tce/bin to $PATH in regression test script for git.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_pascal
+++ b/src/tools/dev/scripts/regressiontest_pascal
@@ -265,6 +265,9 @@ rm -f checkout_${testHost}
 cat <<EOF > checkout_${testHost}
 #!/bin/sh
 
+# So the script uses the correct git.
+export PATH=/usr/tce/bin:$PATH
+
 dateTag=\$1
 
 # Update the repository.
@@ -341,6 +344,9 @@ chmod 750 checkout_${testHost}
 rm -f runit_${testHost}
 cat <<EOF > runit_${testHost}
 #!/bin/sh
+
+# So the script uses the correct git.
+export PATH=/usr/tce/bin:$PATH
 
 dateTag=\$1
 
@@ -494,6 +500,9 @@ chmod 750 runit_${testHost}
 rm -f postit_${testHost}
 cat <<EOF > postit_${testHost}
 #!/bin/sh
+
+# So the script uses the correct git.
+export PATH=/usr/tce/bin:$PATH
 
 if test "\$#" -ne 1; then
     echo "Usage: \$0 date_tag"


### PR DESCRIPTION
### Description

I modified the regression test script to add `/usr/tce/bin` to the `$PATH` so that it would find the correct version of git. The default path in a cron job is `/usr/bin:/bin`, which is different from a login shell. The cron job finds the one in `/usr/bin`, which doesn't have lfs support and fails.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I haven't tested this. I'll find out when the test suite runs tonight.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
