### PR TITLE
escape paths in mfem json to avoid parsing issues (#18573) (develop PR)

### DIFF
--- a/src/common/misc/FileFunctions.C
+++ b/src/common/misc/FileFunctions.C
@@ -914,12 +914,33 @@ FileFunctions::Normalize(const std::string &path, const std::string &pathSep)
 //    Kathleen Biagas, Thu Jan 29 15:53:12 MST 2015
 //    Some tweaks on windows to hanlde cwd_context of '.'.
 //
+//    Cyrus Harrison, Thu Mar 16 10:07:17 PDT 2023
+//    Fix for windows case where path could be appended itself.
+//
 // ****************************************************************************
 
 const char *
 FileFunctions::Absname(const char *cwd_context, const char *path, 
     const char *pathSep)
 {
+    // if we already have an abs path, return it!
+#ifdef _WIN32
+    // if non null,
+    // use  windows api check for relative path to determine
+    // if we have abs path
+    if(path && !PathIsRelative(path))
+    {
+        return path;
+    }
+#else
+    // if non-null and starts with `/`
+    // we already have an abs on *nix systems
+    if(path && path[0] == '/')
+    {
+        return path;
+    }
+#endif
+
     // Clear our temporary array for handling char * return values.
     StaticStringBuf[0] = '\0';
 

--- a/src/common/utility/StringHelpers.C
+++ b/src/common/utility/StringHelpers.C
@@ -916,7 +916,7 @@ StringHelpers::append(std::vector<std::string> &argv,
 //
 // ****************************************************************************
 std::vector<std::string>
-StringHelpers::split(const std::string input, const char separator)
+StringHelpers::split(const std::string &input, const char separator)
 {
     std::istringstream iss(input);
     std::string cur;
@@ -1292,7 +1292,7 @@ StringHelpers::StringToInt(const string &input, int &output)
 //
 // ****************************************************************************
 bool
-StringHelpers::ParseRange(const string range, std::vector<int> &list)
+StringHelpers::ParseRange(const string &range, std::vector<int> &list)
 {
     std::vector<std::string> rangeTokens = StringHelpers::split(range, ',');
 
@@ -1366,6 +1366,82 @@ StringHelpers::ParseRange(const string range, std::vector<int> &list)
     return parseError;
 }
 
+// ****************************************************************************
+//  Method:  StringHelpers::EscapeString
+//
+//  Purpose:
+//   Escapes any special chars in a string. Need when you want to
+//   prepare a string that can later be parsed by JSON.
+//
+//  Logic from:
+//   conduit::utils::escape_special_chars in:
+//  https://github.com/LLNL/conduit/blob/develop/src/libs/conduit/conduit_utils.cpp
+//
+//
+//  Programmer:  Cyrus Harrison
+//  Creation:    Wed Mar 15 10:28:03 PDT 2023
+//
+//  Modifications:
+//
+// ****************************************************************************
+std::string
+StringHelpers::EscapeSpecialChars(const std::string &input)
+{
+        std::string res;
+        for(size_t i = 0; i < input.size(); ++i)
+        {
+            char val = input[i];
+            // supported special chars
+            switch(val)
+            {
+                // quotes and slashes
+                case '\"':
+                case '\\':
+                {
+                    res += '\\';
+                    res += val;
+                    break;
+                }
+                // newline
+                case '\n':
+                {
+                    res += "\\n";
+                    break;
+                }
+                // tab
+                case '\t':
+                {
+                    res += "\\t";
+                    break;
+                }
+                // backspace
+                case '\b':
+                {
+                    res += "\\b";
+                    break;
+                }
+                // formfeed
+                case '\f':
+                {
+                    res += "\\f";
+                    break;
+                }
+                // carriage return
+                case '\r':
+                {
+                    res += "\\r";
+                    break;
+                }
+
+                default:
+                {
+                    res += val;
+                }
+            }
+        }
+
+        return res;
+}
 
 // ****************************************************************************
 //  Method:  StringHelpers::ends_with

--- a/src/common/utility/StringHelpers.h
+++ b/src/common/utility/StringHelpers.h
@@ -70,8 +70,10 @@ namespace StringHelpers
     std::string UTILITY_API cdr(const std::string, const char separator);
     void UTILITY_API append(std::vector<std::string> &,
                             std::vector<std::string>);
-    std::vector<std::string> UTILITY_API split(const std::string,
+
+    std::vector<std::string> UTILITY_API split(const std::string &input,
                                                const char separator);
+
     void UTILITY_API rtrim(std::string &var);
     void UTILITY_API ltrim(std::string &var);
     void UTILITY_API  trim(std::string &var);
@@ -91,7 +93,10 @@ namespace StringHelpers
     std::string UTILITY_API UpperCase(const std::string &src);
 
     bool UTILITY_API StringToInt(const std::string &, int &);
-    bool UTILITY_API ParseRange(const std::string , std::vector<int> &);
+    bool UTILITY_API ParseRange(const std::string &, std::vector<int> &);
+
+    std::string UTILITY_API  EscapeSpecialChars(const std::string &str);
+
 // ****************************************************************************
 //  Function: str_to_u_numeric
 //


### PR DESCRIPTION

### Description

Resolves #18577 and #18570  on develop.

* escapes paths in mfem json to avoid parsing issues

* Update src/databases/MFEM/JSONRoot.C

* Update src/common/utility/StringHelpers.C

* harden absname for cases where abspath is already given

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on windows on RC by @biagas 

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
