### PR TITLE
Add blueprint support for 2D rz cylindrical meshes 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@
 # TO USE A NEW CONTAINER, UPDATE TAG NAME HERE AS PART OF YOUR PR!
 #####
 variables:
-  container_tag: visitdav/visit-ci-develop:2022-05-19-sha135d90
+  container_tag: visitdav/visit-ci-develop:2023-03-07-sha24859d
 
 # only build merge target pr to develop
 trigger: none
@@ -97,7 +97,8 @@ stages:
            git lfs pull --include blueprint_v0.8.2_braid_examples_test_data.tar.xz
            git lfs pull --include blueprint_v0.8.2_polytess_test_data.tar.xz
            git lfs pull --include blueprint_v0.8.4_part_map_examples.tar.xz
-           git lfs pull --include blueprint_v0.8.4_strided_structured_examples.tar.gz
+           git lfs pull --include blueprint_v0.8.4_strided_structured_examples.tar.xz
+           git lfs pull --include blueprint_v0.8.6_rz_examples.tar.xz
            cd ../
            git lfs pull  --include test/baseline/databases/silo
            git lfs pull  --include test/baseline/databases/blueprint
@@ -114,6 +115,7 @@ stages:
            tar xvf ../../data/blueprint_v0.8.2_polytess_test_data.tar.xz
            tar xvf ../../data/blueprint_v0.8.4_part_map_examples.tar.xz
            tar xvf ../../data/blueprint_v0.8.4_strided_structured_examples.tar.gz
+           tar xvf ../../data/blueprint_v0.8.6_rz_examples.tar.xz
 
         displayName: 'Prep Test Data'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ stages:
            tar xvf ../../data/blueprint_v0.8.2_braid_examples_test_data.tar.xz
            tar xvf ../../data/blueprint_v0.8.2_polytess_test_data.tar.xz
            tar xvf ../../data/blueprint_v0.8.4_part_map_examples.tar.xz
-           tar xvf ../../data/blueprint_v0.8.4_strided_structured_examples.tar.gz
+           tar xvf ../../data/blueprint_v0.8.4_strided_structured_examples.tar.xz
            tar xvf ../../data/blueprint_v0.8.6_rz_examples.tar.xz
 
         displayName: 'Prep Test Data'

--- a/data/blueprint_v0.8.6_rz_examples.tar.xz
+++ b/data/blueprint_v0.8.6_rz_examples.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bceeacbeae4d9f6eb2d5984e64e09fca14030fba65759c561e79f586badd806
-size 1116
+oid sha256:4124b37f20999bcf81709a17ab685e8da92fda2c881b14e53a5b57ce2628525f
+size 1140

--- a/data/blueprint_v0.8.6_rz_examples.tar.xz
+++ b/data/blueprint_v0.8.6_rz_examples.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bceeacbeae4d9f6eb2d5984e64e09fca14030fba65759c561e79f586badd806
+size 1116

--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
@@ -788,6 +788,7 @@ UniformCoordsToVTKRectilinearGrid(const Node &n_coords)
 {
     vtkRectilinearGrid *rectgrid = vtkRectilinearGrid::New();
 
+    AVT_CONDUIT_BP_INFO("UniformCoordsToVTKRectilinearGrid");
     AVT_CONDUIT_BP_INFO(n_coords.to_yaml());
 
     int nx[3];
@@ -924,6 +925,8 @@ UniformCoordsToVTKRectilinearGrid(const Node &n_coords)
 vtkDataSet *
 RectilinearCoordsToVTKRectilinearGrid(const Node &n_coords)
 {
+    AVT_CONDUIT_BP_INFO("RectilinearCoordsToVTKRectilinearGrid");
+    
     vtkRectilinearGrid *rectgrid = vtkRectilinearGrid::New();
 
     const Node &n_coords_values  = n_coords["values"];
@@ -933,6 +936,8 @@ RectilinearCoordsToVTKRectilinearGrid(const Node &n_coords)
     std::string coord_sys_type = conduit::blueprint::mesh::utils::coordset::coordsys(n_coords);
 
     vtkDataArray *coords[3] = {0,0,0};
+
+    AVT_CONDUIT_BP_INFO("coord system type: " << coord_sys_type);
 
     if(coord_sys_type == "cylindrical")
     {
@@ -949,14 +954,17 @@ RectilinearCoordsToVTKRectilinearGrid(const Node &n_coords)
     else // cartesian
     {
         dims[0] = n_coords_values["x"].dtype().number_of_elements();
+        
         if (n_coords_values.has_child("y"))
             dims[1] = n_coords_values["y"].dtype().number_of_elements();
+        
         if (n_coords_values.has_child("z"))
             dims[2] = n_coords_values["z"].dtype().number_of_elements();
+
         rectgrid->SetDimensions(dims);
 
-        vtkDataArray *coords[3] = {0,0,0};
         coords[0] = ConduitArrayToVTKDataArray(n_coords_values["x"]);
+        
         if (n_coords_values.has_child("y"))
             coords[1] = ConduitArrayToVTKDataArray(n_coords_values["y"]);
         else
@@ -965,6 +973,7 @@ RectilinearCoordsToVTKRectilinearGrid(const Node &n_coords)
             coords[1]->SetNumberOfTuples(1);
             coords[1]->SetComponent(0,0,0);
         }
+        
         if (n_coords_values.has_child("z"))
             coords[2] = ConduitArrayToVTKDataArray(n_coords_values["z"]);
         else

--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
@@ -5,6 +5,7 @@
 #include <avtConduitBlueprintDataAdaptor.h>
 #include <conduit.hpp>
 #include <conduit_blueprint.hpp>
+#include <conduit_blueprint_mesh_utils.hpp>
 #include "avtConduitBlueprintLogging.h"
 #include "avtConduitBlueprintInfoWarningHandler.h"
 
@@ -572,7 +573,7 @@ ExplicitCoordsToVTKPoints(const Node &n_coords, const Node &n_topo)
     }
     else
     {
-        npts = (int) n_vals["x"].dtype().number_of_elements();
+        npts = (int) n_vals.child(0).dtype().number_of_elements();
     }
 
     AVT_CONDUIT_BP_INFO("ExplicitCoordsToVTKPoints:: number of points ="  << npts );
@@ -587,54 +588,78 @@ ExplicitCoordsToVTKPoints(const Node &n_coords, const Node &n_topo)
     bool have_z = false;
 
     Node n_vals_double;
+    std::string coord_sys_type = conduit::blueprint::mesh::utils::coordset::coordsys(n_coords);
 
-    if(!n_vals["x"].dtype().is_double())
+    if(coord_sys_type == "cylindrical")
     {
-        n_vals["x"].to_double_array(n_vals_double["x"]);
-        x_vals = n_vals_double["x"].value();
-    }
-    else
-    {
-        x_vals = n_vals["x"].value();
-    }
-
-
-    if(n_vals.has_child("y"))
-    {
-        have_y = true;
-
-        if(!n_vals["y"].dtype().is_double())
-        {
-            n_vals["y"].to_double_array(n_vals_double["y"]);
-            y_vals = n_vals_double["y"].value();
-        }
-        else
-        {
-            y_vals = n_vals["y"].value();
-        }
-    }
-
-    if(n_vals.has_child("z"))
-    {
-        have_z = true;
-
         if(!n_vals["z"].dtype().is_double())
         {
             n_vals["z"].to_double_array(n_vals_double["z"]);
-            z_vals = n_vals_double["z"].value();
+            x_vals = n_vals_double["z"].value();
         }
         else
         {
-            z_vals = n_vals["z"].value();
+            x_vals = n_vals["z"].value();
+        }
+
+        have_y = true;
+
+        if(!n_vals["r"].dtype().is_double())
+        {
+            n_vals["r"].to_double_array(n_vals_double["r"]);
+            y_vals = n_vals_double["r"].value();
+        }
+        else
+        {
+            y_vals = n_vals["r"].value();
         }
     }
+    else
+    {
+        if(!n_vals["x"].dtype().is_double())
+        {
+            n_vals["x"].to_double_array(n_vals_double["x"]);
+            x_vals = n_vals_double["x"].value();
+        }
+        else
+        {
+            x_vals = n_vals["x"].value();
+        }
 
+        if(n_vals.has_child("y"))
+        {
+            have_y = true;
+
+            if(!n_vals["y"].dtype().is_double())
+            {
+                n_vals["y"].to_double_array(n_vals_double["y"]);
+                y_vals = n_vals_double["y"].value();
+            }
+            else
+            {
+                y_vals = n_vals["y"].value();
+            }
+        }
+
+        if(n_vals.has_child("z"))
+        {
+            have_z = true;
+
+            if(!n_vals["z"].dtype().is_double())
+            {
+                n_vals["z"].to_double_array(n_vals_double["z"]);
+                z_vals = n_vals_double["z"].value();
+            }
+            else
+            {
+                z_vals = n_vals["z"].value();
+            }
+        }
+    }
 
     points->SetDataTypeToDouble();
     points->SetNumberOfPoints(npts);
 
-    //TODO: we could describe the VTK data array via
-    // and push the conversion directly into its memory.
 
     if(ndstrided) // strided case
     {
@@ -772,18 +797,33 @@ UniformCoordsToVTKRectilinearGrid(const Node &n_coords)
     rectgrid->SetDimensions(nx);
 
     double dx[3] = {1.0,1.0,1.0};
+    std::string coord_sys_type = conduit::blueprint::mesh::utils::coordset::coordsys(n_coords);
+
     if(n_coords.has_child("spacing"))
     {
         const Node &n_spacing = n_coords["spacing"];
 
-        if(n_spacing.has_child("dx"))
-            dx[0] = n_spacing["dx"].to_double();
+        if(coord_sys_type == "cylindrical")
+        {
+            // note: we always treat z as horz axis for
+            // RZ meshes
+            if(n_spacing.has_child("dz"))
+                dx[0] = n_spacing["dz"].to_double();
 
-        if(n_spacing.has_child("dy"))
-            dx[1] = n_spacing["dy"].to_double();
+            if(n_spacing.has_child("dr"))
+                dx[1] = n_spacing["dr"].to_double();
+        }
+        else // xyz
+        {
+            if(n_spacing.has_child("dx"))
+                dx[0] = n_spacing["dx"].to_double();
 
-        if(n_spacing.has_child("dz"))
-            dx[2] = n_spacing["dz"].to_double();
+            if(n_spacing.has_child("dy"))
+                dx[1] = n_spacing["dy"].to_double();
+
+            if(n_spacing.has_child("dz"))
+                dx[2] = n_spacing["dz"].to_double();
+        }
     }
 
     double x0[3] = {0.0, 0.0, 0.0};
@@ -792,25 +832,46 @@ UniformCoordsToVTKRectilinearGrid(const Node &n_coords)
     {
         const Node &n_origin =  n_coords["origin"];
 
-        if(n_origin.has_child("x"))
-            x0[0] = n_origin["x"].to_double();
+        if(coord_sys_type == "cylindrical")
+        {
+            if(n_origin.has_child("z"))
+                x0[0] = n_origin["z"].to_double();
 
-        if(n_origin.has_child("y"))
-            x0[1] = n_origin["y"].to_double();
+            if(n_origin.has_child("r"))
+                x0[1] = n_origin["r"].to_double();
+        }
+        else
+        {
+            if(n_origin.has_child("x"))
+                x0[0] = n_origin["x"].to_double();
 
-        if(n_origin.has_child("z"))
-            x0[2] = n_origin["z"].to_double();
+            if(n_origin.has_child("y"))
+                x0[1] = n_origin["y"].to_double();
 
+            if(n_origin.has_child("z"))
+                x0[2] = n_origin["z"].to_double();
+        }
     }
 
     for (int i = 0; i < 3; i++)
     {
         vtkDataArray *da = NULL;
         DataType dt = DataType::c_double();
+
         // we have we origin, we can infer type from it
-        if(n_coords.has_path("origin/x"))
+        if(coord_sys_type == "cylindrical")
         {
-            dt = n_coords["origin"]["x"].dtype();
+            if(n_coords.has_path("origin/z"))
+            {
+                dt = n_coords["origin"]["z"].dtype();
+            }
+        }
+        else
+        {
+            if(n_coords.has_path("origin/x"))
+            {
+                dt = n_coords["origin"]["x"].dtype();
+            }
         }
 
         // since vtk uses the c-native style types
@@ -869,30 +930,49 @@ RectilinearCoordsToVTKRectilinearGrid(const Node &n_coords)
 
     int dims[3] = {1,1,1};
 
-    dims[0] = n_coords_values["x"].dtype().number_of_elements();
-    if (n_coords_values.has_child("y"))
-        dims[1] = n_coords_values["y"].dtype().number_of_elements();
-    if (n_coords_values.has_child("z"))
-        dims[2] = n_coords_values["z"].dtype().number_of_elements();
-    rectgrid->SetDimensions(dims);
+    std::string coord_sys_type = conduit::blueprint::mesh::utils::coordset::coordsys(n_coords);
 
     vtkDataArray *coords[3] = {0,0,0};
-    coords[0] = ConduitArrayToVTKDataArray(n_coords_values["x"]);
-    if (n_coords_values.has_child("y"))
-        coords[1] = ConduitArrayToVTKDataArray(n_coords_values["y"]);
-    else
+
+    if(coord_sys_type == "cylindrical")
     {
-        coords[1] = coords[0]->NewInstance();
-        coords[1]->SetNumberOfTuples(1);
-        coords[1]->SetComponent(0,0,0);
-    }
-    if (n_coords_values.has_child("z"))
-        coords[2] = ConduitArrayToVTKDataArray(n_coords_values["z"]);
-    else
-    {
+        dims[0] = n_coords_values["z"].dtype().number_of_elements();
+        dims[1] = n_coords_values["r"].dtype().number_of_elements();
+        rectgrid->SetDimensions(dims);
+
+        coords[0] = ConduitArrayToVTKDataArray(n_coords_values["z"]);
+        coords[1] = ConduitArrayToVTKDataArray(n_coords_values["r"]);
         coords[2] = coords[0]->NewInstance();
         coords[2]->SetNumberOfTuples(1);
         coords[2]->SetComponent(0,0,0);
+    }
+    else // cartesian
+    {
+        dims[0] = n_coords_values["x"].dtype().number_of_elements();
+        if (n_coords_values.has_child("y"))
+            dims[1] = n_coords_values["y"].dtype().number_of_elements();
+        if (n_coords_values.has_child("z"))
+            dims[2] = n_coords_values["z"].dtype().number_of_elements();
+        rectgrid->SetDimensions(dims);
+
+        vtkDataArray *coords[3] = {0,0,0};
+        coords[0] = ConduitArrayToVTKDataArray(n_coords_values["x"]);
+        if (n_coords_values.has_child("y"))
+            coords[1] = ConduitArrayToVTKDataArray(n_coords_values["y"]);
+        else
+        {
+            coords[1] = coords[0]->NewInstance();
+            coords[1]->SetNumberOfTuples(1);
+            coords[1]->SetComponent(0,0,0);
+        }
+        if (n_coords_values.has_child("z"))
+            coords[2] = ConduitArrayToVTKDataArray(n_coords_values["z"]);
+        else
+        {
+            coords[2] = coords[0]->NewInstance();
+            coords[2]->SetNumberOfTuples(1);
+            coords[2]->SetComponent(0,0,0);
+        }
     }
 
     rectgrid->SetXCoordinates(coords[0]);

--- a/src/avt/Blueprint/avtConduitBlueprintLogging.h
+++ b/src/avt/Blueprint/avtConduitBlueprintLogging.h
@@ -24,12 +24,12 @@
 
 #define AVT_CONDUIT_BP_INFO(  msg  )                                \
 {                                                                   \
-    debug5 << msg;                                                  \
+    debug5 << msg << std::endl;                                     \
 }                                                                   \
 
 #define AVT_CONDUIT_BP_WARNING(  msg  )                             \
 {                                                                   \
-    debug5 << "[blueprint warning] " << msg;                        \
+    debug5 << "[blueprint warning] " << msg << std::endl;           \
 }                                                                   \
 
 #define AVT_CONDUIT_BP_EXCEPTION1(  etype , msg )                   \

--- a/src/databases/Blueprint/avtBlueprintFileFormat.C
+++ b/src/databases/Blueprint/avtBlueprintFileFormat.C
@@ -729,12 +729,15 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
         const Node &n_coordsets = n_mesh_info["coordsets"];
         const Node &n_coords = n_coordsets[coordset_name];
 
+        std::string coord_sys_type = n_coords["coord_system/type"].as_string();
+
         int ndims = n_coords["coord_system/axes"].number_of_children();
         topo_dims[topo_name] = ndims;
 
         BP_PLUGIN_INFO("coordinate system: "
-                       << n_coords["coord_system"].to_yaml()
-                       << " (ndims=" << ndims << ")");
+                        << n_coords["coord_system"].to_yaml()
+                        << " (type=" << coord_sys_type
+                        << " ndims=" << ndims << ")");
 
         avtMeshMetaData *mmd = new avtMeshMetaData(mesh_topo_name,
                                                    nblocks,
@@ -744,6 +747,17 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
         if(is_mfem_mesh)
         {
             mmd->containsOriginalCells = true;
+        }
+
+        if(coord_sys_type == "cylindrical")
+        {
+            mmd->meshCoordType = AVT_RZ;
+            mmd->xLabel = "Z-Axis";
+            mmd->yLabel = "R-Axis";
+        }
+        else
+        {
+            mmd->meshCoordType = AVT_XY;
         }
 
         mmd->LODs = 20;

--- a/src/resources/help/en_US/relnotes3.3.3.html
+++ b/src/resources/help/en_US/relnotes3.3.3.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Updated the VTKm library from version 1.7.0 to 1.9.0 to add support for AMD GPUs.</li>
   <li>Added original cell id support for MFEM Meshes in the Blueprint Plugin. With this change the Mesh plot will now plot outlines of high order elements, instead of the elements of the low order refined mesh.</li>
   <li>The X Ray Image Query now includes a new topology in the Conduit Blueprint output types, the Spatial Energy Reduced Mesh.</li>
+  <li>Added support to read RZ (2D cylindrical) meshes to the Blueprint Plugin.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/test/tests/databases/blueprint.py
+++ b/src/test/tests/databases/blueprint.py
@@ -40,6 +40,8 @@ bp_devilray_mfem_test_dir = "blueprint_v0.8.3_devilray_mfem_test_data"
 bp_part_map_test_dir = "blueprint_v0.8.4_part_map_examples"
 bp_struct_strided_test_dir = "blueprint_v0.8.4_strided_structured_examples"
 
+bp_rz_test_dir = "blueprint_v0.8.6_rz_examples"
+
 braid_2d_hdf5_root = data_path(pjoin(bp_test_dir,"braid_2d_examples.blueprint_root_hdf5"))
 braid_3d_hdf5_root = data_path(pjoin(bp_test_dir,"braid_3d_examples.blueprint_root_hdf5"))
 
@@ -102,6 +104,12 @@ bp_struct_strided_2d_root = data_path(pjoin(bp_struct_strided_test_dir,
 
 bp_struct_strided_3d_root = data_path(pjoin(bp_struct_strided_test_dir, 
                                       "strided_structured_3d_hdf5.root"));
+
+bp_rz_examples = []
+bp_rz_examples.append(data_path(pjoin(bp_rz_test_dir,"blueprint_rz_cyl_rectilinear.root")))
+bp_rz_examples.append(data_path(pjoin(bp_rz_test_dir,"blueprint_rz_cyl_uniform.root")))
+bp_rz_examples.append(data_path(pjoin(bp_rz_test_dir,"blueprint_rz_cyl_structured.root")))
+bp_rz_examples.append(data_path(pjoin(bp_rz_test_dir,"blueprint_rz_cyl_unstructured.root")))
 
 
 braid_2d_meshes = ["points", "uniform", "rect", "struct", "tris","quads"]
@@ -441,6 +449,24 @@ def test_venn(tag_name, venn_db_file):
 
     CloseDatabase(venn_db_file)
 
+def test_rz_example(tag_name, rz_db_file):
+    OpenDatabase(rz_db_file)
+    AddPlot("Pseudocolor", "mesh_topo/cyl")
+    AddPlot("Mesh", "mesh_topo")
+    DrawPlots()
+    ResetView()
+    Test(tag_name + "_plot_2D")
+    DeleteAllPlots()
+    # now revolve
+    AddPlot("Pseudocolor", "mesh_topo/cyl")
+    AddOperator("Revolve")
+    DrawPlots()
+    ResetView()
+    Test(tag_name + "_plot_revolved_to_3D")
+    DeleteAllPlots()
+    CloseDatabase(rz_db_file)
+
+
 def test_paren_vars():
     TestSection("Variables With Parens")
 
@@ -456,6 +482,8 @@ def test_paren_vars():
     DeleteAllPlots()
     ResetView()
     CloseDatabase(uniform_root)
+
+
 
 
 TestSection("2D Example JSON Mesh Files")
@@ -668,5 +696,9 @@ Test("bp_strided_struct_3d_vert_vals")
 DeleteAllPlots()
 CloseDatabase(bp_struct_strided_3d_root)
 
+TestSection("Blueprint RZ Examples, 0.8.6")
+for db in bp_rz_examples:
+    tag_name = os.path.basename(os.path.split(db)[1])
+    test_rz_example(tag_name,db)
 
 Exit()

--- a/src/test/tests/databases/blueprint.py
+++ b/src/test/tests/databases/blueprint.py
@@ -26,6 +26,9 @@
 #    Cyrus Harrison, Thu Dec 22 13:53:17 PST 2022
 #    Added bp part map and initial strided structured tests/ 
 #
+#    Cyrus Harrison, Mon, Mar 20, 2023  3:34:04 PM 
+#    Added rz test examples
+#
 # ----------------------------------------------------------------------------
 RequiredDatabasePlugin("Blueprint")
 
@@ -39,7 +42,6 @@ bp_poly_test_dir = "blueprint_v0.8.2_polytess_test_data"
 bp_devilray_mfem_test_dir = "blueprint_v0.8.3_devilray_mfem_test_data"
 bp_part_map_test_dir = "blueprint_v0.8.4_part_map_examples"
 bp_struct_strided_test_dir = "blueprint_v0.8.4_strided_structured_examples"
-
 bp_rz_test_dir = "blueprint_v0.8.6_rz_examples"
 
 braid_2d_hdf5_root = data_path(pjoin(bp_test_dir,"braid_2d_examples.blueprint_root_hdf5"))
@@ -457,6 +459,7 @@ def test_rz_example(tag_name, rz_db_file):
     ResetView()
     Test(tag_name + "_plot_2D")
     DeleteAllPlots()
+    ResetView()
     # now revolve
     AddPlot("Pseudocolor", "mesh_topo/cyl")
     AddOperator("Revolve")
@@ -464,6 +467,7 @@ def test_rz_example(tag_name, rz_db_file):
     ResetView()
     Test(tag_name + "_plot_revolved_to_3D")
     DeleteAllPlots()
+    ResetView()
     CloseDatabase(rz_db_file)
 
 

--- a/src/test/tests/databases/blueprint.py
+++ b/src/test/tests/databases/blueprint.py
@@ -488,8 +488,6 @@ def test_paren_vars():
     CloseDatabase(uniform_root)
 
 
-
-
 TestSection("2D Example JSON Mesh Files")
 OpenDatabase(braid_2d_json_root)
 for mesh_name in braid_2d_meshes:

--- a/src/tools/dev/masonry/opts/mb-3.3.1-darwin-10.15-x86_64-release.json
+++ b/src/tools/dev/masonry/opts/mb-3.3.1-darwin-10.15-x86_64-release.json
@@ -15,7 +15,6 @@
  "build_visit":  { "cmake_ver": "3.18.2",
                    "args":"--no-thirdparty",
                    "libs":["cmake",
-                       "vtkh",
                        "vtkm",
                        "ispc",
                        "embree",

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_rectilinear.root_plot_2D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_rectilinear.root_plot_2D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe0e242d360a49a08a8849fda8959547838c8fab5de0f9ab12929f1d714eaeb
+size 991

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_rectilinear.root_plot_revolved_to_3D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_rectilinear.root_plot_revolved_to_3D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efc7ffd7cfb5f51fd232f7c950bc3fbf845fd373d82cc4848ea431a55d9764ba
+size 2672

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_structured.root_plot_2D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_structured.root_plot_2D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe0e242d360a49a08a8849fda8959547838c8fab5de0f9ab12929f1d714eaeb
+size 991

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_structured.root_plot_revolved_to_3D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_structured.root_plot_revolved_to_3D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e378f131ea46b867ef8e6a57c3a02dac5e75f58ba7b25da97ea7db50e5d34c3a
+size 2671

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_uniform.root_plot_2D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_uniform.root_plot_2D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe0e242d360a49a08a8849fda8959547838c8fab5de0f9ab12929f1d714eaeb
+size 991

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_uniform.root_plot_revolved_to_3D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_uniform.root_plot_revolved_to_3D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e378f131ea46b867ef8e6a57c3a02dac5e75f58ba7b25da97ea7db50e5d34c3a
+size 2671

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_unstructured.root_plot_2D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_unstructured.root_plot_2D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe0e242d360a49a08a8849fda8959547838c8fab5de0f9ab12929f1d714eaeb
+size 991

--- a/test/baseline/databases/blueprint/blueprint_rz_cyl_unstructured.root_plot_revolved_to_3D.png
+++ b/test/baseline/databases/blueprint/blueprint_rz_cyl_unstructured.root_plot_revolved_to_3D.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e378f131ea46b867ef8e6a57c3a02dac5e75f58ba7b25da97ea7db50e5d34c3a
+size 2671


### PR DESCRIPTION
### Description

Adds support to the blueprint plugin to read 2D RZ meshes.

### Type of change

<!-- Please check one of the boxes below -->

~~* [ ] Bug fix~~
* [x] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on my mac using test suite (including new rz tests)
Tested in CI container to create new baselines.
### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
