### PR TITLE
Qt6 prep for Qt::WindowFlags f = 0 in Window constructor signature.

### DIFF
--- a/src/gui/QvisColorGridWidget.h
+++ b/src/gui/QvisColorGridWidget.h
@@ -51,7 +51,7 @@ class GUI_API QvisColorGridWidget : public QvisGridWidget
 {
     Q_OBJECT
 public:
-    QvisColorGridWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisColorGridWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisColorGridWidget();
 
     void setSelectedColor(const QColor &c);

--- a/src/gui/QvisColorSelectionWidget.h
+++ b/src/gui/QvisColorSelectionWidget.h
@@ -37,7 +37,7 @@ class GUI_API QvisColorSelectionWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisColorSelectionWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisColorSelectionWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisColorSelectionWidget();
     virtual QSize sizeHint() const;
 

--- a/src/gui/QvisDelayedWindow.h
+++ b/src/gui/QvisDelayedWindow.h
@@ -44,7 +44,7 @@ class GUI_API QvisDelayedWindow : public QvisWindowBase
 {
     Q_OBJECT
 public:
-    QvisDelayedWindow(const QString &captionString, Qt::WindowFlags f = 0);
+    QvisDelayedWindow(const QString &captionString, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisDelayedWindow();
     QWidget *GetCentralWidget();
     virtual void CreateEntireWindow();

--- a/src/gui/QvisDelayedWindowSimpleObserver.h
+++ b/src/gui/QvisDelayedWindowSimpleObserver.h
@@ -40,7 +40,7 @@ class GUI_API QvisDelayedWindowSimpleObserver : public QvisDelayedWindow, public
 {
     Q_OBJECT
 public:
-    QvisDelayedWindowSimpleObserver(const QString &caption, Qt::WindowFlags f = 0);
+    QvisDelayedWindowSimpleObserver(const QString &caption, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisDelayedWindowSimpleObserver();
     virtual void CreateWindowContents() = 0;
     virtual void Update(Subject *TheChangedSubject);

--- a/src/gui/QvisElementSelectionWidget.h
+++ b/src/gui/QvisElementSelectionWidget.h
@@ -40,7 +40,7 @@ class GUI_API QvisElementSelectionWidget : public QWidget
 {
     Q_OBJECT
   public:
-    QvisElementSelectionWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisElementSelectionWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisElementSelectionWidget();
     virtual QSize sizeHint() const;
 

--- a/src/gui/QvisGridWidget.h
+++ b/src/gui/QvisGridWidget.h
@@ -37,7 +37,7 @@ class GUI_API QvisGridWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisGridWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisGridWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisGridWidget();
     virtual QSize sizeHint () const;
     virtual QSize minimumSize() const;

--- a/src/gui/QvisHohlraumFluxQueryWidget.h
+++ b/src/gui/QvisHohlraumFluxQueryWidget.h
@@ -31,7 +31,7 @@ class GUI_API QvisHohlraumFluxQueryWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisHohlraumFluxQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisHohlraumFluxQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisHohlraumFluxQueryWidget();
 
     bool GetQueryParameters(MapNode &params);

--- a/src/gui/QvisLineoutQueryWidget.h
+++ b/src/gui/QvisLineoutQueryWidget.h
@@ -34,7 +34,7 @@ class GUI_API QvisLineoutQueryWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisLineoutQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisLineoutQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisLineoutQueryWidget();
 
     bool                GetQueryParameters(MapNode &);

--- a/src/gui/QvisPeriodicTableWidget.h
+++ b/src/gui/QvisPeriodicTableWidget.h
@@ -37,7 +37,7 @@ class GUI_API QvisPeriodicTableWidget : public QvisGridWidget
 {
     Q_OBJECT
 public:
-    QvisPeriodicTableWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisPeriodicTableWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisPeriodicTableWidget();
 
     void setSelectedElement(int e);

--- a/src/gui/QvisPickQueryWidget.h
+++ b/src/gui/QvisPickQueryWidget.h
@@ -41,7 +41,7 @@ class GUI_API QvisPickQueryWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisPickQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisPickQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisPickQueryWidget();
 
     bool                 GetQueryParameters(MapNode &params);

--- a/src/gui/QvisScreenPositioner.h
+++ b/src/gui/QvisScreenPositioner.h
@@ -29,7 +29,7 @@ class GUI_API QvisScreenPositioner : public QWidget
 {
     Q_OBJECT
 public:
-    QvisScreenPositioner(QWidget *parent = 0, Qt::WindowFlags = 0);
+    QvisScreenPositioner(QWidget *parent = 0, Qt::WindowFlags = Qt::Widget);
     virtual ~QvisScreenPositioner();
     virtual QSize sizeHint () const;
     virtual QSize minimumSize() const;

--- a/src/gui/QvisXRayImageQueryWidget.h
+++ b/src/gui/QvisXRayImageQueryWidget.h
@@ -51,7 +51,7 @@ class GUI_API QvisXRayImageQueryWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisXRayImageQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisXRayImageQueryWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisXRayImageQueryWidget();
 
     bool GetQueryParameters(MapNode &params);

--- a/src/tools/examples/mcurvit/QvisColorGridWidget.h
+++ b/src/tools/examples/mcurvit/QvisColorGridWidget.h
@@ -51,7 +51,7 @@ class GUI_API QvisColorGridWidget : public QvisGridWidget
 {
     Q_OBJECT
 public:
-    QvisColorGridWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisColorGridWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisColorGridWidget();
 
     void setSelectedColor(const QColor &c);

--- a/src/tools/examples/mcurvit/QvisColorSelectionWidget.h
+++ b/src/tools/examples/mcurvit/QvisColorSelectionWidget.h
@@ -37,7 +37,7 @@ class GUI_API QvisColorSelectionWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisColorSelectionWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisColorSelectionWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisColorSelectionWidget();
     virtual QSize sizeHint() const;
 

--- a/src/tools/examples/mcurvit/QvisGridWidget.h
+++ b/src/tools/examples/mcurvit/QvisGridWidget.h
@@ -37,7 +37,7 @@ class GUI_API QvisGridWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QvisGridWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    QvisGridWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
     virtual ~QvisGridWidget();
     virtual QSize sizeHint () const;
     virtual QSize minimumSize() const;


### PR DESCRIPTION
### Description
Qt::WindowFlags f = 0 in Window constructor signatures yields an invalid conversion from int to Qt::WindowType error with Qt6.

Replace with: Qt::WindowFlags f = Qt::Widget.

Qt::Widget's value is 0, so replacement changes nothing.

Part of work for #18605.

### Type of change

<!-- Please check one of the boxes below -->

~~* [ ] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
* [X] Other~~ <!-- please explain with a note below -->

Prep for QT 6.

### How Has This Been Tested?

Compiled successfully on linux with Qt 5.10 and Windows with QT 5.14.
Impacted windows behave normally.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
