### PR TITLE
Fix numerics in revolved_volume for line segs nearly parallel to axis of rev

### DIFF
--- a/src/avt/Expressions/MeshQuality/avtRevolvedVolume.C
+++ b/src/avt/Expressions/MeshQuality/avtRevolvedVolume.C
@@ -531,7 +531,7 @@ avtRevolvedVolume::GetTriangleVolume2(double x[3], double y[3])
 //    Renamed some vars for clarity.
 //
 //    Mark C. Miller, Tue Apr 11 09:24:54 PDT 2023
-//    Reduce numerical sensitivity for line segments nearly paralle to axis
+//    Reduce numerical sensitivity for line segments nearly parallel to axis
 //    of revolution.
 // ****************************************************************************
  
@@ -559,12 +559,11 @@ avtRevolvedVolume::RevolveLineSegment(double x[2], double y[2], double *slope)
         }
         return 0.;
     }
-    // using if (y[0]==y[1]) here means lines nearly parallel to axis
-    // don't get handled here and instead we try to compute an x-intercept
-    // for them. Those are really ill-conditioned 2x2 matrix and we get
-    // bad results. So, instead we treat all nearly equal values as
-    // parallel to axis.
-    if (abs(y[0]-y[1]) < 1e-6)
+    // Treat all lines which are almost parallel to axis as indeed
+    // parallel and defining a volume of cylinder. This is numerically
+    // better for lines almost parallel to axis because computing
+    // intercept is ill-conditioned in these cases.
+    if (abs(y[1]-y[0]) < (1e-6)*abs(x[1]-x[0]))
     {
 #if defined(_WIN32) && !defined(M_PI)
 #define M_PI 3.14159265358979323846

--- a/src/avt/Expressions/MeshQuality/avtRevolvedVolume.C
+++ b/src/avt/Expressions/MeshQuality/avtRevolvedVolume.C
@@ -18,6 +18,8 @@
 
 #include <InvalidDimensionsException.h>
 
+#include <cmath>
+
 
 // ****************************************************************************
 //  Method: avtRevolvedVolume constructor
@@ -528,6 +530,9 @@ avtRevolvedVolume::GetTriangleVolume2(double x[3], double y[3])
 //    Kathleen Bonnell, Thu Feb  2 11:26:23 PST 2006
 //    Renamed some vars for clarity.
 //
+//    Mark C. Miller, Tue Apr 11 09:24:54 PDT 2023
+//    Reduce numerical sensitivity for line segments nearly paralle to axis
+//    of revolution.
 // ****************************************************************************
  
 double
@@ -554,7 +559,12 @@ avtRevolvedVolume::RevolveLineSegment(double x[2], double y[2], double *slope)
         }
         return 0.;
     }
-    if (y[0] == y[1])
+    // using if (y[0]==y[1]) here means lines nearly parallel to axis
+    // don't get handled here and instead we try to compute an x-intercept
+    // for them. Those are really ill-conditioned 2x2 matrix and we get
+    // bad results. So, instead we treat all nearly equal values as
+    // parallel to axis.
+    if (abs(y[0]-y[1]) < 1e-6)
     {
 #if defined(_WIN32) && !defined(M_PI)
 #define M_PI 3.14159265358979323846


### PR DESCRIPTION
### Description

Resolves #18638 

`revolved_volume` expression breaks elements into triangles and triangles into line segements and computes the revolved volume of each line segment and then combines those appropriate for final result. There is logic to handle cases where line segments are *exactly* horizontal (e.g. defines a piece of a cylinder). But, that logic was too strict and not getting triggered for cases where a line segment is _nearly_ parallel to axis of revolution. For the case of nearly parallel lines, we know that computing their intersection (e.g. solving the 2x2 matrix) is ill-conditioned...we get numerically poor results. This was causing negative volumes and wildly different volumes for neighbor cells of identical shape/size.

This change just adjusts the logic for entering the *cylinder* logic case to work for *nearly* parallel lines.

Side note...I don't see a `release_notes3.3.4.html` to edit. Should creating the *next* release notes file be part of creating a release?

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I tested manually with a dataset I was given from a customer.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
