### PR TITLE
Add better error message for Revolved volume query failure. (#18654)

### DIFF
--- a/src/avt/Queries/Queries/avtTotalRevolvedVolumeQuery.C
+++ b/src/avt/Queries/Queries/avtTotalRevolvedVolumeQuery.C
@@ -122,6 +122,10 @@ avtTotalRevolvedVolumeQuery::ApplyFilters(avtDataObject_p inData)
 //    Added test for topological dimension, as that is no longer performed by
 //    base class.  
 //
+//    Kathleen Biagas, Wed Apr 19, 2023
+//    Added test for spatial dimension !=2, as avtRevolvedVolume will throw
+//    an Exception but the error message will be lost. 
+//
 // ****************************************************************************
 
 void
@@ -137,6 +141,15 @@ avtTotalRevolvedVolumeQuery::VerifyInput(void)
     {
         EXCEPTION1(NonQueryableInputException,
             "Requires plot with topological dimension > 0.");
+    }
+
+    // avtRevolvedVolume throws an Exception if spatialDim !=2, but
+    // The exception gets lost through the update cycle, so perform the
+    // check here for better error messaging.
+    if (GetInput()->GetInfo().GetAttributes().GetSpatialDimension() != 2)
+    {
+        EXCEPTION1(NonQueryableInputException,
+            "Requires plot with spatial dimension == 2.\n");
     }
 
     SetUnits(GetInput()->GetInfo().GetAttributes().GetXUnits());

--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -1,0 +1,45 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Language" content="en-us">
+  <title>VisIt 3.3.4 Release Notes</title>
+</head>
+<body>
+<center><b><font size="6">VisIt 3.3.4 Release Notes</font></b></center>
+
+<p>Welcome to VisIt's release notes page. This page describes the important
+enhancements and bug-fixes that were added to this release.</p>
+
+<p><b>Sections</b></p>
+<ul>
+  <li><a href="#Bugs_fixed">Bug Fixes</a></li>
+  <li><a href="#Enhancements">Enhancements</a></li>
+  <li><a href="#Dev_changes">Changes for VisIt developers</a></li>
+</ul>
+
+<a name="Bugs_fixed"></a>
+<p><b><font size="4">Bugs fixed in version 3.3.4</font></b></p>
+<ul>
+  <li>A better error message was added for Revolved volume query when applied to meshes whose spatial dimension is not 2.</li>
+  <li>Bugs Fixed 2</li>
+</ul>
+
+<a name="Enhancements"></a>
+<p><b><font size="4">Enhancements in version 3.3.4</font></b></p>
+<ul>
+  <li>Enhancement 1</li>
+  <li>Enhancement 2</li>
+</ul>
+
+<a name="Dev_changes"></a>
+<p><b><font size="4">Changes for VisIt developers in version 3.3.4</font></b></p>
+<ul>
+  <li>Developer Changes 1</li>
+  <li>Developer Changes 2</li>
+</ul>
+
+<p>Click the following link to view the release notes for the previous version
+of VisIt: <a href=relnotes3.3.3.html>3.3.3</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
### Description
The query will fail when the spatial dimension of the mesh is not 2, but the error message given was cryptic and not helpful.
Resolves #18647 

Merge from 3.3RC

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran the query with data provided in ticket, better error message.

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
