### PR TITLE
X Ray Image Query Tests: Use YAML/JSON I/O bugfix in new conduit for more tests

### DIFF
--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -96,6 +96,12 @@
 #    energy group bins.
 #     - More consistent query args for blueprint tests
 #     - Added slice tests for specific energy group bins.
+# 
+#    Justin Privitera, Wed Apr 26 14:07:01 PDT 2023
+#    The new conduit we are using for VisIt (0.8.7) can read in simple yaml
+#    and json (w/o bp index?) (bug was fixed) so I am updating the x ray query
+#    tests to take advantage of this and add tests back in for yaml and json
+#    cases.
 #
 # ----------------------------------------------------------------------------
 

--- a/src/test/tests/queries/xrayimage.py
+++ b/src/test/tests/queries/xrayimage.py
@@ -626,7 +626,7 @@ def z_slice(zval, mesh_name):
     SliceAtts.meshName = mesh_name
     SetOperatorOptions(SliceAtts, 0, 1)
 
-def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
+def blueprint_test(output_type, outdir, testtextnumber, testname):
     for i in range(0, 2):
         setup_bp_test()
 
@@ -786,33 +786,32 @@ def blueprint_test(output_type, outdir, testtextnumber, testname, hdf5 = False):
 
         CloseDatabase(conduit_db)
 
-    if (hdf5):
-        units = UNITS_OFF if i == 0 else UNITS_ON
-        
-        qro = query_result_options(num_bins=3, abs_name="darr", emis_name="parr", \
-            bin_state=ENERGY_GROUP_BOUNDS, units=units, \
-            int_max=1, pl_max=892.02588)
-        test_bp_data(testname + str(i), conduit_db, qro) # bounds
-        
-        setup_bp_test()
-        
-        Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"), [1,2,3])
-        qro = query_result_options(num_bins=1, abs_name="d", emis_name="p", \
-            bin_state=ENERGY_GROUP_BOUNDS_MISMATCH, units=UNITS_OFF, \
-            int_max=0.24153, pl_max=148.67099)
-        test_bp_data(testname + str(i), conduit_db, qro) # bounds mismatch
-        
-        Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
-        qro = query_result_options(num_bins=1, abs_name="d", emis_name="p", \
-            bin_state=NO_ENERGY_GROUP_BOUNDS, units=UNITS_OFF, \
-            int_max=0.24153, pl_max=148.67099)
-        test_bp_data(testname + str(i), conduit_db, qro) # no bounds
-        
-        teardown_bp_test()
+    units = UNITS_OFF if i == 0 else UNITS_ON
+    
+    qro = query_result_options(num_bins=3, abs_name="darr", emis_name="parr", \
+        bin_state=ENERGY_GROUP_BOUNDS, units=units, \
+        int_max=1, pl_max=892.02588)
+    test_bp_data(testname + str(i), conduit_db, qro) # bounds
+    
+    setup_bp_test()
+    
+    Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"), [1,2,3])
+    qro = query_result_options(num_bins=1, abs_name="d", emis_name="p", \
+        bin_state=ENERGY_GROUP_BOUNDS_MISMATCH, units=UNITS_OFF, \
+        int_max=0.24153, pl_max=148.67099)
+    test_bp_data(testname + str(i), conduit_db, qro) # bounds mismatch
+    
+    Query("XRay Image", output_type, outdir, 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 200, ("d", "p"))
+    qro = query_result_options(num_bins=1, abs_name="d", emis_name="p", \
+        bin_state=NO_ENERGY_GROUP_BOUNDS, units=UNITS_OFF, \
+        int_max=0.24153, pl_max=148.67099)
+    test_bp_data(testname + str(i), conduit_db, qro) # no bounds
+    
+    teardown_bp_test()
 
-blueprint_test("hdf5", conduit_dir_hdf5, 32, "Blueprint_HDF5_X_Ray_Output", hdf5=True)
-blueprint_test("json", conduit_dir_json, 34, "Blueprint_JSON_X_Ray_Output", hdf5=False)
-blueprint_test("yaml", conduit_dir_yaml, 36, "Blueprint_YAML_X_Ray_Output", hdf5=False)
+blueprint_test("hdf5", conduit_dir_hdf5, 32, "Blueprint_HDF5_X_Ray_Output")
+blueprint_test("json", conduit_dir_json, 34, "Blueprint_JSON_X_Ray_Output")
+blueprint_test("yaml", conduit_dir_yaml, 36, "Blueprint_YAML_X_Ray_Output")
 
 # test detector height and width are always positive in blueprint output
 


### PR DESCRIPTION
### Description

Addresses a bullet in #17791 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
The new conduit we are using for VisIt (0.8.7) can read in simple yaml and json (w/o bp index) (bug was fixed) so I am updating the x ray query tests to take advantage of this and add tests back in for yaml and json cases.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->
testing update

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
ran the tests for the x ray image query on rztopaz; they all pass.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
