### PR TITLE
Add xml2python target to a SetDefaults method in the .code file.

### DIFF
--- a/src/plots/Boundary/BoundaryAttributes.code
+++ b/src/plots/Boundary/BoundaryAttributes.code
@@ -31,6 +31,7 @@ BoundaryAttributes::VarChangeRequiresReset()
 }
 
 
+Target: xml2python
 Function: PyBoundaryAttributes_SetDefaults
 Declaration: PyBoundaryAttributes_SetDefaults
 Definition:

--- a/src/plots/Boundary/PyBoundaryAttributes.C
+++ b/src/plots/Boundary/PyBoundaryAttributes.C
@@ -1344,12 +1344,15 @@ PyBoundaryAttributes_SetParent(PyObject *obj, PyObject *parent)
     obj2->parent = parent;
 }
 
+// ****************************************************************************
+//  Modifications:
+//    Kathleen Bonnell, Mon Dec  2 18:06:04 PST 2002
+//    Make defaultAtts point to the passed atts directly.
+//
+// ****************************************************************************
 void
 PyBoundaryAttributes_SetDefaults(const BoundaryAttributes *atts)
 {
-    if(defaultAtts)
-        delete defaultAtts;
-
-    defaultAtts = new BoundaryAttributes(*atts);
+    defaultAtts = const_cast<BoundaryAttributes*>(atts);
 }
 


### PR DESCRIPTION
### Description

I discovered the problem while running the  gen_xxx_all targets to test changes to XML code for qt 6 port.

The Target designation was accidentally removed during prior removal of deprecated code.

Rerun xml2python for boundary plot.

### Type of change

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
