### PR TITLE
Add method for underlining of text

### DIFF
--- a/src/doc/_static/custom.css
+++ b/src/doc/_static/custom.css
@@ -23,3 +23,8 @@
 .wy-table-responsive table td {
     white-space: normal;
 }
+
+/* Support underlining text */
+.vundl {
+  text-decoration: underline;
+}

--- a/src/doc/_static/custom.css
+++ b/src/doc/_static/custom.css
@@ -24,7 +24,9 @@
     white-space: normal;
 }
 
-/* Support underlining text */
+/* Support underlining text via :vundl:`some text`.
+   There is some corresponding logic in conf.py that
+   defines the role :vundl: as a class. */
 .vundl {
   text-decoration: underline;
 }

--- a/src/doc/conf.py
+++ b/src/doc/conf.py
@@ -79,6 +79,8 @@ rst_epilog = """
 .. |*nix| replace:: Centos, Debian, Fedora, Redhat, TOSS, Ubuntu
 .. |fs*nix| replace:: Redhat, TOSS, Ubuntu
 .. |ps*nix| replace:: Centos, Debian, Fedora
+.. role:: vundl
+    :class: vundl
 """
 
 # Add any paths that contain templates here, relative to this directory.

--- a/src/doc/dev_manual/ContributingToDocumentation/index.rst
+++ b/src/doc/dev_manual/ContributingToDocumentation/index.rst
@@ -99,6 +99,7 @@ use of Sphinx as we move forward. These are discussed at the
 * Bracket word(s) with one star (``*word*``) for *italics*.
 * Bracket word(s) with two stars (``**some words**``) for **bold**.
 * Bracket word(s) with two backticks (:samp:`\ ``some words```) for ``literal``.
+* Use :samp:`\ :v\ undl:`words to underline`` to :vundl:`underline words`.
 * Bracketed word(s) should not span line breaks.
 * Use ``literals`` for code, commands, arguments, file names, etc.
 * Use **bold** to refer to VisIt_ **Widget**, **Operator** or **Plot**

--- a/src/doc/glossary.rst
+++ b/src/doc/glossary.rst
@@ -14,7 +14,7 @@ Glossary
        to decide when it thinks it is best to enable or disable the feature.
     
    Integral Curve
-       An :vundl:`integral curve is a curve` that begins at a seed location and is
+       An integral curve is a curve that begins at a seed location and is
        tangent at every point in a vector field. It is computed by numerical
        integration of the seed location through the vector field.
 

--- a/src/doc/glossary.rst
+++ b/src/doc/glossary.rst
@@ -14,7 +14,7 @@ Glossary
        to decide when it thinks it is best to enable or disable the feature.
     
    Integral Curve
-       An integral curve is a curve that begins at a seed location and is
+       An :vundl:`integral curve is a curve` that begins at a seed location and is
        tangent at every point in a vector field. It is computed by numerical
        integration of the seed location through the vector field.
 


### PR DESCRIPTION
Lets see how this works.

- Added new *role* in `rst_epilog` variable in `conf.py` which associates CSS `class vundl` with `:vundl:` role.
- Added new CSS to define how `class .vundl` will be styled
- Added an example to test behavior.