### PR TITLE
Fix an error in the frontier host profile.

### DIFF
--- a/src/resources/hosts/ornl/host_ornl_frontier.xml
+++ b/src/resources/hosts/ornl/host_ornl_frontier.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Object name="MachineProfile">
-    <Field name="host" type="string">crusher.olcf.ornl.gov</Field>
+    <Field name="host" type="string">frontier.olcf.ornl.gov</Field>
     <Field name="hostAliases" type="string">login#.olcf.ornl.gov login##.olcf.ornl.gov login# login##</Field>
     <Field name="hostNickname" type="string">ORNL Frontier</Field>
     <Field name="directory" type="string">/sw/frontier/ums/ums022/linux-sles15-zen3/gcc-11.2.0/visit-3.3.3-zfoh2caq5tbshlvtujditymjizstvewe</Field>


### PR DESCRIPTION
### Description

The frontier host profile had the machine name as crusher instead of frontier. I fixed that. It only affected client server and not running directly on the machine.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran VisIt client/server from quartz to frontier and successfully created a pseudocolor plot of hardyglobal from noise.silo.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
