### PR TITLE
Add support for installing ffmpeg as part of VisIt.

### DIFF
--- a/src/bin/frontendlauncher.py
+++ b/src/bin/frontendlauncher.py
@@ -56,6 +56,9 @@ import subprocess
 #   Cyrus, Wed Dec 18 09:05:28 PST 2019
 #   Python 2 to 3 tweaks
 #
+#   Eric Brugger, Wed Jun 28 11:39:29 PDT 2023
+#   Added support for ffmpeg.
+#
 ###############################################################################
 
 # -----------------------------------------------------------------------------
@@ -142,6 +145,7 @@ visitargs        = []
 programs = (
 "-add_visit_searchpath",
 "-convert",
+"-ffmpeg",
 "-makemili_driver",
 "-mpeg2encode",
 "-mpeg_encode",
@@ -371,7 +375,7 @@ if GETENV("VISIT_STARTED_FROM_APPBUNDLE") == "TRUE":
 #     If the user specified the minor version then add a -forceversion with
 #     the minor version
 # -----------------------------------------------------------------------------
-if progname != "mpeg2encode" and forceversion_set == 0 and add_forceversion == 1:
+if progname != "mpeg2encode" and progname != "ffmpeg" and forceversion_set == 0 and add_forceversion == 1:
     visitargs = ["-forceversion", ver] + visitargs
 
 # -----------------------------------------------------------------------------

--- a/src/doc/getting_started/Installing_VisIt.rst
+++ b/src/doc/getting_started/Installing_VisIt.rst
@@ -148,6 +148,15 @@ Available options are as follows::
                            %HOMEPATH% for single user.
                            MUST BE THE LAST PARAMETER!
 
+Installing ffmpeg
+~~~~~~~~~~~~~~~~~
+
+Ffmpeg is a high quality MPEG 4 encoder.
+The VisIt_ movie wizard will use ffmpeg if it is found in the user's search path.
+Ffmpeg's licensing is incompatible with VisIt_'s so we do not ship and install ffmpeg with VisIt_.
+It is possible to install ffmpeg as part of a VisIt_ installation so that it is available for all user's.
+
+
 Startup Options
 ~~~~~~~~~~~~~~~
 

--- a/src/doc/getting_started/Installing_VisIt.rst
+++ b/src/doc/getting_started/Installing_VisIt.rst
@@ -151,11 +151,31 @@ Available options are as follows::
 Installing ffmpeg
 ~~~~~~~~~~~~~~~~~
 
-Ffmpeg is a high quality MPEG 4 encoder.
-The VisIt_ movie wizard will use ffmpeg if it is found in the user's search path.
-Ffmpeg's licensing is incompatible with VisIt_'s so we do not ship and install ffmpeg with VisIt_.
-It is possible to install ffmpeg as part of a VisIt_ installation so that it is available for all user's.
+``ffmpeg`` is a high quality MPEG 4 encoder.
+The VisIt_ movie wizard uses ``ffmpeg`` if it is found in the user's search path.
+``ffmpeg``'s licensing is incompatible with VisIt_'s so we do not ship and install ``ffmpeg`` with VisIt_.
+You can install ``ffmpeg`` as part of a VisIt_ installation so that it is available for all user's.
 
+To install ``ffmpeg`` as part of a VisIt_ installation you would do the following steps.
+
+1) Get the ``ffmpeg`` executable for each platform of interest.
+2) Copy the ``ffmpeg`` executable for each platform to the architecture specific bin directory.
+3) Set the group and file permissions appropriately for each executable.
+4) Create a soft link from ``ffmepg`` to ``frontendlauncher`` in the bin directory.
+
+Here we go through an example where we install ``ffmpeg`` into  VisIt_ 3.3.3, which has two architectures (``linux-intel`` and ``linux-x86_64``) installed.
+The ``ffmpeg`` executables are named ``ffmpeg.intel`` and ``ffmpeg.x86_64``.
+We will set the group to ``visit`` and the file permissions to ``775``.
+
+.. code:: bash
+
+    cp ffmpeg.intel visit/3.3.3/linux-intel/bin/ffmpeg
+    chgrp visit visit/3.3.3/linux-intel/bin/ffmpeg
+    chmod 775 visit/3.3.3/linux-intel/bin/ffmpeg
+    cp ffmpeg.x86_64 visit/3.3.3/linux-x86_64/bin/ffmpeg
+    chgrp visit visit/3.3.3/linux-x86_64/bin/ffmpeg
+    chmod 775 visit/3.3.3/linux-x86_64/bin/ffmpeg
+    ln -s frontendlaucher visit/bin/ffmpeg
 
 Startup Options
 ~~~~~~~~~~~~~~~

--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Building with Spack section of the user manual was enhanced with instructions for building with the develpment version of spack. Specific instructions for building on Frontier and Perlmutter were also added.</li>
   <li>A host profile has been added for running on ORNL's Frontier system.</li>
   <li>A host profile has been added for running on NERSC's Perlmutter system.</li>
+  <li>Support has been added for installing ffmpeg as part of a VisIt installation.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #18803

I added support to frontendlauncher.py for installing ffmpeg as part of VisIt. I also added documentation to the "Getting Started" section of the manual for installing ffmpeg in a VisIt installation.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I installed the new frontendlauncher.py script in the 3.3.3 installs on the CZ and RZ and installed ffmpeg following the directions in the documentation. I then tested movie generation with 3.3.3 on toss3, toss4 and blueos as well as 3.3.2 on toss4 and it used the ffmpeg installed in VisIt in all cases.

I generated the new documentation and proofread it.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
