### PR TITLE
Fix spatial extents retrieval for vtkPolyData with VTK-9.

### DIFF
--- a/src/avt/Expressions/MeshQuality/avtNeighborExpression.C
+++ b/src/avt/Expressions/MeshQuality/avtNeighborExpression.C
@@ -78,6 +78,9 @@ avtNeighborExpression::~avtNeighborExpression()
 //    Eric Brugger, Wed Aug 20 16:19:07 PDT 2014
 //    Modified the class to work with avtDataRepresentation.
 //
+//    Kathleen Biagas, Fri June 30, 2023
+//    Remove call to GetBounds, results never used.
+//
 // ****************************************************************************
  
 avtDataRepresentation *
@@ -120,9 +123,6 @@ avtNeighborExpression::ExecuteData(avtDataRepresentation *in_dr)
 
     data->SetNumberOfComponents(1);
     data->SetNumberOfTuples(nPoints);
-
-    double bounds[6];
-    in_ds->GetBounds(bounds);
 
     // Create the point locator
     vtkPointLocator *ptLoc = vtkPointLocator::New();


### PR DESCRIPTION
Previous behavior of 'GetBounds' call on poly data was to return the extents of the cells, new behavior is to return the extents of the point set, which may not be fully connected to cells. To preserve previous behavior, call GetCellsBounds with vtk 9.

This showed up in the  reflect operator test, where Boundary plot of Globe was projected and reflected.

Also removed an unnecessary call to GetBounds in the Neighbor expression because the results were never used.

### Type of change

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran the reflect test on Windows and refl13 now returning correct results.

### Checklist:

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
