### PR TITLE
Fix a bug adding ghost zones for variables defined on materials.

### DIFF
--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7786,9 +7786,9 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundariesFromFile(
 //    Modify to handle meshes with no points or cells.
 //
 //    Eric Brugger, Wed Jul  5 10:41:32 PDT 2023
-//    Handle the case where a domain has mixed materials but no variable.
-//    This can occur with a variable that is only defined on a material
-//    and the material isn't present in the domain.
+//    Modified to handle the case where a domain has mixed materials but
+//    no variable. This can occur with a variable that is only defined on
+//    a material and the material isn't present in the domain.
 //
 // ****************************************************************************
 

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7786,9 +7786,9 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundariesFromFile(
 //    Modify to handle meshes with no points or cells.
 //
 //    Eric Brugger, Wed Jul  5 10:41:32 PDT 2023
-//    Modified to handle the case where a domain has mixed materials but
-//    no variable. This can occur with a variable that is only defined on
-//    a material and the material isn't present in the domain.
+//    Modified to handle the case where a variable is defined on a subset
+//    of the materials and a domain has mixed materials without the material
+//    the variable was defined on.
 //
 // ****************************************************************************
 

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7841,7 +7841,7 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         else
             allmats = false;
 
-	// If the dataset is NULL then it is variable that is defined on
+	// If the dataset is NULL then it is a variable that is defined on
 	// a material and this domain doesn't contain the material.
 	// Exchanging mixed variable information doesn't make sense in this
 	// case.
@@ -8239,7 +8239,7 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
                 {
                     avtMaterial *mat = matList[j];
 
-	            // If the dataset is NULL then it is variable that is
+	            // If the dataset is NULL then it is a variable that is
 		    // defined on a material and this domain doesn't contain
 		    // the material. Exchanging mixed variable information
 		    // doesn't make sense in this case.

--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -23,7 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>A better error message was added for Revolved volume query when applied to meshes whose spatial dimension is not 2.</li>
   <li>Avert potential crash in mdserver matching file names for virtual database recognition.</li>
-  <li>Fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occured when a block had mixed materials and the block didn't contain the material the variable was defined on.</li>
+  <li>Fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occurred when a block had mixed materials and the block didn't contain the material the variable was defined on.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -23,7 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>A better error message was added for Revolved volume query when applied to meshes whose spatial dimension is not 2.</li>
   <li>Avert potential crash in mdserver matching file names for virtual database recognition.</li>
-  <li>Bugs Fixed 2</li>
+  <li>Fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occured when a block had mixed materials and the block didn't contain the material the variable was defined on.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

I fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occurred when a block had mixed materials and the block didn't contain the material the variable was defined on.

The fix involved fixing the test and then also fixing the code that exchanges the mixed material data so that it wouldn't crash in this case.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I got a dataset that exhibited the bug and was able to get the incorrect error message before making the change. After the change, it generated the correct plot.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
