### PR TITLE
Fix the reading of Mili particle data.

### DIFF
--- a/src/avt/Pipeline/Data/avtDatasetExaminer.C
+++ b/src/avt/Pipeline/Data/avtDatasetExaminer.C
@@ -342,7 +342,7 @@ avtDatasetExaminer::GetDataExtents(avtDataset_p &ds, double *de,
     //
     if (de[0] = +DBL_MAX && de[1] == -DBL_MAX)
     {
-        debug1 << "Unable to determine data extents -- the was either no data "
+        debug1 << "Unable to determine data extents -- there was either no data "
                << "or all the data was in ghost zones." << endl;
         foundExtents = false;
     }

--- a/src/avt/Pipeline/Data/avtDatasetExaminer.C
+++ b/src/avt/Pipeline/Data/avtDatasetExaminer.C
@@ -299,6 +299,10 @@ avtDatasetExaminer::GetSpatialExtents(std::vector<avtDataTree_p> &l,double *se)
 //    Kathleen Biagas, Wed May 28 17:38:40 MST 2014
 //    Added connectedNodesOnly.
 //
+//    Eric Brugger, Thu Jul  6 13:31:48 PDT 2023
+//    Added debug output and return false if no values could be found to
+//    set the limits.
+//
 // ****************************************************************************
  
 bool
@@ -332,6 +336,17 @@ avtDatasetExaminer::GetDataExtents(avtDataset_p &ds, double *de,
         }
     }
     
+    //
+    // If the data extents are still their initial values, then there were
+    // no elements or the cells were all ghost cells.
+    //
+    if (de[0] = +DBL_MAX && de[1] == -DBL_MAX)
+    {
+        debug1 << "Unable to determine data extents -- the was either no data "
+               << "or all the data was in ghost zones." << endl;
+        foundExtents = false;
+    }
+
     return foundExtents;
 }
 

--- a/src/databases/Mili/avtMiliMetaData.C
+++ b/src/databases/Mili/avtMiliMetaData.C
@@ -1404,7 +1404,7 @@ MiliClassMetaData::GetNumElements(int domain)
 //
 //  Modifications:
 //    Eric Brugger, Thu Jul  6 13:31:48 PDT 2023
-//    Movied the Mili superClassId M_PARTICLE from the PARTICLE to the
+//    Moved the Mili superClassId M_PARTICLE from the PARTICLE to the
 //    CELL classType.
 //
 // ****************************************************************************

--- a/src/databases/Mili/avtMiliMetaData.C
+++ b/src/databases/Mili/avtMiliMetaData.C
@@ -1403,6 +1403,9 @@ MiliClassMetaData::GetNumElements(int domain)
 //  Creation:   Jan 15, 2019
 //
 //  Modifications:
+//    Eric Brugger, Thu Jul  6 13:31:48 PDT 2023
+//    Movied the Mili superClassId M_PARTICLE from the PARTICLE to the
+//    CELL classType.
 //
 // ****************************************************************************
 
@@ -1417,6 +1420,7 @@ MiliClassMetaData::DetermineType()
         case M_NODE:
             classType = NODE;
             break;
+        case M_PARTICLE:
         case M_TRUSS:
         case M_BEAM:
         case M_TRI:
@@ -1436,9 +1440,6 @@ MiliClassMetaData::DetermineType()
             break;
         case M_SURFACE:
             classType = SURFACE;
-            break;
-        case M_PARTICLE:
-            classType = PARTICLE;
             break;
         default:
             classType = UNKNOWN;

--- a/src/plots/Pseudocolor/avtPseudocolorPlot.C
+++ b/src/plots/Pseudocolor/avtPseudocolorPlot.C
@@ -1267,12 +1267,12 @@ avtPseudocolorPlot::SetLegendRanges()
 
     //
     // Check if the limits were ever set. This would only happen if there
-    // was data and the entire mesh was ghost data.
+    // was no data or the entire mesh was ghost data.
     //
     if (min == DBL_MAX && max == -DBL_MAX)
     {
         EXCEPTION1(ImproperUseException,
-            "The entire mesh consisted of ghost zones.");
+            "The entire mesh consists of ghost zones.");
     }
 
     varLegend->UseBelowRangeColor(atts.GetUseBelowMinColor());

--- a/src/plots/Pseudocolor/avtPseudocolorPlot.C
+++ b/src/plots/Pseudocolor/avtPseudocolorPlot.C
@@ -23,6 +23,7 @@
 #include <avtVertexExtractor.h>
 
 #include <DebugStream.h>
+#include <ImproperUseException.h>
 #include <InvalidLimitsException.h>
 
 #include <string>
@@ -1221,6 +1222,9 @@ avtPseudocolorPlot::SetOpacityFromAtts()
 //    Modified the range limits text to use the current variable limits
 //    if OriginalData is not set.
 //
+//    Eric Brugger, Thu Jul  6 13:31:48 PDT 2023
+//    Throw an improper use exception if the variable range was never set.
+//
 // ****************************************************************************
 
 void
@@ -1258,6 +1262,16 @@ avtPseudocolorPlot::SetLegendRanges()
     else
         mapper->GetCurrentVarRange(min, max);
     varLegend->SetVarRange(min, max);
+
+    //
+    // Check if the limits were ever set. This would only happen if there
+    // was data and the entire mesh was ghost data.
+    //
+    if (min == DBL_MAX && max == -DBL_MAX)
+    {
+        EXCEPTION1(ImproperUseException,
+            "The entire mesh consisted of ghost zones.");
+    }
 
     varLegend->UseBelowRangeColor(atts.GetUseBelowMinColor());
     varLegend->UseAboveRangeColor(atts.GetUseAboveMaxColor());

--- a/src/plots/Pseudocolor/avtPseudocolorPlot.C
+++ b/src/plots/Pseudocolor/avtPseudocolorPlot.C
@@ -26,6 +26,8 @@
 #include <ImproperUseException.h>
 #include <InvalidLimitsException.h>
 
+#include <float.h>
+
 #include <string>
 #include <vector>
 

--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -24,6 +24,8 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>A better error message was added for Revolved volume query when applied to meshes whose spatial dimension is not 2.</li>
   <li>Avert potential crash in mdserver matching file names for virtual database recognition.</li>
   <li>Fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occurred when a block had mixed materials and the block didn't contain the material the variable was defined on.</li>
+  <li>Fixed a bug reading particle data from Mili files. The particle data would not appear and could cause the engine to crash if the number of particles was larger than the number of elements.</li>
+  <li>Fixed a bug where the pseudocolor plot would have NaNs in the legend if the mesh contained no elements or all the elements were ghost elements. Now it preints an error message with a description of the error.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #18819

I fixed the reading of particle data in the Mili reader. The fix was actually provided by @durrenberger1. It consisted of classifying particles as elements instead of particles. Everything just worked properly after that.

During my testing I ran across the case where at cycle 0, all the particles were sanded out (ghost zones). When I plotted a variable defined only on particles I got the mesh with the brick elements and no particles, which was correct. This legend had NaNs in it and `MAX_DBL` as the minimum value and `-MAX_DBL` as the maximum value. I then modified the pseudocolor plot to throw an exception in this case, so that no plot would be displayed.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I plotted the mesh from the Mili file before my change and the engine crashed. After the change, when I plotted the mesh and the sand_mesh they both displayed properly. I also displayed a variable that was only defined on the particles ("Primal/sph/sph_mat_intact") and I got an error message at cycle 0 and the correct plot at cycle 1.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
