### PR TITLE
Fix a typo in an if statement where I had = instead of ==.

### DIFF
--- a/src/avt/Pipeline/Data/avtDatasetExaminer.C
+++ b/src/avt/Pipeline/Data/avtDatasetExaminer.C
@@ -340,7 +340,7 @@ avtDatasetExaminer::GetDataExtents(avtDataset_p &ds, double *de,
     // If the data extents are still their initial values, then there were
     // no elements or the cells were all ghost cells.
     //
-    if (de[0] = +DBL_MAX && de[1] == -DBL_MAX)
+    if (de[0] == +DBL_MAX && de[1] == -DBL_MAX)
     {
         debug1 << "Unable to determine data extents -- there was either no data "
                << "or all the data was in ghost zones." << endl;


### PR DESCRIPTION
### Description

In my commit of a fix for the mili reader I added some additional tests to some limit calculating code and accidently had "=" instead of "==".

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

The original commit caused some test suite failures. I tried one of the failures and it now worked properly.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
