### PR TITLE
Update CMake logic for finding pthreads.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -517,6 +517,9 @@
 #    Eric Brugger, Fri Feb 24 14:57:15 PST 2023
 #    I replaced vtkh with vtkm.
 #
+#    Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#    Switched pthreads check to modern usage using find_package.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
@@ -1896,11 +1899,10 @@ CHECK_TYPE_SIZE("off64_t" SIZEOF_OFF64_T)
 TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
 
 # Check for threads
-IF(WIN32)
-    SET(HAVE_THREADS  1)
-ELSE(WIN32)
-    SET(HAVE_THREADS  ${CMAKE_USE_PTHREADS})
-ENDIF(WIN32)
+find_package(Threads)
+message(STATUS "Threads_FOUND=${Threads_FOUND}")
+#message(STATUS "Threads::Threads=${Threads::Threads}")
+set(HAVE_THREADS  ${Threads_FOUND})
 
 # manually check for socklen_t as CHECK_SYMBOL_EXISTS
 # doesn't appear to work on linux (at least)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1901,7 +1901,6 @@ TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
 # Check for threads
 find_package(Threads)
 message(STATUS "Threads_FOUND=${Threads_FOUND}")
-#message(STATUS "Threads::Threads=${Threads::Threads}")
 set(HAVE_THREADS  ${Threads_FOUND})
 
 # manually check for socklen_t as CHECK_SYMBOL_EXISTS

--- a/src/avt/Filters/CMakeLists.txt
+++ b/src/avt/Filters/CMakeLists.txt
@@ -61,6 +61,9 @@
 #   Kathleen Biagas, Wed Mar 15, 2023 
 #   Only link with pthread if not on Windows.
 #
+#   Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#   Change pthread to Threads::Threads.
+#
 #****************************************************************************/
 
 SET(AVTFILTERS_SOURCES
@@ -202,7 +205,7 @@ ENDIF()
 if(HAVE_LIBVTKM)
     target_link_libraries(avtfilters_ser vtkm_cont vtkm_filter_contour vtkm_filter_entity_extraction vtkm_filter_field_conversion)
     if(NOT WIN32)
-        target_link_libraries(avtfilters_ser pthread)
+        target_link_libraries(avtfilters_ser Threads::Threads)
     endif()
     if(VTKm_ENABLE_KOKKOS)
         target_link_libraries(avtfilters_ser amdhip64)
@@ -223,7 +226,7 @@ IF(VISIT_PARALLEL)
     if(HAVE_LIBVTKM)
         target_link_libraries(avtfilters_par vtkm_cont vtkm_filter_contour vtkm_filter_entity_extraction vtkm_filter_field_conversion)
         if(NOT WIN32)
-            target_link_libraries(avtfilters_par pthread)
+            target_link_libraries(avtfilters_par Threads::Threads)
         endif()
         if(VTKm_ENABLE_KOKKOS)
             target_link_libraries(avtfilters_par amdhip64)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -59,6 +59,9 @@
 #   Eric Brugger, Thu Aug  5 11:21:21 PDT 2021
 #   Removed support for SeedMe.
 #
+#   Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#   Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 
@@ -483,7 +486,7 @@ if(WIN32)
     # for std::filesystem::path used in FileFunctions
     target_compile_features(visitcommon PRIVATE cxx_std_17)
 else()
-    target_link_libraries(visitcommon ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS} ${DL_LIB})
+    target_link_libraries(visitcommon ${ZLIB_LIBRARY} Threads::Threads ${DL_LIB})
 endif()
 
 if(VISIT_ENABLE_UNIT_TESTS)
@@ -492,27 +495,27 @@ if(VISIT_ENABLE_UNIT_TESTS)
 
     add_executable(Namescheme_test utility/Namescheme_test.C)
     target_link_libraries(Namescheme_test ${VISIT_EXE_LINKER_FLAGS} 
-         visitcommon ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS} ${DL_LIB})
+         visitcommon ${ZLIB_LIBRARY} Threads::Threads ${DL_LIB})
     set_target_properties(Namescheme_test PROPERTIES FOLDER unit_tests)
 
     add_executable(Utility_test utility/Utility_test.C)
     target_link_libraries(Utility_test ${VISIT_EXE_LINKER_FLAGS} visitcommon 
-        ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS} ${DL_LIB})
+	    ${ZLIB_LIBRARY} Threads::Threads ${DL_LIB})
     set_target_properties(Utility_test PROPERTIES FOLDER unit_tests)
 
     add_executable(StringHelpers_test utility/StringHelpers_test.C)
     target_link_libraries(StringHelpers_test ${VISIT_EXE_LINKER_FLAGS}
-            visitcommon ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS} ${DL_LIB})
+            visitcommon ${ZLIB_LIBRARY} Threads::Threads ${DL_LIB})
     set_target_properties(StringHelpers_test PROPERTIES FOLDER unit_tests)
 
     if(NOT WIN32)
         add_executable(exprconfig expr/ExprConfig.C)
         target_link_libraries(exprconfig ${VISIT_EXE_LINKER_FLAGS} 
-            visitcommon ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS} ${DL_LIB})
+            visitcommon ${ZLIB_LIBRARY} Threads::Threads ${DL_LIB})
 
         add_executable(exprtest expr/test.C)
         target_link_libraries(exprtest ${VISIT_EXE_LINKER_FLAGS} 
-            visitcommon ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS} ${DL_LIB})
+            visitcommon ${ZLIB_LIBRARY} Threads::Threads ${DL_LIB})
 
         add_custom_target(init)
         add_dependencies(init exprconfig)

--- a/src/engine/main/CMakeLists.txt
+++ b/src/engine/main/CMakeLists.txt
@@ -46,6 +46,9 @@
 #    Eric Brugger, Fri Feb 24 14:57:15 PST 2023
 #    Replace vtkjpeg with vtkjpeg_LIBRARIES and vtkpng with vtkpng_LIBRARIES.
 #
+#    Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#    Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 set(LIBENGINE_SOURCES
@@ -193,7 +196,7 @@ target_link_libraries(engine_ser_exe
     ${vtkpng_LIBRARIES}
     ${VTK_FREETYPE_LIBRARIES}
     ${ALL_THIRDPARTY_IO_LIB}
-    ${CMAKE_THREAD_LIBS}
+    Threads::Threads
     ${ZLIB_LIBRARY}
 )
 
@@ -307,7 +310,7 @@ if(VISIT_PARALLEL)
         ${VTK_FREETYPE_LIBRARIES}
         ${ALL_THIRDPARTY_IO_LIB}
         ${ICET_STATIC_LIB}
-        ${CMAKE_THREAD_LIBS}
+        Threads::Threads
         ${ZLIB_LIBRARY}
     )
 

--- a/src/launcher/main/CMakeLists.txt
+++ b/src/launcher/main/CMakeLists.txt
@@ -16,6 +16,9 @@
 #   Brad Whitlock, Fri May 18 16:09:34 PST 2012
 #   Use different resource file.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 SET(VCL_SOURCES
@@ -42,7 +45,7 @@ TARGET_LINK_LIBRARIES(vcl
     ${VISIT_EXE_LINKER_FLAGS}
     vclrpc
     visitcommon
-    ${CMAKE_THREAD_LIBS}
+    Threads::Threads
     ${DL_LIB}
 )
 
@@ -51,7 +54,7 @@ IF(VISIT_CREATE_SOCKET_RELAY_EXECUTABLE AND NOT WIN32)
     TARGET_LINK_LIBRARIES(visit_socket_relay
         ${VISIT_EXE_LINKER_FLAGS}
         visitcommon
-        ${CMAKE_THREAD_LIBS}
+        Threads::Threads
         ${DL_LIB}
     )
     VISIT_INSTALL_TARGETS(visit_socket_relay)
@@ -59,6 +62,6 @@ ENDIF()
 
 IF (NOT WIN32)
     ADD_EXECUTABLE(testvcl EXCLUDE_FROM_ALL testvcl.C)
-    TARGET_LINK_LIBRARIES(testvcl vclproxy vclrpc visitcommon ${CMAKE_THREAD_LIBS} ${DL_LIB})
+    TARGET_LINK_LIBRARIES(testvcl vclproxy vclrpc visitcommon Threads::Threads ${DL_LIB})
 ENDIF (NOT WIN32)
 VISIT_INSTALL_TARGETS(vcl)

--- a/src/mdserver/main/CMakeLists.txt
+++ b/src/mdserver/main/CMakeLists.txt
@@ -35,6 +35,9 @@
 #   Replaced vtktiff with vtktiff_LIBRARIES, vtkpng with vtkpng_LIBRARIES,
 #   and vtkjpeg with vtkjpeg_LIBRARIES.
 #
+#   Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#   Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 SET(MDSERVER_SOURCES
@@ -119,7 +122,7 @@ TARGET_LINK_LIBRARIES(mdserver
     ${vtkpng_LIBRARIES}
     ${vtkjpeg_LIBRARIES}
     ${ZLIB_LIBRARY}
-    ${CMAKE_THREAD_LIBS}
+    Threads::Threads
     ${DL_LIB}
 )
 

--- a/src/tools/data/convert/CMakeLists.txt
+++ b/src/tools/data/convert/CMakeLists.txt
@@ -25,6 +25,9 @@
 #   Eric Brugger, Fri Feb 24 14:57:15 PST 2023
 #   Replaced vtkjpeg with vtkjpeg_LIBRARIES and vtkpng with vtkpng_LIBRARIES.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 INCLUDE_DIRECTORIES(
@@ -101,7 +104,7 @@ IF(VISIT_DBIO_ONLY)
         visit_vtk
         ${ALL_THIRDPARTY_IO_LIB}
         ${VTK_EXTRA_LIBS}
-        ${CMAKE_THREAD_LIBS}
+        Threads::Threads
         ${ZLIB_LIBRARY}
     )
 ELSE()
@@ -126,7 +129,7 @@ ELSE()
         ${ALL_THIRDPARTY_IO_LIB}
         ${VTK_EXTRA_LIBS}
         ${OPENGL_LIBRARIES}
-        ${CMAKE_THREAD_LIBS}
+        Threads::Threads
         ${ZLIB_LIBRARY}
     )
     if(HAVE_OSMESA)
@@ -165,7 +168,7 @@ IF(VISIT_PARALLEL)
             visit_vtk
             ${ALL_THIRDPARTY_IO_LIB}
             ${VTK_EXTRA_LIBS}
-            ${CMAKE_THREAD_LIBS}
+            Threads::Threads
             ${ZLIB_LIBRARY}
         )
     ELSE()
@@ -189,7 +192,7 @@ IF(VISIT_PARALLEL)
             ${ALL_THIRDPARTY_IO_LIB}
             ${VTK_EXTRA_LIBS}
             ${OPENGL_LIBRARIES}
-            ${CMAKE_THREAD_LIBS}
+            Threads::Threads
             ${ZLIB_LIBRARY}
         )
         if(HAVE_OSMESA)

--- a/src/tools/dev/diagnostics/osmesatest/CMakeLists.txt
+++ b/src/tools/dev/diagnostics/osmesatest/CMakeLists.txt
@@ -7,6 +7,9 @@
 #   Kathleen Biagas, Wed Oct 22 14:20:27 MST 2014
 #   Send 'diagnostics/osmesatest' type argument to VISIT_TOOLS_ADD_FOLDER.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change PTHREAD to Threads::Threads.
+#
 #****************************************************************************
 
 SET(TARGETS osmesatest_ser osmesavtktest_ser)
@@ -40,21 +43,20 @@ vtkInteractionStyle
 
 IF(NOT WIN32)
     SET(LIBDL dl)
-    SET(PTHREAD pthread)
 ENDIF(NOT WIN32)
 
 ADD_EXECUTABLE(osmesatest_ser osmesatest.cpp)
-TARGET_LINK_LIBRARIES(osmesatest_ser ${VISIT_EXE_LINKER_FLAGS} ${OSMESA_LIBRARIES} ${LIBDL} ${PTHREAD})
+TARGET_LINK_LIBRARIES(osmesatest_ser ${VISIT_EXE_LINKER_FLAGS} ${OSMESA_LIBRARIES} ${LIBDL} Threads::Threads)
 
 ADD_EXECUTABLE(osmesavtktest_ser osmesavtktest.cpp)
-TARGET_LINK_LIBRARIES(osmesavtktest_ser ${VISIT_EXE_LINKER_FLAGS} visit_vtk_offscreen visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} ${PTHREAD})
+TARGET_LINK_LIBRARIES(osmesavtktest_ser ${VISIT_EXE_LINKER_FLAGS} visit_vtk_offscreen visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} Threads::Threads)
 
 IF(VISIT_PARALLEL)
     ADD_PARALLEL_EXECUTABLE(osmesatest_par osmesatest.cpp)
-    PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesatest_par ${OSMESA_LIBRARIES} ${LIBDL} ${PTHREAD})
+    PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesatest_par ${OSMESA_LIBRARIES} ${LIBDL} Threads::Threads)
 
     ADD_PARALLEL_EXECUTABLE(osmesavtktest_par osmesavtktest.cpp)
-    PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesavtktest_par visit_vtk_offscreen visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} ${PTHREAD})
+    PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesavtktest_par visit_vtk_offscreen visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} Threads::Threads)
 
     SET(TARGETS ${TARGETS} osmesatest_par osmesavtktest_par)
 ENDIF(VISIT_PARALLEL)

--- a/src/tools/dev/protocol/CMakeLists.txt
+++ b/src/tools/dev/protocol/CMakeLists.txt
@@ -11,6 +11,9 @@
 #   Replaced vtktiff with vtktiff_LIBRARIES, vtkjpeg with vtkjpeg_LIBRARIES,
 #   and vtkpng with vtkpng_LIBRARIES.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 INCLUDE_DIRECTORIES(
@@ -74,7 +77,7 @@ ${VTK_EXTRA_LIBS}
 ${ALL_THIRDPARTY_IO_LIB}
 ${MESA_LIB}
 ${OPENGL_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 )
 IF(NOT WIN32)
     TARGET_LINK_LIBRARIES(visitprotocol dl)

--- a/src/tools/examples/avtexamples/CMakeLists.txt
+++ b/src/tools/examples/avtexamples/CMakeLists.txt
@@ -16,6 +16,9 @@
 #   Eric Brugger, Thu Jul 15 13:34:12 PDT 2021
 #   Added qtviswinExample.C
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 INCLUDE_DIRECTORIES(
@@ -85,7 +88,7 @@ visitcommon
 visit_vtk
 ${ALL_THIRDPARTY_IO_LIB}
 ${OPENGL_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 ${ZLIB_LIBRARY}
 )
 
@@ -115,7 +118,7 @@ visitcommon
 visit_vtk
 ${ALL_THIRDPARTY_IO_LIB}
 ${OPENGL_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 ${ZLIB_LIBRARY}
 )
 
@@ -142,7 +145,7 @@ visitcommon
 visit_vtk
 ${ALL_THIRDPARTY_IO_LIB}
 ${OPENGL_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 ${ZLIB_LIBRARY}
 )
 
@@ -172,7 +175,7 @@ visitcommon
 visit_vtk
 ${ALL_THIRDPARTY_IO_LIB}
 ${OPENGL_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 ${ZLIB_LIBRARY}
 )
 
@@ -203,7 +206,7 @@ visitcommon
 visit_vtk
 ${ALL_THIRDPARTY_IO_LIB}
 ${OPENGL_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 ${ZLIB_LIBRARY}
 )
 

--- a/src/tools/examples/dataserver/CMakeLists.txt
+++ b/src/tools/examples/dataserver/CMakeLists.txt
@@ -11,6 +11,9 @@
 #   Replaced vtktiff with vtktiff_LIBRARIES, vtkjpeg with vtkjpeg_LIBRARIES,
 #   and vtkpng with vtkpng_LIBRARIES.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 INCLUDE_DIRECTORIES(
@@ -65,7 +68,7 @@ mdserverproxy
 visitcommon
 ${PYTHON_LIBRARY}
 ${VTK_EXTRA_LIBS}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 ${ZLIB_LIBRARY}
 )
 IF(NOT WIN32)

--- a/src/viewer/core/CMakeLists.txt
+++ b/src/viewer/core/CMakeLists.txt
@@ -8,6 +8,9 @@
 #    Cyrus Harrison, Tue Dec 10 08:51:21 PST 2019
 #    Add xml tools code gen targets
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 #
@@ -134,7 +137,7 @@ avtplotter_ser
 avtfilters_ser
 avtviswindow_ser
 avtwriter_ser
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 )
 
 if(HAVE_OSMESA OR HAVE_EGL)

--- a/src/viewer/main/CMakeLists.txt
+++ b/src/viewer/main/CMakeLists.txt
@@ -23,6 +23,9 @@
 #  Eric Brugger, Fri Feb 24 14:57:15 PST 2023
 #  Replaced vtkpng with vtkpng_LIBRARIES and vtkjpeg with vtkjpeg_LIBRARIES.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 IF(VISIT_PARALLEL AND WIN32 AND HAVE_HPC_SCHEDULER)
@@ -229,7 +232,7 @@ avtwriter_ser
 avtqtviswindow
 winutil
 ${VIEWER_QT_LIBS}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 vtkGUISupportQt
 )
 

--- a/src/visitpy/CMakeLists.txt
+++ b/src/visitpy/CMakeLists.txt
@@ -56,6 +56,9 @@
 #  Kathleen Biagas, Fri Sep 9, 2022
 #  Link with CMAKE_THREAD_LIBS.
 #
+#  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
+#  Change CMAKE_THREAD_LIBS to Threads::Threads.
+#
 #****************************************************************************
 
 #########################################################
@@ -391,7 +394,7 @@ avtdbatts
 viewerrpc
 visitcommon
 ${PYTHON_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 )
 
 # Create the CLI
@@ -412,7 +415,7 @@ avtdbatts
 visitcommon
 visitpy
 ${PYTHON_LIBRARIES}
-${CMAKE_THREAD_LIBS}
+Threads::Threads
 )
 IF(NOT WIN32)
     TARGET_LINK_LIBRARIES(cli dl)


### PR DESCRIPTION
### Description

Partially resolves #18844

Changed the CMake logic that detects pthreads. The current logic didn't work on Frontier.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built VisIt on Quartz and checked that the engine launch window came up. I build VisIt on Frontier and checked that the engine launch window came up.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [X] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
