### PR TITLE
Remove the index argument from avtDatasetQuery::SetResultValue.

### DIFF
--- a/src/avt/Queries/Abstract/avtDatasetQuery.C
+++ b/src/avt/Queries/Abstract/avtDatasetQuery.C
@@ -366,15 +366,18 @@ avtDatasetQuery::ApplyFilters(avtDataObject_p dob)
 //  Programmer: Kathleen Bonnell
 //  Creation:   November 12, 2003
 //
+//  Modifications:
+//    Eric Brugger, Mon Aug  7 14:34:00 PDT 2023
+//    Removed the index argument.
+//
 // ****************************************************************************
 
 void
-avtDatasetQuery::SetResultValue(const double &d, const int i)
+avtDatasetQuery::SetResultValue(const double &d)
 {
-    if (i < 0 || i >= (int)resValue.size())
-        EXCEPTION2(BadIndexException, i, (int)resValue.size()-1)
-
-    resValue[i] = d;
+    if (!resValue.empty())
+        resValue.clear();
+    resValue.push_back(d);
 }
 
 

--- a/src/avt/Queries/Abstract/avtDatasetQuery.h
+++ b/src/avt/Queries/Abstract/avtDatasetQuery.h
@@ -71,6 +71,9 @@ class vtkDataSet;
 //    Kathleen Bonnell, Tue Mar  1 15:59:48 PST 2011
 //    Removed AddResultValue, not used.
 //
+//    Eric Brugger, Mon Aug  7 14:34:00 PDT 2023
+//    Removed the index argument from SetResultValue.
+//
 // ****************************************************************************
 
 class QUERY_API avtDatasetQuery : public avtDataObjectQuery,
@@ -87,7 +90,7 @@ class QUERY_API avtDatasetQuery : public avtDataObjectQuery,
                                  { resMsg = m; };
 
     virtual double           GetResultValue(const int i = 0);
-    virtual void             SetResultValue(const double &d, const int i = 0);
+    virtual void             SetResultValue(const double &d);
 
     virtual doubleVector     GetResultValues(void) { return resValue; };
     virtual void             SetResultValues(const doubleVector &d)


### PR DESCRIPTION
### Description

I removed the index argument from `avtDatasetQuery::SetResultValue` and always had it set the first value in the result values. There were no instances in the code where it was used and if it was used with any value other than 0, it would most likely fail since the result values vector had a length of 1 by default before my change last week.

The code now clears and pushes the value into the double vector instead of setting it into the position specified by the index. This used to work with an index of 0 since the result values vector always had a length of 1, but now a length of 0 is valid and indicates no return values.

This fixes all the test suite failures in the test suite.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built the code on quartz and then ran all the tests that were failing in the test suite.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
