### PR TITLE
X Ray Image Query: Debug Warnings

### DIFF
--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1319,6 +1319,9 @@ avtXRayImageQuery::GetSecondaryVars(std::vector<std::string> &outVars)
 //    Justin Privitera, Fri Jul 14 17:33:07 PDT 2023
 //    New logic to determine if old camera properties are being used.
 // 
+//    Justin Privitera, Mon Aug  7 15:49:36 PDT 2023
+//    Add more context to debug message for blueprint failing to verify.
+// 
 // ****************************************************************************
 
 void
@@ -2586,6 +2589,10 @@ avtXRayImageQuery::WriteBlueprintMetadata(conduit::Node &metadata,
 //    Justin Privitera, Wed Mar 15 17:51:13 PDT 2023
 //    Leverage conduit's features to make the code more legible.
 //    Added spectra coordset.
+// 
+//    Justin Privitera, Mon Aug  7 15:49:36 PDT 2023
+//    Warn to debug when missing energy group bounds for blueprint output and
+//    when provided energy group bounds are not the right size.
 //
 // ****************************************************************************
 #ifdef HAVE_CONDUIT

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1611,7 +1611,7 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             conduit::Node verify_info;
             if(!conduit::blueprint::mesh::verify(data_out, verify_info))
             {
-                debug1 << "Blueprint Output failed to verify:\n"
+                debug1 << "X Ray Image Query WARNING: Blueprint Output: failed to verify:\n"
                        << verify_info.to_yaml();
                 SetResultMessage("ERROR: Blueprint mesh verification failed!");
                 EXCEPTION1(VisItException, "Blueprint mesh verification failed!");
@@ -2652,6 +2652,7 @@ avtXRayImageQuery::WriteBlueprintMeshCoordsets(conduit::Node &coordsets,
             out << "Energy group bounds size mismatch: provided " 
                 << nEnergyGroupBounds << " bounds, but " 
                 << z_coords_dim << " in query results.";
+            debug1 << "X Ray Image Query WARNING: Blueprint Output: " << out.str() << "\n";
             spatial_coords["info"] = out.str();
             spatial_coords["values/z"].set(conduit::DataType::float64(z_coords_dim));
             double *zvals = spatial_coords["values/z"].value();
@@ -2660,6 +2661,7 @@ avtXRayImageQuery::WriteBlueprintMeshCoordsets(conduit::Node &coordsets,
     }
     else
     {
+        debug1 << "X Ray Image Query WARNING: Blueprint Output: Energy group bounds not provided." << "\n";
         spatial_coords["info"] = "Energy group bounds not provided.";
         spatial_coords["values/z"].set(conduit::DataType::float64(z_coords_dim));
         double *zvals = spatial_coords["values/z"].value();

--- a/src/avt/Queries/Queries/avtXRayImageQuery.C
+++ b/src/avt/Queries/Queries/avtXRayImageQuery.C
@@ -1611,7 +1611,7 @@ avtXRayImageQuery::Execute(avtDataTree_p tree)
             conduit::Node verify_info;
             if(!conduit::blueprint::mesh::verify(data_out, verify_info))
             {
-                debug1 << "X Ray Image Query WARNING: Blueprint Output: failed to verify:\n"
+                debug1 << "X Ray Image Query ERROR: Blueprint Output: failed to verify:\n"
                        << verify_info.to_yaml();
                 SetResultMessage("ERROR: Blueprint mesh verification failed!");
                 EXCEPTION1(VisItException, "Blueprint mesh verification failed!");


### PR DESCRIPTION
### Description

Addresses a bullet in #17791 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
warning sent to debug1 when you do not give the right number of energy values, no energy values, or blueprint fails to verify.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->
more debugging support

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
tested to see if debug warnings appear when triggered

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
