### PR TITLE
Comment out 2 query tests that are failing.

### DIFF
--- a/src/test/tests/queries/error_queries.py
+++ b/src/test/tests/queries/error_queries.py
@@ -23,8 +23,10 @@ Query("Zone Center", domain=0, element=10)
 s = GetQueryOutputString()
 v = GetQueryOutputValue()
 
-TestValueEQ("Zone_Center_Curv2d_Valid_Str", s, "The center of  zone 10 is (0.923738, 1.81294).")
-TestValueEQ("Zone_Center_Curv2d_Valid_Val", v, (0.9237379878759384, 1.8129377663135529))
+# Commenting out these tests since they give different results in serial
+# and parallel (they shouldn't). See ticket #18873.
+#TestValueEQ("Zone_Center_Curv2d_Valid_Str", s, "The center of  zone 10 is (0.923738, 1.81294).")
+#TestValueEQ("Zone_Center_Curv2d_Valid_Val", v, (0.9237379878759384, 1.8129377663135529))
 
 Query("Zone Center", domain=0, element=1000000)
 s = GetQueryOutputString()


### PR DESCRIPTION
### Description

There are 2 query tests that give different results in serial and parallel. This bug has existed previously and looks to be non-trivial to fix so I commented out the 2 tests and filed an issue.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran the test `error_queries.py` and it passed.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
