### PR TITLE
Fix LaunchNowin() for windows

### DIFF
--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occurred when a block had mixed materials and the block didn't contain the material the variable was defined on.</li>
   <li>Fixed a bug reading particle data from Mili files. The particle data would not appear and could cause the engine to crash if the number of particles was larger than the number of elements.</li>
   <li>Fixed a bug where the pseudocolor plot would have NaNs in the legend if the mesh contained no elements or all the elements were ghost elements. Now it preints an error message with a description of the error.</li>
+  <li>Fixed a bug with 'LaunchNowin' on Windows.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.3.4.html
+++ b/src/resources/help/en_US/relnotes3.3.4.html
@@ -26,7 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where an error would incorrectly be detected when creating ghost zones. Specifically, it occurred when a block had mixed materials and the block didn't contain the material the variable was defined on.</li>
   <li>Fixed a bug reading particle data from Mili files. The particle data would not appear and could cause the engine to crash if the number of particles was larger than the number of elements.</li>
   <li>Fixed a bug where the pseudocolor plot would have NaNs in the legend if the mesh contained no elements or all the elements were ghost elements. Now it preints an error message with a description of the error.</li>
-  <li>Fixed a bug with 'LaunchNowin' on Windows.</li>
+  <li>Fixed a bug where 'LaunchNowin' would fail on Windows when additional launch arguments were specified with `AddArgument`.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/visitpy/visitmodule/py_src/frontend.py
+++ b/src/visitpy/visitmodule/py_src/frontend.py
@@ -250,7 +250,7 @@ class VisItModuleState(object):
     def __read_visit_env(cls,vcmd):
         if sys.platform.startswith("win"):
             pcmd = [vcmd, "-env", "-nodialog"]
-            # launch_args no londer used in constructing the vcmd arg, so add them here
+            # launch_args no longer used in constructing the vcmd arg, so add them here
             pcmd += cls.launch_args
         else:
             pcmd = vcmd + " -env"

--- a/src/visitpy/visitmodule/py_src/frontend.py
+++ b/src/visitpy/visitmodule/py_src/frontend.py
@@ -44,6 +44,11 @@
 #      wasn't set.
 #    Add '-nodialog' to 'visit.exe -env' command so that environment string
 #      can be retrieved. Otherwise we get a dialog box and nothing to stdout.
+#
+#  Kathleen Biagas, Tue Aug 15, 2023
+#  For Windows, don't add launch args to vcmd passed to __read_visit_env,
+#  instead add them to the pcmd constructed in that function.
+#
 ###############################################################################
 
 import sys
@@ -107,7 +112,10 @@ class VisItModuleState(object):
     def launch(cls,vdir=None,proxy=None):
         launched = False
         try:
-            vcmd = cls.__visit_cmd(vdir,cls.launch_args)
+            if sys.platform.startswith("win"):
+                vcmd = cls.__visit_cmd(vdir,[])
+            else:
+                vcmd = cls.__visit_cmd(vdir,cls.launch_args)
             env  = cls.__read_visit_env(vcmd)
             mod  = cls.__visit_module_path(env["LIBPATH"])
             #print("Using visitmodule: %s" % mod)
@@ -239,6 +247,7 @@ class VisItModuleState(object):
     def __read_visit_env(cls,vcmd):
         if sys.platform.startswith("win"):
             pcmd = [vcmd, "-env", "-nodialog"]
+            pcmd += cls.launch_args
         else:
             pcmd = vcmd + " -env"
         # universal_newlines needed to make sure

--- a/src/visitpy/visitmodule/py_src/frontend.py
+++ b/src/visitpy/visitmodule/py_src/frontend.py
@@ -113,6 +113,9 @@ class VisItModuleState(object):
         launched = False
         try:
             if sys.platform.startswith("win"):
+                # adding launch_args to vcmd here causes problems
+                # with the command constructed for subprocess.Popen
+                # in __read_visit_env so let that method handle them
                 vcmd = cls.__visit_cmd(vdir,[])
             else:
                 vcmd = cls.__visit_cmd(vdir,cls.launch_args)
@@ -247,6 +250,7 @@ class VisItModuleState(object):
     def __read_visit_env(cls,vcmd):
         if sys.platform.startswith("win"):
             pcmd = [vcmd, "-env", "-nodialog"]
+            # launch_args no londer used in constructing the vcmd arg, so add them here
             pcmd += cls.launch_args
         else:
             pcmd = vcmd + " -env"


### PR DESCRIPTION
### Description

Resolves #18885

On Windows, instead of using launch_args to construct the visit command passed to the read environment method, have the read environment method add the launch args to it's own constructed command separately.

Thanks to @cmoen65 for reporting and also pointing to the source of the error.


<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Used the modified frontend.py in an installed VisIt  3.3.3 to successfully use the LaunchNowin() method.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
