### PR TITLE
Set VarLegend message to NULL when limits aren't constant.

### DIFF
--- a/src/avt/Plotter/avtVariableLegend.C
+++ b/src/avt/Plotter/avtVariableLegend.C
@@ -633,6 +633,9 @@ avtVariableLegend::SetColorBarVisibility(const bool val)
 //    Alister Maguire, Wed Jan 16 13:54:14 PST 2019
 //    Tell the lookup table to grey out nan values. 
 //
+//    Kathleen Biagas, Tue Sep 19, 2023
+//    Call 'SetMessage(NULL)' when not constant.
+//
 // ****************************************************************************
 
 void
@@ -646,12 +649,13 @@ avtVariableLegend::SetRange(double nmin, double nmax)
         //
         //  Set a message and don't build labels.
         //
-        SetMessage("Constant.");
+        SetMessage("Constant");
         sBar->SetNumberOfLabels(0);
         sBar->SetRange(min, max);
     }
     else if (min == FLT_MAX || max == -FLT_MAX )
     {
+        SetMessage(NULL);
         debug5 << "avtVariableLegend did not get valid range." << endl;
         //
         //  We didn't get good values for the range. 
@@ -660,6 +664,7 @@ avtVariableLegend::SetRange(double nmin, double nmax)
     }
     else 
     {
+        SetMessage(NULL);
         sBar->SetNumberOfLabels(numTicks);
         if (lut != NULL)
         {
@@ -906,6 +911,8 @@ avtVariableLegend::ChangeFontHeight(double fh)
 void                          
 avtVariableLegend::SetNumTicks(int nt)
 {
+cerr << "avtVariableLegend::SetNumTicks" << endl;
+cerr << "    min,max: " << min << ", " << max << endl;
     numTicks = nt;
     if (min != max)
         sBar->SetNumberOfLabels(numTicks);

--- a/src/resources/help/en_US/relnotes3.4.0.html
+++ b/src/resources/help/en_US/relnotes3.4.0.html
@@ -109,6 +109,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the python cli's TurnOffMaterials() method where it would give a poor error message when passing an integer instead of a string.</li>
   <li>The <code>GetLastError()</code> CLI method now accepts an optional integer argument indicating whether to clear out the last error message after retrieving it.</li>
   <li>For the Mili plugin, if a class is missing from a top level mili file, the plugin will now throw an exception explaining what happened instead of failing mysteriously.</li>
+  <li>Fixed a bug where Pseudocolor's legend would state 'Constant' when the data limits weren't constant.</li>
 </ul>
 
 <a name="Configuration_changes"></a>


### PR DESCRIPTION
### Description

Resolves #18902 

Ensure variable legend's message reset to NULL when limits are non-constant.
Removed '.' from 'Constant.'

### Type of change

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ensured 'Constant' wasn't in the legend when following the steps outlined in the ticket.

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
