### PR TITLE
Fix problems with plugin vs installed visit.

### DIFF
--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -78,6 +78,9 @@
 #   Fix a few uses of paths on Windows, now that VISIT_INSTALLED_VERSION_XXX
 #   are relative paths. 
 #
+#   Kathleen Biagas, Thu Sep 28 16:33:45 PDT 2023
+#   Set PYLIB to the python library name, used by PluginVsInstall.cmake.in.
+#
 #****************************************************************************/
 
 # - Find python libraries
@@ -202,6 +205,8 @@ if(PYTHONINTERP_FOUND)
         message(STATUS "PYTHON_CONFIG_LIBRARY:    ${PYTHON_CONFIG_LIBRARY}")
 
         set(PYTHON_LIBRARY "")
+        set(PYLIB "") # for PluginVsInstall.cmake.in
+
         # look for shared libs first
         # shared libdir + ldlibrary
         if(NOT EXISTS ${PYTHON_LIBRARY})
@@ -210,6 +215,7 @@ if(PYTHONINTERP_FOUND)
                 message(STATUS "Checking for python library at: ${_PYTHON_LIBRARY_TEST}")
                 if(EXISTS ${_PYTHON_LIBRARY_TEST})
                     set(PYTHON_LIBRARY ${_PYTHON_LIBRARY_TEST})
+                    set(PYLIB ${PYTHON_CONFIG_LDLIBRARY})
                 endif()
             endif()
         endif()
@@ -221,6 +227,7 @@ if(PYTHONINTERP_FOUND)
                 message(STATUS "Checking for python library at: ${_PYTHON_LIBRARY_TEST}")
                 if(EXISTS ${_PYTHON_LIBRARY_TEST})
                     set(PYTHON_LIBRARY ${_PYTHON_LIBRARY_TEST})
+                    set(PYLIB ${PYTHON_CONFIG_LDLIBRARY})
                 endif()
             endif()
         endif()
@@ -232,6 +239,7 @@ if(PYTHONINTERP_FOUND)
                 message(STATUS "Checking for python library at: ${_PYTHON_LIBRARY_TEST}")
                 if(EXISTS ${_PYTHON_LIBRARY_TEST})
                     set(PYTHON_LIBRARY ${_PYTHON_LIBRARY_TEST})
+                    set(PYLIB ${PYTHON_CONFIG_LIBRARY})
                 endif()
             endif()
         endif()
@@ -243,6 +251,7 @@ if(PYTHONINTERP_FOUND)
                 message(STATUS "Checking for python library at: ${_PYTHON_LIBRARY_TEST}")
                 if(EXISTS ${_PYTHON_LIBRARY_TEST})
                     set(PYTHON_LIBRARY ${_PYTHON_LIBRARY_TEST})
+                    set(PYLIB ${PYTHON_CONFIG_LIBRARY})
                 endif()
             endif()
         endif()
@@ -253,6 +262,7 @@ if(PYTHONINTERP_FOUND)
         message(STATUS "Checking for python library at: ${_PYTHON_LIBRARY_TEST}")
         if(EXISTS ${_PYTHON_LIBRARY_TEST})
             set(PYTHON_LIBRARY ${_PYTHON_LIBRARY_TEST})
+            set(PYLIB python${PYTHON_CONFIG_VERSION}.lib)
         endif()
     endif()
 

--- a/src/tools/dev/xml/GenerateCMake.h
+++ b/src/tools/dev/xml/GenerateCMake.h
@@ -183,6 +183,9 @@
 //    Kathleen Biagas, Thu Mar 30, 2023
 //    Use AUTOMOC target property instead of QT_WRAP_CPP macro.
 //
+//    Kathleen Biagas, Thu Sep 28 13:33:32 PDT 2023
+//    Add AUTOMOC_EXECUTABLE target property when building against an install.
+//
 // ****************************************************************************
 
 class CMakeGeneratorPlugin : public Plugin
@@ -820,6 +823,9 @@ class CMakeGeneratorPlugin : public Plugin
         }
         out << "    ADD_LIBRARY(G"<<name<<ptype<<" ${LIBG_SOURCES})" << Endl;
         out << "    set_target_properties(G"<<name<<ptype<<" PROPERTIES AUTOMOC ON)" << Endl;
+        if (!using_dev)
+            out << "    set_target_properties(G"<<name<<ptype<<" PROPERTIES AUTOMOC_EXECUTABLE \${QT_MOC_EXECUTABLE})" << Endl;
+
         out << "    TARGET_LINK_LIBRARIES(G" << name << ptype <<" visitcommon "
             << guilibname << " " << ToString(libs) << ToString(glibs);
         if (!vtk8_libs.empty())


### PR DESCRIPTION
### Description
Add AUTOMOC_EXECUTABLE to target so CMake knows how to automoc. 
Set PYLIB to python library name, used by PluginVsInstall.cmake.in.

Resolves #18950

### Type of change

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I compiled on pascal and successfully ran the pluginvsinstall tests.
I also copied Threshold operator to a new directory, and treated it like a private plugin. I ran xml2cmake from the install (from the regression testing build), ran cmake and make, copied the .so's to ~/.visit and ran VisIt.
The plugin operated successfully.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
