### PR TITLE
Improve performance in avtDataAttributes.C

### DIFF
--- a/src/avt/Pipeline/Data/avtDataAttributes.C
+++ b/src/avt/Pipeline/Data/avtDataAttributes.C
@@ -1092,25 +1092,27 @@ avtDataAttributes::Copy(const avtDataAttributes &di)
     *(thisProcsActualSpatial)  = *(di.thisProcsActualSpatial);
 
     canUseThisProcsAsOriginalOrActual = di.canUseThisProcsAsOriginalOrActual;
+
+    // We assume that variables is empty, and that everything in di.variables is valid.
+    // Therefore, rather than performing checks and searching for indices each step of
+    // the way, we can just perform a straight copy.
     for (size_t i = 0 ; i < di.variables.size() ; i++)
     {
         const char *vname = di.variables[i]->varname.c_str();
-        AddVariable(vname, di.variables[i]->varunits);
-        SetVariableType(di.variables[i]->vartype, vname);
-        SetVariableSubnames(di.variables[i]->subnames, vname);
-        SetVariableBinRanges(di.variables[i]->binRange, vname);
-        SetVariableDimension(di.variables[i]->dimension, vname);
-        SetCentering(di.variables[i]->centering, vname);
-        SetTreatAsASCII(di.variables[i]->treatAsASCII, vname);
-        SetUseForAxis(di.variables[i]->useForAxis, vname);
-        *(variables[i]->originalData)              = *(di.variables[i]->originalData);
-        *(variables[i]->thisProcsOriginalData)    = 
-                                      *(di.variables[i]->thisProcsOriginalData);
-        *(variables[i]->desiredData)         =
-                                      *(di.variables[i]->desiredData);
-        *(variables[i]->actualData)           = *(di.variables[i]->actualData);
-        *(variables[i]->thisProcsActualData) = 
-                                      *(di.variables[i]->thisProcsActualData);
+        VarInfo *new_var = new VarInfo(vname, di.variables[i]->varunits);
+        variables.push_back(new_var);
+        variables[i]->vartype = di.variables[i]->vartype;
+        variables[i]->subnames = di.variables[i]->subnames;
+        variables[i]->binRange = di.variables[i]->binRange;
+        SetVariableDimension(di.variables[i]->dimension, i);
+        variables[i]->centering = di.variables[i]->centering;
+        variables[i]->treatAsASCII = di.variables[i]->treatAsASCII;
+        variables[i]->useForAxis = di.variables[i]->useForAxis;
+        *(variables[i]->originalData) = *(di.variables[i]->originalData);
+        *(variables[i]->thisProcsOriginalData) = *(di.variables[i]->thisProcsOriginalData);
+        *(variables[i]->desiredData) = *(di.variables[i]->desiredData);
+        *(variables[i]->actualData) = *(di.variables[i]->actualData);
+        *(variables[i]->thisProcsActualData) = *(di.variables[i]->thisProcsActualData);
         *(variables[i]->componentExtents) = *(di.variables[i]->componentExtents);
     }
     activeVariable = di.activeVariable;
@@ -2091,47 +2093,16 @@ avtDataAttributes::SetSpatialDimension(int td)
 //  Arguments:
 //      vd       The new variable dimension.
 //
-//  Programmer: Hank Childs
-//  Creation:   September 4, 2001
+//  Programmer: Justin Privitera
+//  Creation:   October 4th, 2023
 //
 //  Modifications:
-//    Kathleen Bonnell, Wed Oct  3 10:57:13 PDT 2001
-//    Add actualData, thisProcsActualData.
-//
-//    Hank Childs, Mon Feb 23 14:19:15 PST 2004
-//    Account for multiple variables.
-//
-//    Kathleen Bonnell, Thu Mar 11 10:32:04 PST 2004 
-//    DataExtents now always have dimension of 1. 
-//
-//    Kathleen Bonnell, Wed Mar 31 08:03:47 PST 2004
-//    Added a reason to the exception.
-//
-//    Hank Childs, Wed Dec  1 15:29:56 PST 2004
-//    Make sure varname is non-NULL, or we'll crash.
-//
-//    Jeremy Meredith, Thu Feb  7 17:52:59 EST 2008
-//    Added component extents for array variables.
 //
 // ****************************************************************************
 
 void
-avtDataAttributes::SetVariableDimension(int vd, const char *varname)
+avtDataAttributes::SetVariableDimension(int vd, int index)
 {
-    int index = VariableNameToIndex(varname);
-    if (index < 0)
-    {
-        //
-        // We were asked to set the variable dimension of a non-existent
-        // variable.
-        //
-        const char *varname_to_print = (varname != NULL ? varname
-                                         : "<null>");
-        string reason = "Attempting to set dimension of non-existent";
-        reason = reason +  " variable: " + varname_to_print + ".\n";
-        EXCEPTION1(ImproperUseException, reason);
-    }
-
     if (vd == variables[index]->dimension)
     {
         return;
@@ -2174,6 +2145,60 @@ avtDataAttributes::SetVariableDimension(int vd, const char *varname)
         delete variables[index]->componentExtents;
     }
     variables[index]->componentExtents = new avtExtents(vd);
+}
+
+
+// ****************************************************************************
+//  Method: avtDataAttributes::SetVariableDimension
+//
+//  Purpose:
+//      Sets the variable dimension.
+//
+//  Arguments:
+//      vd       The new variable dimension.
+//
+//  Programmer: Hank Childs
+//  Creation:   September 4, 2001
+//
+//  Modifications:
+//    Kathleen Bonnell, Wed Oct  3 10:57:13 PDT 2001
+//    Add actualData, thisProcsActualData.
+//
+//    Hank Childs, Mon Feb 23 14:19:15 PST 2004
+//    Account for multiple variables.
+//
+//    Kathleen Bonnell, Thu Mar 11 10:32:04 PST 2004 
+//    DataExtents now always have dimension of 1. 
+//
+//    Kathleen Bonnell, Wed Mar 31 08:03:47 PST 2004
+//    Added a reason to the exception.
+//
+//    Hank Childs, Wed Dec  1 15:29:56 PST 2004
+//    Make sure varname is non-NULL, or we'll crash.
+//
+//    Jeremy Meredith, Thu Feb  7 17:52:59 EST 2008
+//    Added component extents for array variables.
+//
+// ****************************************************************************
+
+void
+avtDataAttributes::SetVariableDimension(int vd, const char *varname)
+{
+    int index = VariableNameToIndex(varname);
+    if (index < 0)
+    {
+        //
+        // We were asked to set the variable dimension of a non-existent
+        // variable.
+        //
+        const char *varname_to_print = (varname != NULL ? varname
+                                         : "<null>");
+        string reason = "Attempting to set dimension of non-existent";
+        reason = reason +  " variable: " + varname_to_print + ".\n";
+        EXCEPTION1(ImproperUseException, reason);
+    }
+
+    SetVariableDimension(vd, index);
 }
 
 

--- a/src/avt/Pipeline/Data/avtDataAttributes.C
+++ b/src/avt/Pipeline/Data/avtDataAttributes.C
@@ -1040,6 +1040,11 @@ avtDataAttributes::Print(ostream &out)
 //
 //    Alister Maguire, Tue Jul 16 14:34:29 PDT 2019
 //    Added forceRemoveFacesBeforeGhosts.
+// 
+//    Justin Privitera, Thu Oct  5 14:50:38 PDT 2023
+//    Greatly simplified the for-loop in this function. This fixes a 
+//    performance bottleneck I ran into when using a huge number of 
+//    complicated expressions.
 //
 // ****************************************************************************
 

--- a/src/avt/Pipeline/Data/avtDataAttributes.h
+++ b/src/avt/Pipeline/Data/avtDataAttributes.h
@@ -316,6 +316,7 @@ class PIPELINE_API avtDataAttributes
     int                      GetSpatialDimension(void) const
                                    { return spatialDimension; };
 
+    void                     SetVariableDimension(int, int);
     void                     SetVariableDimension(int, const char * = NULL);
     int                      GetVariableDimension(const char * = NULL) const;
 

--- a/src/avt/Pipeline/Data/avtDataAttributes.h
+++ b/src/avt/Pipeline/Data/avtDataAttributes.h
@@ -250,6 +250,9 @@ class     avtWebpage;
 //
 //    Mark C. Miller, Tue Jun 21 10:46:44 PDT 2022
 //    Added commentInDB for holding the database comment
+// 
+//    Justin Privitera, Thu Oct  5 14:50:38 PDT 2023
+//    Added an alternative version of SetVariableDimension.
 // ****************************************************************************
 
 class PIPELINE_API avtDataAttributes

--- a/src/resources/help/en_US/relnotes3.4.0.html
+++ b/src/resources/help/en_US/relnotes3.4.0.html
@@ -111,6 +111,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The <code>GetLastError()</code> CLI method now accepts an optional integer argument indicating whether to clear out the last error message after retrieving it.</li>
   <li>For the Mili plugin, if a class is missing from a top level mili file, the plugin will now throw an exception explaining what happened instead of failing mysteriously.</li>
   <li>Fixed a bug where Pseudocolor's legend would state 'Constant' when the data limits weren't constant.</li>
+  <li>Improved performance when working with large numbers of very complicated expressions.</li>
 </ul>
 
 <a name="Configuration_changes"></a>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
When using an input deck that calls the X Ray Image Query using data generated with HYDRA, it is necessary to adjust the emissivity variable we are sending to the query. Our approach thus far has been to define a fairly complicated series of expressions (~170 total) which produce a new zone centered array mesh variable that can be passed to the query as a replacement for the given emissivity. These expressions are fairly complicated, and end up creating thousands of intermediate steps at various points in VisIt's execution. One such place is in the for-loop I have modified in `src/avt/Pipeline/Data/avtDataAttributes.C`. Upon each run of the loop, we were using the index to determine a variable name which was then being passed to a number of setters which each performed a worst-case lookup using the variable name to determine what the index was. This is pointless because we already have the index from the start. I cut out the middleman. This improved performance; my fake x ray image query workflow would originally time out after 30 minutes of running in serial; this change reduces the total time down to about 2 minutes and 40 seconds running in serial.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
I have built and ran on rztopaz and run using my simplified x ray image query workflow. It works as expected.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
