### PR TITLE
Add support for M_PARTICLE to MiliCellTypes in the Mili reader.

### DIFF
--- a/src/databases/Mili/avtMiliMetaData.h
+++ b/src/databases/Mili/avtMiliMetaData.h
@@ -492,14 +492,17 @@ class MiliMaterialMetaData
 //      Added support for retrieving all variable meta data associated with
 //      a shortname.
 //
+//      Eric Brugger, Mon Oct 23 11:34:17 PDT 2023
+//      Added M_PARTICLE to MiliCellTypes.
+//
 // ****************************************************************************
 
 class avtMiliMetaData
 {
   public:
 
-    const int MiliCellTypes[8] =
-      { M_TRUSS, M_BEAM, M_TRI, M_QUAD, M_TET, M_PYRAMID, M_WEDGE, M_HEX };
+    const int MiliCellTypes[9] =
+      { M_PARTICLE, M_TRUSS, M_BEAM, M_TRI, M_QUAD, M_TET, M_PYRAMID, M_WEDGE, M_HEX };
 
                                         avtMiliMetaData(int);
                                        ~avtMiliMetaData(void);
@@ -620,7 +623,7 @@ class avtMiliMetaData
     //
     // The number of available mili cell types.
     //
-    const int                         numMiliCellTypes = 8;
+    const int                         numMiliCellTypes = 9;
 };
 
 #endif


### PR DESCRIPTION
### Description

I added M_PARTICLE to the list of MiliCellTypes. I didn't update the release notes since there is already a comment in the 3.3.4 release notes that mentions fixing a bug with the reading of particle data that can easily encompass this change.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I built VisIt on the RZ and tested it with a mili file with particle data. It plotted the mesh fine.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
