### PR TITLE
Fix Plugin Window Faulty Indexing

### DIFF
--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -776,7 +776,7 @@ QvisPluginWindow::databaseOptionsSetButtonClicked()
     {
         QvisDBOptionsDialog *optsdlg = new QvisDBOptionsDialog(&opts, NULL);
         QString caption = tr("Default file opening options for %1 reader").
-                          arg(fileOpenOptions->GetTypeNames()[index].c_str());
+                          arg(fileOpenOptions->GetTypeNames()[databaseIndexes[index]].c_str());
         optsdlg->setWindowTitle(caption);
         int result = optsdlg->exec();
         delete optsdlg;
@@ -906,7 +906,7 @@ QvisPluginWindow::dbAddToPreferedButtonClicked()
     if (index < 0)
         return;
 
-    string id = fileOpenOptions->GetTypeIDs()[index];
+    string id = fileOpenOptions->GetTypeIDs()[databaseIndexes[index]];
     if (! preferredOptionsContainsID(id))
     {
         fileOpenOptions->GetPreferredIDs().push_back(id);

--- a/src/gui/QvisPluginWindow.C
+++ b/src/gui/QvisPluginWindow.C
@@ -761,6 +761,9 @@ QvisPluginWindow::clearOperatorCategories()
 //
 //    Jeremy Meredith, Wed Dec 30 16:44:59 EST 2009
 //    Moved some contents to a common function.
+// 
+//    Justin Privitera, Tue Oct 24 15:37:50 PDT 2023
+//    Use index redirection to get at the fileOpenOptions.
 //
 // ****************************************************************************
 void
@@ -896,6 +899,9 @@ QvisPluginWindow::unSelectAllReadersButtonClicked()
 // Modifications:
 //   Jeremy Meredith, Fri Jan 15 17:08:22 EST 2010
 //   Give visual cue when a disabled plugin is preferred.
+// 
+//   Justin Privitera, Tue Oct 24 15:37:50 PDT 2023
+//   Use index redirection to get at the fileOpenOptions.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.4.0.html
+++ b/src/resources/help/en_US/relnotes3.4.0.html
@@ -112,6 +112,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>For the Mili plugin, if a class is missing from a top level mili file, the plugin will now throw an exception explaining what happened instead of failing mysteriously.</li>
   <li>Fixed a bug where Pseudocolor's legend would state 'Constant' when the data limits weren't constant.</li>
   <li>Improved performance when working with large numbers of very complicated expressions.</li>
+  <li>Fixed an issue where adding an item to the preferred plugin list in the plugin manager would add the wrong plugin.</li>
 </ul>
 
 <a name="Configuration_changes"></a>


### PR DESCRIPTION
### Description

Resolves #18970 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

We have a vector that we use to do index redirection. The index of the plugin in the GUI list is used to get the index of the plugin under the hood. Before my changes in #17585, the indices were the same in both lists, so we could get away with not using the index indirection every time. Now, we are forced to.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Built and ran on rztopaz toss4. This gui window now works as I expect.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
