### PR TITLE
Update the parallel launching logic in the scalable.py test.

### DIFF
--- a/src/test/tests/rendering/scalable.py
+++ b/src/test/tests/rendering/scalable.py
@@ -28,7 +28,7 @@
 #    Added tests '08-10, testing auto-opaque mesh and sr mode.
 #
 #    Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
-#    Added ability to swtich between Silo's HDF5 and PDB data.
+#    Added ability to switch between Silo's HDF5 and PDB data.
 #
 #    Eric Brugger, Fri Aug 15 10:19:33 PDT 2014
 #    Modified the script to use srun to launch the parallel engine on edge.
@@ -45,6 +45,10 @@
 #
 #    Kathleen Biagas, Tue Feb 8 2022
 #    Use run_dir for location of saving windows, it is cleaned up on exit.
+#
+#    Eric Brugger, Wed Nov  1 13:46:08 PDT 2023
+#    Updated the list of hosts where srun was used to launch a parallel
+#    compute engine.
 #
 # ----------------------------------------------------------------------------
 
@@ -76,9 +80,9 @@ if len(engines) > 0:
         # explicitly open a parallel engine, if possible
         # if it fails, the OpenDatabase will start a serial engine
         import socket
-        if "surface" in socket.gethostname() or \
+        if "quartz" in socket.gethostname() or \
            "pascal"  in socket.gethostname() or \
-           "quartz"  in socket.gethostname() or \
+           "poodle"  in socket.gethostname() or \
            "syrah"   in socket.gethostname():
             haveParallelEngine = OpenComputeEngine("localhost", ("-l", "srun", "-np", "2"))
         else:


### PR DESCRIPTION
### Description

The `tests/rendering/scalable.py` test uses the host name to determine if it should use srun to launch a parallel engine. I updated that list to remove surface and add poodle.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I ran the `tests/rendering/scalable.py` test on poodle and it was successful.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
