### PR TITLE
Fix vtkpython modules on Windows. (#19066)

### DIFF
--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -39,6 +39,9 @@
 #   Use 'manuals.vcxproj' for building manuals during an install on Windows
 #   with MSVC.
 #
+#   Kathleen Biagas, Wed Nov 15, 2023
+#   Use sphinx-build.exe on Windows, due to newer python and sphinx.
+#
 #****************************************************************************
 
 if(VISIT_PYTHON_DIR AND VISIT_ENABLE_MANUALS AND NOT VISIT_STATIC)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -131,8 +131,8 @@ IF(VISIT_PYTHON_FILTERS)
                 COMMAND ${CMAKE_COMMAND} -E copy_directory
                         ${VTK_PY_WRAPPERS_DIR}
                         ${VISIT_LIBRARY_DIR}/site-packages
-                COMMENT "Copying ${VTK_PY_WRAPPERS_DIR}/vtkmodules to ${VISIT_LIBRARY_DIR}/site-packages/vtkmodules"
-      )
+                COMMENT "Copying ${VTK_PY_WRAPPERS_DIR}/vtkmodules to ${VISIT_LIBRARY_DIR}/site-packages/vtkmodules")
+      visit_add_to_util_builds(vtk_python_modules)
   endif()
 ENDIF(VISIT_PYTHON_FILTERS)
 


### PR DESCRIPTION
Update windows config-site with python 3.7.16, enable gdal. Use sphinx-build.exe for building manuals on Windows, due to new python and sphinx.

Merge from 3.4RC.
Some changes were already on develop.


