### PR TITLE
OBJ Writer: Fix Max and Min texture coordinates

### DIFF
--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -375,6 +375,10 @@ avtDatasetFileWriter::WriteOBJTree(avtDataTree_p dt, int idx,
 //    Justin Privitera, Fri Nov  3 15:25:32 PDT 2023
 //    The new arguments (writeMTL, MTLHasTex, and texFilename) are used to
 //    setup needed parameters for the upgraded vtkOBJWriter.
+// 
+//    Justin Privitera, Mon Nov 27 14:57:17 PST 2023
+//    I added some logic to adjust the texture coordinates slightly so that
+//    they do not fall off the ends.
 //
 // ****************************************************************************
 
@@ -437,6 +441,11 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
         tcoords->SetNumberOfComponents(2);
         tcoords->SetNumberOfTuples(scalars->GetNumberOfTuples());
 
+        // What is going on here?
+        // We want to add a pixel to either end of the color table.
+        // This is to prevent unwanted behavior with the max and min texture coordinates
+        // wrapping around. If we're going to add pixels, we must adjust the texture
+        // coords. We add two pixels and scale appropriately.
         const double ncolors = 256.0; // this must match the GetColors() function
         const double fudge_factor = 1.0 / ncolors;
         const double new_divisor = 1.0 + fudge_factor * 2.0;

--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -436,11 +436,17 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
         vtkDataArray *tcoords = scalars->NewInstance();
         tcoords->SetNumberOfComponents(2);
         tcoords->SetNumberOfTuples(scalars->GetNumberOfTuples());
+
+        const double ncolors = 256.0; // this must match the GetColors() function
+        const double fudge_factor = 1.0 / ncolors;
+        const double new_divisor = 1.0 + fudge_factor * 2.0;
+
         for (int i = 0 ; i < scalars->GetNumberOfTuples() ; i++)
         {
             double *p = scalars->GetTuple(i);
             double s[2];
-            s[0] = (*p - range[0]) / gap;
+            // assuming we have ncolors colors and want to add a duplicate to either end
+            s[0] = (((*p - range[0]) / gap) + fudge_factor) / new_divisor;
             s[1] = 0.;
             tcoords->SetTuple(i, s);
         }

--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -377,8 +377,12 @@ avtDatasetFileWriter::WriteOBJTree(avtDataTree_p dt, int idx,
 //    setup needed parameters for the upgraded vtkOBJWriter.
 // 
 //    Justin Privitera, Mon Nov 27 14:57:17 PST 2023
-//    I added some logic to adjust the texture coordinates slightly so that
-//    they do not fall off the ends.
+//    Most downstream tools expect to *wrap* textures. This means that textur
+//    coordinate 0.0 is treated identically to texture coordinate 1.0 (e.g. circular
+//    wrapping). However, this means that most downstream tools will *average*
+//    the colors associated with these two texture coordinates, producing a color
+//    that may not be in the table. To work-around this behavior, we *pad* the color
+//    texture duplicating the minimum and maximum color pixels on each end.
 //
 // ****************************************************************************
 

--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -377,7 +377,7 @@ avtDatasetFileWriter::WriteOBJTree(avtDataTree_p dt, int idx,
 //    setup needed parameters for the upgraded vtkOBJWriter.
 // 
 //    Justin Privitera, Mon Nov 27 14:57:17 PST 2023
-//    Most downstream tools expect to *wrap* textures. This means that textur
+//    Most downstream tools expect to *wrap* textures. This means that texture
 //    coordinate 0.0 is treated identically to texture coordinate 1.0 (e.g. circular
 //    wrapping). However, this means that most downstream tools will *average*
 //    the colors associated with these two texture coordinates, producing a color

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -225,6 +225,9 @@ avtWavefrontOBJWriter::GetCombineMode(const std::string &) const
 // Creation:    11/03/23
 //
 // Modifications:
+//    Justin Privitera, Mon Nov 27 14:57:17 PST 2023
+//    I added extra pixels on either end of the color table to act as padding
+//    so that texture coordinates do not fall off the ends (and wrap around).
 //
 //****************************************************************************
 
@@ -235,7 +238,8 @@ avtWavefrontOBJWriter::GetColorTable()
     const ColorControlPointList *table = colorTables->GetColorControlPoints(colorTable);
     if (table)
     {
-        // We don't have color tables that have this many control points:
+        // We don't have color tables that have this many control points,
+        // so this should be a good choice for the number of colors.
         const int ncolors = 256;
         unsigned char rgb[ncolors * 3];
         
@@ -243,9 +247,9 @@ avtWavefrontOBJWriter::GetColorTable()
 
         vtkImageData *imageData = vtkImageData::New();
 
-        // we need two extra colors, so (ncolors - 1 + 2) -> (ncolors + 1)
-        // x: [0, ncolors + 1], y: [0, 0], z: [0, 0]
-        // these pixels will sit on the ends and act as padding so the texture coords
+        // We need two extra colors, so (ncolors - 1 + 2) -> (ncolors + 1)
+        // hence x: [0, ncolors + 1], y: [0, 0], z: [0, 0]
+        // These pixels will sit on the ends and act as padding so the texture coords
         // don't lead to strange behavior with max and min values wrapping around
         imageData->SetExtent(0, ncolors + 1, 0, 0, 0, 0);
         imageData->SetSpacing(1., 1., 1.);
@@ -254,7 +258,7 @@ avtWavefrontOBJWriter::GetColorTable()
         unsigned char *pixels = (unsigned char *)imageData->GetScalarPointer(0, 0, 0);
         unsigned char *ipixel = pixels;
         
-        // color first one twice
+        // the first extra pixel will get the same color as the first real pixel
         *ipixel = rgb[0];
         ipixel ++;
         *ipixel = rgb[1];
@@ -272,9 +276,8 @@ avtWavefrontOBJWriter::GetColorTable()
             ipixel ++;
         }
 
+        // the second (and last) extra pixel will get the same color as the last real pixel
         int last_index = ncolors * 3 - 3;
-
-        // color last one twice
         *ipixel = rgb[last_index];
         ipixel ++;
         *ipixel = rgb[last_index + 1];

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -243,13 +243,25 @@ avtWavefrontOBJWriter::GetColorTable()
 
         vtkImageData *imageData = vtkImageData::New();
 
-        // x: [0, ncolors - 1], y: [0, 0], z: [0, 0]
-        imageData->SetExtent(0, ncolors - 1, 0, 0, 0, 0);
+        // we need two extra colors, so (ncolors - 1 + 2) -> (ncolors + 1)
+        // x: [0, ncolors + 1], y: [0, 0], z: [0, 0]
+        // these pixels will sit on the ends and act as padding so the texture coords
+        // don't lead to strange behavior with max and min values wrapping around
+        imageData->SetExtent(0, ncolors + 1, 0, 0, 0, 0);
         imageData->SetSpacing(1., 1., 1.);
         imageData->SetOrigin(0., 0., 0.);
         imageData->AllocateScalars(VTK_UNSIGNED_CHAR, 3);
         unsigned char *pixels = (unsigned char *)imageData->GetScalarPointer(0, 0, 0);
         unsigned char *ipixel = pixels;
+        
+        // color first one twice
+        *ipixel = rgb[0];
+        ipixel ++;
+        *ipixel = rgb[1];
+        ipixel ++;
+        *ipixel = rgb[2];
+        ipixel ++;
+
         for (int i = 0; i < ncolors * 3; i += 3)
         {
             *ipixel = rgb[i];
@@ -259,6 +271,16 @@ avtWavefrontOBJWriter::GetColorTable()
             *ipixel = rgb[i + 2];
             ipixel ++;
         }
+
+        int last_index = ncolors * 3 - 3;
+
+        // color last one twice
+        *ipixel = rgb[last_index];
+        ipixel ++;
+        *ipixel = rgb[last_index + 1];
+        ipixel ++;
+        *ipixel = rgb[last_index + 2];
+        ipixel ++;
 
         return imageData;
     }

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -20,7 +20,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.4.1</font></b></p>
 <ul>
-  <li>Fixed a bug in the Wavefront OBJ Writer that caused maximum and minimum variable values to be displayed improperly when viewing meshes written by the writer in an external tool like Powerpoint.</li>
+  <li>Fixed a bug in the Wavefront OBJ Writer that would result in incorrect coloring for minimum or maximum values in downstream tools such as PowerPoint.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -1,0 +1,35 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Language" content="en-us">
+  <title>VisIt 3.4.1 Release Notes</title>
+</head>
+<body>
+<center><b><font size="6">VisIt 3.4.1 Release Notes</font></b></center>
+
+<p>Welcome to VisIt's release notes page. This page describes the important
+enhancements and bug-fixes that were added to this release.</p>
+
+<p><b>Sections</b></p>
+<ul>
+  <li><a href="#Bugs_fixed">Bug Fixes</a></li>
+  <li><a href="#Enhancements">Enhancements</a></li>
+</ul>
+
+<a name="Bugs_fixed"></a>
+<p><b><font size="4">Bugs fixed in version 3.4.1</font></b></p>
+<ul>
+  <li>Fixed a bug in the Wavefront OBJ Writer that caused maximum and minimum variable values to be displayed improperly when viewing meshes written by the writer in an external tool like Powerpoint.</li>
+</ul>
+
+<a name="Enhancements"></a>
+<p><b><font size="4">Enhancements in version 3.4.1</font></b></p>
+<ul>
+  <li>enhancement</li>
+</ul>
+
+<p>Click the following link to view the release notes for the previous version
+of VisIt: <a href=relnotes3.4.0.html>3.4.0</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
I noticed that when using the OBJ writer and loading resulting meshes into powerpoint, the min and max values of the exported field were displaying incorrectly. In the case of variable `u` from `curv3d.silo`, the min is -1 and the max is 1. The texture coordinates wrap around, so that if you have a texture coordinate of 0 (corresponding to a minimum field value), it will be halfway between the blue pixel at one end of the texture and the red pixel at the other end of the texture. Same goes for the texture coordinates of 1.

![image](https://github.com/visit-dav/visit/assets/35237779/33aa27b3-1edb-44a7-aa42-3e748709c260)

My solution was to add another pixel to either end of the texture, and then adjust the texture coordinates so that they fall in the correct range. The results speak for themselves.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Built and ran on rztopaz toss4 and loaded meshes into powerpoint; they look as expected.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
