### PR TITLE
Escape path separators in string vectors on Windows.

### DIFF
--- a/src/common/state/Variant.C
+++ b/src/common/state/Variant.C
@@ -2976,6 +2976,10 @@ Variant::TokenizeQuotedString(const string &val,stringVector &tokens)
 //  Programmer:  Cyrus Harrison
 //  Creation:    December 17, 2007
 //
+//  Modifications:
+//    Kathleen Biagas, Fri Dec 1 2023
+//    If on Windows, also escape path separators and convert unix-style.
+//
 // ****************************************************************************
 string
 Variant::EscapeQuotedString(const string &val)
@@ -2989,6 +2993,18 @@ Variant::EscapeQuotedString(const string &val)
             res.push_back('\\');
             res.push_back('"');
         }
+#ifdef _WIN32
+        else if(val[i] == '\\')
+        {
+            res.push_back('\\');
+            res.push_back('\\');
+        }
+        else if(val[i] == '/')
+        {
+            res.push_back('\\');
+            res.push_back('\\');
+        }
+#endif
         else
         {
             res.push_back(val[i]);


### PR DESCRIPTION
### Description
Prevents removal of windows-style path separators when QueryOutputObject is converted to Python dictionary.

This came about as a partial fix for #19087. See comments in @JustinPrivitera PR attempt to fix: #19106 .

This should probably go on 3.4RC as well.



### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Am current running test suite on Windows to see if the change causes unexpected problems.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
