### PR TITLE
vtkThreshold::ThresholdBetween has been deprecated in VTK 9

### DIFF
--- a/src/operators/InverseGhostZone/avtInverseGhostZoneFilter.C
+++ b/src/operators/InverseGhostZone/avtInverseGhostZoneFilter.C
@@ -7,6 +7,8 @@
 // ************************************************************************* //
 
 #include <avtInverseGhostZoneFilter.h>
+
+#include <visit-config.h> // For LIB_VERSION_LE
 #include <avtExtents.h>
 
 #include <vtkCellData.h>
@@ -140,6 +142,10 @@ avtInverseGhostZoneFilter::Equivalent(const AttributeGroup *a)
 //    I modified the routine to return a NULL in the case where it previously
 //    returned an avtDataRepresentation with a NULL vtkDataSet.
 //
+//    Kathleen Biagas, Fri Dec 1 2023
+//    vtkThreshold::ThresholdBetween has been deprecated for VTK-9, so use
+//    the new methods SetUpper/LowerThreshold instead when using VTK-9.
+//
 // ****************************************************************************
 
 avtDataRepresentation *
@@ -223,7 +229,12 @@ avtInverseGhostZoneFilter::ExecuteData(avtDataRepresentation *in_dr)
     temp_ds->GetCellData()->SetActiveScalars("avtRetainThese");
     
     vtkThreshold *t = vtkThreshold::New();
+#if LIB_VERSION_LE(VTK,8,1,0)
     t->ThresholdBetween(0.5, 1.5);
+#else
+    t->SetLowerThreshold(0.5);
+    t->SetUpperThreshold(1.5);
+#endif
     t->SetInputArrayToProcess(0,0,0,vtkDataObject::FIELD_ASSOCIATION_CELLS,
                               "avtRetainThese");
     t->SetInputData(temp_ds);


### PR DESCRIPTION
### Description

Use SetLowerThreshold and SetUpperThreshold when running with VTK 9.

Resolves a runtime warning when using the operator.

### Type of change

<!-- Please check one of the boxes below -->

* [X ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran the inverse ghost zone test again and didn't see the warning.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
