### PR TITLE
Enhance surface_normal expression so it can accept more mesh types.

### DIFF
--- a/src/avt/Expressions/General/avtSurfaceNormalExpression.C
+++ b/src/avt/Expressions/General/avtSurfaceNormalExpression.C
@@ -146,7 +146,8 @@ avtSurfaceNormalExpression::DeriveVariable(vtkDataSet *in_ds, int currentDomains
     if (arr == NULL)
     {
         n->Delete();
-        geom->Delete();
+        if(geom != NULL)
+            geom->Delete();
         EXCEPTION2(ExpressionException, outputVariableName, 
                    "An internal error occurred where "
                    "the surface normals could not be calculated.  Please "
@@ -155,7 +156,8 @@ avtSurfaceNormalExpression::DeriveVariable(vtkDataSet *in_ds, int currentDomains
 
     arr->Register(NULL);
     n->Delete();
-    geom->Delete();
+    if(geom != NULL)
+        geom->Delete();
 
     return arr;
 }

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -1,0 +1,95 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="GENERATOR" content="Microsoft FrontPage 5.0">
+  <meta name="ProgId" content="FrontPage.Editor.Document">
+  <title>VisIt 3.5 Release Notes</title>
+</head>
+<body>
+
+<center><b><font size="6">VisIt 3.5 Release Notes</font></b></center>
+<center><b><font size="4">Month, Year</font></b></center>
+
+<p>Welcome to VisIt's release notes page. This page describes the important
+enhancements and bug-fixes that were added to this release.</p>
+
+<p><b>Sections</b></p>
+<ul>
+  <li><a href="#General_features">Features for all users</a></li>
+  <li><a href="#GUI_changes">Changes in GUI behavior</a></li>
+  <li><a href="#File_format">Changes to file format readers</a></li>
+  <li><a href="#Plot_changes">Changes to plots</a></li>
+  <li><a href="#Expression_changes">Changes to expressions</a></li>
+  <li><a href="#Query_changes">Changes to picks and queries</a></li>
+  <li><a href="#Bugs_fixed">Other bug fixes</a></li>
+  <li><a href="#Configuration_changes">Configuration changes</a></li>
+  <li><a href="#Build_features">Changes to build_visit</a></li>
+  <li><a href="#Dev_changes">Changes for VisIt developers</a></li>
+</ul>
+
+<a name="General_features"></a>
+<p><b><font size="4">General features added in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="GUI_changes"></a>
+<p><b><font size="4">Changes in GUI behavior for version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="File_format"></a>
+<p><b><font size="4">File format reader changes in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Plot_changes"></a>
+<p><b><font size="4">Changes to VisIt's plots in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Expression_changes"></a>
+<p><b><font size="4">Changes to VisIt's expression language in version 3.5</font></b></p>
+<ul>
+  <li>The <i>surface_normal</i> operator now accepts mesh types other than polydata, allowing it to be used more easily as an operator-created variable.</li>
+</ul>
+
+<a name="Query_changes"></a>
+<p><b><font size="4">Changes to VisIt's picks and queries in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Bugs_fixed"></a>
+<p><b><font size="4">Other bugs fixed in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Configuration_changes"></a>
+<p><b><font size="4">Configuration changes in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Build_features"></a>
+<p><b><font size="4">Changes to build_visit in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<a name="Dev_changes"></a>
+<p><b><font size="4">Changes for VisIt developers in version 3.5</font></b></p>
+<ul>
+  <li></li>
+</ul>
+
+<p>Click the following link to view the release notes for the previous version
+of VisIt: <a href=relnotes3.3.3.html>3.4.1</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
### Description

Resolves #19125 

This PR enhances the surface_normal expression so it runs a vtkGeometryFilter on the input dataset if the dataset is not polydata. This allows other mesh types to make surface normals.

### Type of change

<!-- Please check one of the boxes below -->

* [x ] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other <!-- please explain with a note below -->

### How Has This Been Tested?

I tested this manually with my dataset and with curve3d.silo and they both make surface normals using operator-created variables.
![surface_normals](https://github.com/visit-dav/visit/assets/2072964/59b9e1b2-ddfd-4407-a060-93f248e0e77c)

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ x] I have commented my code where applicable.~~
- [ x] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
