### PR TITLE
Redo surface_normal expression enhancement on 3.4RC.

### DIFF
--- a/src/avt/Expressions/General/avtSurfaceNormalExpression.C
+++ b/src/avt/Expressions/General/avtSurfaceNormalExpression.C
@@ -10,6 +10,7 @@
 
 #include <vtkCellData.h>
 #include <vtkDataSet.h>
+#include <vtkGeometryFilter.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <vtkRectilinearGrid.h>
@@ -90,6 +91,11 @@ avtSurfaceNormalExpression::~avtSurfaceNormalExpression()
 //    Kathleen Biagas, Fri Jan 25 16:28:49 PST 2013
 //    Call 'Update' on filter instead of data object.
 //
+//    Brad Whitlock, Tue Dec  5 16:30:57 PST 2023
+//    Execute vtkGeometryFilter on input dataset if it is not polydata. The
+//    old recommendation in the code did not work for vtkUnstructuredGrids
+//    that contained surfaces.
+//
 // ****************************************************************************
 
 vtkDataArray *
@@ -100,20 +106,20 @@ avtSurfaceNormalExpression::DeriveVariable(vtkDataSet *in_ds, int currentDomains
         return RectilinearDeriveVariable((vtkRectilinearGrid *) in_ds);
     }
 
+    // Execute a geometry filter if the input dataset is not already polydata.
+    vtkPolyData *pd = NULL;
+    vtkGeometryFilter *geom = NULL;
     if (in_ds->GetDataObjectType() != VTK_POLY_DATA)
     {
-        EXCEPTION2(ExpressionException, outputVariableName, 
-                   "The Surface normal expression "
-                   "can only be calculated on surfaces.  Use the External"
-                   "Surface operator to generate the external surface of "
-                   "this object.  You must also use the DeferExpression "
-                   "operator to defer the evaluation of this expression until "
-                   "after the external surface operator.  The external surface"
-                   " and defer expression operators are available through "
-                   "the plugin manager located under the Options menu");
+        geom = vtkGeometryFilter::New();
+        geom->SetInputData(in_ds);
+        geom->Update();
+        pd = (vtkPolyData *) geom->GetOutput();
     }
-
-    vtkPolyData *pd = (vtkPolyData *) in_ds;
+    else
+    {
+        pd = (vtkPolyData *) in_ds;
+    }
 
     vtkVisItPolyDataNormals *n = vtkVisItPolyDataNormals::New();
     n->SetSplitting(false);
@@ -140,6 +146,8 @@ avtSurfaceNormalExpression::DeriveVariable(vtkDataSet *in_ds, int currentDomains
     if (arr == NULL)
     {
         n->Delete();
+        if(geom != NULL)
+            geom->Delete();
         EXCEPTION2(ExpressionException, outputVariableName, 
                    "An internal error occurred where "
                    "the surface normals could not be calculated.  Please "
@@ -148,6 +156,8 @@ avtSurfaceNormalExpression::DeriveVariable(vtkDataSet *in_ds, int currentDomains
 
     arr->Register(NULL);
     n->Delete();
+    if(geom != NULL)
+        geom->Delete();
 
     return arr;
 }

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Added the ability to invert the color table for the Wavefront OBJ writer.</li>
   <li>Upgraded MFEM library version to 4.6.0.</li>
+  <li>The <i>surface_normal</i> expression now accepts mesh types other than polydata, allowing it to be used more easily as an operator-created variable.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version


### PR DESCRIPTION
### Description

I made a change to the surface_normal expression that allows it to make vtkPolyData first if the input dataset is not already vtkPolyData. This lets operator-created variables for the SurfaceNormal operator work with my Blueprint data file.

### Type of change

<!-- Please check one of the boxes below -->

* [x ] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I tested manually with my dataset and with curve3d.silo.

![surface_normals](https://github.com/visit-dav/visit/assets/2072964/6ca92e77-39a0-4676-8c6b-6431477ca9b9)

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x ] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
