### PR TITLE
Fix some VTK 9 update related regression errors with Pick

### DIFF
--- a/src/avt/Queries/Pick/avtLocateQuery.C
+++ b/src/avt/Queries/Pick/avtLocateQuery.C
@@ -10,7 +10,6 @@
 
 #include <float.h>
 
-#include <vtkBox.h>
 #include <vtkCellData.h>
 #include <vtkDataArray.h>
 #include <vtkIdList.h>
@@ -245,6 +244,11 @@ avtLocateQuery::GetPickAtts()
 //    Hank Childs, Tue Sep 11 13:11:17 PDT 2007
 //    Code around VTK bug with ComputeCellId.
 //
+//    Kathleen Biagas, The Dec 7, 2023
+//    Swap vtkBox::IntersectBox with vtkVisItUtility::IntersectBox. The VTK 9
+//    version of the former utilizes a tolerance that adjusts the bounds and
+//    interferes with results (especially for 2D).
+//
 // ****************************************************************************
 
 int
@@ -281,7 +285,7 @@ avtLocateQuery::RGridIsect(vtkRectilinearGrid *rgrid, double &dist,
         {
            rayDir[i] = rayPt2[i] - rayPt1[i];
         }
-        if (vtkBox::IntersectBox(dsBounds, rayPt1, rayDir, isect, t))
+        if (vtkVisItUtility::IntersectBox(dsBounds, rayPt1, rayDir, isect, t))
         {
             success = vtkVisItUtility::ComputeStructuredCoordinates(rgrid,
                           isect, ijk);
@@ -417,6 +421,10 @@ avtLocateQuery::LocatorFindCell(vtkDataSet *ds, double &dist, double *isect)
 //  Creation:   October 6, 2004
 //
 //  Modifications:
+//    Kathleen Biagas, The Dec 7, 2023
+//    Swap vtkBox::IntersectBox with vtkVisItUtility::IntersectBox. The VTK 9
+//    version of the former utilizes a tolerance that adjusts the bounds and
+//    interferes with results (especially for 2D).
 //
 // ****************************************************************************
 
@@ -432,7 +440,7 @@ avtLocateQuery::RayIntersectsDataSet(vtkDataSet *ds)
         dir[i] = pt2[i] - pt1[i];
     }
     double dummy1[3], dummy2;
-    return (vtkBox::IntersectBox(bnds, pt1, dir, dummy1, dummy2));
+    return (vtkVisItUtility::IntersectBox(bnds, pt1, dir, dummy1, dummy2));
 }
 
 

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -21,6 +21,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.4.1</font></b></p>
 <ul>
   <li>Fixed a bug in the Wavefront OBJ Writer that would result in incorrect coloring for minimum or maximum values in downstream tools such as PowerPoint.</li>
+  <li>Fixed a bug with Pick unable to return results for 2D datasets.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/skip.json
+++ b/src/test/skip.json
@@ -19,7 +19,7 @@
                     {"category":"operators","file":"dual_mesh.py","cases":["ops_dualmesh_mesh_plot_2d_01"]},
                     {"category":"plots","file":"volumePlot.py","cases":["volumeOpacity_05"]},
                     {"category":"queries","file":"avg_value.py","cases":["avg_value_02"]},
-                    {"category":"queries","file":"pick.py","cases":["Pick2D","Pick3DTo2D","PickAMR","PickBox","PickIndexSelect","PickSamrai_01","PickSamrai_05"]},
+                    {"category":"queries","file":"pick.py","cases":["Pick3DTo2D"]},
                     {"category":"rendering","file":"bigdata.py","cases":["bigdata_01"]},
                     {"category":"rendering","file":"legends.py","cases":["legends_07"]},
                     {"category":"rendering","file":"pixeldata.py","cases":["pixeldata_0_05","pixeldata_0_07","pixeldata_0_08","pixeldata_0_09","pixeldata_0_10","pixeldata_0_11"]},

--- a/src/visit_vtk/lightweight/vtkVisItUtility.h
+++ b/src/visit_vtk/lightweight/vtkVisItUtility.h
@@ -47,6 +47,9 @@ class vtkRectilinearGrid;
 //    I made the default data type for Create1DRGrid and CreateEmptyRGrid
 //    be VTK_DOUBLE instead of VTK_FLOAT.
 //
+//    Kathleen Biagas, Thu Dec 7, 2023
+//    Added IntersectBox.
+//
 // ****************************************************************************
 
 namespace vtkVisItUtility
@@ -95,5 +98,11 @@ namespace vtkVisItUtility
     VISIT_VTK_LIGHT_API void       RegisterStaticVTKObject(vtkObject*);
     VISIT_VTK_LIGHT_API void       CleanupStaticVTKObjects();
     VISIT_VTK_LIGHT_API float      SafeDoubleToFloat(double);
+    VISIT_VTK_LIGHT_API bool       IntersectBox(double bounds[6],
+                                                double origin[3],
+                                                double dir[3],
+                                                double coord[3],
+                                                double& t);
+
 }
 #endif


### PR DESCRIPTION
Added the VTK  8 version of vtkBox::IntersectBox to vtkVisItUtiltiy. 
Changed avtLocateQuery to use that version.
The new VTK 9 version uses a tolerance to change the bounds, and interferes with results needed for pick. 
Update skip list to remove those Pick tests fixed by this PR.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Run the pick test on Windows and Linux with success. Ran full regression suite on Linux to ensure nothing else was affected.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
