### PR TITLE
Fix vtk error message when adding Image Annotation. (#19148)

### DIFF
--- a/src/avt/VisWindow/Colleagues/avtImageColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtImageColleague.C
@@ -8,6 +8,8 @@
 
 #include <avtImageColleague.h>
 
+#include <visit-config.h> // for LIB_VERSION_GE
+
 #include <vtkActor2D.h>
 #include <vtkCoordinate.h>
 #include <vtkImageData.h>
@@ -421,6 +423,9 @@ avtImageColleague::SetOptions(const AnnotationObject &annot)
 //   terminal when they cannot read the file.
 //   Also, do not attempt to create a reader if the filename is empty.
 //
+//   Kathleen Biagas, Mon Dec 11, 2023
+//   Make usage of extension-match dependent on using VTK 9.2.6 ore newer.
+//
 // ****************************************************************************
 
 bool
@@ -433,7 +438,7 @@ avtImageColleague::UpdateImage(string filename)
     if (!filename.empty())
     {
         filename = FileFunctions::ExpandPath(filename);
-
+#if LIB_VERSION_GE(VTK, 9,2,6)
         size_t i = filename.rfind('.', filename.length());
         if(i != string::npos)
         {
@@ -441,7 +446,7 @@ avtImageColleague::UpdateImage(string filename)
             // Get a reader for extension if possible.
             r = vtkImageReader2Factory::CreateImageReader2FromExtension(ext.c_str());
         }
-
+#endif
         if(!r)
         {
             // Get a reader for filename if possible.

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -22,6 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug in the Wavefront OBJ Writer that would result in incorrect coloring for minimum or maximum values in downstream tools such as PowerPoint.</li>
   <li>Fixed a bug with Pick unable to return results for 2D datasets.</li>
+  <li>Fixed a bug where vtk error messages were printed to the terminal when adding an Image Annotation Object to the viewer window.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #19129.
Made avtImageColleague::UpdateImage utilize vtkImageReader2Factory::CreateImageReaderFromExtension.
The other method, vtkImageReader2Factory::CreateImageReader (which uses full filename), attempts all available Image readers, and some of them print error message when they cannot read the file. Using the file-matched version should mitigate this.

Use the filename version if the extent-matched version fails or the filename does not contain an extension.

Also, prevent creation of the vtkImageReader2 if filename is null.

Merge from 3.4RC


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

