### PR TITLE
Fix avtImageColleague for VTK 8.

### DIFF
--- a/src/avt/VisWindow/Colleagues/avtImageColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtImageColleague.C
@@ -8,6 +8,8 @@
 
 #include <avtImageColleague.h>
 
+#include <visit-config.h> // for LIB_VERSION_GE
+
 #include <vtkActor2D.h>
 #include <vtkCoordinate.h>
 #include <vtkImageData.h>
@@ -421,6 +423,9 @@ avtImageColleague::SetOptions(const AnnotationObject &annot)
 //   terminal when they cannot read the file.
 //   Also, do not attempt to create a reader if the filename is empty.
 //
+//   Kathleen Biagas, Mon Dec 11, 2023
+//   Make usage of extension-match dependent on using VTK 9.2.6 ore newer.
+//
 // ****************************************************************************
 
 bool
@@ -433,7 +438,7 @@ avtImageColleague::UpdateImage(string filename)
     if (!filename.empty())
     {
         filename = FileFunctions::ExpandPath(filename);
-
+#if LIB_VERSION_GE(VTK, 9,2,6)
         size_t i = filename.rfind('.', filename.length());
         if(i != string::npos)
         {
@@ -441,7 +446,7 @@ avtImageColleague::UpdateImage(string filename)
             // Get a reader for extension if possible.
             r = vtkImageReader2Factory::CreateImageReader2FromExtension(ext.c_str());
         }
-
+#endif
         if(!r)
         {
             // Get a reader for filename if possible.


### PR DESCRIPTION
### Description

Fixes previous commit to work with VTK 8, by making logic that utilizes vtkImageReader2Factory::CreateImageReader2FromExtension dependent on VTK 9.2.6 or newer.
