### PR TITLE
Fix default cycle guessing from filename 

### DIFF
--- a/src/avt/Database/Formats/avtFileFormat.C
+++ b/src/avt/Database/Formats/avtFileFormat.C
@@ -737,6 +737,10 @@ avtFileFormat::AddSpeciesToMetaData(avtDatabaseMetaData *md, string name,
 //
 //    Mark C. Miller, Wed Aug  8 13:34:53 PDT 2007
 //    Adjusted regular expression to take last group of digits.
+//
+//    Mark C. Miller, Wed Dec 13 15:23:05 PST 2023
+//    Adjusted regular expression to take last group of digits BEFORE
+//    any extension if present.
 // ****************************************************************************
 
 int
@@ -746,7 +750,7 @@ avtFileFormat::GuessCycle(const char *fname, const char *re)
     if (reToUse == "")
         reToUse = re ? re : "";
     if (reToUse == "")
-        reToUse = "<([0-9]+)[^0-9]*$> \\0";
+        reToUse = "<([0-9]+)([^0-9]*)\\..*$> \\1";
 
     double d = GuessCycleOrTime(fname, reToUse.c_str());
 

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -23,6 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Wavefront OBJ Writer that would result in incorrect coloring for minimum or maximum values in downstream tools such as PowerPoint.</li>
   <li>Fixed a bug with Pick unable to return results for 2D datasets.</li>
   <li>Fixed a bug where vtk error messages were printed to the terminal when adding an Image Annotation Object to the viewer window.</li>
+  <li>Changed default logic for guessing cycles from file names to not consider any digits in the file name extension if present. This fixed the guessing logic for cases where a file extension includes a digit (e.g. <code>.h5m</code>)</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #19152

Our default logic to guess a cycle number from a file name was a bit off for any extension type that include a digit in the extension (e.g. `.h5m` or `.7z`).

The logic aims to take the last sequence of digits available in the filename string and treat them as the a state *identifier* (e.g. a cycle number). For extensions with digits in them, this would mean all files are seen as having the same *identifier* (e.g. it would take the `5` from `.h5m`.).

This adjusts the regular expression logic a bit to not consider digits in the extension part of the file name if present.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I did some manual testing of the new regular expression using `StringHelpers_test`

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
