### PR TITLE
Fix default cycle guess from filename (#19157)

### DIFF
--- a/src/avt/Database/Formats/avtFileFormat.C
+++ b/src/avt/Database/Formats/avtFileFormat.C
@@ -737,6 +737,10 @@ avtFileFormat::AddSpeciesToMetaData(avtDatabaseMetaData *md, string name,
 //
 //    Mark C. Miller, Wed Aug  8 13:34:53 PDT 2007
 //    Adjusted regular expression to take last group of digits.
+//
+//    Mark C. Miller, Wed Dec 13 15:23:05 PST 2023
+//    Adjusted regular expression to take last group of digits BEFORE
+//    any extension if present.
 // ****************************************************************************
 
 int
@@ -746,7 +750,7 @@ avtFileFormat::GuessCycle(const char *fname, const char *re)
     if (reToUse == "")
         reToUse = re ? re : "";
     if (reToUse == "")
-        reToUse = "<([0-9]+)[^0-9]*$> \\0";
+        reToUse = "<([0-9]+)([^0-9]*)\\..*$> \\1";
 
     double d = GuessCycleOrTime(fname, reToUse.c_str());
 

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -23,6 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Wavefront OBJ Writer that would result in incorrect coloring for minimum or maximum values in downstream tools such as PowerPoint.</li>
   <li>Fixed a bug with Pick unable to return results for 2D datasets.</li>
   <li>Fixed a bug where vtk error messages were printed to the terminal when adding an Image Annotation Object to the viewer window.</li>
+  <li>Changed default logic for guessing cycles from file names to not consider any digits in the file name extension if present. This fixed the guessing logic for cases where a file extension includes a digit (e.g. <code>.h5m</code>)</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

4.3.1RC->Dev merge of #19157

Resolves #19152 <!-- If this PR is unrelated to a ticket, please erase this line -->