### PR TITLE
Fix PC plot glyphed line endpoints coloring bug. (#19160)

### DIFF
--- a/src/avt/Filters/avtLineGlyphFilter.C
+++ b/src/avt/Filters/avtLineGlyphFilter.C
@@ -594,6 +594,10 @@ avtLineGlyphFilter::AddRibbons(vtkPolyData *input,
 //    Kathleen Biagas, Thu Aug 11 2022
 //    Support VTK9: use vtkCellArrayIterator.
 //
+//    Kathleen Biagas, Thu Dec 14, 2023
+//    Don't increment lineIndex in the for loop statement (VTK 9), as it is
+//    incremented at the bottom of the loop.
+//
 // ****************************************************************************
 
 void
@@ -610,11 +614,11 @@ avtLineGlyphFilter::AddEndPoints(vtkPolyData *input, vtkPolyData *output,
     const avtDataAttributes &datts = GetInput()->GetInfo().GetAttributes();
     string activeVar = datts.GetVariableName();
 
-    double ratio           = lineGlyphAtts.GetEndPointRatio();
-    bool varyRadius        = lineGlyphAtts.GetEndPointRadiusVarEnabled();
-    std::string radiusVar  = lineGlyphAtts.GetEndPointRadiusVar();
-    double  radiusFactor   = lineGlyphAtts.GetEndPointRadiusVarRatio();
-    int resolution         = lineGlyphAtts.GetEndPointResolution();
+    double ratio          = lineGlyphAtts.GetEndPointRatio();
+    bool   varyRadius     = lineGlyphAtts.GetEndPointRadiusVarEnabled();
+    string radiusVar      = lineGlyphAtts.GetEndPointRadiusVar();
+    double radiusFactor   = lineGlyphAtts.GetEndPointRadiusVarRatio();
+    int    resolution     = lineGlyphAtts.GetEndPointResolution();
 
     vtkDataArray *radiusArray = NULL;
     double range[2] = {0,1}, scale = 1;
@@ -653,7 +657,7 @@ avtLineGlyphFilter::AddEndPoints(vtkPolyData *input, vtkPolyData *output,
     const vtkIdType *ptIndexs;
 
     auto lines = vtk::TakeSmartPointer(input->GetLines()->NewIterator());
-    for (lines->GoToFirstCell(); !lines->IsDoneWithTraversal(); lines->GoToNextCell(), ++lineIndex)
+    for (lines->GoToFirstCell(); !lines->IsDoneWithTraversal(); lines->GoToNextCell())
     {
         lines->GetCurrentCell(numPts, ptIndexs);
 #endif
@@ -782,7 +786,6 @@ avtLineGlyphFilter::AddEndPoints(vtkPolyData *input, vtkPolyData *output,
                     {
                         outputCellData->SetActiveScalars(activeVar.c_str());
                     }
-
                     for (int k = 0; k < ncells; ++k)
                         scalars->InsertTuple(k, array->GetTuple(lineIndex));
 

--- a/src/avt/Filters/avtLineGlyphFilter.h
+++ b/src/avt/Filters/avtLineGlyphFilter.h
@@ -6,8 +6,8 @@
 //  avtLineGlyphFilter.h
 // ****************************************************************************
 
-#ifndef AVT_LINE_GEOMETRY_FILTER_H
-#define AVT_LINE_GEOMETRY_FILTER_H
+#ifndef AVT_LINE_GLYPH_FILTER_H
+#define AVT_LINE_GLYPH_FILTER_H
 
 #include <avtSIMODataTreeIterator.h>
 
@@ -34,7 +34,7 @@ class vtkPolyData;
 //  Notes:    Pulled out from (now defunct) avtPseudocolorGeometryFilter.
 //
 //  Programmer: Kathleen Biagas
-//  Creation:   June 4, 2020 
+//  Creation:   June 4, 2020
 //
 //  Modifications:
 //

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -24,6 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with Pick unable to return results for 2D datasets.</li>
   <li>Fixed a bug where vtk error messages were printed to the terminal when adding an Image Annotation Object to the viewer window.</li>
   <li>Changed default logic for guessing cycles from file names to not consider any digits in the file name extension if present. This fixed the guessing logic for cases where a file extension includes a digit (e.g. <code>.h5m</code>)</li>
+  <li>Fixed a bug where glyphed line endpoints could be colored incorrectly in the Pseudocolor plot.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/test/baseline/plots/pseudocolor/pseudocolor_mixed_cells_05.png
+++ b/test/baseline/plots/pseudocolor/pseudocolor_mixed_cells_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46ce8ec60ed78f82c91f53377d63f5fc08a678bc6ffe3934aea9ffca8e5bafe9
-size 3765
+oid sha256:9f6bc2c9e1d3b0fbca7880fc7287d25a0ab2d50bd60a59cf7bdc975a7e319ae2
+size 3793


### PR DESCRIPTION
### Description
Resolves #19091

A counter var 'lineIndex' was being incremented in multiple locations. 
Update release notes.
Update related baseline.

Merge from 3.4RC

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->


### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
