### PR TITLE
Update building on Windows.

### DIFF
--- a/src/doc/building_visit/BuildingOnWindows/Prerequisites.rst
+++ b/src/doc/building_visit/BuildingOnWindows/Prerequisites.rst
@@ -13,7 +13,7 @@ For building a released version of VisIt version 3.2.1 or earlier, you can downl
 Look for the *Win 10/8/7 development*  link for the particular version you want.
 The file will be named *visitdev3.2.1.exe* (or similar, based on version chosen).
 
-For building a released version of VisIt version 3.2.2 or newer, download the *Source* tgz file as well as the *Win 10/8/7 development* file which will be named *visit_windowsdev_3.2.2.zip* (or similar, based on version chosen).
+For building a released version of VisIt version 3.2.2 or newer, download the *Source* tgz file as well as the *Win 10 development* file which will be named *visit_windowsdev_3.2.2.zip* (or similar, based on version chosen).
 The .zip file contains all the pre-built third-party binaries needed for building VisIt on Windows.
 It is best to extract these files to the same folder so that *src* from the source tarball is peer to *windowsbuild* from the windows-dev zip file.
 
@@ -26,11 +26,11 @@ If you want to build the latest development version from our repository, you nee
 Other Software
 ~~~~~~~~~~~~~~
 
-1. `CMake <https://cmake.org/download>`_ version 3.15 or greater.
+1. `CMake <https://cmake.org/download>`_ version 3.24 or greater.
 
    * Don't use the CMake included with cygwin if you plan on using the pre-built thirdparty libraries.
 
-2. Visual Studio 2017 64-bit
+2. Visual Studio 2022 (VisIt 3.4.0 and newer) or Visual Studio 2017
 
    * Needed if you want to use our pre-built thirdparty libraries.
 
@@ -41,3 +41,4 @@ Other Software
 4. `Microsoft MPI <https://www.microsoft.com/en-us/download/details.aspx?id=57467>`_. *Optional*
 
    * For building VisIt's parallel engine.  Redistributable binaries and SDK's are needed, so download and install both msmpisdk.msi and msmpisetup.exe.
+


### PR DESCRIPTION
Add MSVC 2022 requirement for 3.4.0 and newer.
Update CMake version to 3.24.

### Type of change

~~* [ ] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Other~~
* [X] Documentation update


