### PR TITLE
Add multiple curves to plot information

### DIFF
--- a/src/avt/Filters/avtCurveConstructorFilter.h
+++ b/src/avt/Filters/avtCurveConstructorFilter.h
@@ -47,6 +47,10 @@
 //    Kathleen Bonnell, Thu Feb 17 09:18:43 PST 2011
 //    Added CreateSingeOutput method.
 //
+//    Kathleen Biagas, Tue Dec 19, 2023
+//    Add a MapNode to store multi-curve output for adding to PlotInformation.
+//    Add vname and count arguments to CreateSingleOutput.
+//
 // ****************************************************************************
 
 class AVTFILTERS_API avtCurveConstructorFilter : public avtDatasetToDatasetFilter
@@ -62,7 +66,8 @@ class AVTFILTERS_API avtCurveConstructorFilter : public avtDatasetToDatasetFilte
 
   protected:
     doubleVector              outputArray;
-    vtkDataSet               *CreateSingleOutput(avtDataTree_p inTree);
+    MapNode                   outputInfo;
+    vtkDataSet               *CreateSingleOutput(avtDataTree_p inTree, const std::string &vname, const int count);
 
     virtual void              Execute(void);
     virtual void              PostExecute(void);

--- a/src/doc/python_scripting/functions.rst
+++ b/src/doc/python_scripting/functions.rst
@@ -4269,11 +4269,14 @@ return type : dictionary
 **Description:**
 
     The GetPlotInformation function returns information about the active plot.
-    For example, a Curve plot will return the xy pairs that comprise the
-    curve.  The tuple is arranged <x1, y1, x2, y2, ..., xn, yn>.
+    For example, a Curve plot will return the xy pairs that comprise the curve.
+    The tuple is arranged <x1, y1, x2, y2, ..., xn, yn>.
+
+    For time queries that create multiple curves, e.g. Time Pick with multiple variables, the dictionary contains a 'Curves' object, and each curve is referenced by it's associated variable name.
+    This was introduced in VisIt 3.4.1.
 
 
-**Example:**
+**Single Curve Example:**
 
 ::
 
@@ -4286,6 +4289,21 @@ return type : dictionary
   info = GetPlotInformation()
   lineout = info["Curve"]
   print("The first lineout point is: [%g, %g] " % lineout[0], lineout[1])
+
+**Multiple Curve Example:**
+
+::
+
+  #% visit -cli
+  OpenDatabase("/usr/gapps/visit/data/wave.visit")
+  AddPlot("Pseudocolor", "pressure")
+  DrawPlots()
+  PickByNode(domain=0,element=10,do_time=1,vars=("pressure", "v"))
+  SetActiveWindow(2)
+  info = GetPlotInformation()
+  pressure = info["Curves"]["pressure"]
+  print("The first pressure point is: [%g, %g] " % pressure[0], pressure[1])
+
 
 
 GetPlotList

--- a/src/plots/MultiCurve/avtMultiCurveFilter.C
+++ b/src/plots/MultiCurve/avtMultiCurveFilter.C
@@ -445,7 +445,7 @@ avtMultiCurveFilter::Execute(void)
                 xLine[1] = (double)i + 0.5 + var->GetTuple1(i*nx+j) * scale;
                 points->InsertNextPoint(xLine);
                 outputArray.push_back(xLine[0]);
-                outputArray.push_back(xLine[1]);
+                outputArray.push_back(var->GetTuple1(i*nx+j));
 
                 // curve markers
                 if (var2 == NULL)

--- a/src/plots/MultiCurve/avtMultiCurveFilter.C
+++ b/src/plots/MultiCurve/avtMultiCurveFilter.C
@@ -112,6 +112,9 @@ avtMultiCurveFilter::PreExecute(void)
 //    input a collection of poly data data sets representing the individual
 //    curves to display.
 //
+//    Kathleen Biagas, Tue Dec 19, 2023
+//    Add curves info to PlotInformation.
+//
 // ****************************************************************************
 
 void
@@ -164,6 +167,7 @@ avtMultiCurveFilter::PostExecute(void)
         axisTickSpacing["spacing"] = yAxisTickSpacing;
         outAtts.AddPlotInformation("AxisTickSpacing", axisTickSpacing);
     }
+    outAtts.AddPlotInformation("Curves", outputInfo);
 }
 
 
@@ -214,7 +218,7 @@ avtMultiCurveFilter::PostExecute(void)
 //    only if the number of labels matches the number of y-axes beig creaed.
 //
 //    Kathleen Biagas, Wed Oct 17 11:22:32 PDT 2012
-//    Support double-precision in coordinates and/or data by using 
+//    Support double-precision in coordinates and/or data by using
 //    vtkDataArray GetTuple1 methods instead of VoidPointer. Merged the
 //    separate 'for (int j = 0; j < nx; j++)' loops into one.
 //
@@ -226,6 +230,9 @@ avtMultiCurveFilter::PostExecute(void)
 //    Increased the maximum number of curves to 20. Modified the end cap
 //    tick calculation to generate a single tick with 16 or more axes.
 //    Previously this gave no tick marks.
+//
+//    Kathleen Biagas, Tue Dec 19, 2023
+//    Fill outputInfo with the xy values of curves.
 //
 // ****************************************************************************
 
@@ -401,6 +408,7 @@ avtMultiCurveFilter::Execute(void)
 
     stringVector inLabels;
     GetInput()->GetInfo().GetAttributes().GetLabels(inLabels);
+    doubleVector outputArray;
     for (int i = 0; i < ny; i++)
     {
         //
@@ -436,6 +444,8 @@ avtMultiCurveFilter::Execute(void)
                 xLine[0] = xpts->GetTuple1(j);
                 xLine[1] = (double)i + 0.5 + var->GetTuple1(i*nx+j) * scale;
                 points->InsertNextPoint(xLine);
+                outputArray.push_back(xLine[0]);
+                outputArray.push_back(xLine[1]);
 
                 // curve markers
                 if (var2 == NULL)
@@ -489,20 +499,22 @@ avtMultiCurveFilter::Execute(void)
         ids->Delete();
 
         out_ds[i] = polyData;
-    
+
         //
         // Create the label.
         //
         if(inLabels.size() != (size_t)ny)
         {
             char label[80];
-        
-            snprintf(label, 80, atts.GetYAxisTitleFormat().c_str(), 
+
+            snprintf(label, 80, atts.GetYAxisTitleFormat().c_str(),
                      ypts->GetTuple1(i));
             labels.push_back(label);
         }
         else
             labels.push_back(inLabels[i]);
+        outputInfo[labels[labels.size()-1]] = outputArray;
+        outputArray.clear();
     }
 
     //

--- a/src/plots/MultiCurve/avtMultiCurveFilter.h
+++ b/src/plots/MultiCurve/avtMultiCurveFilter.h
@@ -12,6 +12,7 @@
 
 #include <avtDatasetToDatasetFilter.h>
 #include <MultiCurveAttributes.h>
+#include <MapNode.h>
 
 
 // ****************************************************************************
@@ -33,6 +34,9 @@
 //    I modified the filter could would also accept as input a collection
 //    of poly data data sets representing the individual curves to display.
 //
+//    Kathleen Biagas, Tue Dec 19, 2023
+//    Add outputInfo, for storing curves in PlotInformation.
+//
 // ****************************************************************************
 
 class avtMultiCurveFilter : public avtDatasetToDatasetFilter
@@ -41,9 +45,9 @@ class avtMultiCurveFilter : public avtDatasetToDatasetFilter
                               avtMultiCurveFilter(MultiCurveAttributes &);
     virtual                  ~avtMultiCurveFilter();
 
-    virtual const char       *GetType(void)   { return "avtMultiCurveFilter"; };
+    virtual const char       *GetType(void)   { return "avtMultiCurveFilter"; }
     virtual const char       *GetDescription(void)
-                                  { return "Performing MultiCurve"; };
+                                  { return "Performing MultiCurve"; }
 
     void                      SetAttributes(const MultiCurveAttributes &);
 
@@ -51,6 +55,7 @@ class avtMultiCurveFilter : public avtDatasetToDatasetFilter
     MultiCurveAttributes      atts;
     bool                      setYAxisTickSpacing;
     double                    yAxisTickSpacing;
+    MapNode                   outputInfo;
 
     virtual void              Execute(void);
 

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Upgraded MFEM library version to 4.6.0.</li>
   <li>The <i>surface_normal</i> expression now accepts mesh types other than polydata, allowing it to be used more easily as an operator-created variable.</li>
   <li>Added more keywords ("MFA", "2fa", "Autentication", and "OTP") that cause VisIt clients to open a second popup for a password.</li>
+  <li>GetPlotInformation() can now entries for multiple-curves when Query-over-time is performed on multiple variables. For example, if a pick-through-time was preformed for variables 'u' and 'v', the curve for 'v' would be retrieved via 'GetPlotInformation()['Curves']['v']. Single variable results will still be retrieved via 'GetPlotInformation()['Curve'].
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -35,7 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Upgraded MFEM library version to 4.6.0.</li>
   <li>The <i>surface_normal</i> expression now accepts mesh types other than polydata, allowing it to be used more easily as an operator-created variable.</li>
   <li>Added more keywords ("MFA", "2fa", "Autentication", and "OTP") that cause VisIt clients to open a second popup for a password.</li>
-  <li>GetPlotInformation() can now entries for multiple-curves when Query-over-time is performed on multiple variables. For example, if a pick-through-time was preformed for variables 'u' and 'v', the curve for 'v' would be retrieved via 'GetPlotInformation()['Curves']['v']. Single variable results will still be retrieved via 'GetPlotInformation()['Curve'].
+  <li>GetPlotInformation() can now contain entries for multiple-curves when Query-over-time is performed on multiple variables. For example, if a pick-through-time was performed for variables 'u' and 'v', the curve for 'v' would be retrieved via 'GetPlotInformation()['Curves']['v']. Single variable results will still be retrieved via 'GetPlotInformation()['Curve'].
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/test/tests/queries/pickNamedArgs.py
+++ b/src/test/tests/queries/pickNamedArgs.py
@@ -87,7 +87,7 @@ def TimePick():
     SetActiveWindow(2);
     Test("TimePick_NamedArgs_03")
 
-    # these should be the same as TimePick_NamedArgs_01
+    # these should be the same as TimePick_NamedArgs_00
     firstYVal=GetPlotInformation()["Curves"]["pressure"][1]
     TestValueEQ("Curve type 1, pressure first value", firstYVal, PFirstYVal, 14)
     firstYVal=GetPlotInformation()["Curves"]["v"][1]

--- a/src/test/tests/queries/pickNamedArgs.py
+++ b/src/test/tests/queries/pickNamedArgs.py
@@ -51,6 +51,15 @@ def TimePick():
     PickByNode(element=8837, vars=vars, do_time=1, preserve_coord=0,curve_plot_type=0)
     SetActiveWindow(2);
     Test("TimePick_NamedArgs_00")
+
+    # this test and NamedArgs_03 using curve type 1 should return same values
+    PFirstYVal =  0.019999999552965164
+    VFirstYVal =  0.0010749432258307394
+
+    firstYVal=GetPlotInformation()["Curves"]["pressure"][1]
+    TestValueEQ("Curve type 0, pressure first value", firstYVal, PFirstYVal, 14)
+    firstYVal=GetPlotInformation()["Curves"]["v"][1]
+    TestValueEQ("Curve type 0, v first value", firstYVal,  VFirstYVal, 14)
     DeleteAllPlots()
 
     c.curveColor = (0, 255, 0, 255)
@@ -77,6 +86,12 @@ def TimePick():
     PickByNode(element=8837, vars=vars, do_time=1, preserve_coord=0,curve_plot_type=1)
     SetActiveWindow(2);
     Test("TimePick_NamedArgs_03")
+
+    # these should be the same as TimePick_NamedArgs_01
+    firstYVal=GetPlotInformation()["Curves"]["pressure"][1]
+    TestValueEQ("Curve type 1, pressure first value", firstYVal, PFirstYVal, 14)
+    firstYVal=GetPlotInformation()["Curves"]["v"][1]
+    TestValueEQ("Curve type 1, v first value", firstYVal,  VFirstYVal, 14)
     DeleteAllPlots()
 
     SetActiveWindow(1);


### PR DESCRIPTION
### Description

Resolves #19137

When a time-query creates multiple curves (eg pick with multiple vars), the plot information will now contain separate curves for each var. The root object is 'Curves' with individual curves referenced by associated var name.
So, to if a time-pick was performed with vars 'A' and 'B', the curve for variable 'B' can be retrieved via
`GetPlotInformation()['Curves']['B']`

Single curve plot information is still retrieved via `GetPlotInformation()['Curve']`, in order to preserve current functionality in the patch release.

MultiCurve plot was also modified to add it's curves to PlotInformation.

Tests were added.


Docs for GetPlotInformation was updated


### Type of change

* [ ] Bug fix~~
* [X] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Full regression was run with success (eg no changes).
Tests for the new functionality were added to pickNamedArgs.py

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
