### PR TITLE
Ensure mesh plot opacity applied to all actors. (#19185)

### DIFF
--- a/src/plots/Mesh/avtMeshPlotMapper.C
+++ b/src/plots/Mesh/avtMeshPlotMapper.C
@@ -132,6 +132,9 @@ avtMeshPlotMapper::CreateActorMapperPairs(vtkDataSet **children)
 //    Kathleen Biagas, Wed Apr  3 16:11:45 PDT 2019
 //    Added pointSize.
 //
+//    Kathleen Biagas, Thu Dec 15, 2023
+//    Ensure opacity is set for all actors. 
+//
 // ****************************************************************************
 
 void
@@ -144,6 +147,7 @@ avtMeshPlotMapper::CustomizeMappers()
 
         mappers[i]->SetScalarVisibility(false);
         vtkProperty *prop = actors[i]->GetProperty();
+        prop->SetOpacity(opacity);
 
         if (mappers[i]->IsA("vtkPointGlyphMapper"))
         {
@@ -183,7 +187,6 @@ avtMeshPlotMapper::CustomizeMappers()
             prop->SetDiffuse(0.);
             prop->SetColor(linesColor);
             prop->SetLineWidth(lineWidth);
-            prop->SetOpacity(opacity);
             prop->SetPointSize(pointSize);
         }
         else if (labels[i].compare(0, 11, string("mesh_polys_")) == 0)

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -26,6 +26,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Changed default logic for guessing cycles from file names to not consider any digits in the file name extension if present. This fixed the guessing logic for cases where a file extension includes a digit (e.g. <code>.h5m</code>)</li>
   <li>Fixed a bug where glyphed line endpoints could be colored incorrectly in the Pseudocolor plot.</li>
   <li>Fixed a VTK Texture Buffer error that caused error messages to be printed to the command line.</li>
+  <li>Fixed a Mesh plot bug where transparency would not be honored.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
Fixes bug where transparency wasn't always being honored.

Resolves #19141

Merge from 3.4RC