### PR TITLE
Fix parallel bug with Volume plot (vtk9). (#19207)

### DIFF
--- a/src/plots/VolumeVTK9/avtVolumeResampleFilter.C
+++ b/src/plots/VolumeVTK9/avtVolumeResampleFilter.C
@@ -258,6 +258,10 @@ avtVolumeResampleFilter::Execute(void)
 //    Catch the exception that can occur when using an operator that produces
 //    a variable that doesn't exist in the database.
 //
+//    Kathleen Biagas, Wed Jan  3 13:26:29 PST 2024
+//    Retreive value returned by UnifyBitwiseOrValue, and moved the call to
+//    the end of the method.
+//
 // ****************************************************************************
 
 int
@@ -289,12 +293,6 @@ avtVolumeResampleFilter::DataMustBeResampled(avtDataObject_p input)
     vtkDataSet **leaves = tree->GetAllLeaves(nsets);
     if( nsets > 1 )
         resampling |= MultipleDatasets;
-
-    // When there are more domains than ranks, it is possible for some
-    // ranks to have one data set while others have more than one. As
-    // such, when this case occurs the resampling must be acorss all
-    // ranks so unify the resampling.
-    UnifyBitwiseOrValue(resampling);
 
     for (int i = 0; i < nsets; ++i)
     {
@@ -334,6 +332,13 @@ avtVolumeResampleFilter::DataMustBeResampled(avtDataObject_p input)
             resampling |= DifferentCentering;
         }
     }
+
+    // When there are more domains than ranks, it is possible for some
+    // ranks to have one data set while others have more than one. As
+    // such, when this case occurs the resampling must be acorss all
+    // ranks so unify the resampling.
+    resampling = UnifyBitwiseOrValue(resampling);
+
     return resampling;
 }
 

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -28,6 +28,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a VTK Texture Buffer error that caused error messages to be printed to the command line.</li>
   <li>Fixed a Mesh plot bug where transparency would not be honored.</li>
   <li>Fixed compile error where some executable targets were missing QSurfaceFormat include.</li>
+  <li>Fixed a Volume plot but that would cause the parallel engine to crash when certain operators were used in conjunction with the plot.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/operators/reflect.py
+++ b/src/test/tests/operators/reflect.py
@@ -246,17 +246,15 @@ AddOperator("Reflect")
 DrawPlots()
 Test("ops_refl13")
 
-# This test hangs in parallel.
-if TestEnv.params["serial"]:
-    # The "mass volume extractor" of the volume renderer depends on the
-    # rectilinear grid not being inverted.  Test that here ('6321).
-    DeleteAllPlots()
-    OpenDatabase(silo_data_path("rect3d.silo"))
+# The "mass volume extractor" of the volume renderer depends on the
+# rectilinear grid not being inverted.  Test that here ('6321).
+DeleteAllPlots()
+OpenDatabase(silo_data_path("rect3d.silo"))
 
-    AddPlot("Volume", "d")
-    AddOperator("Reflect")
-    DrawPlots()
-    Test("ops_refl14")
+AddPlot("Volume", "d")
+AddOperator("Reflect")
+DrawPlots()
+Test("ops_refl14")
 
 #
 # Now test reflecting different datasets over arbitrary planes.

--- a/src/test/tests/plots/volumePlot.py
+++ b/src/test/tests/plots/volumePlot.py
@@ -650,9 +650,7 @@ def TestCommandRecording():
 InitAnnotationsLegendOn()
 volume_colors()
 TestVolumeGaussianControlPoints()
-# This test hangs in parallel.
-if TestEnv.params["serial"]:
-    TestVolumeAspect()
+TestVolumeAspect()
 TestVolumeOpacity()
 TestCommandRecording()
 InitAnnotations()


### PR DESCRIPTION
The return value from UnifyBitwiseOrValue wasn't being captured and utilized, so different ranks had different values for the 'resampling' var.
Re-enable the two skipped tests affected by this bug.
Resolves #19204.
Resolves #19205.

Merge from 3.4RC



### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran the affected tests in parallel on pascal with success.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
