### PR TITLE
Fix problems with path-filtering in regression suite on Windows. (#19223)

### DIFF
--- a/src/common/state/Variant.C
+++ b/src/common/state/Variant.C
@@ -2980,6 +2980,10 @@ Variant::TokenizeQuotedString(const string &val,stringVector &tokens)
 //    Kathleen Biagas, Fri Dec 1 2023
 //    If on Windows, also escape path separators and convert unix-style.
 //
+//    Kathleen Biagas, Wed Jan 3 2024
+//    Revert conversion of unix-style path separator on Windows, it caused
+//    problems for 'dir/var' strings that weren't file-paths. 
+//
 // ****************************************************************************
 string
 Variant::EscapeQuotedString(const string &val)
@@ -2995,11 +2999,6 @@ Variant::EscapeQuotedString(const string &val)
         }
 #ifdef _WIN32
         else if(val[i] == '\\')
-        {
-            res.push_back('\\');
-            res.push_back('\\');
-        }
-        else if(val[i] == '/')
         {
             res.push_back('\\');
             res.push_back('\\');

--- a/src/test/py_src/visit_test_main.py
+++ b/src/test/py_src/visit_test_main.py
@@ -1681,6 +1681,10 @@ def ProcessDiffImage(case_name, baseimg, testimg, diffimg):
 #
 #   Mark C. Miller, Fri Sep 11 19:55:17 PDT 2020
 #   Added numdifftol arg
+#
+#   Kathleen Biagas, Tue Jan 2, 2024
+#   Handle cases where there are extra path-separator escapes on Windows.
+#
 # ----------------------------------------------------------------------------
 
 def FilterTestText(inText, baseText, numdifftol):
@@ -1691,10 +1695,16 @@ def FilterTestText(inText, baseText, numdifftol):
     # We have to filter out the absolute path information we might see in
     # this string. runtest passes the value for visitTopDir here.
     #
+
+    # handle cases where there are extra path-separator escapes
+    if platform.system() == "Windows":
+        inText = inText.replace("\\\\", "\\")
+
     inText = inText.replace(TestEnv.params["run_dir"], "VISIT_TOP_DIR/test")
     inText = inText.replace(out_path(), "VISIT_TOP_DIR/test")
     inText = inText.replace(test_root_path(), "VISIT_TOP_DIR/test")
     inText = inText.replace(data_path(), "VISIT_TOP_DIR/data")
+
     #
     # Only consider doing any string substitution if numerical diff threshold
     # is non-zero


### PR DESCRIPTION
Added logic to handle cases where there are extra path-separator escapes when filtering paths in text to substitute VISIT_TOP_DIR.

Also reverted a change in Variant.C where unix-style paths were converted to Windows-style in 'EscapeQuotedString'.

This is a merge from 3.4RC.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran the XRayImage query with full success on Windows.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
