### PR TITLE
Ensure Standard editor default tab in Expression Window. (#19229)

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -648,8 +648,7 @@ QvisExpressionsWindow::CreateWindowContents()
     // tab 2 -> python filter editor
     CreatePythonFilterEditor();
     editorTabs->addTab(pyEditorWidget, tr("Python expression editor"));
-
-
+    editorTabs->setCurrentIndex(0);
     definitionLayout->addWidget(editorTabs,row,0,1,2);
     definitionLayout->setColumnStretch(1, 10);
 
@@ -966,6 +965,13 @@ QvisExpressionsWindow::UpdateWindowSingleItem()
 //    Added a call to update() to remove the visual artificats present during
 //    the first draw of the expressions window.
 //
+//    Kathleen Biagas, Thu Jan 11, 2024
+//    Fixed problem with stdEditor not being the default open tab when
+//    Expression window first opened.  Calling setEnabled with a value of
+//    on the tabs widget seems to be changing which tab is considered current.
+//    Capture currentIndex before setting enablement of the tabs, then reset
+//    it afterwards.
+//
 // ****************************************************************************
 
 void
@@ -990,8 +996,12 @@ QvisExpressionsWindow::UpdateWindowSensitivity()
     typeList->setEnabled(enable);
     notHidden->setEnabled(enable);
 
+    // calling setTableEnbled with a value of false seems to change the
+    // current index, so capture that information and reset it after.
+    int ci = editorTabs->currentIndex();
     editorTabs->setTabEnabled(0, enable && stdExprActive);
     editorTabs->setTabEnabled(1, enable && pyExprActive);
+    editorTabs->setCurrentIndex(ci);
     editorTabs->update();
     
     this->update();

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed compile error where some executable targets were missing QSurfaceFormat include.</li>
   <li>Fixed a Volume plot but that would cause the parallel engine to crash when certain operators were used in conjunction with the plot.</li>
   <li>Fixed a Cube reader bug that didn't read in multiple orbital data files correctly.</li>
+  <li>Fixed a bug with the Expression window that caused the 'Python' editor to be the default tab when the window was first opened.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Looks like Qt6 changed the behavior of 'setTabEnabled' for TabWIdget to also change the current index of the widget.
 logic to grab the current index and use it to reset current index after the calls to setTabEnabled.
Resolves #19217


### Type of change

<!-- Please check one of the boxes below -->

* [X Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I verified that the Standard editor tab is the default when the Expressions window is first opened. Then also verified correct behavior when expressions are added, either Standard or Python that the correct tab is displayed when each expression is selected.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

