### PR TITLE
Remove custom mouse press event code from opacity slider

### DIFF
--- a/src/gui/QvisOpacitySlider.C
+++ b/src/gui/QvisOpacitySlider.C
@@ -1436,7 +1436,7 @@ QvisOpacitySlider::subtractLine()
 // Modifications:
 //
 // ****************************************************************************
-#include <iostream>
+
 void
 QvisOpacitySlider::handle_valueChanged(int val)
 {

--- a/src/gui/QvisOpacitySlider.C
+++ b/src/gui/QvisOpacitySlider.C
@@ -978,19 +978,6 @@ QvisOpacitySlider::mouseMoveEvent(QMouseEvent *e)
     if(state != Dragging)
         return;
 
-    QRect r = rect();
-    int m = maximumSliderDragDistance();
-    if(m >= 0)
-    {
-        r.setRect(r.x() - m, r.y() - 2*m/3,
-                  r.width() + 2*m, r.height() + 3*m);
-        if(!r.contains(e->pos()))
-        {
-            moveSlider( positionFromValue( sliderStartVal) );
-            return;
-        }
-    }
-
     moveSlider(e->pos().x() - clickOffset );
 }
 
@@ -1449,7 +1436,7 @@ QvisOpacitySlider::subtractLine()
 // Modifications:
 //
 // ****************************************************************************
-
+#include <iostream>
 void
 QvisOpacitySlider::handle_valueChanged(int val)
 {

--- a/src/gui/QvisOpacitySlider.C
+++ b/src/gui/QvisOpacitySlider.C
@@ -907,6 +907,7 @@ QvisOpacitySlider::paintEvent(QPaintEvent *)
 // Modifications:
 //   Brad Whitlock, Thu Jun  5 14:21:18 PDT 2008
 //   Qt 4.
+// 
 //
 // ****************************************************************************
 
@@ -969,6 +970,9 @@ QvisOpacitySlider::mousePressEvent(QMouseEvent *e)
 // Creation:   Thu Dec 7 12:46:37 PDT 2000
 //
 // Modifications:
+//   Justin Privitera, Tue Jan 16 15:32:16 PST 2024
+//   Remove custom code snapping the slider value to zero when dragging it 
+//   outside the window.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a Cube reader bug that didn't read in multiple orbital data files correctly.</li>
   <li>Fixed a bug with the Expression window that caused the 'Python' editor to be the default tab when the window was first opened.</li>
   <li>Fixed a bug with the Cartographic Projection operator where the projections were a no-op.</li>
+  <li>Removed custom logic forcing the opacity slider to snap to zero if the mouse dragged the slider outside the widget it belongs to.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #19142 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
I removed the custom code that forces the opacity slider to go to zero when the mouse drags it out of the window.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Built and ran on rztopaz; the opacity slider works as desired.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
