### PR TITLE
On Windows, use `os.add_dll_directory` to point to location of ThirdParty dlls. (#19258)

### DIFF
--- a/src/avt/PythonFilters/PythonInterpreter.C
+++ b/src/avt/PythonFilters/PythonInterpreter.C
@@ -207,6 +207,30 @@ PythonInterpreter::AddSystemPath(const std::string &path)
     return RunScript("sys.path.insert(1,r'" + path + "')\n");
 }
 
+#ifdef _WIN32
+// ****************************************************************************
+//  Method: PythonInterpreter::AddDLLPath
+//
+//  Purpose:
+//      Adds passed path to "os.add_dll_directory"
+//
+//  Arguments:
+//      path      Path to DLLs  (eg VisIt's third party dlls)
+//
+//  Programmer:   Kathleen Biagas 
+//  Creation:     January 24, 2024 
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+bool
+PythonInterpreter::AddDLLPath(const std::string &path)
+{
+    return RunScript("os.add_dll_directory(r'" + path + "')\n");
+}
+#endif
+
 // ****************************************************************************
 //  Method: PythonInterpreter::RunScript
 //

--- a/src/avt/PythonFilters/PythonInterpreter.h
+++ b/src/avt/PythonFilters/PythonInterpreter.h
@@ -23,6 +23,10 @@ typedef _object PyObject;
 //  Programmer:  Cyrus Harrison
 //  Creation:    May 2, 2008
 //
+//  Modifications:
+//    Kathleen Biagas, Wed Jan 24, 2024
+//    Added new method 'AddDLLPath'.
+//
 // ****************************************************************************
 class AVTPYTHON_FILTERS_API PythonInterpreter
 {
@@ -36,6 +40,9 @@ public:
     void         Shutdown();
 
     bool         AddSystemPath(const std::string &path);
+#ifdef _WIN32
+    bool         AddDLLPath(const std::string &path);
+#endif
     bool         RunScript(const std::string &script);
     bool         RunScriptFile(const std::string &fname);
 

--- a/src/avt/PythonFilters/avtPythonFilterEnvironment.C
+++ b/src/avt/PythonFilters/avtPythonFilterEnvironment.C
@@ -95,6 +95,10 @@ avtPythonFilterEnvironment::~avtPythonFilterEnvironment()
 //    Cyrus Harrison, Tue Feb 23 17:04:32 PST 2021
 //    Use MPI_Comm_c2f handle to init mpicom module.
 //
+//    Kathleen Biagas, Wed Jan 24, 2024
+//    When running a dev version on Windows, add ThirdParty directory
+//    to dll directory.
+//
 // ****************************************************************************
 
 bool
@@ -113,6 +117,16 @@ avtPythonFilterEnvironment::Initialize()
     if(!pyi->AddSystemPath(vlibsp)) // vtk module is symlinked here
         return false;
 
+#ifdef _WIN32
+    // need to add ThirdParty dll directory to dll path if it is available
+    // (eg for development builds)
+    if(GetIsDevelopmentVersion())
+    {
+        string vdlldir = GetVisItThirdPartyDirectory();
+        if(!vdlldir.empty() && !pyi->AddDLLPath(vdlldir))
+            return false;
+    }
+#endif
     // import pyavt and vtk
     if(!pyi->RunScript("from pyavt.filters import *\n"))
         return false;

--- a/src/common/misc/InstallationFunctions.C
+++ b/src/common/misc/InstallationFunctions.C
@@ -420,6 +420,40 @@ GetSystemVisItHostsDirectory()
     return retVal;
 }
 
+#ifdef _WIN32
+#include <filesystem>
+// ****************************************************************************
+// Method:  GetVisItThirdPartyDirectory
+//
+// Purpose:
+//   Returns the path to the ThirdParty directory for a dev build of VisIt.
+//   Returns an empty string if not running from a development build.
+//
+// Arguments:
+//   none
+//
+// Programmer:  Kathleen Biagas 
+// Creation:    January 24, 2024
+//
+// Modifications:
+//
+// ****************************************************************************
+
+std::string
+GetVisItThirdPartyDirectory()
+{
+    std::string retval;
+    if(GetIsDevelopmentVersion())
+    {
+        std::filesystem::path homeDir(GetVisItInstallationDirectory());
+        auto dllDir = homeDir.parent_path() / "ThirdParty";
+        retval = dllDir.string();
+    }
+    return retval;
+}
+
+#endif
+
 // ****************************************************************************
 // Method: GetVisItResourcesDirectory
 //

--- a/src/common/misc/InstallationFunctions.h
+++ b/src/common/misc/InstallationFunctions.h
@@ -36,6 +36,10 @@ std::string MISC_API GetAndMakeUserVisItHostsDirectory();
 std::string MISC_API GetVisItHostsDirectory();
 std::string MISC_API GetSystemVisItHostsDirectory();
 
+#ifdef _WIN32
+std::string MISC_API GetVisItThirdPartyDirectory();
+#endif
+
 typedef enum {
     VISIT_RESOURCES,
     VISIT_RESOURCES_COLORTABLES,

--- a/src/visitpy/cli/cli.C
+++ b/src/visitpy/cli/cli.C
@@ -563,6 +563,18 @@ main(int argc, char *argv[])
         oss << "sys.path.append(pjoin(r'" << vlibdir  <<"','site-packages'))";
         PyRun_SimpleString(oss.str().c_str());
 
+#ifdef _WIN32
+        if(GetIsDevelopmentVersion())
+        {
+            // retrieve ThirdParty directory
+            std::string dlldir  = GetVisItThirdPartyDirectory(); 
+            // Add thirdparty DLL's directory
+            std::ostringstream ss;
+            ss << "os.add_dll_directory(r'" << dlldir  <<"')";
+            PyRun_SimpleString(ss.str().c_str());
+        }
+#endif
+
         // Initialize the VisIt module.
         cli_initvisit(bufferDebug ? -debugLevel : debugLevel,
                       verbose,


### PR DESCRIPTION
To fix issues where Python 3.9 cannot import vtk modules due to change in how paths are searched for DLLs.
 Added function to retrieve ThirdParty path for dev version of Windows (for non-dev, the dlls live with the executables). Use that path in call to  `os.add_dll_directory`.
   
Merge from 3.4RC

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran visit -cli, import of vtk succeeded.
Ran py_expr and py_query tests with success.

### Checklist:

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
