### PR TITLE
remove invalid sxterm options from llnl ibm lsf systems

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Cartographic Projection operator where the projections were a no-op.</li>
   <li>Removed custom logic forcing the opacity slider to snap to zero if the mouse dragged the slider outside the widget it belongs to.</li>
   <li>Fixed a bug in the Blueprint reader causing unstructured point topologies to display incorrectly if they did not use all of the provided coordinates.</li>
+  <li>Removed sxterm host profile options for LLNL LSF Machines. sxterm is not available on these systems.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/hosts/llnl/host_llnl_lassen.xml
+++ b/src/resources/hosts/llnl/host_llnl_lassen.xml
@@ -139,45 +139,5 @@
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pbatch</Field>
     </Object>
-    <Object name="LaunchProfile">
-        <Field name="timeout" type="int">480</Field>
-        <Field name="numProcessors" type="int">40</Field>
-        <Field name="numNodesSet" type="bool">false</Field>
-        <Field name="numNodes" type="int">1</Field>
-        <Field name="partitionSet" type="bool">false</Field>
-        <Field name="partition" type="string"></Field>
-        <Field name="bankSet" type="bool">false</Field>
-        <Field name="bank" type="string"></Field>
-        <Field name="timeLimitSet" type="bool">false</Field>
-        <Field name="timeLimit" type="string"></Field>
-        <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">mpirun</Field>
-        <Field name="forceStatic" type="bool">true</Field>
-        <Field name="forceDynamic" type="bool">false</Field>
-        <Field name="active" type="bool">false</Field>
-        <Field name="arguments" type="stringVector"></Field>
-        <Field name="parallel" type="bool">true</Field>
-        <Field name="launchArgsSet" type="bool">false</Field>
-        <Field name="launchArgs" type="string"></Field>
-        <Field name="sublaunchArgsSet" type="bool">false</Field>
-        <Field name="sublaunchArgs" type="string"></Field>
-        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPreCmd" type="string"></Field>
-        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPostCmd" type="string"></Field>
-        <Field name="machinefileSet" type="bool">false</Field>
-        <Field name="machinefile" type="string"></Field>
-        <Field name="visitSetsUpEnv" type="bool">false</Field>
-        <Field name="canDoHWAccel" type="bool">false</Field>
-        <Field name="GPUsPerNode" type="int">1</Field>
-        <Field name="XArguments" type="string"></Field>
-        <Field name="launchXServers" type="bool">false</Field>
-        <Field name="XDisplay" type="string">:%l</Field>
-        <Field name="numThreads" type="int">0</Field>
-        <Field name="constrainNodeProcs" type="bool">false</Field>
-        <Field name="allowableNodes" type="intVector"></Field>
-        <Field name="allowableProcs" type="intVector"></Field>
-        <Field name="profileName" type="string">parallel sxterm</Field>
-    </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>

--- a/src/resources/hosts/llnl/host_llnl_rzansel.xml
+++ b/src/resources/hosts/llnl/host_llnl_rzansel.xml
@@ -98,45 +98,5 @@
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pdebug</Field>
     </Object>
-    <Object name="LaunchProfile">
-        <Field name="timeout" type="int">480</Field>
-        <Field name="numProcessors" type="int">40</Field>
-        <Field name="numNodesSet" type="bool">false</Field>
-        <Field name="numNodes" type="int">1</Field>
-        <Field name="partitionSet" type="bool">false</Field>
-        <Field name="partition" type="string"></Field>
-        <Field name="bankSet" type="bool">false</Field>
-        <Field name="bank" type="string"></Field>
-        <Field name="timeLimitSet" type="bool">false</Field>
-        <Field name="timeLimit" type="string"></Field>
-        <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">mpirun</Field>
-        <Field name="forceStatic" type="bool">true</Field>
-        <Field name="forceDynamic" type="bool">false</Field>
-        <Field name="active" type="bool">false</Field>
-        <Field name="arguments" type="stringVector"></Field>
-        <Field name="parallel" type="bool">true</Field>
-        <Field name="launchArgsSet" type="bool">false</Field>
-        <Field name="launchArgs" type="string"></Field>
-        <Field name="sublaunchArgsSet" type="bool">false</Field>
-        <Field name="sublaunchArgs" type="string"></Field>
-        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPreCmd" type="string"></Field>
-        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPostCmd" type="string"></Field>
-        <Field name="machinefileSet" type="bool">false</Field>
-        <Field name="machinefile" type="string"></Field>
-        <Field name="visitSetsUpEnv" type="bool">false</Field>
-        <Field name="canDoHWAccel" type="bool">false</Field>
-        <Field name="GPUsPerNode" type="int">1</Field>
-        <Field name="XArguments" type="string"></Field>
-        <Field name="launchXServers" type="bool">false</Field>
-        <Field name="XDisplay" type="string">:%l</Field>
-        <Field name="numThreads" type="int">0</Field>
-        <Field name="constrainNodeProcs" type="bool">false</Field>
-        <Field name="allowableNodes" type="intVector"></Field>
-        <Field name="allowableProcs" type="intVector"></Field>
-        <Field name="profileName" type="string">parallel sxterm</Field>
-    </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_sierra.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_sierra.xml
@@ -139,45 +139,5 @@
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pbatch</Field>
     </Object>
-    <Object name="LaunchProfile">
-        <Field name="timeout" type="int">480</Field>
-        <Field name="numProcessors" type="int">40</Field>
-        <Field name="numNodesSet" type="bool">false</Field>
-        <Field name="numNodes" type="int">1</Field>
-        <Field name="partitionSet" type="bool">false</Field>
-        <Field name="partition" type="string"></Field>
-        <Field name="bankSet" type="bool">false</Field>
-        <Field name="bank" type="string"></Field>
-        <Field name="timeLimitSet" type="bool">false</Field>
-        <Field name="timeLimit" type="string"></Field>
-        <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">mpirun</Field>
-        <Field name="forceStatic" type="bool">true</Field>
-        <Field name="forceDynamic" type="bool">false</Field>
-        <Field name="active" type="bool">false</Field>
-        <Field name="arguments" type="stringVector"></Field>
-        <Field name="parallel" type="bool">true</Field>
-        <Field name="launchArgsSet" type="bool">false</Field>
-        <Field name="launchArgs" type="string"></Field>
-        <Field name="sublaunchArgsSet" type="bool">false</Field>
-        <Field name="sublaunchArgs" type="string"></Field>
-        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPreCmd" type="string"></Field>
-        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPostCmd" type="string"></Field>
-        <Field name="machinefileSet" type="bool">false</Field>
-        <Field name="machinefile" type="string"></Field>
-        <Field name="visitSetsUpEnv" type="bool">false</Field>
-        <Field name="canDoHWAccel" type="bool">false</Field>
-        <Field name="GPUsPerNode" type="int">1</Field>
-        <Field name="XArguments" type="string"></Field>
-        <Field name="launchXServers" type="bool">false</Field>
-        <Field name="XDisplay" type="string">:%l</Field>
-        <Field name="numThreads" type="int">0</Field>
-        <Field name="constrainNodeProcs" type="bool">false</Field>
-        <Field name="allowableNodes" type="intVector"></Field>
-        <Field name="allowableProcs" type="intVector"></Field>
-        <Field name="profileName" type="string">parallel sxterm</Field>
-    </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>

--- a/src/resources/hosts/llnl_rz/host_llnl_rzansel.xml
+++ b/src/resources/hosts/llnl_rz/host_llnl_rzansel.xml
@@ -99,45 +99,5 @@
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pdebug</Field>
     </Object>
-    <Object name="LaunchProfile">
-        <Field name="timeout" type="int">480</Field>
-        <Field name="numProcessors" type="int">40</Field>
-        <Field name="numNodesSet" type="bool">false</Field>
-        <Field name="numNodes" type="int">1</Field>
-        <Field name="partitionSet" type="bool">false</Field>
-        <Field name="partition" type="string"></Field>
-        <Field name="bankSet" type="bool">false</Field>
-        <Field name="bank" type="string"></Field>
-        <Field name="timeLimitSet" type="bool">false</Field>
-        <Field name="timeLimit" type="string"></Field>
-        <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">mpirun</Field>
-        <Field name="forceStatic" type="bool">true</Field>
-        <Field name="forceDynamic" type="bool">false</Field>
-        <Field name="active" type="bool">false</Field>
-        <Field name="arguments" type="stringVector"></Field>
-        <Field name="parallel" type="bool">true</Field>
-        <Field name="launchArgsSet" type="bool">false</Field>
-        <Field name="launchArgs" type="string"></Field>
-        <Field name="sublaunchArgsSet" type="bool">false</Field>
-        <Field name="sublaunchArgs" type="string"></Field>
-        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPreCmd" type="string"></Field>
-        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
-        <Field name="sublaunchPostCmd" type="string"></Field>
-        <Field name="machinefileSet" type="bool">false</Field>
-        <Field name="machinefile" type="string"></Field>
-        <Field name="visitSetsUpEnv" type="bool">false</Field>
-        <Field name="canDoHWAccel" type="bool">false</Field>
-        <Field name="GPUsPerNode" type="int">1</Field>
-        <Field name="XArguments" type="string"></Field>
-        <Field name="launchXServers" type="bool">false</Field>
-        <Field name="XDisplay" type="string">:%l</Field>
-        <Field name="numThreads" type="int">0</Field>
-        <Field name="constrainNodeProcs" type="bool">false</Field>
-        <Field name="allowableNodes" type="intVector"></Field>
-        <Field name="allowableProcs" type="intVector"></Field>
-        <Field name="profileName" type="string">parallel sxterm</Field>
-    </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>


### PR DESCRIPTION
### Description

Resolves #19236

Removes sxterm options from lsf systems.

They were a shell out to mpirun, which won't work well on these systems.

Folks can use command line + lrun options to achieve the intended use case.


### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

configuration update

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
