### PR TITLE
Fix findblosc2 for windows.

### DIFF
--- a/src/CMake/FindBlosc2.cmake
+++ b/src/CMake/FindBlosc2.cmake
@@ -4,5 +4,9 @@
 
 # Use the BLOSC_DIR hint from the config-site .cmake file
 
-SET_UP_THIRD_PARTY(BLOSC2 LIBS blosc2)
+if(WIN32)
+    SET_UP_THIRD_PARTY(BLOSC2 LIBS libblosc2)
+else()
+    SET_UP_THIRD_PARTY(BLOSC2 LIBS blosc2)
+endif()
 


### PR DESCRIPTION
Adjust logic to support windows version of the library name.

