### PR TITLE
Use original extents in OBJ Writer

### DIFF
--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -383,6 +383,10 @@ avtDatasetFileWriter::WriteOBJTree(avtDataTree_p dt, int idx,
 //    the colors associated with these two texture coordinates, producing a color
 //    that may not be in the table. To work-around this behavior, we *pad* the color
 //    texture duplicating the minimum and maximum color pixels on each end.
+// 
+//    Justin Privitera, Mon Feb 12 15:20:31 PST 2024
+//    I moved the extents calculation to the beginning to get around the bugged
+//    vtkCellDataToPointData.
 //
 // ****************************************************************************
 

--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -399,6 +399,12 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
     // Make sure that we have polydata.
     vtkGeometryFilter *geom = vtkGeometryFilter::New();
 
+    // Compute the range here since VTK cannot be trusted to get the extents
+    // right after transforming from cell data to point data.
+    // See https://github.com/visit-dav/visit/issues/19028
+    double range[2];
+    activeDS->GetScalarRange(range);
+
     //
     // The OBJ file is going to expect the dataset as having node-centered
     // data.
@@ -434,8 +440,6 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
         //
         // Get some information for normalizing the variable.
         //
-        double range[2];
-        activeDS->GetScalarRange(range);
         double gap = (range[1] != range[0] ? range[1] - range[0] : 1.);
 
         //

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Removed custom logic forcing the opacity slider to snap to zero if the mouse dragged the slider outside the widget it belongs to.</li>
   <li>Fixed a bug in the Blueprint reader causing unstructured point topologies to display incorrectly if they did not use all of the provided coordinates.</li>
   <li>Removed sxterm host profile options for LLNL LSF Machines. sxterm is not available on these systems.</li>
+  <li>Fixed a bug in the Wavefront OBJ Writer that caused zonal variables saved out using the writer to have some incorrect colors in downstream tools such as PowerPoint.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Related to #19028

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

Because `vtkCellDataToPointData` is bugged (see the linked ticket above), we were getting bad extents for zonal data going through the obj writer logic. To correct this, I moved the code to calculate the extents to before we transform from zonal to nodal data. See the before and after below:

![image](https://github.com/visit-dav/visit/assets/35237779/0c49d157-9cf7-4069-b2ef-22f4aede8026)

This is `d` from `curv3d.silo`.

The left has purple because it thinks those nodes have a value of 0, which is wrong. One end of the texture is blue and the other is red so it interpolates. The right image appears as it does in VisIt.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Built and ran on rztopaz. I exported obj files with the current visit and then with my changes. Then I loaded these files into powerpoint and compared them.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
