### PR TITLE
Fix silo global node ids for point meshes

### DIFF
--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -13226,7 +13226,7 @@ avtSiloFileFormat::GetPointMesh(DBfile *dbfile, const char *mn, int domain)
         // so that it can be obtained through the GetAuxiliaryData call
         //
         void_ref_ptr vr = void_ref_ptr(arr, avtVariableCache::DestructVTKObject);
-        cache->CacheVoidRef(meshname, AUXILIARY_DATA_GLOBAL_NODE_IDS, timestep, 
+        cache->CacheVoidRef(meshname, AUXILIARY_DATA_GLOBAL_ZONE_IDS, timestep, 
                             domain, vr);
     }
     
@@ -14017,12 +14017,12 @@ avtSiloFileFormat::GetAuxiliaryData(const char *var, int domain,
     }
     else if (strcmp(type, AUXILIARY_DATA_GLOBAL_NODE_IDS) == 0)
     {
-        rv = (void *) GetGlobalNodeIds(domain, var);
+        rv = (void *) GetGlobalIds(domain, var, "node");
         df = avtVariableCache::DestructVTKObject;
     }
     else if (strcmp(type, AUXILIARY_DATA_GLOBAL_ZONE_IDS) == 0)
     {
-        rv = (void *) GetGlobalZoneIds(domain, var);
+        rv = (void *) GetGlobalIds(domain, var, "zone");
         df = avtVariableCache::DestructVTKObject;
     }
     else if (strcmp(type, AUXILIARY_DATA_SPATIAL_EXTENTS) == 0)
@@ -14303,15 +14303,16 @@ avtSiloFileFormat::GetSpecies(int dom, const char *spec)
 
 
 // ****************************************************************************
-//  Method: avtSiloFileFormat::AllocAndDetermineMeshnameForUcdmesh
+//  Method: avtSiloFileFormat::AllocAndDetermineMeshnameForMeshType
 //
 //  Purpose:
-//      Allocate space for and determine the real mesh name for a ucd mesh,
-//      which may be a multimesh 
+//      Allocate space for and determine the real mesh name for a multiblock
+//      mesh of a specific type.
 //
 //  Arguments:
 //      dom     The domain of the mesh.
-//      mesh    The mesh we want the real name for 
+//      mesh    The mesh we want the real name for .
+//      mtype   The Silo type for the mesh.
 //
 //  Returns:    The real mesh name 
 //
@@ -14326,7 +14327,8 @@ avtSiloFileFormat::GetSpecies(int dom, const char *spec)
 // ****************************************************************************
 
 char *
-avtSiloFileFormat::AllocAndDetermineMeshnameForUcdmesh(int dom, const char *mesh)
+avtSiloFileFormat::AllocAndDetermineMeshnameForMeshType(int dom,
+    const char *mesh, int mtype)
 {
     //
     // Get the file handle, throw an exception if it hasn't already been opened
@@ -14341,11 +14343,10 @@ avtSiloFileFormat::AllocAndDetermineMeshnameForUcdmesh(int dom, const char *mesh
     int type = DBInqVarType(dbfile, m);
     VisitMutexUnlock("avtSiloFileFormat");
 
-    if (type != DB_MULTIMESH && type != DB_UCDMESH)
+    if (type != DB_MULTIMESH && type != mtype)
     {
         //
-        // This is not a ucd mesh or a multi-mesh, so it does not have a
-        // facelist.
+        // This is not the desired mesh type or a multi-mesh.
         //
         return NULL;
     }
@@ -14368,14 +14369,14 @@ avtSiloFileFormat::AllocAndDetermineMeshnameForUcdmesh(int dom, const char *mesh
         {
             EXCEPTION2(BadDomainException, dom, mm->nblocks);
         }
-        if (mm_ent->MeshType(dom) != DB_UCDMESH)
+        if (mm_ent->MeshType(dom) != mtype)
         {
             return NULL;
         }
         mb_meshname = mm_ent->GenerateName(dom);
         meshname = CXX_strdup(mb_meshname.c_str());
     }
-    else // (type == DB_UCDMESH)
+    else // (type == mtype)
     {
         if (dom != 0)
         {
@@ -14433,7 +14434,7 @@ avtSiloFileFormat::GetExternalFacelist(int dom, const char *mesh)
 
     DBfile *dbfile = GetFile(tocIndex);
 
-    char *meshname = AllocAndDetermineMeshnameForUcdmesh(dom, mesh);
+    char *meshname = AllocAndDetermineMeshnameForMeshType(dom, mesh, DB_UCDMESH);
     if (meshname == NULL || string(meshname) == "EMPTY")
         return NULL;
 
@@ -14456,9 +14457,8 @@ avtSiloFileFormat::GetExternalFacelist(int dom, const char *mesh)
     return rv;
 }
 
-
 // ****************************************************************************
-//  Method: avtSiloFileFormat::GetGlobalNodeIds
+//  Method: avtSiloFileFormat::GetGlobalIds
 //
 //  Purpose:
 //      Gets the global node ids from the Silo file
@@ -14492,18 +14492,37 @@ avtSiloFileFormat::GetExternalFacelist(int dom, const char *mesh)
 //    down so that it appears in debug logs only when there is actually data
 //    being read and returned from the plugin.
 // ****************************************************************************
+#define LOAD_GLOBAL_IDS(DBTYP, GETFUNC, FREEFUNC, MASK, GIDTYP, NIDS, IDS) \
+do {                                                                       \
+    DBSetDataReadMask2(MASK);                                              \
+    DBTYP *obj = GETFUNC(domain_file, directory_mesh.c_str());             \
+    if (obj && obj->IDS)                                                   \
+    {                                                                      \
+        gids = obj->IDS;                                                   \
+        ngids = obj->NIDS;                                                 \
+        gidtype = obj->GIDTYP;                                             \
+        obj->IDS = 0;                                                      \
+    }                                                                      \
+    FREEFUNC(obj);                                                         \
+} while (0)
 
 vtkDataArray *
-avtSiloFileFormat::GetGlobalNodeIds(int dom, const char *mesh)
+avtSiloFileFormat::GetGlobalIds(int dom, char const *mesh, char const *idtype)
 {
     DBfile *dbfile = GetFile(tocIndex);
 
-    char *meshname = AllocAndDetermineMeshnameForUcdmesh(dom, mesh);
+    int mtype = DB_UCDMESH;
+    char *meshname = AllocAndDetermineMeshnameForMeshType(dom, mesh, mtype);
     if (meshname == NULL || string(meshname) == "EMPTY")
     {
-        if (meshname != NULL)
-            delete [] meshname;
-        return NULL;
+        mtype = DB_POINTMESH;
+        meshname = AllocAndDetermineMeshnameForMeshType(dom, mesh, mtype);
+        if (meshname == NULL || string(meshname) == "EMPTY")
+        {
+            if (meshname != NULL)
+                delete [] meshname;
+            return NULL;
+        }
     }
 
     //
@@ -14517,31 +14536,32 @@ avtSiloFileFormat::GetGlobalNodeIds(int dom, const char *mesh)
     // We want to get just the global node ids.  So we need to get the ReadMask,
     // set it to read global node ids, then set it back.
     unsigned long long mask = DBGetDataReadMask2();
-    DBSetDataReadMask2(DBUMGlobNodeNo);
-    DBucdmesh *um = DBGetUcdmesh(domain_file, directory_mesh.c_str());
-    DBSetDataReadMask2(mask);
-    if (um == NULL)
+
+    int ngids, gidtype;
+    void *gids = 0;
+    if (mtype == DB_UCDMESH)
     {
-        if (!ignoreMissingBlocks)
-        {
-            EXCEPTION1(InvalidVariableException, mesh);
-        }
-        return 0;
+        if (string(idtype) == "node")
+            LOAD_GLOBAL_IDS(DBucdmesh, DBGetUcdmesh, DBFreeUcdmesh, DBUMGlobNodeNo, gnznodtype, nnodes, gnodeno);
+        else
+            LOAD_GLOBAL_IDS(DBucdmesh, DBGetUcdmesh, DBFreeUcdmesh, DBUMZonelist|DBZonelistGlobZoneNo|DBZonelistInfo,
+                zones->gnznodtype, zones->nzones, zones->gzoneno);
     }
+    else if (mtype == DB_POINTMESH)
+    {
+        LOAD_GLOBAL_IDS(DBpointmesh, DBGetPointmesh, DBFreePointmesh, DBPMGlobNodeNo, gnznodtype, nels, gnodeno);
+    }
+    DBSetDataReadMask2(mask);
 
     vtkDataArray *rv = NULL;
-    if (um->gnodeno != NULL)
+    if (gids)
     {
 
-        debug5 << "Reading in domain " << dom << ", global node ids for " << mesh << endl;
+        debug5 << "Reading in domain " << dom << ", global " << idtype << " ids for " << mesh << endl;
         debug5 << "Reading in from toc " << filenames[tocIndex] << endl;
 
-        rv = CreateDataArray(um->gnznodtype, um->gnodeno, um->nnodes);
-        um->gnodeno = 0; // vtkDataArray owns the data now.
-
+        rv = CreateDataArray(gidtype, gids, ngids);
     }
-
-    DBFreeUcdmesh(um);
 
     delete [] meshname;
 
@@ -14630,90 +14650,6 @@ avtSiloFileFormat::GetLocalDomainBoundaryInfo(int domain, const char *var)
 
     //res->Print(cout);
     return res;
-}
-
-// ****************************************************************************
-//  Method: avtSiloFileFormat::GetGlobalZoneIds
-//
-//  Purpose:
-//      Gets the global zone ids from the Silo file
-//
-//  Programmer: Mark C. Miller
-//  Creation:   August 9, 2004
-//
-//  Modifications:
-//    Mark C. Miller, Thu Oct 14 15:18:31 PDT 2004
-//    Uncommented the data read mask
-//
-//    Mark C. Miller, Tue Jun 28 17:28:56 PDT 2005
-//    Made it handle the new "EMPTY" domain convention
-//
-//    Mark C. Miller, Sun Dec  3 12:20:11 PST 2006
-//    Moved code to set data read mask back to its original value to *before*
-//    throwing of exeption.
-//
-//    Mark C. Miller, Thu Oct 15 21:31:07 PDT 2009
-//    Add DBZonelistInfo to data read mask to work around a bug in Silo
-//    library where attempt to DBGetUcdmesh causes call to DBGetZonelist
-//    and a subsequent segv down in the bowels of Silo due to invalid
-//    assumptions regarding the existence of certain zonelist strutures.
-//
-//    Mark C. Miller, Tue Jan 12 17:55:54 PST 2010
-//    Use CreateDataArray for global zone numbers, handling long long too.
-//
-//    Cyrus Harrison, Wed Dec 21 15:22:21 PST 2011
-//    Limited support for Silo nameschemes, use new multi block cache data
-//    structures.
-//
-// ****************************************************************************
-
-vtkDataArray *
-avtSiloFileFormat::GetGlobalZoneIds(int dom, const char *mesh)
-{
-    debug5 << "Reading in domain " << dom << ", global zone ids for " << mesh << endl;
-    debug5 << "Reading in from toc " << filenames[tocIndex] << endl;
-
-    DBfile *dbfile = GetFile(tocIndex);
-
-    char *meshname = AllocAndDetermineMeshnameForUcdmesh(dom, mesh);
-    if (meshname == NULL || string(meshname) == "EMPTY")
-        return NULL;
-
-    //
-    // Some Silo objects are distributed across several files,
-    // so handle that here.
-    //
-    DBfile *domain_file = dbfile;
-    string directory_mesh;
-    DetermineFileAndDirectory(meshname, "", domain_file, directory_mesh);
-
-    // We want to get just the global node ids.  So we need to get the ReadMask,
-    // set it to read global node ids, then set it back.
-    unsigned long long mask = DBGetDataReadMask2();
-    DBSetDataReadMask2(DBUMZonelist|DBZonelistGlobZoneNo|DBZonelistInfo);
-    DBucdmesh *um = DBGetUcdmesh(domain_file, directory_mesh.c_str());
-    DBSetDataReadMask2(mask);
-    if (um == NULL)
-    {
-        if (!ignoreMissingBlocks)
-        {
-            EXCEPTION1(InvalidVariableException, mesh);
-        }
-        return 0;
-    }
-
-    vtkDataArray *rv = NULL;
-    if (um->zones->gzoneno != NULL)
-    {
-        rv = CreateDataArray(um->zones->gnznodtype, um->zones->gzoneno, um->zones->nzones); 
-        um->zones->gzoneno = 0; // vtkDataArray owns the data now.
-    }
-
-    DBFreeUcdmesh(um);
-
-    delete [] meshname;
-
-    return rv;
 }
 
 // ****************************************************************************

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -13226,7 +13226,7 @@ avtSiloFileFormat::GetPointMesh(DBfile *dbfile, const char *mn, int domain)
         // so that it can be obtained through the GetAuxiliaryData call
         //
         void_ref_ptr vr = void_ref_ptr(arr, avtVariableCache::DestructVTKObject);
-        cache->CacheVoidRef(meshname, AUXILIARY_DATA_GLOBAL_ZONE_IDS, timestep, 
+        cache->CacheVoidRef(meshname, AUXILIARY_DATA_GLOBAL_NODE_IDS, timestep, 
                             domain, vr);
     }
     

--- a/src/databases/Silo/avtSiloFileFormat.h
+++ b/src/databases/Silo/avtSiloFileFormat.h
@@ -262,6 +262,10 @@ typedef struct _GroupInfo
 //    Mark C. Miller, Wed Jun 15 09:16:56 PDT 2016
 //    Added support for loading the block decomposition as a variable
 //    under certain conditions.
+//
+//    Mark C. Miller, Tue Feb 13 10:08:31 PST 2024
+//    Switch char * AllocAndDetermineMeshnameForUcdmesh to
+//    string AllocAndDetermineMeshnameForMeshType
 // ****************************************************************************
 
 class avtSiloFileFormat : public avtSTMDFileFormat
@@ -488,7 +492,7 @@ class avtSiloFileFormat : public avtSTMDFileFormat
                                                         std::string &location_out);
 
     void                  GetRelativeVarName(const char *,const char *,char *);
-    char                 *AllocAndDetermineMeshnameForMeshType(int, const char *, int);
+    std::string           DetermineMeshnameForMeshType(int, const char *, int);
 
     std::string           DetermineMultiMeshForSubVariable(DBfile *dbfile,
                                                            const char *name,

--- a/src/databases/Silo/avtSiloFileFormat.h
+++ b/src/databases/Silo/avtSiloFileFormat.h
@@ -453,8 +453,7 @@ class avtSiloFileFormat : public avtSTMDFileFormat
     avtFacelist          *CalcExternalFacelist(DBfile *, const char *);
     avtMaterial          *CalcMaterial(DBfile *, const char *, const char *, int dom);
     avtSpecies           *CalcSpecies(DBfile *, const char *);
-    vtkDataArray         *GetGlobalNodeIds(int, const char *);
-    vtkDataArray         *GetGlobalZoneIds(int, const char *);
+    vtkDataArray         *GetGlobalIds(int, char const *, char const *);
 
     avtIntervalTree      *GetSpatialExtents(const char *);
     avtIntervalTree      *GetDataExtents(const char *);
@@ -489,7 +488,7 @@ class avtSiloFileFormat : public avtSTMDFileFormat
                                                         std::string &location_out);
 
     void                  GetRelativeVarName(const char *,const char *,char *);
-    char                 *AllocAndDetermineMeshnameForUcdmesh(int, const char *);
+    char                 *AllocAndDetermineMeshnameForMeshType(int, const char *, int);
 
     std::string           DetermineMultiMeshForSubVariable(DBfile *dbfile,
                                                            const char *name,

--- a/src/resources/help/en_US/relnotes3.4.1.html
+++ b/src/resources/help/en_US/relnotes3.4.1.html
@@ -35,6 +35,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Removed custom logic forcing the opacity slider to snap to zero if the mouse dragged the slider outside the widget it belongs to.</li>
   <li>Fixed a bug in the Blueprint reader causing unstructured point topologies to display incorrectly if they did not use all of the provided coordinates.</li>
   <li>Removed sxterm host profile options for LLNL LSF Machines. sxterm is not available on these systems.</li>
+  <li>Fixed a problem with global node ids on point meshes from Silo plugin.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #19244

The basic problem was that the auxiliary data requests for global node/zone ids were designed only for UCD meshes. I refactored the logic to combine gets for global node ids and global zone ids and for UCD and Point meshes. I confirmed they work on @ndimensionalspace data set. I will await tonights tests for any issues before finally merging.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
