### PR TITLE
Upgrading the unv plugin

### DIFF
--- a/src/databases/unv/avtunvFileFormat.h
+++ b/src/databases/unv/avtunvFileFormat.h
@@ -19,52 +19,68 @@
 // Define my classes for the mesh
 class UnvRange { // Element class
 public:
-  double trange[6] ;
+    double trange[6] ;
 } ;
 class UnvElement { // Element class
 public:
-  int number;
-  int label;
-  int typelt ;
-  mutable int matid ; // mutable
-  int* nodes ;
-  struct compare_UnvElement
-  {
-    bool operator () (const UnvElement& e1, const UnvElement& e2) const
+    int number;
+    int label;
+    int typelt ;
+    int nbnel;
+    mutable int matid ; // mutable
+    int* nodes ;
+    struct compare_UnvElement
     {
-      return (e1.label < e2.label);
+        bool operator () (const UnvElement& e1, const UnvElement& e2) const
+        {
+            return (e1.label < e2.label);
+        };
     };
-  };
 };
 
 class UnvNode { // Node class
 public:
-  int number; // Numbered nodes
-  int label; // Global node label
-  double x,y,z ;
-  mutable std::vector<int> nod2elts; // Reverse mesh connectivity
-  struct compare_UnvNode
-  {
-    bool operator () (const UnvNode& n1, const UnvNode& n2) const
+    int number; // Numbered nodes
+    int label; // Global node label
+    double x,y,z ;
+    mutable std::vector<int> nod2elts; // Reverse mesh connectivity
+    struct compare_UnvNode
     {
-      return (n1.label < n2.label);
+        bool operator () (const UnvNode& n1, const UnvNode& n2) const
+        {
+            return (n1.label < n2.label);
+        };
     };
-  };
 };
+
+class UnvInterface { // Interface class
+public:
+    int number;
+    int label;
+    mutable std::string name ;
+    struct compare_UnvInterface
+    {
+        bool operator () (const UnvInterface& n1, const UnvInterface& n2) const
+        {
+            return (n1.label < n2.label);
+        };
+    };
+};
+
 class UnvFace { // Face class, can be a boundary face or internal one
 public:
-  int number;
-  int element ;
-  int facloc ;
-  int matid ;
-  double pressure ;
+    int number;
+    int element ;
+    int facloc ;
+    int matid ;
+    double pressure ;
 };
 class UnvFacePressure { // a set of faces
 public:
-  int number;
-  int label ;
-  std::string name ;
-  std::vector<UnvFace> faces;
+    int number;
+    int label ;
+    std::string name ;
+    std::vector<UnvFace> faces;
 };
 // ****************************************************************************
 //  Class: avtunvFileFormat
@@ -79,8 +95,8 @@ public:
 
 class avtunvFileFormat : public avtSTSDFileFormat
 {
-  public:
-                       avtunvFileFormat(const char *filename);
+public:
+    avtunvFileFormat(const char *filename);
     virtual           ~avtunvFileFormat() {;};
 
     //
@@ -88,7 +104,7 @@ class avtunvFileFormat : public avtSTSDFileFormat
     // information to information about block connectivity.
     //
     virtual void      *GetAuxiliaryData(const char *var, const char *type,
-                                      void *args, DestructorFunction &);
+                                        void *args, DestructorFunction &);
     //
 
     //
@@ -100,14 +116,16 @@ class avtunvFileFormat : public avtSTSDFileFormat
     // virtual double    GetTime(void);
     //
 
-    virtual const char    *GetType(void)   { return "unv"; };
-    virtual void           FreeUpResources(void); 
+    virtual const char    *GetType(void)   {
+        return "unv";
+    };
+    virtual void           FreeUpResources(void);
 
     virtual vtkDataSet    *GetMesh(const char *);
     virtual vtkDataArray  *GetVar(const char *);
     virtual vtkDataArray  *GetVectorVar(const char *);
- 
-  protected:
+
+protected:
     // DATA MEMBERS
 
     virtual void           PopulateDatabaseMetaData(avtDatabaseMetaData *);
@@ -115,8 +133,7 @@ class avtunvFileFormat : public avtSTSDFileFormat
     virtual int is3DKnownElt(int ); // Provides 3D element value in connectivity nodefac array
     virtual int is2DKnownElt(int ); // Provides 2D element value in connectivity nodefac array
     virtual int is1DKnownElt(int ); // Provides 1D element value in connectivity nodefac array
-    virtual int isKnownElt(int ); // Provides element value in counter array nbletsptyp
-    virtual int getNbnodes(int ); // Provides 3D element number of nodes
+    virtual int getNbvertices(int ); // Provides 3D element number of nodes
     virtual int getNbfaces(int ); // Provides 3D element number of faces
     virtual int getEltDim(int ); // Provides element topological dimension
 
@@ -129,15 +146,17 @@ class avtunvFileFormat : public avtSTSDFileFormat
     virtual int getNbnolsv( ); // Provides the number of nodes to build the Face Pressure Load-Set nbnolsv
     virtual int getNbfaextv( ); // Provides the number of free faces nbfaextv
     virtual int getfastNbfaextv( ); // Provides the number of free faces nbfaextv
-    virtual int getNbnodesFreeFaces( ); // Provides the number of nodes to build the Face Faces nbnff
+    virtual int getNbverticesFreeFaces( ); // Provides the number of nodes to build the Face Faces nbnff
     virtual void getNormal3D (float *one_entry, std::set<UnvElement, UnvElement::compare_UnvElement>::iterator itre, int iflo, int facloc); // Provides the normal to a face
     virtual void getNormal2D (float *one_entry, std::set<UnvElement, UnvElement::compare_UnvElement>::iterator itre, int facloc); // Provides the normal to a segment
-    virtual void getvolNormal2D (float *one_entry, std::set<UnvElement, UnvElement::compare_UnvElement>::iterator itre); // Provides the normal to a 2D face 
+    virtual void getvolNormal2D (float *one_entry, std::set<UnvElement, UnvElement::compare_UnvElement>::iterator itre); // Provides the normal to a 2D face
+    virtual void getvolTangent1D (float *one_entry, std::set<UnvElement, UnvElement::compare_UnvElement>::iterator itre); // Provides the tangent to a 1D edge
 
     virtual int getNbfreeSets(); // Gets the number of boundaries, i.e. free connected faces
 
     FILE* handle; // File handle for unv file
     gzFile gzhandle ; // File handle for unv.gz file
+    char * fileinfo_str ;
     int nbnodes ; // Total number of nodes in the mesh
     int maxnodl ; // Maximum node label in the mesh
     int nb3dmats ; // Highest material numbre for 3D elements
@@ -148,7 +167,7 @@ class avtunvFileFormat : public avtSTSDFileFormat
     int nb1dcells ; // Store the total number of surface cells
     std::string filename; // Mesh file name, including .unv or .unv.gz extension
     bool fileRead; // Says if file has already been read or not
-    int debuglevel ; 
+    int debuglevel ;
     double range[6] ; // geometrical mesh range
     int nbloadsets ; // Number of load-sets of 3D face pressure
     int nbfalsv ; // Number of known 3D elements in load-sets
@@ -163,6 +182,8 @@ class avtunvFileFormat : public avtSTSDFileFormat
     std::set<UnvElement, UnvElement::compare_UnvElement> meshUnvElements;  // Full mesh all types of elements
     std::vector<UnvFacePressure> meshUnvFacePressures; // read face pressure load sets
     std::vector<UnvFace> freeUnvFaces; // List of free faces for 3D mesh.
+    std::set<UnvInterface, UnvInterface::compare_UnvInterface> meshUnvInterfaces;
+    std::vector<UnvInterface> listUnvInterfaces;
 };
 
 

--- a/src/databases/unv/unvCommonPluginInfo.C
+++ b/src/databases/unv/unvCommonPluginInfo.C
@@ -55,6 +55,6 @@ unvCommonPluginInfo::SetupDatabase(const char *const *list,
         }
     }
     avtSTSDFileFormatInterface *inter
-           = new avtSTSDFileFormatInterface(ffl, nTimestep, nBlock);
+        = new avtSTSDFileFormatInterface(ffl, nTimestep, nBlock);
     return new avtGenericDatabase(inter);
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
This is large improvement of the unv plugin:
 * reads and draws quadratic (aka parabolic) elements (1D, 2D, 3D),
 * reads antique SDRC/I-Deas files prior to Master Series (versions 4,5 and 6)
 * reads GMSH hidden polygon linear element,
 * reads some undocumented file formats (that I do not wish to comment)
 * adds a Bounding Box,
 * adds tangent vectors for 1D elements,
 * bug corrected : normals for quads were twice the area,
 * I have run "astyle" on the source code (https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html#reformatting).

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Tested using "poly.msh"
[poly.tar.gz](https://github.com/visit-dav/visit/files/14267655/poly.tar.gz)

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).
I would be happy to have a review from @markcmiller86 

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
