### PR TITLE
Add setuptools-68.0.0 to bv_python.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -259,6 +259,11 @@ function bv_python_info
     export PYTHON_BUILD_DIR="Python-$PYTHON_VERSION"
     export PYTHON_SHA256_CHECKSUM="504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354"
 
+    export SETUPTOOLS_URL=""
+    export SETUPTOOLS_FILE="setuptools-68.0.0.tar.gz"
+    export SETUPTOOLS_BUILD_DIR="setuptools-68.0.0"
+    export SETUPTOOLS_SHA256_CHECKSUM=""
+
     export PILLOW_URL=${PILLOW_URL:-"https://github.com/python-pillow/Pillow/archive/refs/tags/"}
     export PILLOW_FILE="Pillow-10.0.0.tar.gz"
     export PILLOW_BUILD_DIR="Pillow-10.0.0"
@@ -651,12 +656,64 @@ function build_python
         return 1
     fi
 
-    fix_py_permissions
-
     cd "$START_DIR"
     info "Done with Python"
 
+
+    # wheel and its dependencies
+    download_py_module ${FLITCORE_FILE} ${FLITCORE_URL}
+    if test $? -ne 0 ; then
+        return 1
+    fi
+  
+    download_py_module ${WHEEL_FILE} ${WHEEL_URL}
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+
+    extract_py_module ${FLITCORE_BUILD_DIR} ${FLITCORE_FILE}  "flit_core"
+    if test $? -ne 0 ; then
+        return 1
+    fi
+
+    extract_py_module ${WHEEL_BUILD_DIR} ${WHEEL_FILE} "wheel"
+    if test $? -ne 0 ; then
+        return 1
+    fi
+
+    install_py_module ${FLITCORE_BUILD_DIR} "flit_core"
+    if test $? -ne 0 ; then
+        return 1
+    fi
+
+    install_py_module ${WHEEL_BUILD_DIR} "wheel"
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+
+    # setuptools
+    # need the newest version required by a module, not the default
+    # version from python
+    download_py_module ${SETUPTOOLS_FILE} ${SETUPTOOLS_URL}
+    if test $? -ne 0 ; then
+        return 1
+    fi
+
+    extract_py_module ${SETUPTOOLS_BUILD_DIR} ${SETUPTOOLS_FILE} "setuptools"
+    if test $? -ne 0 ; then
+        return 1
+    fi
+
+    install_py_module ${SETUPTOOLS_BUILD_DIR} "setuptools"
+    if test $? -ne 0 ; then
+        return 1
+    fi
+
+    fix_py_permissions
+
+    info "Done with python setuptools module."
     return 0
+
 }
 
 # *************************************************************************** #
@@ -982,46 +1039,6 @@ function build_mpi4py
 
     install_py_module ${MPI4PY_BUILD_DIR} "mpi4py"
     if test $? -ne 0 ; then
-        return 1
-    fi
-
-    fix_py_permissions
-
-    return 0
-}
-
-# *************************************************************************** #
-#                                  build_wheel                                #
-# *************************************************************************** #
-function build_wheel
-{
-    download_py_module ${FLITCORE_FILE} ${FLITCORE_URL}
-    if test $? -ne 0 ; then
-        return 1
-    fi
-  
-    download_py_module ${WHEEL_FILE} ${WHEEL_URL}
-    if [[ $? != 0 ]] ; then
-        return 1
-    fi
-
-    extract_py_module ${FLITCORE_BUILD_DIR} ${FLITCORE_FILE}  "flit_core"
-    if test $? -ne 0 ; then
-        return 1
-    fi
-
-    extract_py_module ${WHEEL_BUILD_DIR} ${WHEEL_FILE} "wheel"
-    if test $? -ne 0 ; then
-        return 1
-    fi
-
-    install_py_module ${FLITCORE_BUILD_DIR} "flit_core"
-    if test $? -ne 0 ; then
-        return 1
-    fi
-
-    install_py_module ${WHEEL_BUILD_DIR} "wheel"
-    if [[ $? != 0 ]] ; then
         return 1
     fi
 
@@ -1580,17 +1597,6 @@ function bv_python_build
             # of these python modules
             export PYHOME="${VISITDIR}/python/${PYTHON_VERSION}/${VISITARCH}"
             export PYTHON_COMMAND="${PYHOME}/bin/python3"
-
-            # most every module needs wheel to build properly via pip
-            check_if_py_module_installed "wheel"
-            if [[ $? != 0 ]] ; then
-                info "Building the wheel module"
-                build_wheel
-                if [[ $? != 0 ]] ; then
-                    error "wheel build failed. Bailing out."
-                fi
-                info "Done building the wheel module."
-            fi
 
             check_if_py_module_installed "numpy"
             if [[ $? != 0 ]] ; then


### PR DESCRIPTION
Moved build_wheel logic into build_python function.
Added setuptools to build_python function.
Used version 68.0.0 since it was already in our thirpdarty repo, and 67.8 was the newest required (by Pillow).


Resolves issues with proper installation of Pygments, sphinxcontrib-applehelp and sphinxcontrib-htmlhelp.

Resolves #19281


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran build_visit on cz, verified  Pygments, sphinxcontrib-applehelp and sphinxcontrib-html help were installed correctly in site-packages.
Then successfully built VisIt against that python version.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
