### PR TITLE
Skip failing unit tests for 'dir()' and 'help()'

### DIFF
--- a/src/test/tests/unit/atts_assign.py
+++ b/src/test/tests/unit/atts_assign.py
@@ -16,6 +16,10 @@
 #    Assigning Max32BitInt+1 to int on Windows causes TypeError, not
 #    ValueError, so change expected results in those cases.
 #
+#    Kathleen Biagas, Friday Feb 9, 2024
+#    Manually skipping some dir() and help() tests that fail with
+#    Python 3.9.18 until #19264 is addressed.
+#
 # ----------------------------------------------------------------------------
 import copy, io, numpy, sys
 
@@ -1093,11 +1097,17 @@ def TestDir(global_dir_result):
     #
     # Test a random handful of object level dirs
     #
+
+    """ 
+    # These fail with Python 3.9.18, see bug ticket #19264.
+    # Impossible to add them to skip list due to unhandled exceptions
+    # So they are being skipped here with a note added to the ticket.
     TestDirOutput(SILRestriction(), ['NumSets', 'TurnOnAll', 'Wholes'])
     TestDirOutput(PseudocolorAttributes(), ['GetCentering', 'GetColorTableName',
         'GetLightingFlag', 'GetLimitsMode', 'GetMax', 'SetCentering',
         'SetColorTableName', 'SetLegendFlag', 'SetLimitsMode'])
     TestDirOutput(ColorAttributeList(), ['AddColors', 'ClearColors', 'GetColors'])
+    """
 
 
 # Class to facilitate stdout redirect for testing `help()`
@@ -1137,11 +1147,18 @@ def TestHelp():
     TestHelpOutput(CreateDatabaseCorrelation,
         ['IndexForIndexCorrelation', 'CycleCorrelation', 'StretchedIndexCorrelation'])
     TestHelpOutput(SILRestriction(),[]) # should not except
+
+    """
+    # These tests fail with Python 3.9.18 see bug ticket #19264.
+    # due to nature of thee way these tests are named
+    # (different name for failure than success),
+    # they need to be skipped manually until #19264 is addressed
     TestHelpOutput(SILRestriction, ['GlobalAttributes', 'SetPlotSILRestriction',
         'TurnDomainsOff', 'TurnDomainsOn', 'TurnMaterialsOff', 'TurnMaterialsOn'])
     TestHelpOutput('wholes', ['SILRestriction'])
     TestHelpOutput('tensor', ['DefineArrayExpression', 'DefineTensorExpression',
         'LCSAttributes', 'SPHResampleAttributes', 'TensorAttributes'])
+    """
 
 #
 # Scalar assignments

--- a/src/test/tests/unit/default_methods.py
+++ b/src/test/tests/unit/default_methods.py
@@ -45,6 +45,9 @@ WriteScript('bar.py')
 TestValueEQ("WriteScript('foo.py') == WriteScript(f)", filecmp.cmp('foo.py','bar.py'), True)
 TestValueGT("WriteScript() file size", os.path.getsize('foo.py'), 3000)
 
+### dir is causing exceptions with Python 3.9.18
+### so manually skip these tests until #19264 can be addressed
+"""
 # Test dir() on some objects
 dout = dir(SILRestriction())
 TestValueIN("SetsInCategory in dir(SILAttributes())", dout, 'SetsInCategory')
@@ -53,5 +56,6 @@ dout = dir(View3DAttributes())
 TestValueIN("RotateAxis in dir(View3Dattributes())", dout, 'RotateAxis')
 TestValueIN("GetImageZoom in dir(View3Dattributes())", dout, 'GetImageZoom')
 TestValueIN("SetImagePan in dir(View3Dattributes())", dout, 'SetImagePan')
+"""
 
 Exit()


### PR DESCRIPTION
### Description
This is the 3.4RC version of #19296.
Skipping  tests until #19264 is addressed.
