### PR TITLE
refactor to use setuptools and pip instead of setup.py and distutils

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@
 # TO USE A NEW CONTAINER, UPDATE TAG NAME HERE AS PART OF YOUR PR!
 #####
 variables:
-  container_tag: visitdav/visit-ci-develop:2024-02-10-sha117ab0
+  container_tag: visitdav/visit-ci-develop:2024-02-21-shaa67324
 
 # only build merge target pr to develop
 trigger: none

--- a/src/CMake/FindPySide.cmake
+++ b/src/CMake/FindPySide.cmake
@@ -433,10 +433,11 @@ function(PYSIDE_ADD_HYBRID_MODULE module_name
 
     message(STATUS "Configuring PySide hybrid module: ${module_name}")
 
-    PYTHON_ADD_PIP_SETUP("${module_name}_py_setup"
-                         ${dest_dir}
-                         ${mod_py_setup}
-                         ${mod_py_sources})
+    PYTHON_ADD_PIP_SETUP(NAME "${module_name}_py_setup"
+                         DEST_DIR ${dest_dir}
+                         PY_MODULE_DIR {module_name}
+                         PY_SETUP_FILE ${mod_py_setup}
+                         PY_SOURCES ${mod_py_sources})
 
     PYSIDE_ADD_MODULE(${module_name}
                   ${dest_dir}/${module_name}

--- a/src/CMake/FindPySide.cmake
+++ b/src/CMake/FindPySide.cmake
@@ -355,8 +355,7 @@ endfunction(PYSIDE_ADD_GENERATOR_TARGET)
 
 #****************************************************************************
 # PYSIDE_ADD_MODULE
-# Defines a new PySide module and creates a dependent generator target and
-# distutils setup call.
+# Defines a new PySide module and creates a dependent generator target.
 #****************************************************************************
 function(PYSIDE_ADD_MODULE module_name
                            dest_dir
@@ -419,7 +418,7 @@ endfunction(PYSIDE_ADD_MODULE)
 #****************************************************************************
 # PYSIDE_ADD_HYBRID_MODULE
 # Defines a new PySide module and creates a dependent generator target and
-# distutils setup call.
+# pip setup call.
 #****************************************************************************
 function(PYSIDE_ADD_HYBRID_MODULE module_name
                                   dest_dir
@@ -434,10 +433,10 @@ function(PYSIDE_ADD_HYBRID_MODULE module_name
 
     message(STATUS "Configuring PySide hybrid module: ${module_name}")
 
-    PYTHON_ADD_DISTUTILS_SETUP("${module_name}_py_setup"
-                            ${dest_dir}
-                            ${mod_py_setup}
-                            ${mod_py_sources})
+    PYTHON_ADD_PIP_SETUP("${module_name}_py_setup"
+                         ${dest_dir}
+                         ${mod_py_setup}
+                         ${mod_py_sources})
 
     PYSIDE_ADD_MODULE(${module_name}
                   ${dest_dir}/${module_name}

--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -502,8 +502,8 @@ FUNCTION(PYTHON_ADD_HYBRID_MODULE)
         set_target_properties(${args_NAME} PROPERTIES
              LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>/${args_DEST_DIR}/${args_NAME}/")
     endif()
-    add_dependencies(${args_NAME} "${target_name}_py_setup")
-    VISIT_INSTALL_TARGETS_RELATIVE(${args_DEST_DIR}/${target_name} ${args_NAME})
+    add_dependencies(${args_NAME} "${args_NAME}_py_setup")
+    VISIT_INSTALL_TARGETS_RELATIVE(${args_DEST_DIR}/${args_NAME} ${args_NAME})
 
 ENDFUNCTION(PYTHON_ADD_HYBRID_MODULE)
 

--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -125,13 +125,13 @@ if(PYTHONINTERP_FOUND)
     message(STATUS "PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE}")
 
     execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                    "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('VERSION'))"
+                            "import sys;from sysconfig import get_config_var; sys.stdout.write(get_config_var('VERSION'))"
                     OUTPUT_VARIABLE PYTHON_CONFIG_VERSION
                     ERROR_VARIABLE  ERROR_FINDING_PYTHON_VERSION)
     message(STATUS "PYTHON_CONFIG_VERSION ${PYTHON_CONFIG_VERSION}")
 
     execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                            "import sys;from distutils.sysconfig import get_python_inc;sys.stdout.write(get_python_inc())"
+                            "import sys;from sysconfig import get_path;sys.stdout.write(get_path('include'))"
                     OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
                     ERROR_VARIABLE ERROR_FINDING_INCLUDES)
     message(STATUS "PYTHON_INCLUDE_DIR ${PYTHON_INCLUDE_DIR}")
@@ -139,7 +139,8 @@ if(PYTHONINTERP_FOUND)
     if(NOT EXISTS ${PYTHON_INCLUDE_DIR})
         message(FATAL_ERROR "Reported PYTHON_INCLUDE_DIR ${PYTHON_INCLUDE_DIR} does not exist!")
     endif()
-
+    
+    # TODO: replacing distutils.get_python_lib() isn't straight forward
     execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
                             "import sys;from distutils.sysconfig import get_python_lib;sys.stdout.write(get_python_lib())"
                     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_DIR
@@ -167,7 +168,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     # our goal is to find the specific python lib, based on info
-    # we extract from distutils.sysconfig from the python executable
+    # we extract from sysconfig from the python executable
     #
     # check if python libs differs for windows python installs
     if(NOT WIN32)
@@ -183,22 +184,22 @@ if(PYTHONINTERP_FOUND)
         #  LIBPL + LIBRARY
 
         execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                                "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBDIR'))"
+                                "import sys;from sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBDIR'))"
                         OUTPUT_VARIABLE PYTHON_CONFIG_LIBDIR
                         ERROR_VARIABLE  ERROR_FINDING_PYTHON_LIBDIR)
 
         execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                                "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBPL'))"
+                                "import sys;from sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBPL'))"
                         OUTPUT_VARIABLE PYTHON_CONFIG_LIBPL
                             ERROR_VARIABLE  ERROR_FINDING_PYTHON_LIBPL)
 
         execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                                "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('LDLIBRARY'))"
+                                "import sys;from sysconfig import get_config_var; sys.stdout.write(get_config_var('LDLIBRARY'))"
                         OUTPUT_VARIABLE PYTHON_CONFIG_LDLIBRARY
                         ERROR_VARIABLE  ERROR_FINDING_PYTHON_LDLIBRARY)
 
         execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                                "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBRARY'))"
+                                "import sys;from sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBRARY'))"
                         OUTPUT_VARIABLE PYTHON_CONFIG_LIBRARY
                         ERROR_VARIABLE  ERROR_FINDING_PYTHON_LIBRARY)
 

--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -439,24 +439,6 @@ FUNCTION(PYTHON_ADD_PIP_SETUP)
 
 ENDFUNCTION(PYTHON_ADD_PIP_SETUP)
 
-function(PYTHON_ADD_HYBRID_MODULE target_name dest_dir setup_file py_sources)
-    message(STATUS "Configuring hybrid python module: ${target_name}")
-    PYTHON_ADD_DISTUTILS_SETUP("${target_name}_py_setup"
-                               ${dest_dir}
-                               ${setup_file}
-                               ${py_sources})
-    PYTHON_ADD_MODULE(${target_name} ${ARGN})
-    if(NOT WIN32)
-        set_target_properties(${target_name} PROPERTIES
-            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${dest_dir}/${target_name}/)
-    else()
-        set_target_properties(${target_name} PROPERTIES
-            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>/${dest_dir}/${target_name}/")
-    endif()
-    add_dependencies(${target_name} "${target_name}_py_setup")
-    VISIT_INSTALL_TARGETS_RELATIVE(${dest_dir}/${target_name} ${target_name})
-
-endfunction()
 
 ##############################################################################
 # Macro to create a pip script and compiled python module
@@ -509,16 +491,19 @@ FUNCTION(PYTHON_ADD_HYBRID_MODULE)
                          PY_SOURCES    ${args_PY_SOURCES}
                          FOLDER        ${args_FOLDER})
 
-    PYTHON_ADD_MODULE(${target_name} ${ARGN})
+    PYTHON_ADD_MODULE(${args_NAME} ${args_SOURCES})
+
+
+    ##### visit specific code:
     if(NOT WIN32)
-         set_target_properties(${target_name} PROPERTIES
-             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${dest_dir}/${target_name}/)
+         set_target_properties(${args_NAME} PROPERTIES
+             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${args_DEST_DIR}/${args_NAME}/)
     else()
-        set_target_properties(${target_name} PROPERTIES
-             LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>/${dest_dir}/${target_name}/")
+        set_target_properties(${args_NAME} PROPERTIES
+             LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>/${args_DEST_DIR}/${args_NAME}/")
     endif()
-    add_dependencies(${target_name} "${target_name}_py_setup")
-    VISIT_INSTALL_TARGETS_RELATIVE(${dest_dir}/${target_name} ${target_name})
+    add_dependencies(${args_NAME} "${target_name}_py_setup")
+    VISIT_INSTALL_TARGETS_RELATIVE(${args_DEST_DIR}/${target_name} ${args_NAME})
 
 ENDFUNCTION(PYTHON_ADD_HYBRID_MODULE)
 

--- a/src/bin/makemovie.py
+++ b/src/bin/makemovie.py
@@ -9,13 +9,13 @@ import signal
 import socket
 import subprocess
 import sys
+import shutil
 
 if (sys.version_info > (3, 0)):
     import _thread
 else:
     import thread as _thread
 
-import distutils.spawn
 
 import xml
 import xml.sax
@@ -35,19 +35,15 @@ from visit_utils import encoding
 #   Hank Childs, Thu Apr  1 09:33:16 PST 2004
 #   Simplified a bit (previous implementation was not portable).
 #
+#   Cyrus Harrison, Fri Feb 16 13:43:25 PST 2024
+#   Remove use of distutils
+#
 ###############################################################################
 
 def CommandInPath(command):
     retval = 0
-    if(sys.platform != "win32"):
-        # Look for the command using the which command
-        cmd = "which %s > /dev/null" % command
-        rv = os.system(cmd)
-        if (rv == 0):
-            retval = 1
-    else:
-        if distutils.spawn.find_executable(command) != None:
-            retval = 1
+    if shutil.which(command) != None:
+        retval = 1
     return retval
 
 ###############################################################################

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
                           py_src/visit_test_suite.py)
 
     PYTHON_ADD_PIP_SETUP(NAME visit_testing_py_setup
-                         DEST_DIR site-packages
+                         DEST_DIR lib/site-packages
                          PY_MODULE_DIR visit_testing
                          PY_SETUP_FILE setup.py
                          PY_SOURCES ${pytesting_sources})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -66,10 +66,11 @@ else()
                           py_src/visit_test_reports.py
                           py_src/visit_test_suite.py)
 
-
-    PYTHON_ADD_PIP_SETUP(visit_testing_py_setup
-                         site-packages
-                         ${pytesting_sources})
+    PYTHON_ADD_PIP_SETUP(NAME visit_testing_py_setup
+                         DEST_DIR site-packages
+                         PY_MODULE_DIR visit_testing
+                         PY_SETUP_FILE setup.py
+                         PY_SOURCES ${pytesting_sources})
 
     if(BUILD_CTEST_TESTING)
         add_subdirectory(tests)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -67,9 +67,9 @@ else()
                           py_src/visit_test_suite.py)
 
 
-    PYTHON_ADD_DISTUTILS_SETUP(visit_testing_py_setup
-                               site-packages
-                               ${pytesting_sources})
+    PYTHON_ADD_PIP_SETUP(visit_testing_py_setup
+                         site-packages
+                         ${pytesting_sources})
 
     if(BUILD_CTEST_TESTING)
         add_subdirectory(tests)

--- a/src/test/setup.py
+++ b/src/test/setup.py
@@ -6,9 +6,11 @@
 # distutils gen + setup script for the 'visit_testing' module.
 #
 # Modifications:
-#    Cyrus Harrison, Wed Sep  7 11:34:36 PDT 2022
-#    Refactor to use real source dir.
+#  Cyrus Harrison, Wed Sep  7 11:34:36 PDT 2022
+#  Refactor to use real source dir.
 #
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Move to use setuptools.
 # ----------------------------------------------------------------------------
 
 
@@ -17,7 +19,7 @@ import os
 import shutil
 
 from os.path import join  as pjoin
-from distutils.core import setup
+from setuptools import setup
 
 
 #
@@ -38,7 +40,6 @@ except:
 
 
 setup(name='visit_testing',
-      version='0.1',
       author = 'VisIt Team',
       description='VisIt Testing Module',
       package_dir = {'visit_testing':'py_src'},

--- a/src/visitpy/CMakeLists.txt
+++ b/src/visitpy/CMakeLists.txt
@@ -478,7 +478,7 @@ ELSE(VISIT_STATIC)
 ENDIF(VISIT_STATIC)
 
 #
-# For distutils setup of the pure python parts of the visit module
+# For module setup of the pure python parts of the visit module
 #
 ADD_SUBDIRECTORY(visitmodule)
 ADD_SUBDIRECTORY(visit_utils)

--- a/src/visitpy/mpicom/CMakeLists.txt
+++ b/src/visitpy/mpicom/CMakeLists.txt
@@ -35,7 +35,7 @@ IF(VISIT_PARALLEL)
 
     # Create the mpicom
     PYTHON_ADD_HYBRID_MODULE(NAME mpicom
-                             DEST_DIR site-packages
+                             DEST_DIR lib/site-packages
                              PY_MODULE_DIR mpicom
                              PY_SETUP_FILE setup.py
                              PY_SOURCES "${MPICOM_PY_SOURCES}"
@@ -71,7 +71,7 @@ IF(VISIT_PARALLEL)
 ELSE(VISIT_PARALLEL)
     # we still need to build the module w/ the mpi stub
     PYTHON_ADD_PIP_SETUP(NAME mpicom_py_setup
-                         DEST_DIR site-packages
+                         DEST_DIR lib/site-packages
                          PY_MODULE_DIR mpicom
                          PY_SETUP_FILE setup.py
                          PY_SOURCES ${MPICOM_PY_SOURCES})

--- a/src/visitpy/mpicom/CMakeLists.txt
+++ b/src/visitpy/mpicom/CMakeLists.txt
@@ -69,10 +69,10 @@ IF(VISIT_PARALLEL)
 
 ELSE(VISIT_PARALLEL)
     # we still need to build the module w/ the mpi stub
-    PYTHON_ADD_DISTUTILS_SETUP(mpicom_py_setup
-                               site-packages
-                               setup.py
-                               ${MPICOM_PY_SOURCES})
+    PYTHON_ADD_PIP_SETUP(mpicom_py_setup
+                         site-packages
+                         setup.py
+                         ${MPICOM_PY_SOURCES})
 # add to main target?
 ENDIF(VISIT_PARALLEL)
 

--- a/src/visitpy/mpicom/CMakeLists.txt
+++ b/src/visitpy/mpicom/CMakeLists.txt
@@ -34,11 +34,12 @@ IF(VISIT_PARALLEL)
 
 
     # Create the mpicom
-    PYTHON_ADD_HYBRID_MODULE(mpicom
-                             site-packages
-                             setup.py
-                             "${MPICOM_PY_SOURCES}"
-                             ${MPICOM_SOURCES})
+    PYTHON_ADD_HYBRID_MODULE(NAME mpicom
+                             DEST_DIR site-packages
+                             PY_MODULE_DIR mpicom
+                             PY_SETUP_FILE setup.py
+                             PY_SOURCES "${MPICOM_PY_SOURCES}"
+                             SOURCES ${MPICOM_SOURCES})
 
     IF(UNIX)
         SET_TARGET_PROPERTIES(mpicom PROPERTIES COMPILE_FLAGS "-fno-strict-aliasing")
@@ -69,10 +70,12 @@ IF(VISIT_PARALLEL)
 
 ELSE(VISIT_PARALLEL)
     # we still need to build the module w/ the mpi stub
-    PYTHON_ADD_PIP_SETUP(mpicom_py_setup
-                         site-packages
-                         setup.py
-                         ${MPICOM_PY_SOURCES})
+    PYTHON_ADD_PIP_SETUP(NAME mpicom_py_setup
+                         DEST_DIR site-packages
+                         PY_MODULE_DIR mpicom
+                         PY_SETUP_FILE setup.py
+                         PY_SOURCES ${MPICOM_PY_SOURCES})
+
 # add to main target?
 ENDIF(VISIT_PARALLEL)
 

--- a/src/visitpy/mpicom/setup.py
+++ b/src/visitpy/mpicom/setup.py
@@ -11,24 +11,16 @@
 #
 #
 # Modifications:
-#
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Move to use setuptools.
 #
 ###############################################################################
 
-import sys
-from distutils.core import setup
-from distutils.command.install_egg_info import install_egg_info
-
-# disable install_egg_info
-class SkipEggInfo(install_egg_info):
-    def run(self):
-        pass
-
+from setuptools import setup
 
 setup (name = 'mpicom',
        description = 'mpicom',
        package_dir = {'mpicom':'py_src'},
-       packages=['mpicom'],
-       cmdclass={'install_egg_info': SkipEggInfo})
+       packages=['mpicom'])
 
 

--- a/src/visitpy/pyavt/CMakeLists.txt
+++ b/src/visitpy/pyavt/CMakeLists.txt
@@ -24,7 +24,7 @@ SET(pyavt_sources py_src/__init__.py
                   py_src/templates/simple_query.py)
 
 PYTHON_ADD_PIP_SETUP(NAME pyavt_py_setup
-                     DEST_DIR site-packages
+                     DEST_DIR lib/site-packages
                      PY_MODULE_DIR pyavt
                      PY_SETUP_FILE setup.py
                      PY_SOURCES ${pyavt_sources})

--- a/src/visitpy/pyavt/CMakeLists.txt
+++ b/src/visitpy/pyavt/CMakeLists.txt
@@ -10,6 +10,9 @@
 #  Cyrus Harrison, Wed Apr 11 14:21:57 PDT 2012
 #  Use new cmake commands for distutils setup.
 #
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Use new cmake commands for pip setup.
+#
 #****************************************************************************
 
 # deps for pyavt
@@ -20,10 +23,10 @@ SET(pyavt_sources py_src/__init__.py
                   py_src/templates/simple_expression.py
                   py_src/templates/simple_query.py)
 
-PYTHON_ADD_DISTUTILS_SETUP(pyavt_py_setup
-                           site-packages
-                           setup.py
-                           ${pyavt_sources})
+PYTHON_ADD_PIP_SETUP(pyavt_py_setup
+                     site-packages
+                     setup.py
+                     ${pyavt_sources})
 
 
 

--- a/src/visitpy/pyavt/CMakeLists.txt
+++ b/src/visitpy/pyavt/CMakeLists.txt
@@ -23,10 +23,11 @@ SET(pyavt_sources py_src/__init__.py
                   py_src/templates/simple_expression.py
                   py_src/templates/simple_query.py)
 
-PYTHON_ADD_PIP_SETUP(pyavt_py_setup
-                     site-packages
-                     setup.py
-                     ${pyavt_sources})
+PYTHON_ADD_PIP_SETUP(NAME pyavt_py_setup
+                     DEST_DIR site-packages
+                     PY_MODULE_DIR pyavt
+                     PY_SETUP_FILE setup.py
+                     PY_SOURCES ${pyavt_sources})
 
 
 

--- a/src/visitpy/pyavt/setup.py
+++ b/src/visitpy/pyavt/setup.py
@@ -4,32 +4,23 @@
 
 ###############################################################################
 # file: setup.py
-# Purpose: disutils setup for pyavt module.
+# Purpose: setuptools setup for pyavt module.
 #
 # Programmer: Cyrus Harrison
 # Creation: Thu Apr  5 08:42:40 PDT 2012
 #
 #
 # Modifications:
-#
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Move to use setuptools.
 #
 ###############################################################################
 
-import sys
-from distutils.core import setup
-from distutils.command.install_egg_info import install_egg_info
-
-# disable install_egg_info
-class SkipEggInfo(install_egg_info):
-    def run(self):
-        pass
-
+from setuptools import setup
 
 setup (name = 'pyavt',
        description = 'pyavt',
        package_dir = {'pyavt':'py_src'},
        packages=['pyavt'],
-       package_data= { "pyavt": ["templates/*.py"]},
-       cmdclass={'install_egg_info': SkipEggInfo})
-
+       package_data= { "pyavt": ["templates/*.py"]})
 

--- a/src/visitpy/pyui/pyside/gui/setup.py
+++ b/src/visitpy/pyui/pyside/gui/setup.py
@@ -11,24 +11,17 @@
 #
 #
 # Modifications:
-#
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Move to use setuptools.
 #
 ###############################################################################
 
-import sys
-from distutils.core import setup
-from distutils.command.install_egg_info import install_egg_info
-
-# disable install_egg_info
-class SkipEggInfo(install_egg_info):
-    def run(self):
-        pass
+from setuptools import setup
 
 
 setup (name = 'pyside_gui',
        description = 'pyside_gui',
        package_dir = {'pyside_gui':'py_src'},
-       packages=['pyside_gui'],
-       cmdclass={'install_egg_info': SkipEggInfo})
+       packages=['pyside_gui'])
 
 

--- a/src/visitpy/pyui/pyside/hook/setup.py
+++ b/src/visitpy/pyui/pyside/hook/setup.py
@@ -11,24 +11,16 @@
 #
 #
 # Modifications:
-#
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Move to use setuptools.
 #
 ###############################################################################
 
-import sys
-from distutils.core import setup
-from distutils.command.install_egg_info import install_egg_info
-
-# disable install_egg_info
-class SkipEggInfo(install_egg_info):
-    def run(self):
-        pass
-
+from setuptools import setup
 
 setup (name = 'pyside_hook',
        description = 'pyside_hook',
        package_dir = {'pyside_hook':'py_src'},
-       packages=['pyside_hook'],
-       cmdclass={'install_egg_info': SkipEggInfo})
+       packages=['pyside_hook'])
 
 

--- a/src/visitpy/visit_flow/flow/CMakeLists.txt
+++ b/src/visitpy/visit_flow/flow/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 #****************************************************************************/
 # Modifications:
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Use new cmake commands for pip setup.
 #
 #****************************************************************************/
 
@@ -34,10 +36,10 @@ SET(visit_flow_sources src/__init__.py
                        src/parser/generator.py
                        src/parser/parser.py)
 
-PYTHON_ADD_DISTUTILS_SETUP(visit_flow_py_setup
-                           site-packages
-                           setup.py
-                           ${visit_flow_sources})
+PYTHON_ADD_PIP_SETUP(visit_flow_py_setup
+                     site-packages
+                     setup.py
+                     ${visit_flow_sources})
 
 
 

--- a/src/visitpy/visit_flow/flow/CMakeLists.txt
+++ b/src/visitpy/visit_flow/flow/CMakeLists.txt
@@ -36,12 +36,12 @@ SET(visit_flow_sources src/__init__.py
                        src/parser/generator.py
                        src/parser/parser.py)
 
-PYTHON_ADD_PIP_SETUP(visit_flow_py_setup
-                     site-packages
-                     setup.py
-                     ${visit_flow_sources})
 
-
+PYTHON_ADD_PIP_SETUP(NAME visit_flow_py_setup
+                     DEST_DIR site-packages
+                     PY_MODULE_DIR visit_flow
+                     PY_SETUP_FILE setup.py
+                     PY_SOURCES  ${visit_flow_sources})
 
 
 

--- a/src/visitpy/visit_flow/flow/CMakeLists.txt
+++ b/src/visitpy/visit_flow/flow/CMakeLists.txt
@@ -38,7 +38,7 @@ SET(visit_flow_sources src/__init__.py
 
 
 PYTHON_ADD_PIP_SETUP(NAME visit_flow_py_setup
-                     DEST_DIR site-packages
+                     DEST_DIR lib/site-packages
                      PY_MODULE_DIR visit_flow
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  ${visit_flow_sources})

--- a/src/visitpy/visit_flow/flow/setup.py
+++ b/src/visitpy/visit_flow/flow/setup.py
@@ -43,7 +43,7 @@ setup(name='visit_flow',
       author_email = 'cyrush@llnl.gov',
       description  ='visit_flow: A small, flexible python data flow framework.',
       package_dir  = {'visit_flow':'src'},
-      packages=['visit_flow','visit_flow.core','visit_flow.parser','visit_flow.filters']})
+      packages=['visit_flow','visit_flow.core','visit_flow.parser','visit_flow.filters'])
       #cmdclass = { 'test': setup_tests.ExecuteTests})
 
 if using_visit:

--- a/src/visitpy/visit_flow/flow/setup.py
+++ b/src/visitpy/visit_flow/flow/setup.py
@@ -14,9 +14,12 @@
 import sys
 __system_bytecode_setting = sys.dont_write_bytecode
 sys.dont_write_bytecode = True
-from distutils.core import setup
+from setuptools import setup
 import sys
-import setup_tests
+# TODO: update setup_tests
+# and cmdclass = { 'test': setup_tests.ExecuteTests}
+#import setup_tests
+
 
 
 #
@@ -36,13 +39,12 @@ except:
     pass
 
 setup(name='visit_flow',
-      version      ='0.1',
       author       = 'Cyrus Harrison',
       author_email = 'cyrush@llnl.gov',
       description  ='visit_flow: A small, flexible python data flow framework.',
       package_dir  = {'visit_flow':'src'},
-      packages=['visit_flow','visit_flow.core','visit_flow.parser','visit_flow.filters'],
-      cmdclass = { 'test': setup_tests.ExecuteTests})
+      packages=['visit_flow','visit_flow.core','visit_flow.parser','visit_flow.filters']})
+      #cmdclass = { 'test': setup_tests.ExecuteTests})
 
 if using_visit:
     sys.exit(0)

--- a/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
+++ b/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
@@ -9,14 +9,14 @@
 #
 #****************************************************************************
 
-PYTHON_ADD_PIP_SETUP(visit_flow_vpe_py_setup
-                     site-packages
-                     setup.py
-                     src/__init__.py
-                     src/visit_flow_exec.vpe
-                     src/visit_flow_vpe.py)
 
-
+PYTHON_ADD_PIP_SETUP(NAME visit_flow_vpe_py_setup
+                     DEST_DIR site-packages
+                     PY_MODULE_DIR visit_flow_vpe
+                     PY_SETUP_FILE setup.py
+                     PY_SOURCES  src/__init__.py
+                                 src/visit_flow_exec.vpe
+                                 src/visit_flow_vpe.py)
 
 
 

--- a/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
+++ b/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 
 PYTHON_ADD_PIP_SETUP(NAME visit_flow_vpe_py_setup
-                     DEST_DIR site-packages
+                     DEST_DIR lib/site-packages
                      PY_MODULE_DIR visit_flow_vpe
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  src/__init__.py

--- a/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
+++ b/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
@@ -4,15 +4,17 @@
 
 #****************************************************************************
 # Modifications:
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Use new cmake commands for pip setup.
 #
 #****************************************************************************
 
-PYTHON_ADD_DISTUTILS_SETUP(visit_flow_vpe_py_setup
-                           site-packages
-                           setup.py
-                           src/__init__.py
-                           src/visit_flow_exec.vpe
-                           src/visit_flow_vpe.py)
+PYTHON_ADD_PIP_SETUP(visit_flow_vpe_py_setup
+                     site-packages
+                     setup.py
+                     src/__init__.py
+                     src/visit_flow_exec.vpe
+                     src/visit_flow_vpe.py)
 
 
 

--- a/src/visitpy/visit_flow/visit_flow_vpe/setup.py
+++ b/src/visitpy/visit_flow/visit_flow_vpe/setup.py
@@ -14,9 +14,11 @@
 import sys
 __system_bytecode_setting = sys.dont_write_bytecode
 sys.dont_write_bytecode = True
-from distutils.core import setup
+from setuptools import setup
 import sys
-import setup_tests
+# TODO: update setup_tests
+# and cmdclass = { 'test': setup_tests.ExecuteTests}
+#import setup_tests
 
 
 #
@@ -36,14 +38,13 @@ except:
     pass
 
 setup(name='flow',
-      version      ='0.1',
       author       = 'Cyrus Harrison',
       author_email = 'cyrush@llnl.gov',
       description  ='visit_flow_vpe',
       package_dir  = {'visit_flow_vpe':'src'},
       packages=['visit_flow_vpe'],
-      package_data= { "visit_flow_vpe": ["*.vpe"]},
-      cmdclass = { 'test': setup_tests.ExecuteTests})
+      package_data= { "visit_flow_vpe": ["*.vpe"]})
+      # cmdclass = { 'test': setup_tests.ExecuteTests})
 
 if using_visit:
     sys.exit(0)

--- a/src/visitpy/visit_utils/CMakeLists.txt
+++ b/src/visitpy/visit_utils/CMakeLists.txt
@@ -10,9 +10,8 @@
 PYTHON_ADD_PIP_SETUP(NAME visit_utils_py_setup
                      DEST_DIR site-packages
                      PY_MODULE_DIR visit_utils
-                     PY_SETUP_FILE  setup.py
-                     PY_SOURCES
-                     src/__init__.py
+                     PY_SETUP_FILE setup.py
+                     PY_SOURCES src/__init__.py
                      # core mods
                      src/common.py
                      src/encoding.py

--- a/src/visitpy/visit_utils/CMakeLists.txt
+++ b/src/visitpy/visit_utils/CMakeLists.txt
@@ -8,7 +8,7 @@
 #****************************************************************************
 
 PYTHON_ADD_PIP_SETUP(NAME visit_utils_py_setup
-                     DEST_DIR site-packages
+                     DEST_DIR lib/site-packages
                      PY_MODULE_DIR visit_utils
                      PY_SETUP_FILE setup.py
                      PY_SOURCES src/__init__.py

--- a/src/visitpy/visit_utils/CMakeLists.txt
+++ b/src/visitpy/visit_utils/CMakeLists.txt
@@ -7,38 +7,40 @@
 #
 #****************************************************************************
 
-PYTHON_ADD_DISTUTILS_SETUP(visit_utils_py_setup
-                           site-packages
-                           setup.py
-                           src/__init__.py
-                           # core mods
-                           src/common.py
-                           src/encoding.py
-                           src/engine.py
-                           src/exprs.py
-                           src/host_profile.py
-                           src/moab.py
-                           src/property_tree.py
-                           src/query.py
-                           src/slurm.py
-                           src/status.py
-                           src/ult.py
-                           src/windows.py
-                           # builtin module
-                           src/builtin/__init__.py
-                           src/builtin/convert2to3.py
-                           src/builtin/evalfuncs.py
-                           src/builtin/flatten.py
-                           src/builtin/writescript.py
-                           # qannote module
-                           src/qannote/__init__.py
-                           src/qannote/canvas.py
-                           src/qannote/items.py
-                           src/qannote/xinit.py
-                           # qplot module
-                           src/qplot/__init__.py
-                           src/qplot/plots.py
-                           src/qplot/scene.py
+PYTHON_ADD_PIP_SETUP(NAME visit_utils_py_setup
+                     DEST_DIR site-packages
+                     PY_MODULE_DIR visit_utils
+                     PY_SETUP_FILE  setup.py
+                     PY_SOURCES
+                     src/__init__.py
+                     # core mods
+                     src/common.py
+                     src/encoding.py
+                     src/engine.py
+                     src/exprs.py
+                     src/host_profile.py
+                     src/moab.py
+                     src/property_tree.py
+                     src/query.py
+                     src/slurm.py
+                     src/status.py
+                     src/ult.py
+                     src/windows.py
+                     # builtin module
+                     src/builtin/__init__.py
+                     src/builtin/convert2to3.py
+                     src/builtin/evalfuncs.py
+                     src/builtin/flatten.py
+                     src/builtin/writescript.py
+                     # qannote module
+                     src/qannote/__init__.py
+                     src/qannote/canvas.py
+                     src/qannote/items.py
+                     src/qannote/xinit.py
+                     # qplot module
+                     src/qplot/__init__.py
+                     src/qplot/plots.py
+                     src/qplot/scene.py
                        )
 
 # gen scripts that help us test the visit_utils module

--- a/src/visitpy/visit_utils/src/encoding.py
+++ b/src/visitpy/visit_utils/src/encoding.py
@@ -27,7 +27,6 @@ import subprocess
 import glob
 import re
 import string
-import distutils.spawn
 import platform
 import shutil
 
@@ -648,14 +647,8 @@ def ffmpeg_bin():
     """
     Returns path to the 'ffmpeg' binary, or None if this binary is not available.
     """
-    if (platform.system() == "Windows"):
-        return distutils.spawn.find_executable("ffmpeg")
-    else:
-        res = sexe("which ffmpeg",ret_output=True)[1].strip()
-        if os.path.exists(res):
-            return res
-        else:
-            return None
+    return shutil.which("ffmpeg")
+
 
 def ffmpeg_version():
     """

--- a/src/visitpy/visitmodule/CMakeLists.txt
+++ b/src/visitpy/visitmodule/CMakeLists.txt
@@ -12,12 +12,12 @@
 #
 #****************************************************************************
 
-PYTHON_ADD_DISTUTILS_SETUP(visitmodule_py_setup
-                           site-packages
-                           setup.py
-                           py_src/__init__.py
-                           py_src/frontend.py
-                           )
+PYTHON_ADD_PIP_SETUP(visitmodule_py_setup
+                     site-packages
+                     setup.py
+                     py_src/__init__.py
+                     py_src/frontend.py
+                    )
 
 
 

--- a/src/visitpy/visitmodule/CMakeLists.txt
+++ b/src/visitpy/visitmodule/CMakeLists.txt
@@ -13,7 +13,7 @@
 #****************************************************************************
 
 PYTHON_ADD_PIP_SETUP(NAME visitmodule_py_setup
-                     DEST_DIR site-packages
+                     DEST_DIR lib/site-packages
                      PY_MODULE_DIR visit_flow_vpe
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  py_src/__init__.py

--- a/src/visitpy/visitmodule/CMakeLists.txt
+++ b/src/visitpy/visitmodule/CMakeLists.txt
@@ -12,13 +12,12 @@
 #
 #****************************************************************************
 
-PYTHON_ADD_PIP_SETUP(visitmodule_py_setup
-                     site-packages
-                     setup.py
-                     py_src/__init__.py
-                     py_src/frontend.py
-                    )
-
+PYTHON_ADD_PIP_SETUP(NAME visitmodule_py_setup
+                     DEST_DIR site-packages
+                     PY_MODULE_DIR visit_flow_vpe
+                     PY_SETUP_FILE setup.py
+                     PY_SOURCES  py_src/__init__.py
+                                 py_src/frontend.py)
 
 
 

--- a/src/visitpy/visitmodule/setup.py
+++ b/src/visitpy/visitmodule/setup.py
@@ -11,23 +11,16 @@
 #
 #
 # Modifications:
-#
+#  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
+#  Move to use setuptools.
 #
 ###############################################################################
 
-import sys
-from distutils.core import setup
-from distutils.command.install_egg_info import install_egg_info
-
-# disable install_egg_info
-class SkipEggInfo(install_egg_info):
-    def run(self):
-        pass
+from setuptools import setup
 
 setup (name = 'visit',
        description = 'visit',
        package_dir = {'visit':'py_src'},
-       packages=['visit'],
-       cmdclass={'install_egg_info': SkipEggInfo})
+       packages=['visit'])
 
 


### PR DESCRIPTION
### Description
refactor to use setuptools and pip instead of setup.py and distutils

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

infra update

### How Has This Been Tested?

testing in progress

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
