### PR TITLE
Fix windows compile errors.

### DIFF
--- a/src/databases/unv/avtunvFileFormat.C
+++ b/src/databases/unv/avtunvFileFormat.C
@@ -61,6 +61,11 @@
 #include <avtParallel.h>
 #endif
 
+#ifdef _MSC_VER
+#include <shlwapi.h>
+#define strcasestr StrStrIA
+#endif
+
 using     std::string;
 using namespace std;
 
@@ -2678,7 +2683,7 @@ avtunvFileFormat::GetMesh(const char *meshname)
             case 34:
             {
                 int nbnel = itre->nbnel ;
-                vtkIdType cverts[nbnel];
+                vtkIdType *cverts = new vtkIdType[nbnel];
                 for (int i=0; i < nbnel; i++)
                 {
                     anUnvNode.label = itre->nodes[i];
@@ -2689,6 +2694,7 @@ avtunvFileFormat::GetMesh(const char *meshname)
 #endif
                 }
                 ugrid->InsertNextCell(VTK_POLYGON, nbnel, cverts);
+                delete [] cverts;
                 break;
             }
             case 24:
@@ -2866,7 +2872,7 @@ avtunvFileFormat::GetMesh(const char *meshname)
                 case 34:
                 {
                     int nbnel = itre->nbnel ;
-                    vtkIdType cverts[nbnel];
+                    vtkIdType *cverts = new vtkIdType[nbnel];
                     for (int i=0; i < nbnel; i++)
                     {
                         anUnvNode.label = itre->nodes[i];
@@ -2877,6 +2883,7 @@ avtunvFileFormat::GetMesh(const char *meshname)
 #endif
                     }
                     ugrid->InsertNextCell(VTK_POLYGON, nbnel, cverts);
+                    delete [] cverts;
                     break;
                 }
                 default:
@@ -2940,7 +2947,7 @@ avtunvFileFormat::GetMesh(const char *meshname)
                 case 34:
                 {
                     int nbnel = itre->nbnel ;
-                    vtkIdType cverts[nbnel];
+                    vtkIdType *cverts = new vtkIdType[nbnel];
                     for (int i=0; i < nbnel; i++)
                     {
                         anUnvNode.label = itre->nodes[i];
@@ -2951,6 +2958,7 @@ avtunvFileFormat::GetMesh(const char *meshname)
 #endif
                     }
                     ugrid->InsertNextCell(VTK_POLYGON, nbnel, cverts);
+                    delete [] cverts;
                     break;
                 }
                 default:


### PR DESCRIPTION
vtkIdType cverts[nbnel] yields 'does not evaluate to constant' error. In order for this to work 'nbnel' must be a constant at compile time, so need to use 'new' to allocate the array.

strcasestr not defined on Windows, #define it to be 'StrStrIA'.


### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [X] Other~~ <!-- please explain with a note below -->
compilation error

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
