### PR TITLE
Fix volume plot's problem with multidomain data and 'NoResampling'

### DIFF
--- a/src/plots/VolumeVTK9/avtVisItVTKRenderFilter.C
+++ b/src/plots/VolumeVTK9/avtVisItVTKRenderFilter.C
@@ -399,6 +399,8 @@ avtVisItVTKRenderFilter::CreateFinalImage(const void *colorBuffer,
 //  Creation:   30 November 2021
 //
 //  Modifications:
+//   Kathleen Biagas, Tue Feb 6, 2024
+//   Pass in_ds to NeedImage.
 //
 // ****************************************************************************
 
@@ -433,7 +435,8 @@ avtVisItVTKRenderFilter::Execute()
 
     // The data and opacity ranges must be known before calling
     // UpdateRenderingState.
-    if( NeedImage() )
+    vtkDataSet* in_ds = datasetPtrs[ 0 ];
+    if( NeedImage(in_ds) )
     {
         // GetDataExtents is a parallel call so do them regardless if
         // there is data or not. Otherwise MPI crashes.
@@ -498,7 +501,6 @@ avtVisItVTKRenderFilter::Execute()
             renderer->SetAmbient(1., 1., 1.);
         }
 
-        vtkDataSet* in_ds = datasetPtrs[ 0 ];
 
         UpdateRenderingState(in_ds, renderer);
 

--- a/src/plots/VolumeVTK9/avtVisItVTKRenderer.C
+++ b/src/plots/VolumeVTK9/avtVisItVTKRenderer.C
@@ -221,12 +221,26 @@ avtVisItVTKRenderer::NumberOfComponents(const std::string activeVariable,
 //  Creation:  30 November 2021
 //
 //  Modifications:
+//    Kathleen Biagas, Tue Feb 6 2024
+//    Check if current input matches previous (only doing pointer comparison).
+//    This will allow multi-domain problems that were not resampled to still
+//    have all their domains rendered (as long as they are rect grids).
 //
 // ****************************************************************************
 
 bool
-avtVisItVTKRenderer::NeedImage()
+avtVisItVTKRenderer::NeedImage(vtkDataSet *input)
 {
+    // if the input is different than previous we are probably
+    // dealing with a multi-domain that wasn't resampled.
+    // Set m_firstPass to true so m_needImage will be re-evaluated
+    // and the new dataset/domain can be rendered.
+    if(input != previousInput)
+    {
+        m_firstPass = true;
+        previousInput = input;
+    }
+
     if( m_firstPass == true ||
 
         // Color variable change or min/max change. The active var

--- a/src/plots/VolumeVTK9/avtVisItVTKRenderer.h
+++ b/src/plots/VolumeVTK9/avtVisItVTKRenderer.h
@@ -20,6 +20,20 @@ class vtkVolume;
 class vtkVolumeMapper;
 class vtkVolumeProperty;
 
+
+// ****************************************************************************
+//  Class: avtVisItVTKRenderer
+//
+//  Purpose:
+//
+//  Modifications:
+//    Added storage for previousInput, so multiple inputs can be rendered
+//    if the current being rendered doesn't match previous.
+//    Added vtkDataSet* argument to NeedImage.
+//
+// ****************************************************************************
+
+
 class avtVisItVTKRenderer
 {
 public:
@@ -33,7 +47,7 @@ protected:
     int            NumberOfComponents(const std::string activeVariable,
                                       const std::string opacityVariable);
 
-    bool           NeedImage();
+    bool           NeedImage(vtkDataSet *);
     void           UpdateRenderingState(vtkDataSet * in_ds,
                                         vtkRenderer* renderer);
 
@@ -74,6 +88,8 @@ protected:
     vtkVolumeProperty         *m_volumeProperty{nullptr};
     vtkVolumeMapper           *m_volumeMapper  {nullptr};
     vtkVolume                 *m_volume        {nullptr};
+
+    vtkDataSet                *previousInput{nullptr};
 };
 
 #endif

--- a/src/plots/VolumeVTK9/avtVolumeRenderer.C
+++ b/src/plots/VolumeVTK9/avtVolumeRenderer.C
@@ -109,6 +109,8 @@ avtVolumeRenderer::New(void)
 //  Creation:    October  1, 2003
 //
 //  Modifications:
+//    Kathleen Biagas, Tues Feb 6 2024
+//    Pass input dataset to NeedImage.
 //
 // ****************************************************************************
 
@@ -151,7 +153,7 @@ avtVolumeRenderer::Render(vtkDataSet *in_ds)
 
     // The data and opacity ranges must be known before calling
     // UpdateRenderingState.
-    if( NeedImage() )
+    if( NeedImage(in_ds) )
     {
         // Get the local data range so to ignore NO_DATA_VALUE values.
         // dataArr->GetRange( m_dataRange );


### PR DESCRIPTION
### Description

Fixes problem with VTK 9 volume plot, where a multi-domain data with 'No Resampling' option chosen only renders 1 domain.

See [my comment](https://github.com/visit-dav/visit/issues/19103#issuecomment-1930853926) for #19103.

This a draft for comments as to whether this is a good solution to the problem introduced by changes to the volume plot for vtk 9.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

See the comment referenced above.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
