### PR TITLE
X Ray Query Docs Fix Examples

### DIFF
--- a/src/doc/using_visit/Quantitative/XRayImageQuery.rst
+++ b/src/doc/using_visit/Quantitative/XRayImageQuery.rst
@@ -494,10 +494,13 @@ x ray image shows some variation. ::
   params = GetQueryParameters("XRay Image")
   params['image_size'] = (300, 300)
   params['divide_emis_by_absorb'] = 1
-  params['width'] = 4.
-  params['height'] = 4.
-  params['theta'] = 90.
-  params['phi'] = 0.
+  params['parallel_scale'] = 2.
+  params['near_plane'] = -40.0
+  params['far_plane'] = 40.0
+  params['normal'] = (1,0,0)
+  params['focus'] = (0,0,0)
+  params['view_up'] = (0,1,0)
+  params['perspective'] = 0
   params['vars'] = ("w1", "v1")
   Query("XRay Image", params)
 

--- a/src/doc/using_visit/Quantitative/XRayImageQuery.rst
+++ b/src/doc/using_visit/Quantitative/XRayImageQuery.rst
@@ -417,8 +417,13 @@ down the Z Axis and the resulting image. ::
   params = GetQueryParameters("XRay Image")
   params['image_size'] = (300, 300)
   params['divide_emis_by_absorb'] = 1
-  params['width'] = 10.
-  params['height'] = 10.
+  params['parallel_scale'] = 5.
+  params['near_plane'] = -100.0
+  params['far_plane'] = 100.0
+  params['normal'] = (0,0,1)
+  params['focus'] = (0,0,0)
+  params['view_up'] = (0,1,0)
+  params['perspective'] = 0
   params['vars'] = ("d", "p")
   Query("XRay Image", params)
 
@@ -432,10 +437,13 @@ from the side. ::
   params = GetQueryParameters("XRay Image")
   params['image_size'] = (300, 300)
   params['divide_emis_by_absorb'] = 1
-  params['width'] = 10.
-  params['height'] = 10.
-  params['theta'] = 90.
-  params['phi'] = 0.
+  params['parallel_scale'] = 5.
+  params['near_plane'] = -100.0
+  params['far_plane'] = 100.0
+  params['normal'] = (1,0,0)
+  params['focus'] = (0,0,0)
+  params['view_up'] = (0,1,0)
+  params['perspective'] = 0
   params['vars'] = ("d", "p")
   Query("XRay Image", params)
 
@@ -449,11 +457,13 @@ moves the image down and to the right by 1. ::
   params = GetQueryParameters("XRay Image")
   params['image_size'] = (300, 300)
   params['divide_emis_by_absorb'] = 1
-  params['width'] = 10.
-  params['height'] = 10.
-  params['theta'] = 90.
-  params['phi'] = 0.
-  params['origin'] = (0., 1., 1.)
+  params['parallel_scale'] = 5.
+  params['near_plane'] = -100.0
+  params['far_plane'] = 100.0
+  params['normal'] = (1,0,0)
+  params['focus'] = (0,1,1)
+  params['view_up'] = (0,1,0)
+  params['perspective'] = 0
   params['vars'] = ("d", "p")
   Query("XRay Image", params)
 


### PR DESCRIPTION
### Description

Addresses a bullet in #17791 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

After I made the complete camera specification the default, the examples that relied on the simplified camera specification were no longer valid. These changes address that. I have updated each affected example to use the complete camera specification.

I made a script that runs these examples using both the new and old camera specifications and generates output images that you can compare. It also does some other gymnastics to get the proper subset of globe.silo used in the original example. It may be worthwhile to incorporate the script into our tests and then have the docs refer to the tests. Right now the docs examples are never run, so this only got fixed because I happened to be staring at the examples and saw they were wrong.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* [x] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

Like I said above, I ran a script that generates images using both the old and new camera specifications. I compared them and then used the code for the new camera specification as the basis for the docs examples.

RTD build looks good.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
