### PR TITLE
Fix visit python modules install (#19348)

### DIFF
--- a/src/CMake/FindConduit.cmake
+++ b/src/CMake/FindConduit.cmake
@@ -2,6 +2,14 @@
 # Project developers.  See the top-level LICENSE file for dates and other
 # details.  No copyright assignment is required to contribute to VisIt.
 
+#-----------------------------------------------------------------------------
+# Modifications:
+#   Kathleen Biagas, Wed Feb 28, 2024
+#   Removed install logic for conduit python.  Now handled in
+#   lib/CMakeLists.txt with build/lib/site-packages/ directory install.
+#
+#-----------------------------------------------------------------------------
+
 #
 # Use the CONDUIT_DIR hint from the config-site .cmake file 
 #
@@ -17,30 +25,6 @@ if(VISIT_PARALLEL)
     SET_UP_THIRD_PARTY(CONDUIT_MPI
         INCDIR include/conduit
         LIBS conduit_relay_mpi conduit_blueprint_mpi)
-endif()
-
-
-# check if conduit was built with python support, if so we want
-# to install conduit's python modules
-if(EXISTS ${CONDUIT_DIR}/python-modules/conduit)
-    message(STATUS "Found Conduit Python Wrappers - ${CONDUIT_DIR}/python-modules/conduit")
-    install(DIRECTORY ${CONDUIT_DIR}/python-modules/conduit
-            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}/site-packages/
-            FILE_PERMISSIONS
-                    OWNER_WRITE
-                    OWNER_READ
-                    GROUP_WRITE
-                    GROUP_READ
-                    WORLD_READ
-            DIRECTORY_PERMISSIONS
-                    OWNER_WRITE
-                    OWNER_READ
-                    OWNER_EXECUTE
-                    GROUP_WRITE
-                    GROUP_READ
-                    GROUP_EXECUTE
-                    WORLD_READ WORLD_EXECUTE
-                )
 endif()
 
 if(CONDUIT_FOUND)

--- a/src/CMake/FindVTK9.cmake
+++ b/src/CMake/FindVTK9.cmake
@@ -13,6 +13,10 @@
 #  Test for lib vs lib64.
 #  Use QT_MAJOR_VERSION instead of '5' or '6'.
 #
+#  Kathleen Biagas, Wed Feb 28, 2024
+#  Removed install logic for python modules.  Now handled in
+#  lib/CMakeLists.txt with build/lib/site-packages/ directory install.
+#
 #*****************************************************************************
 
 # Use the VTK_DIR hint from the config-site .cmake file
@@ -160,23 +164,6 @@ if(EXISTS ${VTK_PY_WRAPPERS_DIR}/vtkmodules)
 
     if(VISIT_VTK_SKIP_INSTALL)
         message(STATUS "Skipping installation of VTK Python bindings")
-    else()
-        install(FILES ${VTK_PY_WRAPPERS_DIR}/vtk.py
-                DESTINATION ${VISIT_INSTALLED_VERSION_LIB}/site-packages/
-                PERMISSIONS OWNER_READ OWNER_WRITE
-                            GROUP_READ GROUP_WRITE
-                            WORLD_READ
-            )
-
-        install(DIRECTORY ${VTK_PY_WRAPPERS_DIR}/vtkmodules
-                DESTINATION ${VISIT_INSTALLED_VERSION_LIB}/site-packages/
-                FILE_PERMISSIONS OWNER_WRITE OWNER_READ
-                                 GROUP_WRITE GROUP_READ
-                                             WORLD_READ
-                DIRECTORY_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
-                                      GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                                                  WORLD_READ WORLD_EXECUTE
-            )
     endif()
 
     set(VTK_PYTHON_WRAPPERS_FOUND TRUE)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -49,6 +49,11 @@
 #    Kathleen Biagas, Tue Jan 31, 2023
 #    visit_special_builds renamed to visit_util_builds.
 #
+#    Kathleen Biagas, Wed Feb 28, 2024
+#    Add direct install of build/lib/site-packages dir.
+#    Change conduit-python-libs from using symlink to direct copy, to play
+#    well with new direct install of build/lib/site-packages dir.
+#
 #----------------------------------------------------------------------------
 
 IF(VISIT_PYTHON_DIR)
@@ -73,6 +78,27 @@ IF(VISIT_PYTHON_DIR)
 ENDIF()
 
 # prepare site-packages
+
+# is this the correct if-test ?
+if(VISIT_PYTHON_FILTERS OR VISIT_PYTHON_SCRIPTING)
+
+    # there were unresolvable issues with the INSTALL(CODE ...
+    # in FindVisItPython for pip-installed modules
+    # this direct copy of the lib/site-packages dir from the
+    # build works.
+
+    install(DIRECTORY ${VISIT_LIBRARY_DIR}/site-packages
+            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}/
+            FILE_PERMISSIONS OWNER_WRITE OWNER_READ
+                             GROUP_WRITE GROUP_READ
+                                         WORLD_READ
+            DIRECTORY_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                                  GROUP_WRITE GROUP_READ GROUP_EXECUTE
+                                              WORLD_READ WORLD_EXECUTE)
+
+endif()
+
+
 IF(VISIT_PYTHON_FILTERS OR (VISIT_PYTHON_SCRIPTING AND HAVE_LIBPYSIDE))
     IF(NOT WIN32)
         EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory
@@ -171,30 +197,16 @@ if(VISIT_PYTHON_SCRIPTING AND CONDUIT_DIR)
     set(CONDUIT_PY_MODULE ${CONDUIT_DIR}/python-modules/conduit)
     if(NOT EXISTS ${CONDUIT_PY_MODULE})
         message(WARNING "Failed to find Conduit Python Module at ${CONDUIT_PY_MODULE}")
-    endif()
-    if(NOT WIN32)
-        
-        execute_process(COMMAND ${CMAKE_COMMAND} -E remove -f
-                                ${CMAKE_CURRENT_BINARY_DIR}/site-packages/conduit
-                                 RESULT_VARIABLE CONDUIT_PY_SYM_REMOTE)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-                                ${CONDUIT_PY_MODULE}
-                                ${CMAKE_CURRENT_BINARY_DIR}/site-packages/conduit
-                                RESULT_VARIABLE CONDUIT_PY_SYM_CREATE)
-
-        if(NOT "${CONDUIT_PY_SYM_CREATE}" STREQUAL "0")
-            message(WARNING "Failed to create Conduit Python module symlink in lib/site-packages/")
-        endif()
-
-    else() # NOT WIN32
-        # correct lib/${CFG} directory
+    else()
         add_custom_target(conduit_python_module ALL
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CONDUIT_PY_MODULE}
                     ${VISIT_LIBRARY_DIR}/site-packages/conduit
             COMMENT "Copying ${CONDUIT_PY_MODULE} to ${VISIT_LIBRARY_DIR}/site-packages/conduit"
         )
-        visit_add_to_util_builds(conduit_python_module)
+        if(WIN32)
+            visit_add_to_util_builds(conduit_python_module)
+        endif()
     endif()
 endif()
 

--- a/src/visitpy/CMakeLists.txt
+++ b/src/visitpy/CMakeLists.txt
@@ -59,6 +59,10 @@
 #  Eric Brugger, Tue Jul 25 11:23:55 EDT 2023
 #  Change CMAKE_THREAD_LIBS to Threads::Threads.
 #
+#  Kathleen Biagas, Wed Feb 28, 2024
+#  Make visitmodule depend on visitmodule_py_setup, so it will be built after
+#  the python module. Prevents pip install from deleting visitmodule.so
+#
 #****************************************************************************
 
 #########################################################
@@ -481,6 +485,10 @@ ENDIF(VISIT_STATIC)
 # For module setup of the pure python parts of the visit module
 #
 ADD_SUBDIRECTORY(visitmodule)
+# the visitmodule subdir added above creates the visitmodule_py_setup target
+# visitmodule needs to depend on it so it is built after the py module,
+# otherwise pip install will overwrite the directory and delete visitmodule.so
+add_dependencies(visitmodule visitmodule_py_setup)
 ADD_SUBDIRECTORY(visit_utils)
 ADD_SUBDIRECTORY(visit_flow)
 

--- a/src/visitpy/visitmodule/CMakeLists.txt
+++ b/src/visitpy/visitmodule/CMakeLists.txt
@@ -10,11 +10,14 @@
 #   Cyrus Harrison, Wed Feb 24 10:12:20 PST 2021
 #   Moved PySide logic into visit_utils.builtin
 #
+#   Kathleen Biagas, Wed Feb 28, 2024
+#   Changed PY_MODULE_DIR from visit_flow_vpe to visit.
+#
 #****************************************************************************
 
 PYTHON_ADD_PIP_SETUP(NAME visitmodule_py_setup
                      DEST_DIR lib/site-packages
-                     PY_MODULE_DIR visit_flow_vpe
+                     PY_MODULE_DIR visit
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  py_src/__init__.py
                                  py_src/frontend.py)


### PR DESCRIPTION
* Fix make-package problems with visit's python modules. Instead of installing the individual modules with 'pip install', install the build/lib/site-packages dir directly.

* Fix visitmodule's PY_MODULE_DIR.



Resolves #19349


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

compiled,packaged and installed on LC


### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
