### PR TITLE
Fix python modules windows

### DIFF
--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -88,6 +88,11 @@
 #   Removed install(CODE ...) logic for PIP installed modules, in favor of
 #   direct install of build/lib/site-packages directory via lib/CMakeLists.txt
 #
+#   Kathleen Biagas, Tue Mar 5, 2024
+#   In PYTHON_ADD_PIP_SETUP, changed setting of abs_dest_path from using
+#   CMAKE_BINARY_DIR to VISIT_LIBRARY_DIR which accounts for build
+#   configuration being part of the library path on Windows.
+#
 #****************************************************************************/
 
 # - Find python libraries
@@ -388,7 +393,7 @@ FUNCTION(PYTHON_ADD_PIP_SETUP)
     MESSAGE(STATUS "Configuring python pip setup: ${args_NAME}")
 
     # dest for build dir
-    set(abs_dest_path ${CMAKE_BINARY_DIR}/${args_DEST_DIR})
+    set(abs_dest_path ${VISIT_LIBRARY_DIR}/${args_DEST_DIR})
     if(WIN32)
         # on windows, python seems to need standard "\" style paths
         string(REGEX REPLACE "/" "\\\\" abs_dest_path  ${abs_dest_path})
@@ -410,6 +415,10 @@ FUNCTION(PYTHON_ADD_PIP_SETUP)
     # set folder if passed
     if(DEFINED args_FOLDER)
         blt_set_target_folder(TARGET ${args_NAME} FOLDER ${args_FOLDER})
+    endif()
+    
+    if(WIN32)
+        visit_add_to_util_builds(${args_NAME})
     endif()
 
 ENDFUNCTION(PYTHON_ADD_PIP_SETUP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -560,6 +560,10 @@
 #    Rename Windows visit_special_builds to visit_util_builds, add function
 #    for easier use of this uber-target.
 #
+#    Kathleen Biagas, Tue Mar 5, 2024
+#    Modified VISIT_LIBRARY_DIR to use $<CONFIG> instead of
+#    ${CMAKE_CFG_INTDIR} on Windows, since the latter is deprecated.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
@@ -730,9 +734,14 @@ if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${VISIT_BINARY_DIR}/exe CACHE INTERNAL "Single output directory for building all executables.")
 endif()
 
+set(VISIT_LIBRARY_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+set(VISIT_EXECUTABLE_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
-set(VISIT_LIBRARY_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
-set(VISIT_EXECUTABLE_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
+if(WIN32)
+    string(APPEND VISIT_LIBRARY_DIR "/$<CONFIG>")
+    string(APPEND VISIT_EXECUTABLE_DIR "/$<CONFIG>")
+endif()
+
 set(CXX_TEST_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
 #-----------------------------------------------------------------------------

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -7,6 +7,10 @@
 #   Kathleen Biagas, Wed Dec 18, 2019
 #   Added run_visit_test_suite.bat.in configure file for windows.
 #
+#   Kathleen Biagas, Tue Mar 5, 2024
+#   For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#   simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
+#
 #****************************************************************************
 
 IF(WIN32)
@@ -67,7 +71,7 @@ else()
                           py_src/visit_test_suite.py)
 
     PYTHON_ADD_PIP_SETUP(NAME visit_testing_py_setup
-                         DEST_DIR lib/site-packages
+                         DEST_DIR site-packages
                          PY_MODULE_DIR visit_testing
                          PY_SETUP_FILE setup.py
                          PY_SOURCES ${pytesting_sources})

--- a/src/visitpy/mpicom/CMakeLists.txt
+++ b/src/visitpy/mpicom/CMakeLists.txt
@@ -16,6 +16,10 @@
 #  Kathleen Biagas, Thu Sep 27 11:35:34 PDT 2018
 #  Change PYTHON_LIBRARIES to PYTHON_LIBRARY for consistency throughout visit.
 #
+#  Kathleen Biagas, Tue Mar 5, 2024
+#  For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#  simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
+#
 #****************************************************************************
 
 SET(MPICOM_PY_SOURCES py_src/__init__.py
@@ -35,7 +39,7 @@ IF(VISIT_PARALLEL)
 
     # Create the mpicom
     PYTHON_ADD_HYBRID_MODULE(NAME mpicom
-                             DEST_DIR lib/site-packages
+                             DEST_DIR site-packages
                              PY_MODULE_DIR mpicom
                              PY_SETUP_FILE setup.py
                              PY_SOURCES "${MPICOM_PY_SOURCES}"
@@ -71,7 +75,7 @@ IF(VISIT_PARALLEL)
 ELSE(VISIT_PARALLEL)
     # we still need to build the module w/ the mpi stub
     PYTHON_ADD_PIP_SETUP(NAME mpicom_py_setup
-                         DEST_DIR lib/site-packages
+                         DEST_DIR site-packages
                          PY_MODULE_DIR mpicom
                          PY_SETUP_FILE setup.py
                          PY_SOURCES ${MPICOM_PY_SOURCES})

--- a/src/visitpy/pyavt/CMakeLists.txt
+++ b/src/visitpy/pyavt/CMakeLists.txt
@@ -13,6 +13,10 @@
 #  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
 #  Use new cmake commands for pip setup.
 #
+#  Kathleen Biagas, Tue Mar 5, 2024
+#  For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#  simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
+#
 #****************************************************************************
 
 # deps for pyavt
@@ -24,7 +28,7 @@ SET(pyavt_sources py_src/__init__.py
                   py_src/templates/simple_query.py)
 
 PYTHON_ADD_PIP_SETUP(NAME pyavt_py_setup
-                     DEST_DIR lib/site-packages
+                     DEST_DIR site-packages
                      PY_MODULE_DIR pyavt
                      PY_SETUP_FILE setup.py
                      PY_SOURCES ${pyavt_sources})

--- a/src/visitpy/visit_flow/flow/CMakeLists.txt
+++ b/src/visitpy/visit_flow/flow/CMakeLists.txt
@@ -7,6 +7,10 @@
 #  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
 #  Use new cmake commands for pip setup.
 #
+#  Kathleen Biagas, Tue Mar 5, 2024
+#  For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#  simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
+#
 #****************************************************************************/
 
 # deps for flow
@@ -38,7 +42,7 @@ SET(visit_flow_sources src/__init__.py
 
 
 PYTHON_ADD_PIP_SETUP(NAME visit_flow_py_setup
-                     DEST_DIR lib/site-packages
+                     DEST_DIR site-packages
                      PY_MODULE_DIR visit_flow
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  ${visit_flow_sources})

--- a/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
+++ b/src/visitpy/visit_flow/visit_flow_vpe/CMakeLists.txt
@@ -7,11 +7,15 @@
 #  Cyrus Harrison, Fri Feb 16 13:41:04 PST 2024
 #  Use new cmake commands for pip setup.
 #
+#  Kathleen Biagas, Tue Mar 5, 2024
+#  For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#  simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
+#
 #****************************************************************************
 
 
 PYTHON_ADD_PIP_SETUP(NAME visit_flow_vpe_py_setup
-                     DEST_DIR lib/site-packages
+                     DEST_DIR site-packages
                      PY_MODULE_DIR visit_flow_vpe
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  src/__init__.py

--- a/src/visitpy/visit_utils/CMakeLists.txt
+++ b/src/visitpy/visit_utils/CMakeLists.txt
@@ -4,11 +4,14 @@
 
 #****************************************************************************
 # Modifications:
+#  Kathleen Biagas, Tue Mar 5, 2024
+#  For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#  simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
 #
 #****************************************************************************
 
 PYTHON_ADD_PIP_SETUP(NAME visit_utils_py_setup
-                     DEST_DIR lib/site-packages
+                     DEST_DIR site-packages
                      PY_MODULE_DIR visit_utils
                      PY_SETUP_FILE setup.py
                      PY_SOURCES src/__init__.py

--- a/src/visitpy/visitmodule/CMakeLists.txt
+++ b/src/visitpy/visitmodule/CMakeLists.txt
@@ -13,10 +13,14 @@
 #   Kathleen Biagas, Wed Feb 28, 2024
 #   Changed PY_MODULE_DIR from visit_flow_vpe to visit.
 #
+#   Kathleen Biagas, Tue Mar 5, 2024
+#   For PYTHON_ADD_PIP_SETUP change DEST_DIR from lib/site-packages to
+#   simply site-packages. The lib part handled in PYTHON_ADD_PIP_SETUP.
+#
 #****************************************************************************
 
 PYTHON_ADD_PIP_SETUP(NAME visitmodule_py_setup
-                     DEST_DIR lib/site-packages
+                     DEST_DIR site-packages
                      PY_MODULE_DIR visit
                      PY_SETUP_FILE setup.py
                      PY_SOURCES  py_src/__init__.py


### PR DESCRIPTION
### Description

Path for library dir on Windows includes the build configuration, so `lib/Release` or `lib/Debug`.
The DEST_DIR option to PYTHON_ADD_PIP_SETUP  was using `lib/site-packages` so the modules were not being put in the correct location on Windows.
Modified PYTHON_ADD_PIP_SETUP to use VISIT_LIBRARY_DIR instead of CMAKE_BINARY_DIR when creating the `abs_dest_path` var, as VISIT_LIBRARY_DIR accounts for the build configuration.  Also modified all calls to PYTHON_ADD_PIP_SETUP so that only `site-packages` is passed as DEST_DIR.

This allows `abs_dest_path` to be `/path/to/build/lib/site-packages` on non windows and `\path\to\build\lib\<CONFIG>\site-packages` on Windows.

Modified setting of VISIT_LIBRARY_DIR for Windows to use `$<CONFIG>` instead of `${CMAKE_CFG_INTDIR}` which has been deprecated.

Also added logic to clean up build artifacts left in source by `pip install`.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
~~* [ ] New feature~~
~~* [ ] Documentation update~~
~~* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Compiled, created install and ran visit's cli and tests on Windows and Linux with success.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
