### PR TITLE
Fix space-escaping logic for array variables.

### DIFF
--- a/src/databases/Xdmf/avtXdmfFileFormat.C
+++ b/src/databases/Xdmf/avtXdmfFileFormat.C
@@ -608,29 +608,15 @@ void avtXdmfFileFormat::GetDims(int exts[6], int dims[3])
 //  Programmer: Kenneth Leiter
 //  Creation:   March 29, 2010
 //
+//  Modifications
+//    Mark C. Miller, Fri Mar  8 22:57:05 PST 2024
+//    Replace space-backslash-escaping logic with expression systems escape
+//    bracketing. Did space-escaping ever work?
 // ****************************************************************************
 
 std::string avtXdmfFileFormat::GetFormattedExpressionName(std::string & attributeName)
 {
-    std::stringstream formatted;
-
-    // Deal with whitespace
-    std::stringstream stream(attributeName);
-    std::istream_iterator<std::string> it(stream);
-    std::istream_iterator<std::string> end;
-    std::vector<std::string> tokens(it, end);
-
-    std::vector<std::string>::const_iterator iter = tokens.begin();
-    if (iter != tokens.end()) {
-        formatted << *iter;
-        iter++;
-    }
-
-    for (; iter != tokens.end(); ++iter) {
-        formatted << "\\ " << *iter;
-    }
-
-    return formatted.str();
+    return "<" + attributeName + ">";
 }
 
 // ****************************************************************************


### PR DESCRIPTION
### Description

This fixes an issue for me for reading NIF `.h5` files with Xdmf plugin. Whenever the plugin encountered an Xdmf attribute typed as scalar but with a dataset dimension with multiple components, it would rightly create an array variable and then create `array_decompose()` expressions for each member (component) of the array. The problem is that in the `array_decompose()` expressions it created it was backslash-escaping any spaces in the variable's name. I am not sure VisIt ever supported this. Or, if it did, it was obsoleted years ago. I replaced that logic with the expression system's variable name escape bracketing (`<`, `>`) and that fixes the issues with NIF `.h5` files.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
