### PR TITLE
Fix literal include that referenced a file outside the 'src' dir. (#19386)

### DIFF
--- a/src/doc/building_visit/Spack.rst
+++ b/src/doc/building_visit/Spack.rst
@@ -191,7 +191,7 @@ These are patches to `package.py` files that cannot be patched as part of the Vi
 Building on Frontier
 ~~~~~~~~~~~~~~~~~~~~
 
-You will first need to copy the `compilers.yaml` and `packages.yaml` files from `scripts/spack/configs/olcf/frontier/` to your `.spack` directory in your home directory.
+You will first need to copy the `packages.yaml` file from `scripts/spack/configs/olcf/frontier/` to your `.spack` directory in your home directory.
 
 In order to have spack install the packages in the User Managed Software space the following patch will need to be applied.
 
@@ -302,13 +302,193 @@ These files are stored in your ``~/.spack`` directory. ::
     .spack/<platform>/compilers.yaml
     .spack/packages.yaml
 
-The VisIt_ repository at GitHub contains ``compilers.yaml`` and / or ``packages.yaml`` files for popular systems in the directory ``scripts/spack/configs``.
+The VisIt_ repository at GitHub contains ``packages.yaml`` files for popular systems in the directory ``scripts/spack/configs``.
 
 Here is the ``packages.yaml`` file for ``frontier.olcf.ornl.gov`` for VisIt_.
 
-``packages.yaml``
+.. code:: yaml
 
-.. literalinclude:: ../../../scripts/spack/configs/olcf/frontier/packages.yaml
+  packages:
+    autoconf:
+      externals:
+      - spec: autoconf@2.69
+        prefix: /usr
+    automake:
+      externals:
+      - spec: automake@1.15.1
+        prefix: /usr
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+    cmake:
+      buildable: false
+      externals:
+      - spec: cmake@3.23.2
+        prefix: /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/cmake-3.23.2-4r4mpiba7cwdw2hlakh5i7tchi64s3qd
+        modules:
+        - cmake/3.23.2
+    cpio:
+      externals:
+      - spec: cpio@2.12
+        prefix: /usr
+    diffutils:
+      externals:
+      - spec: diffutils@3.6
+        prefix: /usr
+    file:
+      externals:
+      - spec: file@5.32
+        prefix: /usr
+    findutils:
+      externals:
+      - spec: findutils@4.6.0
+        prefix: /usr
+    flex:
+      externals:
+      - spec: flex@2.6.4+lex
+        prefix: /usr
+    gawk:
+      externals:
+      - spec: gawk@4.2.1
+        prefix: /usr
+    gcc:
+      externals:
+      - spec: gcc@7.5.0 languages=c,c++,fortran
+        prefix: /usr
+        extra_attributes:
+          compilers:
+            c: /usr/bin/gcc-7
+            cxx: /usr/bin/g++
+            fortran: /usr/bin/gfortran-7
+    ghostscript:
+      externals:
+      - spec: ghostscript@9.52
+        prefix: /usr
+    git:
+      externals:
+      - spec: git@2.26.2~tcltk
+        prefix: /usr
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+    groff:
+      externals:
+      - spec: groff@1.22.3
+        prefix: /usr
+    m4:
+      externals:
+      - spec: m4@1.4.18
+        prefix: /usr
+    ncurses:
+      externals:
+      - spec: ncurses@6.1.20180317+termlib abi=6
+        prefix: /usr
+    openssh:
+      externals:
+      - spec: openssh@8.1p1
+        prefix: /usr
+    openssl:
+      externals:
+      - spec: openssl@1.1.1d
+        prefix: /usr
+      buildable: False
+    perl:
+      externals:
+      - spec: perl@5.26.1~cpanm+shared+threads
+        prefix: /usr
+    pkg-config:
+      externals:
+      - spec: pkg-config@0.29.2
+        prefix: /usr
+    rsync:
+      externals:
+      - spec: rsync@3.1.3
+        prefix: /usr
+    ruby:
+      externals:
+      - spec: ruby@2.5.9
+        prefix: /usr
+    sed:
+      externals:
+      - spec: sed@4.4
+        prefix: /usr
+    tar:
+      externals:
+      - spec: tar@1.30
+        prefix: /usr
+    texinfo:
+      externals:
+      - spec: texinfo@6.5
+        prefix: /usr
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr
+    all:
+      compiler: [gcc, cce]
+      providers:
+        mpi: [cray-mpich]
+    rocm:
+      buildable: false
+      externals:
+      - prefix: /opt/rocm-5.2.0
+        spec: rocm@5.2.0
+        modules:
+        - rocm/5.2.0
+    cray-mpich:
+      buildable: false
+      externals:
+      - prefix: /opt/cray/pe/mpich/8.1.23/ofi/gnu/9.1
+        spec: cray-mpich@8.1.23%gcc
+        modules:
+        - cray-mpich/8.1.23
+          cray-pmi/6.1.8
+          libfabric/1.15.2.0
+      - prefix: /opt/cray/pe/mpich/8.1.23/ofi/cray/10.0
+        spec: cray-mpich@8.1.23%cce
+        modules:
+        - cray-mpich/8.1.23
+          cray-pmi/6.1.8
+          libfabric/1.15.2.0
+    hip:
+      version: [5.2.0]
+      buildable: false
+      externals:
+      - spec: hip@5.2.0
+        prefix: /opt/rocm-5.2.0/hip
+    llvm-amdgpu:
+      version: [5.2.0]
+      buildable: false
+      externals:
+      - spec: llvm-amdgpu@5.2.0
+        prefix: /opt/rocm-5.2.0/llvm
+    hsa-rocr-dev:
+      version: [5.2.0]
+      buildable: false
+      externals:
+      - spec: hsa-rocr-dev@5.2.0
+        prefix: /opt/rocm-5.2.0/
+    rocminfo:
+      version: [5.2.0]
+      buildable: false
+      externals:
+      - spec: rocminfo@5.2.0
+        prefix: /opt/rocm-5.2.0/
+    rocm-device-libs:
+      version: [5.2.0]
+      buildable: false
+      externals:
+      - spec: rocm-device-libs@5.2.0
+        prefix: /opt/rocm-5.2.0/
+    rocprim:
+      version: [5.2.0]
+      buildable: false
+      externals:
+      - spec: rocprim@5.2.0
+        prefix: /opt/rocm-5.2.0/
+
 
 Debugging a spack package
 -------------------------


### PR DESCRIPTION
This was a problem when building the manuals target from a released source tarball, because the source tarball does not have the `scripts` dir.
 I copied the referenced file and added it to a `.. code:: yaml` directive. I also removed references to frontier's `compilers.yaml` file as it no longer exists.
Resolves #19379.

#
### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* [X] Documentation update
* ~~[ ] Other~~ <!-- please explain with a note below -->

