### PR TITLE
visit-build-open 3.4.1 changes (Dev PR for #19376)

### DIFF
--- a/src/INSTALL_NOTES
+++ b/src/INSTALL_NOTES
@@ -11,7 +11,7 @@ followed by the Unix installation instructions.
 Windows:
 ========
 
-1.  Download the visit3.4.0_x64.exe installer program to
+1.  Download the visit3.4.1_x64.exe installer program to
     your desktop.
 
 2.  Double click on the installer program icon to run the installer.
@@ -24,7 +24,7 @@ MacOS X:
 
 Downloads:
 
-1. Download visit-3.4.0.dmg and copy it to the desktop.
+1. Download visit-3.4.1.dmg and copy it to the desktop.
 
 2. Double click on the file to open it. This will cause MacOS to mount the
    disk image and open it in Finder.
@@ -42,26 +42,19 @@ Unix (gzipped tar file):
 
 1.  Run the visit-install script to install visit.  If you have built your
     own visit binary distribution, you can find the visit-install script
-    in the svn_bin directory.  The visit-install script can create a new
-    distribution directory or update an existing distribution.  This is
-    handled automatically.
+    in the src/tools/dev/scripts/visit-install directory.  The visit-install
+    script can create a new distribution directory or update an existing
+    distribution.  This is handled automatically.
 
-        chmod 755 visit-install3_4_0
-        ./visit-install3_4_0 "version" "platform" "directory"
+        chmod 755 visit-install3_4_1
+        ./visit-install3_4_1 "version" "platform" "directory"
 
     where
 
-        "version" will be 3.4.0 for the current distribution.
+        "version" will be 3.4.1 for the current distribution.
 
-        "platform" will be one of the following:
+        "platform" will be the release relevant to your system, for example:
 
-            linux-x86_64-debian9
-            linux-x86_64-debian10
-            linux-x86_64-debian11
-            linux-x86_64-fedora31
-            linux-x86_64-rhel7
-            linux-x86_64-rhel7-wmesa
-            linux-x86_64-ubuntu18
             linux-x86_64-ubuntu20
 
         The one you use should match the name of the accompanying
@@ -72,12 +65,12 @@ Unix (gzipped tar file):
 
     For example
 
-        chmod 755 visit-install3_4_0
-        ./visit-install3_4_0 3.4.0 linux-x86_64-rhel7 /usr/local/visit
+        chmod 755 visit-install3_4_1
+        ./visit-install3_4_1 3.4.1 linux-x86_64-ubuntu20 /usr/local/visit
 
-    will install the linux-x86_64-rhel7, 3.4.0 version of visit in the
+    will install the linux-x86_64-ubuntu20, 3.4.1 version of visit in the
     directory "/usr/local/visit".  Note that you will need to have the
-    file "visit3_4_0.linux-x86_64-rhel7.tar.gz" present in the current
+    file "visit3_4_1.linux-x86_64-ubuntu20.tar.gz" present in the current
     directory for this to function properly.
 
 2.  Add the bin directory below the installation directory

--- a/src/gui/SplashScreen.C
+++ b/src/gui/SplashScreen.C
@@ -269,6 +269,9 @@
 //    Eric Brugger, Mon Sep 25 13:03:18 PDT 2023
 //    Changed the date on the splash screen to November 2023.
 //
+//    Cyrus Harrison, Tue Mar 19 16:02:47 PDT 2024
+//    Changed the date on the splash screen to April 2024.
+//
 // ****************************************************************************
 
 SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
@@ -389,9 +392,9 @@ SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
            << tr("October")
            << tr("November")
            << tr("December");
-    int currentMonth = 11;
+    int currentMonth = 4;
     lLayout->addWidget(new QLabel(versionText, this));
-    lLayout->addWidget(new QLabel(months[currentMonth-1] + " 2023", this));
+    lLayout->addWidget(new QLabel(months[currentMonth-1] + " 2024", this));
 
     copyrightButton = 0;
     contributorButton = 0;

--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -19,6 +19,9 @@
 #   Eric Brugger, Thu Mar 29 08:32:40 PDT 2018
 #   I modified the script to set ttc when running on rztrona.
 #
+#   Cyrus Harrison, Tue Mar 19 13:02:27 PDT 2024
+#   Use basic linux platform for toss4, instead of it being special
+#
 ###############################################################################
 
 class JobSubmitter_qsub_LLNL(JobSubmitter_qsub):
@@ -304,16 +307,6 @@ class LLNLLauncher(MainLauncher):
 
         # Unset LD_PRELOAD
         UNSETENV("LD_PRELOAD")
-
-        #
-        # Set the visitarch to linux-x86_64-toss4 if the kernel version
-        # starts with "4" and processor type is "x86_64".
-        #
-        kernel = subprocess.run(['uname', '-r'], stdout=subprocess.PIPE)
-        proc = subprocess.run(['uname', '-p'], stdout=subprocess.PIPE)
-        if proc.stdout.decode('utf-8')[:6] == "x86_64" and \
-           kernel.stdout.decode('utf-8')[:1] == "4":
-            self.visitarch = "linux-x86_64-toss4"
 
     #
     # Override the JobSubmitterFactory method so the custom job submitter can

--- a/src/tools/dev/scripts/run-build-visit
+++ b/src/tools/dev/scripts/run-build-visit
@@ -224,7 +224,7 @@ then
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/include \
        ./$build_visit_script --group ${dest_group} --required --optional --mesagl --uintah --parallel\
-       --qt6 --no-pyside --no-gdal --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
+       --qt6 --no-pyside --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.poodle
    # just in case perms
    echo "changing permissions of ${dest_dir}"

--- a/src/tools/dev/scripts/visit-build-open
+++ b/src/tools/dev/scripts/visit-build-open
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #-----------------------------------------------------------------------
 #
 # VISIT-BUILD-OPEN - Build the visit distributions on the open network.
@@ -214,11 +215,16 @@
 #   since all the machines are now off by default. Turning on a machine
 #   is now done with -<machine_name> instead of +<machine_name>.
 #
+#   Cyrus Harrison, Mon Mar 11 12:57:17 PDT 2024
+#   I removed rzgenie, replaced with rzwhippet. Removed cooley.
+#
 #-----------------------------------------------------------------------
 
 test=no
 
 user=`whoami`
+result_dir=/usr/workspace/visit/visit/_release_builds/
+
 
 #
 # Set the user e-mail address.
@@ -257,8 +263,7 @@ esac
 kickit=false
 poodle=false
 lassen=false
-rzgenie=false
-cooley=false
+rzwhippet=false
 
 dist=undefined
 
@@ -282,12 +287,8 @@ do
          lassen=true
          shift
          ;;
-      -rzgenie)
-         rzgenie=true
-         shift
-         ;;
-      -cooley)
-         cooley=true
+      -rzwhippet)
+         rzwhippet=true
          shift
          ;;
       -d)
@@ -300,11 +301,11 @@ done
 #
 # Check that the distribution name was provided.
 #
-if [ $dist = undefined ]
+if [ "$dist" = "undefined" ]
 then
    echo "Usage: [-<machine name>] -d <distribution>"
    echo "Valid machine names:"
-   echo "    kickit poodle lassen rzgenie cooley"
+   echo "    kickit poodle lassen rzwhippet"
    exit
 fi
 
@@ -319,11 +320,19 @@ then
 fi
 
 #
+# make sure landing place for results exist
+#
+if test ! -d $result_dir ; then
+   mkdir -p $result_dir
+fi
+
+#
 # Build on kickit.
 #
 rm -f kickit
 cat <<EOF > kickit
 #!/bin/sh
+set -e
 export PATH=/usr/gapps/gcc/gcc-9.1/bin:\$PATH
 export LD_LIBRARY_PATH=/usr/gapps/gcc/gcc-9.1/lib64
 if test ! -e /home/$user/kickit ; then
@@ -380,9 +389,9 @@ echo "The database plugins:"                  >> resultlog 2>&1
 ls $dist/build/plugins/databases/libI* | sed "s/$dist\/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
 EOF
 
-if [ $kickit = true ]
+if [ "$kickit" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
       echo "Building on kickit"
       cp kickit ~/kickit_buildit
@@ -397,51 +406,51 @@ fi
 rm -f poodle
 cat <<EOF > poodle
 #!/bin/sh
+set -e
 XLOCALEDIR=/usr/lib/X11/locale
 PATH=/usr/bin/X11:\$PATH
-if test ! -d /usr/tmp/$user ; then
-   mkdir /usr/tmp/$user
-fi
+PATH=/usr/workspace/visit/visit/thirdparty_shared/3.4.0/toss4/cmake/3.24.3/linux-x86_64_gcc-10.3/bin/:\$PATH
 if test ! -d /usr/tmp/$user/poodle ; then
-   mkdir /usr/tmp/$user/poodle
+   mkdir -p /usr/tmp/$user/poodle
 fi
 rm -rf /usr/tmp/$user/poodle/visitbuild
 mkdir /usr/tmp/$user/poodle/visitbuild
-mv poodle_$dist.tar.gz /usr/tmp/$user/poodle/visitbuild/$dist.tar.gz
+cp poodle_$dist.tar.gz /usr/tmp/$user/poodle/visitbuild/$dist.tar.gz
 cd /usr/tmp/$user/poodle/visitbuild
-gunzip -c $dist.tar.gz | tar xvf - > buildlog 2>&1
-cd $dist/src
-ver=\`cat VERSION\`
+tar -xzvf $dist.tar.gz > buildlog 2>&1
+ver=\`cat $dist/src/VERSION\`
 ver2=\`echo \$ver | tr "." "_"\`
-mkdir ../build
-cd ../build
-/usr/workspace/wsa/visit/visit/thirdparty_shared/3.4.0/toss4/cmake/3.24.3/linux-x86_64_gcc-10.3/bin/cmake ../src -DCMAKE_BUILD_TYPE:STRING=Release -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON -DVISIT_PARADIS:BOOL=ON >> ../../buildlog 2>&1
-make manuals >> ../../buildlog 2>&1
-make -j 24 package >> ../../buildlog 2>&1
-mv visit\$ver2.linux-x86_64.tar.gz ../..
-cd ../..
+echo "Version: \$ver"
+export CONFIG_SITE=\`readlink -f $dist/src/config-site/poodle18.cmake\`
+echo "CONFIG_SITE=\${CONFIG_SITE}"
+cmake -S $dist/src -B build -DVISIT_CONFIG_SITE=\$CONFIG_SITE -DCMAKE_BUILD_TYPE:STRING=Release -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON -DVISIT_PARADIS:BOOL=ON >> buildlog 2>&1
+cmake --build build --target manuals >> buildlog 2>&1
+cmake --build build --target package -j 24 >> buildlog 2>&1
+cp buildlog $result_dir/buildlog.poodle
+cp build/visit\$ver2.linux-x86_64.tar.gz $result_dir/visit\$ver2.linux-x86_64-poodle.tar.gz
 rm -f resultlog
 echo "        build of visit on poodle"       > resultlog 2>&1
 echo "       --------------------------"      >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
 ls -l                                         >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
-echo "number of database plugins = "\`ls $dist/build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls $dist/build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls $dist/build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
+echo "number of database plugins = "\`ls build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
+echo "number of operator plugins = "\`ls build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
+echo "number of plot plugins = "\`ls build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
 echo "The database plugins:"                  >> resultlog 2>&1
-ls $dist/build/plugins/databases/libI* | sed "s/$dist\/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
+ls build/plugins/databases/libI* | sed "s/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
 EOF
 
-if [ $poodle = true ]
+if [ "$poodle" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
       echo "Building on poodle"
-      scp poodle poodle:poodle_buildit
-      scp $dist.tar.gz poodle:poodle_$dist.tar.gz
-      ssh poodle18 "chmod 750 poodle_buildit;./poodle_buildit" &
+      cp poodle poodle_buildit
+      cp $dist.tar.gz poodle_$dist.tar.gz
+      chmod 750 poodle_buildit
+      ./poodle_buildit
    fi
 fi
 
@@ -451,153 +460,108 @@ fi
 rm -f lassen
 cat <<EOF > lassen
 #!/bin/sh
-if test ! -d /usr/tmp/$user ; then
-   mkdir /usr/tmp/$user
-fi
+set -e
+export PATH=/usr/workspace/visit/visit/thirdparty_shared/3.4.1/blueos/cmake/3.24.3/linux-ppc64le_gcc-8.3/bin/:\$PATH
 if test ! -d /usr/tmp/$user/lassen ; then
-   mkdir /usr/tmp/$user/lassen
+   mkdir -p /usr/tmp/$user/lassen
 fi
 rm -rf /usr/tmp/$user/lassen/visitbuild
 mkdir /usr/tmp/$user/lassen/visitbuild
 mv lassen_$dist.tar.gz /usr/tmp/$user/lassen/visitbuild/$dist.tar.gz
 cd /usr/tmp/$user/lassen/visitbuild
-gunzip -c $dist.tar.gz | tar xvf - > buildlog 2>&1
-cd $dist/src
-ver=\`cat VERSION\`
+tar -xzvf $dist.tar.gz > buildlog 2>&1
+ver=\`cat $dist/src/VERSION\`
 ver2=\`echo \$ver | tr "." "_"\`
-mkdir ../build
-cd ../build
-/usr/workspace/wsa/visit/visit/thirdparty_shared/3.4.0/blueos/cmake/3.24.3/linux-ppc64le_gcc-8.3/bin/cmake ../src -DCMAKE_BUILD_TYPE:STRING=Release -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON >> ../../buildlog 2>&1
-make manuals >> ../../buildlog 2>&1
-make -j 6 package >> ../../buildlog 2>&1
-mv visit\$ver2.linux-intel.tar.gz ../..
-cd ../..
+echo "Version: \$ver"
+export CONFIG_SITE=\`readlink -f $dist/src/config-site/lassen708.cmake\`
+echo "CONFIG_SITE=\${CONFIG_SITE}"
+# skip manuals, old openssl on lassen undermines us
+cmake -S $dist/src -B build -DVISIT_CONFIG_SITE=\$CONFIG_SITE -DCMAKE_BUILD_TYPE:STRING=Release -DVISIT_ENABLE_MANUALS=OFF -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON >> ../../buildlog 2>&1
+# cmake --build build --target manuals >> buildlog 2>&1
+cmake --build build --target package -j 24 >> buildlog 2>&1
+cp buildlog $result_dir/buildlog.lassen
+cp build/visit\$ver2.linux-intel.tar.gz $result_dir/visit\$ver2.linux-intel-lassen.tar.gz
 rm -f resultlog
 echo "        build of visit on lassen"       > resultlog 2>&1
 echo "       -------------------------- "     >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
 ls -l                                         >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
-echo "number of database plugins = "\`ls $dist/build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls $dist/build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls $dist/build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
+echo "number of database plugins = "\`ls build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
+echo "number of operator plugins = "\`ls build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
+echo "number of plot plugins = "\`ls build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
 echo "The database plugins:"                  >> resultlog 2>&1
-ls $dist/build/plugins/databases/libI* | sed "s/$dist\/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
+cp resultlog $result_dir/resultlog.lassen
+ls build/plugins/databases/libI* | sed "s/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
+cp resultlog $result_dir/resultlog.lassen
+mail  -s "VisIt build ($dist): lassen" $emailName < resultlog
 EOF
 
-if [ $lassen = true ]
+if [ "$lassen" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
       echo "Building on lassen"
-      scp lassen lassen708:lassen_buildit
-      scp $dist.tar.gz lassen708:lassen_$dist.tar.gz
-      ssh lassen708 "chmod 750 lassen_buildit;./lassen_buildit" &
+      cp lassen lassen_buildit
+      cp $dist.tar.gz lassen_$dist.tar.gz
+      chmod 750 lassen_buildit
+      ./lassen_buildit
    fi
 fi
 
 #
-# Build on rzgenie.
+# Build on rzwhippet.
 #
-rm -f rzgenie
-cat <<EOF > rzgenie
+rm -f rzwhippet
+cat <<EOF > rzwhippet
 #!/bin/sh
-if test ! -d /usr/tmp/$user ; then
-   mkdir /usr/tmp/$user
+set -e
+XLOCALEDIR=/usr/lib/X11/locale
+PATH=/usr/bin/X11:\$PATH
+export PATH=/usr/workspace/visit/visit/thirdparty_shared/3.4.1/toss4/cmake/3.24.3/linux-x86_64_gcc-10.3/bin/:\$PATH
+if test ! -d /usr/tmp/$user/rzwhippet ; then
+   mkdir -p /usr/tmp/$user/rzwhippet
 fi
-if test ! -d /usr/tmp/$user/rzgenie ; then
-   mkdir /usr/tmp/$user/rzgenie
-fi
-rm -rf /usr/tmp/$user/rzgenie/visitbuild
-mkdir /usr/tmp/$user/rzgenie/visitbuild
-mv rzgenie_$dist.tar.gz /usr/tmp/$user/rzgenie/visitbuild/$dist.tar.gz
-cd /usr/tmp/$user/rzgenie/visitbuild
-gunzip -c $dist.tar.gz | tar xvf - > buildlog 2>&1
-cd $dist/src
-ver=\`cat VERSION\`
+rm -rf /usr/tmp/$user/rzwhippet/visitbuild
+mkdir /usr/tmp/$user/rzwhippet/visitbuild
+mv rzwhippet_$dist.tar.gz /usr/tmp/$user/rzwhippet/visitbuild/$dist.tar.gz
+cd /usr/tmp/$user/rzwhippet/visitbuild
+tar -xzvf $dist.tar.gz > buildlog 2>&1
+ver=\`cat $dist/src/VERSION\`
 ver2=\`echo \$ver | tr "." "_"\`
-export PATH=\$PATH:/usr/bin/X11
-mkdir ../build
-cd ../build
-/usr/workspace/visit/visit/thirdparty_shared/3.4.0/toss3/cmake/3.24.3/linux-x86_64_gcc-8.3/bin/cmake ../src -DCMAKE_BUILD_TYPE:STRING=Release -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON -DVISIT_PARADIS:BOOL=ON >> ../../buildlog 2>&1
-make manuals >> ../../buildlog 2>&1
-make -j 12 package >> ../../buildlog 2>&1
-mv visit\$ver2.linux-x86_64.tar.gz ../..
-cd ../..
+export CONFIG_SITE=\`readlink -f $dist/src/config-site/rzwhippet17.cmake\`
+echo "CONFIG_SITE=\${CONFIG_SITE}"
+cmake -S $dist/src -B build -DVISIT_CONFIG_SITE=\$CONFIG_SITE -DCMAKE_BUILD_TYPE:STRING=Release -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON -DVISIT_PARADIS:BOOL=ON >> buildlog 2>&1
+cmake --build build --target manuals >> buildlog 2>&1
+cmake --build build --target package -j 24 >> buildlog 2>&1
+cp buildlog $result_dir/buildlog.rzwhippet
+cp build/visit\$ver2.linux-x86_64.tar.gz $result_dir/visit\$ver2.linux-x86_64-rzwhippet.tar.gz
 rm -f resultlog
-echo "        build of visit on rzgenie"      > resultlog 2>&1
+echo "        build of visit on rzwhippet"    > resultlog 2>&1
 echo "       ---------------------------"     >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
 ls -l                                         >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
-echo "number of database plugins = "\`ls $dist/build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls $dist/build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls $dist/build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
+echo "number of database plugins = "\`ls build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
+echo "number of operator plugins = "\`ls build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
+echo "number of plot plugins = "\`ls build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
 echo ""                                       >> resultlog 2>&1
 echo "The database plugins:"                  >> resultlog 2>&1
-ls $dist/build/plugins/databases/libI* | sed "s/$dist\/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-mail  -s "VisIt build ($dist): rzgenie" $emailName < resultlog
+ls build/plugins/databases/libI* | sed "s/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
+cp resultlog $result_dir/resultlog.rzwhippet
+mail  -s "VisIt build ($dist): rzwhippet" $emailName < resultlog
 EOF
 
-if [ $rzgenie = true ]
+if [ "$rzwhippet" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
-      echo "Building on rzgenie"
-      scp rzgenie rzgenie:rzgenie_buildit
-      scp $dist.tar.gz rzgenie:rzgenie_$dist.tar.gz
-      ssh rzgenie5 "chmod 750 rzgenie_buildit;./rzgenie_buildit" &
-   fi
-fi
-
-#
-# Build on cooley
-#
-rm -f cooley
-cat <<EOF > cooley
-#!/bin/sh
-if test ! -d /home/ebrugger/cooley; then
-   mkdir /home/ebrugger/cooley
-fi
-rm -rf /home/ebrugger/cooley/visitbuild
-mkdir /home/ebrugger/cooley/visitbuild
-mv cooley_$dist.tar.gz /home/ebrugger/cooley/visitbuild/$dist.tar.gz
-cd /home/ebrugger/cooley/visitbuild
-gunzip -c $dist.tar.gz | tar xvf - > buildlog 2>&1
-cd $dist/src
-ver=\`cat VERSION\`
-ver2=\`echo \$ver | tr "." "_"\`
-mkdir ../build
-cd ../build
-/home/ebrugger/buildvisit/third_party/cmake/3.24.3/linux-rhel_7-x86_64_gcc-4.8/bin/cmake ../src -DCMAKE_BUILD_TYPE:STRING=Release >> ../../buildlog 2>&1
-make manuals >> ../../buildlog 2>&1
-make -j 6 package >> ../../buildlog 2>&1
-mv visit\$ver2.linux-x86_64.tar.gz ../..
-cd ../..
-rm -f resultlog
-echo "        build of visit on cooley"       > resultlog 2>&1
-echo "       --------------------------"      >> resultlog 2>&1
-echo ""                                       >> resultlog 2>&1
-ls -l                                         >> resultlog 2>&1
-echo ""                                       >> resultlog 2>&1
-echo "number of database plugins = "\`ls $dist/build/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls $dist/build/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls $dist/build/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
-echo ""                                       >> resultlog 2>&1
-echo "The database plugins:"                  >> resultlog 2>&1
-ls $dist/build/plugins/databases/libI* | sed "s/$dist\/build\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-mail  -s "VisIt build ($dist): cooley" $emailName < resultlog
-EOF
-
-if [ $cooley = true ]
-then
-   if [ $test = no ]
-   then
-      echo "Building on cooley"
-      cp cooley cooley_buildit
-      cp $dist.tar.gz cooley_$dist.tar.gz
-      chmod 750 cooley_buildit;./cooley_buildit &
+      echo "Building on rzwhippet"
+      cp rzwhippet rzwhippet_buildit
+      cp $dist.tar.gz rzwhippet_$dist.tar.gz
+      chmod 750 rzwhippet_buildit
+      ./rzwhippet_buildit
    fi
 fi
 
@@ -605,7 +569,7 @@ fi
 #
 # Clean up.
 #
-if [ $test = no ]
+if [ "$test" = "no" ]
 then
-   rm -f kickit poodle lassen rzgenie cooley
+   rm -f kickit poodle lassen rzwhippet
 fi

--- a/src/tools/dev/scripts/visit-install-open
+++ b/src/tools/dev/scripts/visit-install-open
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #-----------------------------------------------------------------------
 #
 # VISIT-INSTALL-OPEN - Install the visit distributions on the open
@@ -151,6 +152,9 @@
 #   Turning on a machine is now done with -<machine_name> instead of
 #   +<machine_name>.
 #
+#   Cyrus Harrison, Mon Mar 11 12:57:17 PDT 2024
+#   I removed rzgenie, replaced with rzwhippet. Removed rzansel.
+#
 #-----------------------------------------------------------------------
 
 test=no
@@ -194,10 +198,7 @@ esac
 kickit=false
 poodle=false
 lassen=false
-rztrona=false
-rzgenie=false
-rzansel=false
-cooley=false
+rzwhippet=false
 
 ver=undefined
 
@@ -221,20 +222,12 @@ do
          lassen=true
          shift
          ;;
-      -rztrona)
-         rztrona=true
-         shift
-         ;;
-      -rzgenie)
-         rzgenie=true
+      -rzwhippet)
+         rzwhippet=true
          shift
          ;;
       -rzansel)
          rzansel=true
-         shift
-         ;;
-      -cooley)
-         cooley=true
          shift
          ;;
       -v)
@@ -247,11 +240,11 @@ done
 #
 # Check that the version was provided.
 #
-if [ $ver = undefined ]
+if [ "$ver" = "undefined" ]
 then
    echo "Usage: [-<machine name>] -v <version>"
    echo "Valid machine names:"
-   echo "    kickit poodle lassen rztrona rzgenie rzansel cooley"
+   echo "    kickit poodle lassen rzwhippet"
    exit
 fi
 
@@ -273,6 +266,7 @@ ver=`echo $ver2 | tr "_" "."`
 rm -f kickit_install
 cat <<EOF > kickit_install
 #!/bin/sh
+set -e
 ./visit-install -private -c llnl_open -g visit -b wbronze -gw -l $ver linux-x86_64-rhel7 /usr/gapps/visit > installlog 2>&1
 rm -f resultlog
 echo "        install of visit on kickit"          > resultlog 2>&1
@@ -292,9 +286,9 @@ rm -f resultlog.kickit
 mv resultlog resultlog.kickit
 EOF
 
-if [ $kickit = true ]
+if [ "$kickit" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
       cp /home/$user/kickit/visitbuild/visit$ver2.linux-x86_64.tar.gz visit$ver2.linux-x86_64-rhel7.tar.gz
       cp /home/$user/kickit/visitbuild/visit$ver2.linux-x86_64-wmesa.tar.gz visit$ver2.linux-x86_64-rhel7-wmesa.tar.gz
@@ -308,8 +302,8 @@ fi
 rm -f poodle_install
 cat <<EOF > poodle_install
 #!/bin/sh
+set -e
 ./visit-install -private -c llnl_open_cz -g visit -b wbronze -gw -l $ver linux-x86_64-poodle /usr/gapps/visit > installlog 2>&1
-mv /usr/gapps/visit/$ver+/linux-x86_64 /usr/gapps/visit/$ver+/linux-x86_64-toss4
 rm -f resultlog
 echo ""                                              > resultlog 2>&1
 echo "        install of visit on poodle"            >> resultlog 2>&1
@@ -317,21 +311,21 @@ echo "       ----------------------------"           >> resultlog 2>&1
 echo ""                                              >> resultlog 2>&1
 df -k /usr/gapps/visit                               >> resultlog 2>&1
 echo ""                                              >> resultlog 2>&1
-ls -l /usr/gapps/visit/$ver+/linux-x86_64-toss4/bin  >> resultlog 2>&1
+ls -l /usr/gapps/visit/$ver+/linux-x86_64/bin  >> resultlog 2>&1
 echo ""                                              >> resultlog 2>&1
-echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
+echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
+echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
+echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
 echo ""                                              >> resultlog 2>&1
 echo "The database plugins:"                         >> resultlog 2>&1
-ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-x86_64-toss4\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
+ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-x86_64\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
 rm -f resultlog.poodle
 mv resultlog resultlog.poodle
 EOF
 
-if [ $poodle = true ]
+if [ "$poodle" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
       cp /usr/tmp/$user/poodle/visitbuild/visit$ver2.linux-x86_64.tar.gz visit$ver2.linux-x86_64-poodle.tar.gz
       chmod 750 poodle_install;./poodle_install
@@ -344,6 +338,7 @@ fi
 rm -f lassen_install
 cat <<EOF > lassen_install
 #!/bin/sh
+set -e
 ./visit-install -private -c llnl_open_cz -g visit -b wbronze -gw -l $ver linux-intel-lassen /usr/gapps/visit > installlog 2>&1
 rm -f resultlog
 echo ""                                              > resultlog 2>&1
@@ -364,9 +359,9 @@ rm -f resultlog.lassen
 mv resultlog resultlog.lassen
 EOF
 
-if [ $lassen = true ]
+if [ "$lassen" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
       scp lassen708:/usr/tmp/$user/lassen/visitbuild/visit$ver2.linux-intel.tar.gz visit$ver2.linux-intel-lassen.tar.gz
       chmod 750 lassen_install;./lassen_install
@@ -374,54 +369,20 @@ then
 fi
 
 #
-# Install on rztrona.
+# Install on rzwhippet
 #
-rm -f rztrona_install
-cat <<EOF > rztrona_install
+rm -f rzwhippet_install
+cat <<EOF > rzwhippet_install
 #!/bin/sh
-./visit-install -private -c llnl_open_rz -g visit -b wbronze -gw -l $ver linux-x86_64-poodle /usr/gapps/visit > installlog 2>&1
-mv /usr/gapps/visit/$ver+/linux-x86_64 /usr/gapps/visit/$ver+/linux-x86_64-toss4
+set -e
+./visit-install -private -c llnl_open_rz -g visit -b wbronze -gw -l $ver linux-x86_64-rzwhippet /usr/gapps/visit > installlog 2>&1
 rm -f resultlog
-echo "        install of visit on rztrona"          > resultlog 2>&1
+echo "        install of visit on rzwhippet"        > resultlog 2>&1
 echo "       -----------------------------"         >> resultlog 2>&1
 echo ""                                             >> resultlog 2>&1
 df -k /usr/gapps/visit                              >> resultlog 2>&1
 echo ""                                             >> resultlog 2>&1
-ls -l /usr/gapps/visit/$ver+/linux-x86_64-toss4/bin >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-echo "The database plugins:"                        >> resultlog 2>&1
-ls /usr/gapps/visit/$ver+/linux-x86_64-toss4/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-x86_64-toss4\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-rm -f resultlog.rztrona
-mv resultlog resultlog.rztrona
-mail -s "VisIt install ($ver): rztrona" $emailName < resultlog.rztrona
-EOF
-
-if [ $rztrona = true ]
-then
-   if [ $test = no ]
-   then
-      chmod 750 rztrona_install;./rztrona_install
-   fi
-fi
-
-#
-# Install on rzgenie
-#
-rm -f rzgenie_install
-cat <<EOF > rzgenie_install
-#!/bin/sh
-./visit-install -private -c llnl_open_rz -g visit -b wbronze -gw -l $ver linux-x86_64 /usr/gapps/visit > installlog 2>&1
-rm -f resultlog
-echo "        install of visit on rzgenie"          > resultlog 2>&1
-echo "       -----------------------------"         >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-df -k /usr/gapps/visit                              >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-ls -l /usr/gapps/visit/$ver+/linux-x86_64/bin       >> resultlog 2>&1
+ls -l /usr/gapps/visit/$ver+/linux-x86_64/bin >> resultlog 2>&1
 echo ""                                             >> resultlog 2>&1
 echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
 echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
@@ -429,92 +390,23 @@ echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-x86_64/plugins
 echo ""                                             >> resultlog 2>&1
 echo "The database plugins:"                        >> resultlog 2>&1
 ls /usr/gapps/visit/$ver+/linux-x86_64/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-x86_64\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-rm -f resultlog.rzgenie
-mv resultlog resultlog.rzgenie
-mail -s "VisIt install ($ver): rzgenie" $emailName < resultlog.rzgenie
+rm -f resultlog.rzwhippet
+mv resultlog resultlog.rzwhippet
+mail -s "VisIt install ($ver): rzwhippet" $emailName < resultlog.rzwhippet
 EOF
 
-if [ $rzgenie = true ]
+if [ "$rzwhippet" = "true" ]
 then
-   if [ $test = no ]
+   if [ "$test" = "no" ]
    then
-      chmod 750 rzgenie_install;./rzgenie_install
-   fi
-fi
-
-#
-# Install on rzansel
-#
-rm -f rzansel_install
-cat <<EOF > rzansel_install
-#!/bin/sh
-./visit-install -private -c llnl_open_rz -g visit -b wbronze -gw -l $ver linux-intel-lassen /usr/gapps/visit > installlog 2>&1
-rm -f resultlog
-echo "        install of visit on rzansel"          > resultlog 2>&1
-echo "       -----------------------------"         >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-df -k /usr/gapps/visit                              >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-ls -l /usr/gapps/visit/$ver+/linux-intel/bin        >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-echo "number of database plugins = "\`ls /usr/gapps/visit/$ver+/linux-intel/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls /usr/gapps/visit/$ver+/linux-intel/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls /usr/gapps/visit/$ver+/linux-intel/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
-echo ""                                             >> resultlog 2>&1
-echo "The database plugins:"                        >> resultlog 2>&1
-ls /usr/gapps/visit/$ver+/linux-intel/plugins/databases/libI* | sed "s/\/usr\/gapps\/visit\/$ver+\/linux-intel\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-rm -f resultlog.rzansel
-mv resultlog resultlog.rzansel
-mail -s "VisIt install ($ver): rzansel" $emailName < resultlog.rzansel
-EOF
-
-if [ $rzansel = true ]
-then
-   if [ $test = no ]
-   then
-      chmod 750 rzansel_install;./rzansel_install
-   fi
-fi
-
-#
-# Install on cooley
-#
-rm -f cooley_install
-cat <<EOF > cooley_install
-#!/bin/sh
-./visit-install -private -c anl -l $ver linux-cooley /soft/visualization/visit > installlog 2>&1
-rm -f resultlog
-echo "        install of visit on cooley"               > resultlog 2>&1
-echo "       ----------------------------"              >> resultlog 2>&1
-echo ""                                                 >> resultlog 2>&1
-df -k /soft/visualization/visit                         >> resultlog 2>&1
-echo ""                                                 >> resultlog 2>&1
-ls -l /soft/visualization/visit/$ver+/linux-x86_64/bin  >> resultlog 2>&1
-echo ""                                                 >> resultlog 2>&1
-echo "number of database plugins = "\`ls /soft/visualization/visit/$ver+/linux-x86_64/plugins/databases/libI* | wc -l\` >> resultlog 2>&1
-echo "number of operator plugins = "\`ls /soft/visualization/visit/$ver+/linux-x86_64/plugins/operators/libI* | wc -l\` >> resultlog 2>&1
-echo "number of plot plugins = "\`ls /soft/visualization/visit/$ver+/linux-x86_64/plugins/plots/libI* | wc -l\` >> resultlog 2>&1
-echo ""                                                 >> resultlog 2>&1
-echo "The database plugins:"                            >> resultlog 2>&1
-ls /soft/visualization/visit/$ver+/linux-x86_64/plugins/databases/libI* | sed "s/soft\/visualization\/visit\/$ver+\/linux-x86_64\/plugins\/databases\/libI//" | sed "s/Database.so//" >> resultlog 2>&1
-rm -f resultlog.cooley
-mv resultlog resultlog.cooley
-mail -s "VisIt install ($ver): cooley" $emailName < resultlog.cooley
-EOF
-
-if [ $cooley = true ]
-then
-   if [ $test = no ]
-   then
-      cp /home/ebrugger/cooley/visitbuild/visit$ver2.linux-x86_64.tar.gz visit$ver2.linux-cooley.tar.gz
-      chmod 750 cooley_install;./cooley_install
+      chmod 750 rzwhippet_install;./rzwhippet_install
    fi
 fi
 
 #
 # Clean up.
 #
-if [ $test = no ]
+if [ "$test" = "no" ]
 then
-   rm -f kickit_install poodle_install lassen_install rztrona_install rzgenie_install rzansel_install cooley_install
+   rm -f kickit_install poodle_install lassen_install rzwhippet_install
 fi

--- a/src/tools/dev/scripts/visit_gapps_space_report.py
+++ b/src/tools/dev/scripts/visit_gapps_space_report.py
@@ -1,0 +1,43 @@
+#
+# LLNL /usr/gapps/visit space report script
+#
+
+import glob
+import subprocess
+import json
+import os
+
+def sexe(cmd,ret_output=False,echo = True):
+    """ Helper for executing shell commands. """
+    if echo:
+        print("[exe: {}]".format(cmd))
+    if ret_output:
+        p = subprocess.Popen(cmd,
+                             shell=True,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        res = p.communicate()[0]
+        res = res.decode('utf8')
+        return p.returncode,res
+    else:
+        return subprocess.call(cmd,shell=True)
+
+total_bytes = 0
+vals = {}
+vals["_total_bytes"] = 0
+fs = glob.glob("/usr/gapps/visit/*")
+for f in fs:
+    rc,rv = sexe("du -b {0}".format(f),ret_output=True)
+    lines = [ l.strip() for l in rv.split("\n") if  l.strip() != ""]
+    value = lines[-1]
+    f_key = os.path.split(f)[1]
+    bytes = int(value.split("\t")[0])
+    vals[f] = bytes
+    vals["_total_bytes"] += bytes
+
+print("Bytes used")
+print(json.dumps(vals,indent=2))
+print("Total MB: {0}".format(float(vals["_total_bytes"] / 1e+6)))
+print("Total GB: {0}".format(float(vals["_total_bytes"] / 1e+9)))
+print("Quota info")
+sexe("df -h /usr/gapps/visit")


### PR DESCRIPTION
Dev PR for #19376)

* lc rel build and install script updates

* skip manuals on lassen

* rbv add gdal back to poodle build

* add helper for checking llnl usr gapps usage

* toss4 no longer special

* unadj visitarch for toss4

* more 3.4.1 ver updates

* lots of fixes

