### PR TITLE
Fix writing mapnode vectors (#19479)

### DIFF
--- a/src/common/state/Variant.C
+++ b/src/common/state/Variant.C
@@ -3682,6 +3682,10 @@ Variant::Read(Connection &conn)
 //   Don't use sprintf for the String or String Vector cases.
 //   The 5000 character buffer may be too small & lead to a crash.
 //
+//   Kathleen Biagas, Mon Mar 25 16:23:06 PDT 2024
+//   Remove () and , from being written to surround and separate items
+//   in a vector type.
+//
 // ****************************************************************************
 
 string &
@@ -3730,106 +3734,90 @@ Variant::ConvertToString()
     }
     else if (dataType == BOOL_VECTOR_TYPE)
     {
-        tmp = "(";
         const boolVector &vec = AsBoolVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"%s",vec[i] ? "true" : "false");
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == CHAR_VECTOR_TYPE)
     {
-        tmp = "(";
         const charVector &vec = AsCharVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"\'%c\'",vec[i]);
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == UNSIGNED_CHAR_VECTOR_TYPE)
     {
-        tmp = "(";
         const unsignedCharVector &vec = AsUnsignedCharVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"%d",vec[i]);
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == INT_VECTOR_TYPE)
     {
-        tmp = "(";
         const intVector &vec = AsIntVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"%d",vec[i]);
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == LONG_VECTOR_TYPE)
     {
-        tmp = "(";
         const longVector &vec = AsLongVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"%ld",vec[i]);
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == FLOAT_VECTOR_TYPE)
     {
-        tmp = "(";
         const floatVector &vec = AsFloatVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"%g",vec[i]);
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == DOUBLE_VECTOR_TYPE)
     {
-        tmp = "(";
         const doubleVector &vec = AsDoubleVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             sprintf(retval,"%g",vec[i]);
             tmp += retval;
         }
-        tmp += ")";
     }
     else if (dataType == STRING_VECTOR_TYPE)
     {
-        tmp = "(";
         const stringVector &vec = AsStringVector();
         for(size_t i=0;i<vec.size();i++)
         {
             if (i != 0)
-                tmp += ", ";
+                tmp += " ";
             tmp += "\"" + vec[i] + "\"";
         }
-        tmp += ")";
     }
     return tmp;
 }

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -22,7 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.4.2</font></b></p>
 <ul>
-  <li>Bugs Fixed 1</li>
+  <li>Fixed bug where user supplied legend labels were stored in config and session files wrapped in '()' and comma separated. This prevented the values from being parsed correctly and the '()' and commas appeared as part of the labels.</li>
   <li>Bugs Fixed 2</li>
 </ul>
 


### PR DESCRIPTION
Modified ConvertToString to remove '()' and ','. 
Resolves #19324.

Merge from 3.4RC

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

User specified legend labels are now written to session/config files correctly, no '()' or ',', and parsed correctly when read back in.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
