### PR TITLE
Make `qt6` the default

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -29,7 +29,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.4.2</font></b></p>
 <ul>
-  <li>Enhancement 1</li>
+  <li>Qt6 is now the default version of Qt that is built with VisIt.</li>
   <li>Enhancement 2</li>
 </ul>
 

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -644,6 +644,9 @@ function initialize_build_visit()
             --qt510) DO_QT510="yes"; DO_QT6="no"; DO_QT="yes";;
         esac
         case $arg in
+            --qt) DO_QT6="no"; DO_QT="yes";;
+        esac
+        case $arg in
             --vtk9) DO_VTK9="yes";;
         esac
         case $arg in

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -1479,6 +1479,7 @@ function run_build_visit()
            info "disabling qt, qwt because --server-components-only used"
         fi
         bv_qt_disable
+        bv_qt6_disable
         bv_qwt_disable
     fi
 

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -641,7 +641,7 @@ function initialize_build_visit()
     #
     for arg in "$@" ; do
         case $arg in
-            --qt510) DO_QT510="yes";;
+            --qt510) DO_QT510="yes"; DO_QT6="no"; DO_QT="yes";;
         esac
         case $arg in
             --vtk9) DO_VTK9="yes";;

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -9,8 +9,13 @@ function bv_qt_initialize
 
 function bv_qt_enable
 {
-    DO_QT="yes"
-    DO_QT6="no"
+    if [[ "$DO_QT6" == "no" ]] ; then
+        DO_QT="yes"
+        FORCE_QT="yes"
+    else
+        DO_QT="no"
+        FORCE_QT="no"
+    fi
 }
 
 function bv_qt_disable

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -1,6 +1,6 @@
 function bv_qt_initialize
 {
-    export DO_QT="yes"
+    export DO_QT="no"
     export FORCE_QT="no"
     export USE_SYSTEM_QT="no"
     add_extra_commandline_args "qt" "system-qt" 0 "Use qt found on system"

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -1,6 +1,6 @@
 function bv_qt_initialize
 {
-    export DO_QT="no"
+    export DO_QT="yes"
     export FORCE_QT="no"
     export USE_SYSTEM_QT="no"
     add_extra_commandline_args "qt" "system-qt" 0 "Use qt found on system"
@@ -9,13 +9,8 @@ function bv_qt_initialize
 
 function bv_qt_enable
 {
-    if [[ "$DO_QT6" == "no" ]] ; then
-        DO_QT="yes"
-        FORCE_QT="yes"
-    else
-       DO_QT="no"
-       FORCE_QT="no"
-    fi
+    DO_QT="yes"
+    DO_QT6="no"
 }
 
 function bv_qt_disable

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -6,8 +6,11 @@ function bv_qt6_initialize
 
 function bv_qt6_enable
 { 
-    DO_QT6="yes"
-    DO_QT="no"
+    if [[ "$DO_QT" == "no" ]] ; then
+        DO_QT6="yes"
+    else
+       DO_QT6="no"
+    fi
 }
 
 function bv_qt6_disable

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -6,11 +6,8 @@ function bv_qt6_initialize
 
 function bv_qt6_enable
 { 
-    if [[ "$DO_QT" == "no" ]] ; then
-        DO_QT6="yes"
-    else
-       DO_QT6="no"
-    fi
+    DO_QT6="yes"
+    DO_QT="no"
 }
 
 function bv_qt6_disable

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -1,7 +1,7 @@
  
 function bv_qt6_initialize
 {
-    export DO_QT6="no"
+    export DO_QT6="yes"
 }
 
 function bv_qt6_enable

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -6,8 +6,11 @@ function bv_qt6_initialize
 
 function bv_qt6_enable
 { 
-    DO_QT6="yes"
-    DO_QT="no"
+    if [[ "$DO_QT" == "no" ]] ; then
+        DO_QT6="yes"
+    else
+        DO_QT6="no"
+    fi
 }
 
 function bv_qt6_disable

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -6,6 +6,7 @@
             <lib name="python"/>
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
             <lib name="qt6"/>
+            <lib name="qt"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </required>
@@ -43,7 +44,6 @@
             <lib name="ospray"/>
             <lib name="pidx"/>
             <lib name="pyside"/>
-            <lib name="qt"/>
             <lib name="silo"/>
             <lib name="stripack"/>
             <lib name="szip"/>
@@ -59,6 +59,7 @@
             <lib name="python"/>
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
             <lib name="qt6"/>
+            <lib name="qt"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </group>
@@ -101,6 +102,7 @@
             <lib name="no-cmake"/>
             <lib name="no-python"/>
             <lib name="no-qt6" />
+            <lib name="no-qt" />
             <lib name="no-qwt" />
             <lib name="no-vtk"/>
             <lib name="no-zlib"/>
@@ -156,6 +158,7 @@
             <lib name="xdmf"/>
             <lib name="zlib"/>
             <lib name="no-qt6"/>
+            <lib name="no-qt"/>
             <lib name="no-qwt"/>
             <lib name="no-python"/>
         </group>
@@ -191,6 +194,7 @@
             <lib name="python"/>
             <lib name="vtk"/>
             <lib name="qt6"/>
+            <lib name="qt"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </required>
@@ -208,7 +212,6 @@
             <lib name="mpich"/>
             <lib name="osmesa"/>
             <lib name="pyqt"/>
-            <lib name="qt"/>
             <lib name="uintah"/>
             <lib name="damaris"/>
             <lib name="xercesc"/>
@@ -221,6 +224,7 @@
             <lib name="python"/>
             <lib name="vtk"/>
             <lib name="qt6"/>
+            <lib name="qt"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </group>
@@ -242,6 +246,7 @@
             <lib name="no-cmake"/>
             <lib name="no-python"/>
             <lib name="no-qt6" />
+            <lib name="no-qt" />
             <lib name="no-qwt" />
             <lib name="no-vtk"/>
             <lib name="no-zlib"/>
@@ -256,6 +261,7 @@
             <lib name="uintah"/>
             <lib name="no-python"/>
             <lib name="no-qt6"/>
+            <lib name="no-qt"/>
             <lib name="no-qwt"/>
         </group>
 

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -5,7 +5,7 @@
             <lib name="cmake"/> <!-- cmake is here -->
             <lib name="python"/>
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
-            <lib name="qt"/>
+            <lib name="qt6"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </required>
@@ -43,7 +43,6 @@
             <lib name="ospray"/>
             <lib name="pidx"/>
             <lib name="pyside"/>
-            <lib name="qt6"/>
             <lib name="silo"/>
             <lib name="stripack"/>
             <lib name="szip"/>
@@ -58,7 +57,7 @@
             <lib name="cmake"/> <!-- cmake is here -->
             <lib name="python"/>
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
-            <lib name="qt"/>
+            <lib name="qt6"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </group>
@@ -190,7 +189,7 @@
             <lib name="cmake"/>
             <lib name="python"/>
             <lib name="vtk"/>
-            <lib name="qt"/>
+            <lib name="qt6"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </required>
@@ -208,7 +207,6 @@
             <lib name="mpich"/>
             <lib name="osmesa"/>
             <lib name="pyqt"/>
-            <lib name="qt6"/>
             <lib name="uintah"/>
             <lib name="damaris"/>
             <lib name="xercesc"/>
@@ -220,7 +218,7 @@
             <lib name="cmake"/>
             <lib name="python"/>
             <lib name="vtk"/>
-            <lib name="qt"/>
+            <lib name="qt6"/>
             <lib name="qwt"/>
             <lib name="zlib"/>
         </group>

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -99,7 +99,7 @@
         <group name="no-thirdparty" comment="Do not build required 3rd party libraries" enabled="no">
             <lib name="no-cmake"/>
             <lib name="no-python"/>
-            <lib name="no-qt" />
+            <lib name="no-qt6" />
             <lib name="no-qwt" />
             <lib name="no-vtk"/>
             <lib name="no-zlib"/>
@@ -154,7 +154,7 @@
             <lib name="uintah"/>
             <lib name="xdmf"/>
             <lib name="zlib"/>
-            <lib name="no-qt"/>
+            <lib name="no-qt6"/>
             <lib name="no-qwt"/>
             <lib name="no-python"/>
         </group>
@@ -239,7 +239,7 @@
         <group name="no-thirdparty" comment="Do not build required 3rd party libraries" enabled="no">
             <lib name="no-cmake"/>
             <lib name="no-python"/>
-            <lib name="no-qt" />
+            <lib name="no-qt6" />
             <lib name="no-qwt" />
             <lib name="no-vtk"/>
             <lib name="no-zlib"/>
@@ -253,7 +253,7 @@
             <lib name="zlib"/>
             <lib name="uintah"/>
             <lib name="no-python"/>
-            <lib name="no-qt"/>
+            <lib name="no-qt6"/>
             <lib name="no-qwt"/>
         </group>
 

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -43,6 +43,7 @@
             <lib name="ospray"/>
             <lib name="pidx"/>
             <lib name="pyside"/>
+            <lib name="qt"/>
             <lib name="silo"/>
             <lib name="stripack"/>
             <lib name="szip"/>
@@ -207,6 +208,7 @@
             <lib name="mpich"/>
             <lib name="osmesa"/>
             <lib name="pyqt"/>
+            <lib name="qt"/>
             <lib name="uintah"/>
             <lib name="damaris"/>
             <lib name="xercesc"/>


### PR DESCRIPTION
### Description

Resolves #19073  <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
`qt6` is now the default `qt` version that is built. To get at `qt514`, once must use `--qt` when invoking `build_visit`. `qt510` is still requested with `--qt510`. If both `--qt6 --qt` are requested, `qt6` will be built.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
ran `build_visit` with 4 different invocations and made sure the correct versions of libraries were chosen:
 - `--required` and `--optional` led to qt6 and vtk9 being built as desired
 - `--qt6` led to qt6 and vtk9 being built as desired
 - `--qt` led to qt5.14 being built on blueOS as desired
 - `--qt510` led to qt5.10 being built as desired

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
