### PR TITLE
Silo Plugin Replace `-2` with `VTK_POLYHEDRON`

### DIFF
--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -147,6 +147,8 @@ static int FindFirstNonEmptyBlock(char const *mbobj_name, int nblocks,
 
 static int db_get_index(DBnamescheme const *ns, int natnum);
 
+int constexpr VTK_POLYHEDRON_ZONETYPE = -2;
+
 // ****************************************************************************
 //  Class: avtSiloFileFormat
 //
@@ -10256,8 +10258,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
     // that is all handled here at the bottom of this function. All the
     // logic prior to that simply walks over the arb. polyhedral zones but
     // keeps track of where they occur in the zonelist so we can handle them
-    // later. Note that a setting of 'vtk_zonetype' of -2 represents the
-    // arb. polyhedral zonetype.
+    // later.
     //
     size_t   i, j, k;
     int nsdims = um->ndims; (void) nsdims;
@@ -10273,7 +10274,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
     for (i = 0 ; i < (size_t)zl->nshapes ; i++)
     {
         int vtk_zonetype = SiloZoneTypeToVTKZoneType(zl->shapetype[i]);
-        if (vtk_zonetype != -2)
+        if (vtk_zonetype != VTK_POLYHEDRON_ZONETYPE)
         {
             numCells += zl->shapecnt[i];
             if (zl->shapesize[i] > 0)
@@ -10326,7 +10327,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
         int effective_vtk_zonetype = vtk_zonetype;
         int effective_shapesize = shapesize;
 
-        if (vtk_zonetype < 0 && vtk_zonetype != -2)
+        if (vtk_zonetype < 0 && vtk_zonetype != VTK_POLYHEDRON_ZONETYPE)
         {
             EXCEPTION1(InvalidZoneTypeException, zl->shapetype[i]);
         }
@@ -10359,7 +10360,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
         // "Handle" arbitrary polyhedra by skipping over them here.
         // We deal with them later on in this func.
         //
-        if (vtk_zonetype == -2)
+        if (vtk_zonetype == VTK_POLYHEDRON_ZONETYPE)
         {
             //
             // There are shapecnt zones of arb. type in this segment
@@ -16222,7 +16223,7 @@ SiloZoneTypeToVTKZoneType(int zonetype)
         vtk_zonetype = VTK_QUAD;
         break;
       case DB_ZONETYPE_POLYHEDRON:
-        vtk_zonetype = -2;
+        vtk_zonetype = VTK_POLYHEDRON_ZONETYPE;
         break;
       case DB_ZONETYPE_TET:
         vtk_zonetype = VTK_TETRA;

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -147,8 +147,6 @@ static int FindFirstNonEmptyBlock(char const *mbobj_name, int nblocks,
 
 static int db_get_index(DBnamescheme const *ns, int natnum);
 
-int constexpr VTK_POLYHEDRON_ZONETYPE = -2;
-
 // ****************************************************************************
 //  Class: avtSiloFileFormat
 //
@@ -10243,6 +10241,9 @@ MakePHZonelistFromZonelistArbFragment(const int *nl, int shapecnt)
 //
 //    Kathleen Biagas, Mon Aug 15 14:09:55 PDT 2016
 //    VTK-8, API for updating GhostLevel changed.
+// 
+//    Justin Privitera, Thu May 16 15:38:19 PDT 2024
+//    Use VTK_POLYHEDRON instead of magic number.
 //
 // ****************************************************************************
 
@@ -10274,7 +10275,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
     for (i = 0 ; i < (size_t)zl->nshapes ; i++)
     {
         int vtk_zonetype = SiloZoneTypeToVTKZoneType(zl->shapetype[i]);
-        if (vtk_zonetype != VTK_POLYHEDRON_ZONETYPE)
+        if (vtk_zonetype != VTK_POLYHEDRON)
         {
             numCells += zl->shapecnt[i];
             if (zl->shapesize[i] > 0)
@@ -10327,7 +10328,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
         int effective_vtk_zonetype = vtk_zonetype;
         int effective_shapesize = shapesize;
 
-        if (vtk_zonetype < 0 && vtk_zonetype != VTK_POLYHEDRON_ZONETYPE)
+        if (vtk_zonetype < 0 && vtk_zonetype != VTK_POLYHEDRON)
         {
             EXCEPTION1(InvalidZoneTypeException, zl->shapetype[i]);
         }
@@ -10360,7 +10361,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
         // "Handle" arbitrary polyhedra by skipping over them here.
         // We deal with them later on in this func.
         //
-        if (vtk_zonetype == VTK_POLYHEDRON_ZONETYPE)
+        if (vtk_zonetype == VTK_POLYHEDRON)
         {
             //
             // There are shapecnt zones of arb. type in this segment
@@ -16203,6 +16204,10 @@ SplitDirVarName(const char *dirvar, const char *curdir,
 //
 //  Programmer:  Hank Childs
 //  Creation:    August 15, 2000
+// 
+//  Modifications:
+//     Justin Privitera, Thu May 16 15:38:19 PDT 2024
+//     Use VTK_POLYHEDRON instead of magic number.
 //
 // ****************************************************************************
 
@@ -16223,7 +16228,7 @@ SiloZoneTypeToVTKZoneType(int zonetype)
         vtk_zonetype = VTK_QUAD;
         break;
       case DB_ZONETYPE_POLYHEDRON:
-        vtk_zonetype = VTK_POLYHEDRON_ZONETYPE;
+        vtk_zonetype = VTK_POLYHEDRON;
         break;
       case DB_ZONETYPE_TET:
         vtk_zonetype = VTK_TETRA;

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -10328,7 +10328,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
         int effective_vtk_zonetype = vtk_zonetype;
         int effective_shapesize = shapesize;
 
-        if (vtk_zonetype < 0 && vtk_zonetype != VTK_POLYHEDRON)
+        if (vtk_zonetype < 0)
         {
             EXCEPTION1(InvalidZoneTypeException, zl->shapetype[i]);
         }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

I saw this in the plugin while trying to understand how Silo handles polytopal data and I felt that I had to make this change.

Questions:
1. was `-2` chosen for any particular reason originally?
2. Does anyone foresee any problem with using `VTK_POLYHEDRON` as opposed to using a constant equal to `-2`?

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->
code style

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rzhound toss4
all silo tests pass

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
