### PR TITLE
Adjust reader to use point count rather than storage size in size check

### DIFF
--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -498,7 +498,7 @@ void PMDFile::CloseFile()
 //      I added double dataset and double multiplication factor.
 //
 //      Mark C. Miller, Fri May 17 15:57:48 PDT 2024
-//      Changed smoke-checkiing logic for dataset size and numValues to use a
+//      Changed smoke-checking logic for dataset size and numValues to use a
 //      count of points in the dataset instead of storage size, which can vary
 //      based on the type of HDF5 storage used (e.g. contig/chunked, etc.) and
 //      whether any filters are used.
@@ -675,7 +675,6 @@ PMDFile::ReadFieldScalarBlock(void * array,
     hid_t   datasetId;
     hid_t   datasetType;
     hid_t   datasetSpace;
-    hsize_t datasetStorageSize;
 
     //cerr  << "PMDFile::ReadFieldScalarBlock" << endl;
 
@@ -703,8 +702,6 @@ PMDFile::ReadFieldScalarBlock(void * array,
         datasetType = H5Dget_type(datasetId);
         // Data size
         dataSize = H5Tget_size(datasetType);
-        // Storage size
-        datasetStorageSize = H5Dget_storage_size(datasetId);
         // Dimension from the data space
         ndims = H5Sget_simple_extent_ndims(datasetSpace);
 
@@ -935,7 +932,6 @@ int PMDFile::ReadParticleScalarBlock(void * array,
     hid_t   datasetId;
     hid_t   datasetType;
     hid_t   datasetSpace;
-    hsize_t datasetStorageSize;
 
     //cerr  << "PMDFile::ReadParticleScalarBlock" << endl;
 
@@ -962,8 +958,6 @@ int PMDFile::ReadParticleScalarBlock(void * array,
         datasetType = H5Dget_type(datasetId);
         // Data size
         dataSize = H5Tget_size(datasetType);
-        // Storage size
-        datasetStorageSize = H5Dget_storage_size(datasetId);
         // Dimension from the data space
         ndims  = H5Sget_simple_extent_ndims(datasetSpace);
 

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDFile.C
@@ -498,7 +498,7 @@ void PMDFile::CloseFile()
 //      I added double dataset and double multiplication factor.
 //
 //      Mark C. Miller, Fri May 17 15:57:48 PDT 2024
-//      Changed smoke-checkiing logic for dataset size and numValues to use a
+//      Changed smoke-checking logic for dataset size and numValues to use a
 //      count of points in the dataset instead of storage size, which can vary
 //      based on the type of HDF5 storage used (e.g. contig/chunked, etc.) and
 //      whether any filters are used.

--- a/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
+++ b/src/databases/OpenPMD/OpenPMDClasses/PMDParticle.C
@@ -366,7 +366,11 @@ void PMDParticle::ScanMass(hid_t particleGroupId, char * objectName)
 // Creation:   Fri Oct 14 2016
 //
 // Modifications:
-//
+//   Mark C. Miller, Fri May 17 15:57:48 PDT 2024
+//   Changed smoke-checking logic for dataset size and numValues to use a
+//   count of points in the dataset instead of storage size, which can vary
+//   based on the type of HDF5 storage used (e.g. contig/chunked, etc.) and
+//   whether any filters are used.
 // ***************************************************************************
 void PMDParticle::ScanPositions(hid_t particleGroupId, char * objectName)
 {
@@ -380,7 +384,6 @@ void PMDParticle::ScanPositions(hid_t particleGroupId, char * objectName)
     char              datasetName[64];
     ssize_t           length;
     hsize_t           numObjects;
-    hsize_t           datasetStorageSize;
     hid_t             groupId;
     hid_t             dataSetId;
     hid_t             datasetType;
@@ -440,10 +443,8 @@ void PMDParticle::ScanPositions(hid_t particleGroupId, char * objectName)
                   scalar.dataSize = H5Tget_size(datasetType);
                   // data Class
                   scalar.dataClass = H5Tget_class(datasetType);
-                  // Storage size
-                  datasetStorageSize = H5Dget_storage_size(dataSetId);
                   // Number of elements
-                  scalar.numElements = int(datasetStorageSize/scalar.dataSize);
+                  scalar.numElements = int(H5Sget_simple_extent_npoints(dataSetId));
 
                   H5Dclose(dataSetId);
             }
@@ -496,7 +497,11 @@ void PMDParticle::ScanPositions(hid_t particleGroupId, char * objectName)
 // Creation:   Fri Oct 14 2016
 //
 // Modifications:
-//
+//    Mark C. Miller, Fri May 17 15:57:48 PDT 2024
+//    Changed smoke-checking logic for dataset size and numValues to use a
+//    count of points in the dataset instead of storage size, which can vary
+//    based on the type of HDF5 storage used (e.g. contig/chunked, etc.) and
+//    whether any filters are used.
 // ***************************************************************************
 void PMDParticle::ScanMomenta(hid_t particleGroupId, char * objectName)
 {
@@ -509,7 +514,6 @@ void PMDParticle::ScanMomenta(hid_t particleGroupId, char * objectName)
     int                 vectorDataSetId[3] = {-1,-1,-1};
     char                bufferName[64];
     char                datasetName[64];
-    hsize_t             datasetStorageSize;
     ssize_t             length;
     hid_t               groupId;
     hid_t               dataSetId;
@@ -580,10 +584,8 @@ void PMDParticle::ScanMomenta(hid_t particleGroupId, char * objectName)
                 scalar.dataSize = H5Tget_size(datasetType);
                 // data Class
                 scalar.dataClass = H5Tget_class(datasetType);
-                // Storage size
-                datasetStorageSize = H5Dget_storage_size(dataSetId);
                 // Number of elements
-                scalar.numElements = int(datasetStorageSize/scalar.dataSize);
+                scalar.numElements = int(H5Sget_simple_extent_npoints(dataSetId));
 
                 // We add this scalar object to the vector of scalar datasets
                 this->scalarDataSets.push_back(scalar);
@@ -637,7 +639,11 @@ void PMDParticle::ScanMomenta(hid_t particleGroupId, char * objectName)
 // Creation:   Fri Oct 21 2016
 //
 // Modifications:
-//
+//   Mark C. Miller, Fri May 17 15:57:48 PDT 2024
+//   Changed smoke-checking logic for dataset size and numValues to use a
+//   count of points in the dataset instead of storage size, which can vary
+//   based on the type of HDF5 storage used (e.g. contig/chunked, etc.) and
+//   whether any filters are used.
 // ***************************************************************************
 void PMDParticle::ScanGroup(hid_t particleGroupId,char * objectName)
 {
@@ -650,7 +656,6 @@ void PMDParticle::ScanGroup(hid_t particleGroupId,char * objectName)
     int                 vectorDataSetId[3] = {-1,-1,-1};
     char                datasetName[128];
     ssize_t             length;
-    hsize_t             datasetStorageSize;
     hid_t               groupId;
     hid_t               dataSetId;
     hid_t               datasetType;
@@ -716,10 +721,8 @@ void PMDParticle::ScanGroup(hid_t particleGroupId,char * objectName)
                   scalar.dataSize = H5Tget_size(datasetType);
                   // data Class
                   scalar.dataClass = H5Tget_class(datasetType);
-                  // Storage size
-                  datasetStorageSize = H5Dget_storage_size(dataSetId);
                   // Number of elements
-                  scalar.numElements = int(datasetStorageSize/scalar.dataSize);
+                  scalar.numElements = int(H5Sget_simple_extent_npoints(dataSetId));
 
                   // We add this scalar object to the vector of scalar datasets
                   this->scalarDataSets.push_back(scalar);
@@ -772,7 +775,11 @@ void PMDParticle::ScanGroup(hid_t particleGroupId,char * objectName)
 // Creation:   Fri Oct 21 2016
 //
 // Modifications:
-//
+//   Mark C. Miller, Fri May 17 15:57:48 PDT 2024
+//   Changed smoke-checking logic for dataset size and numValues to use a
+//   count of points in the dataset instead of storage size, which can vary
+//   based on the type of HDF5 storage used (e.g. contig/chunked, etc.) and
+//   whether any filters are used.
 // ***************************************************************************
 void
 PMDParticle::ScanDataSet(hid_t particleGroupId,char * objectName)
@@ -785,7 +792,6 @@ PMDParticle::ScanDataSet(hid_t particleGroupId,char * objectName)
     scalarDataSet       scalar;
     hid_t                dataSetId;
     hid_t                datasetType;
-    hsize_t             datasetStorageSize;
 
       // Openning of the dataset
       dataSetId = H5Dopen2(particleGroupId, objectName , H5P_DEFAULT);
@@ -808,10 +814,8 @@ PMDParticle::ScanDataSet(hid_t particleGroupId,char * objectName)
       scalar.dataSize = H5Tget_size(datasetType);
       // data Class
       scalar.dataClass = H5Tget_class(datasetType);
-      // Storage size
-      datasetStorageSize = H5Dget_storage_size(dataSetId);
       // Number of elements
-      scalar.numElements = int(datasetStorageSize/scalar.dataSize);
+      scalar.numElements = int(H5Sget_simple_extent_npoints(dataSetId));
 
       // We add this scalar object to the vector of scalar datasets
       this->scalarDataSets.push_back(scalar);

--- a/src/databases/OpenPMD/avtOpenPMDFileFormat.C
+++ b/src/databases/OpenPMD/avtOpenPMDFileFormat.C
@@ -1678,7 +1678,6 @@ avtOpenPMDFileFormat::GetVar(int timestate, int domain, const char *varname)
     hid_t   datasetId;
     hid_t   datasetType;
     hid_t   datasetSpace;
-    hsize_t datasetStorageSize;
     int     ndims;
     float * array;
     float   factor;

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -25,7 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed bug where user supplied legend labels were stored in config and session files wrapped in '()' and comma separated. This prevented the values from being parsed correctly and the '()' and commas appeared as part of the labels.</li>
   <li>The location where custom plugins are written when built against installed version of VisIt was corrected.</li>
   <li>Windows build issues for custom plugins against an installed version of VisIt was fixed.</li>
-  <li>Fixed a bug in OpenPMD reader that subvertted its ability to read chunked, as opposed to contiguous datasets.</li>
+  <li>Fixed a bug in OpenPMD reader that subverted its ability to read chunked, as opposed to contiguous datasets.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -25,6 +25,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed bug where user supplied legend labels were stored in config and session files wrapped in '()' and comma separated. This prevented the values from being parsed correctly and the '()' and commas appeared as part of the labels.</li>
   <li>The location where custom plugins are written when built against installed version of VisIt was corrected.</li>
   <li>Windows build issues for custom plugins against an installed version of VisIt was fixed.</li>
+  <li>Fixed a bug in OpenPMD reader that subvertted its ability to read chunked, as opposed to contiguous datasets.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

See #19514.

This same storage size vs. point count logic occurs in multiple places in the reader and so I fixed it in multiple places. I also encountered cases where `datasetStorageSize` was being set but never used and cases where HDF5 objects were being opened but the coorresponding `H5Xclose()` calls were commented out. I uncommented them.

Resolves #19529 

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I tested as a custom plugin against 3.3.1 and opened both the one test case we have and also the data the user attached to the above ref'd discussion. It all worked.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
