### PR TITLE
Add -std=c++11 to  bv_uintah

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -269,7 +269,7 @@ function build_uintah
         info "Invoking command to configure UINTAH"
         set -x
         sh -c "../src/configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -std=c++11 -headerpad_max_install_names\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS -std=c++11\" \
+        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -headerpad_max_install_names\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS -std=c++11\" \
         MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
         --with-zlib=\"$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH\" \
         --prefix=\"$VISITDIR/uintah/$UINTAH_VERSION/$VISITARCH\" \
@@ -290,7 +290,7 @@ function build_uintah
         info "Invoking command to configure UINTAH"
         set -x
         sh -c "../src/configure CXX=\"$PAR_COMPILER_CXX\" CC=\"$PAR_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -std=c++11\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS -std=c++11\" \
+        CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS -std=c++11\" \
         MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
         --with-zlib=\"$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH\" \
         --prefix=\"$VISITDIR/uintah/$UINTAH_VERSION/$VISITARCH\" \

--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -269,7 +269,7 @@ function build_uintah
         info "Invoking command to configure UINTAH"
         set -x
         sh -c "../src/configure CXX=\"$CXX_COMPILER\" CC=\"$C_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -headerpad_max_install_names\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
+        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -std=c++11 -headerpad_max_install_names\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS -std=c++11\" \
         MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
         --with-zlib=\"$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH\" \
         --prefix=\"$VISITDIR/uintah/$UINTAH_VERSION/$VISITARCH\" \
@@ -290,7 +290,7 @@ function build_uintah
         info "Invoking command to configure UINTAH"
         set -x
         sh -c "../src/configure CXX=\"$PAR_COMPILER_CXX\" CC=\"$PAR_COMPILER\" \
-        CFLAGS=\"$CFLAGS $C_OPT_FLAGS\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS\" \
+        CFLAGS=\"$CFLAGS $C_OPT_FLAGS -std=c++11\" CXXFLAGS=\"$CXXFLAGS $CXX_OPT_FLAGS -std=c++11\" \
         MPI_EXTRA_LIB_FLAG=\"$PAR_LIBRARY_NAMES\" \
         --with-zlib=\"$VISITDIR/zlib/$ZLIB_VERSION/$VISITARCH\" \
         --prefix=\"$VISITDIR/uintah/$UINTAH_VERSION/$VISITARCH\" \


### PR DESCRIPTION
Fixes builds with compilers whose default is c++17.

### Description

See #19526

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
