### PR TITLE
Add qt patch  for libxkbcommon-1.6.0 problem.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -293,6 +293,10 @@ function apply_qt_patch
             cd ..
         fi
     elif [[ ${QT_VERSION} == 5.14.2 ]] ; then
+        apply_qt_5142_xkbcommon_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
         apply_qt_5142_numeric_limits_patch
         if [[ $? != 0 ]] ; then
             return 1
@@ -499,6 +503,34 @@ EOF
     fi
 
     return 0;
+}
+
+function apply_qt_5142_xkbcommon_patch
+{
+    info "Patching qt 5.14.2 for libxkbcommon-1.6.0 issue"
+    patch -p0 <<EOF
+--- qtbase/src/platformsupport/input/xkbcommon/qxkbcommon.cpp.orig	2024-05-21 12:54:00.432442000 -0700
++++ qtbase/src/platformsupport/input/xkbcommon/qxkbcommon.cpp	2024-05-21 12:55:35.162440000 -0700
+@@ -271,10 +271,14 @@
+         Xkb2Qt<XKB_KEY_dead_small_schwa,        Qt::Key_Dead_Small_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_capital_schwa,      Qt::Key_Dead_Capital_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_greek,              Qt::Key_Dead_Greek>,
++/* The following for XKB_KEY_dead keys got removed in libxkbcommon 1.6.0
++   The define check is kind of version check here. */
++#ifdef XKB_KEY_dead_lowline
+         Xkb2Qt<XKB_KEY_dead_lowline,            Qt::Key_Dead_Lowline>,
+         Xkb2Qt<XKB_KEY_dead_aboveverticalline,  Qt::Key_Dead_Aboveverticalline>,
+         Xkb2Qt<XKB_KEY_dead_belowverticalline,  Qt::Key_Dead_Belowverticalline>,
+         Xkb2Qt<XKB_KEY_dead_longsolidusoverlay, Qt::Key_Dead_Longsolidusoverlay>,
++#endif
+ 
+         // Special keys from X.org - This include multimedia keys,
+         // wireless/bluetooth/uwb keys, special launcher keys, etc.
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "qt 5.14.2 xkbcommon patch failed."
+        return 1
+    fi
 }
 
 function apply_qt_5142_numeric_limits_patch

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -93,6 +93,7 @@ function bv_qt6_ensure
     return 0
 }
 
+
 function apply_qt6_base_patch
 {
      if [[ "$OPSYS" == "Darwin" ]]; then
@@ -100,6 +101,44 @@ function apply_qt6_base_patch
         if [[ $? != 0 ]] ; then
             return 1
         fi
+    fi
+    qt6_xkbcommon_patch
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+}
+
+function qt6_xkbcommon_patch
+{
+    info "Patching qt 6 for xkbcommon issue"
+    patch -p0 <<EOF
+-- qtbase-everywhere-src-6.4.2/src/gui/platform/unix/qxkbcommon.cpp.orig	2024-05-21 08:51:16.000000000 -0700
++++ qtbase-everywhere-src-6.4.2/src/gui/platform/unix/qxkbcommon.cpp	2024-05-21 08:50:33.000000000 -0700
+@@ -236,16 +236,20 @@
+         Xkb2Qt<XKB_KEY_dead_O,                  Qt::Key_Dead_O>,
+         Xkb2Qt<XKB_KEY_dead_u,                  Qt::Key_Dead_u>,
+         Xkb2Qt<XKB_KEY_dead_U,                  Qt::Key_Dead_U>,
+         Xkb2Qt<XKB_KEY_dead_small_schwa,        Qt::Key_Dead_Small_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_capital_schwa,      Qt::Key_Dead_Capital_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_greek,              Qt::Key_Dead_Greek>,
++/* The following for XKB_KEY_dead keys got removed in libxkbcommon 1.6.0
++   The define check is kind of version check here. */
++#ifdef XKB_KEY_dead_lowline
+         Xkb2Qt<XKB_KEY_dead_lowline,            Qt::Key_Dead_Lowline>,
+         Xkb2Qt<XKB_KEY_dead_aboveverticalline,  Qt::Key_Dead_Aboveverticalline>,
+         Xkb2Qt<XKB_KEY_dead_belowverticalline,  Qt::Key_Dead_Belowverticalline>,
+         Xkb2Qt<XKB_KEY_dead_longsolidusoverlay, Qt::Key_Dead_Longsolidusoverlay>,
++#endif
+ 
+         // Special keys from X.org - This include multimedia keys,
+         // wireless/bluetooth/uwb keys, special launcher keys, etc.
+         Xkb2Qt<XKB_KEY_XF86Back,                Qt::Key_Back>,
+         Xkb2Qt<XKB_KEY_XF86Forward,             Qt::Key_Forward>,
+         Xkb2Qt<XKB_KEY_XF86Stop,                Qt::Key_Stop>,
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "Patching qt 6 for xkbcommon issue failed"
+        return 1
     fi
 }
 


### PR DESCRIPTION
### Description

Resolves #19536

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I ran build_visit to build qt6 and 5.14.2, and verified the patch was applied successfully.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
