### PR TITLE
Add dockerfile for fedora39 and build_visit  patches that allows building with gcc 13

### DIFF
--- a/scripts/docker/Dockerfile-fedora39
+++ b/scripts/docker/Dockerfile-fedora39
@@ -1,0 +1,83 @@
+FROM fedora:39
+MAINTAINER Kathleen Biagas <biagas2@llnl.gov>
+
+# fetch build env
+ENV TZ=America/Los_Angeles
+RUN dnf -y upgrade && dnf -y install \
+    git \
+    wget \
+    bzip2 \
+    unzip \
+    xz \
+    patch \
+    hostname \
+    gcc \
+    gcc-c++ \
+    gcc-gfortran \
+    make \
+    zlib-devel \
+    python3 \
+    libX11* \
+    libX11-* \
+    libXrender \
+    libXrender-devel \
+    xcb* \
+    xcb-* \
+    libxcb* \
+    libxcb-* \
+    xcb-util \
+    xcb-util-devel \
+    xcb-util-keysyms \
+    xcb-util-image \
+    xcb-util-cursor \
+    xcb-util-renderutil-devel \
+    libxcb-devel \
+    libxkbcommon-x11 \
+    libxkbcommon-x11-devel \
+    libxkbcommon-devel \
+    libXext-devel \
+    libXfixes-devel \
+    libXi-devel \
+    libXt-devel \
+    fontconfig \
+    fontconfig-devel \
+    freetype-devel \
+    autoconf \
+    libtool \
+    libxml2 \
+    libxml2-devel \
+    vim \
+    emacs \
+    cpio \
+    mesa-libGL \
+    mesa-libGL-devel \
+    openssl-devel \
+    lapack \
+    lapack-devel \
+    expat \
+    expat-devel \
+    perl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN dnf -y upgrade && dnf -y install libffi-devel && rm -rf /var/lib/apt/lists/*
+
+RUN cd /usr/include && ln -s freetype2 freetype
+
+RUN groupadd -r visit && useradd -ms /bin/bash --no-log-init -r -g visit visit
+USER visit
+WORKDIR /home/visit
+
+# Create the third-party directory
+RUN mkdir third-party
+# Copy build_visit and the script to run it
+COPY --chown=visit:visit build_visit3_4_1 /home/visit
+COPY --chown=visit:visit run_build_visit_fedora39.sh /home/visit
+COPY --chown=visit:visit build_visit_docker_cleanup.py /home/visit
+# Build the third party libraries
+RUN /bin/bash run_build_visit_fedora39.sh
+
+COPY --chown=visit:visit build_test_visit.sh /home/visit
+COPY --chown=visit:visit test_visit.py /home/visit
+COPY --chown=visit:visit visit3.4.1.tar.gz /home/visit
+RUN /bin/bash build_test_visit.sh -v 3.4.1
+

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -158,6 +158,48 @@ function bv_vtk_ensure
 # *************************************************************************** #
 #                            Function 6, build_vtk                            #
 # *************************************************************************** #
+function apply_vtk9_gcc13_patch
+{
+  # patches that allows VTK9 to be built g++-13
+   patch -p0 << \EOF
+--- ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp.orig	2024-05-22 12:53:48.817462000 -0700
++++ ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp	2024-05-22 12:54:07.659499000 -0700
+@@ -33,6 +33,7 @@
+ 
+ #include <vector>
+ #include <string>
++#include <cstdint>
+ 
+ #define CPL_DLL
+
+EOF
+
+    if [[ $? != 0 ]] ; then
+      warn "patch allowing VTK to build with g++-13 failed."
+      return 1
+    fi
+
+   patch -p0 << \EOF
+--- IO/Image/vtkSEPReader.h.orig	2024-05-22 13:50:27.027369000 -0700
++++ IO/Image/vtkSEPReader.h	2024-05-22 13:50:55.044422000 -0700
+@@ -27,6 +27,7 @@
+ 
+ #include <array>  // for std::array
+ #include <string> // for std::string
++#include <cstdint> // for std::uint8_t
+ 
+ namespace details
+ {
+EOF
+
+    if [[ $? != 0 ]] ; then
+      warn "vtkSEPReader patch allowing VTK to build with g++-13 failed."
+      return 1
+    fi
+
+    return 0;
+}
+
 function apply_vtk9_allow_onscreen_and_osmesa_patch
 {
   # patch that allows VTK9 to be built with onscreen and osmesa support.
@@ -2521,6 +2563,11 @@ function apply_vtk_patch
 {
 
     if [[ "$DO_VTK9" == "yes" ]] ; then
+        apply_vtk9_gcc13_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+
         apply_vtk9_allow_onscreen_and_osmesa_patch
         if [[ $? != 0 ]] ; then
             return 1


### PR DESCRIPTION
### Description

Add patch for bv_vtk and bv_mfem, adding `#include <cstdint>` in order to fix compile errors with gcc 13.
Add Dockerfile for Fedora 39.


### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other
 build_visit fixes

### How Has This Been Tested?

Successfully completed a build of VisIt and TP libs in Fedora39 docker container.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
