### PR TITLE
Update dockerfile for Ubuntu22 to allow building of moab and uintah. (#19562)

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu22
+++ b/scripts/docker/Dockerfile-ubuntu22
@@ -76,6 +76,7 @@ RUN apt-get update && apt-get install -y \
     cpio \
     libegl1 \
     libegl1-mesa-dev \
+    liblapack-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y libffi-dev && rm -rf /var/lib/apt/lists/*

--- a/scripts/docker/run_build_visit-ubuntu22.sh
+++ b/scripts/docker/run_build_visit-ubuntu22.sh
@@ -1,1 +1,1 @@
-echo "yes" | ./build_visit3_4_1 --required --optional --mesagl --qt6 --mpich --no-moab --no-visit --thirdparty-path /home/visit/third-party --makeflags -j4 ; python3 build_visit_docker_cleanup.py
+echo "yes" | ./build_visit3_4_1 --required --optional --mesagl --qt6 --mpich --uintah --no-visit --thirdparty-path /home/visit/third-party --makeflags -j4 ; python3 build_visit_docker_cleanup.py


### PR DESCRIPTION


* Update dockerfile for Ubuntu22 to allow building of moab library.

* Add uintah to the build.

Merge from 3.4RC
