### PR TITLE
Fix bug with transparency when using scalable rendering.

### DIFF
--- a/src/avt/Plotter/vtk/vtkParallelImageSpaceRedistributor.C
+++ b/src/avt/Plotter/vtk/vtkParallelImageSpaceRedistributor.C
@@ -242,6 +242,13 @@ vtkParallelImageSpaceRedistributor::GetOutput()
 //    Kathleen Biags, Thu Aug 11, 2022
 //    Support VTK9: use vtkCellArrayIterator.
 //
+//    Eric Brugger, Wed Jun  5 09:41:17 PDT 2024
+//    Restructured the forming of the polydata objects to be sent
+//    to each process to eliminate a bug where the number of nodes in
+//    the output object was set incorrectly resulting in corrupted
+//    data being sent. The new code removes unreferenced points from
+//    the output polydata object as it is being formed.
+//
 // ****************************************************************************
 
 int
@@ -391,8 +398,19 @@ vtkParallelImageSpaceRedistributor::RequestData(
         {
             outgoingPolyData[i] = vtkPolyData::New();
             outgoingPolyData[i]->GetCellData()->CopyAllocate(inCD,outgoingCellCount[i]);
+#if LIB_VERSION_LE(VTK,8,1,0)
             int connSize = outgoingPointCount[i]+outgoingCellCount[i]; // overhead of one for each cell
+#else
+            int connSize = outgoingPointCount[i];
+#endif
             outgoingPolyData[i]->Allocate(connSize);
+
+            outgoingPolyData[i]->GetPointData()->CopyAllocate(inPD,outgoingPointCount[i]);
+            vtkPoints *newPts   = vtkPoints::New(inPts->GetDataType());
+            newPts->SetNumberOfPoints(outgoingPointCount[i]);
+            outgoingPolyData[i]->SetPoints(newPts);
+            newPts->Delete();
+
         }
     }
     visitTimer->StopTimer(TH_allocate, "allocate");
@@ -402,6 +420,13 @@ vtkParallelImageSpaceRedistributor::RequestData(
     //
     int TH_finddestinations = visitTimer->StartTimer();
     vector<int> dests;
+
+    vector<vtkIdType> nPoints;
+    nPoints.resize(size, 0);
+    int maxCellSize = cellArrays[0]->GetMaxCellSize();
+    for (int j = 1 ; j < 4 ; j++)
+        maxCellSize = std::max(maxCellSize, cellArrays[j]->GetMaxCellSize());
+    vtkIdType *ptList = new vtkIdType[maxCellSize];
 
     for (int j = 0 ; j < 4 ; j++)
     {
@@ -453,8 +478,15 @@ vtkParallelImageSpaceRedistributor::RequestData(
             //       dest==-2 means no destinations
             if (dest >= 0)
             {
+                for (int k = 0; k < npts; k++)
+                {
+                    outgoingPolyData[dest]->GetPoints()->SetPoint(nPoints[dest], input->GetPoints()->GetPoint(ptsForThisCell[k]));
+                    outgoingPolyData[dest]->GetPointData()->CopyData(inPD, ptsForThisCell[k], nPoints[dest]);
+                    ptList[k] = nPoints[dest];
+                    nPoints[dest] = nPoints[dest] + 1;
+                }
                 int cnt = outgoingPolyData[dest]->InsertNextCell(cellType,
-                                                       npts, ptsForThisCell);
+                                                       npts, ptList);
 #if LIB_VERSION_LE(VTK,8,1,0)
                 outgoingPolyData[dest]->GetCellData()->CopyData(inCD, i, cnt);
 #else
@@ -465,8 +497,15 @@ vtkParallelImageSpaceRedistributor::RequestData(
             {
                 for (size_t k=0; k<dests.size(); k++)
                 {
+                    for (int l = 0; l < npts; l++)
+                    {
+                        outgoingPolyData[dests[k]]->GetPoints()->SetPoint(nPoints[dests[k]], input->GetPoints()->GetPoint(ptsForThisCell[l]));
+                        outgoingPolyData[dests[k]]->GetPointData()->CopyData(inPD, ptsForThisCell[l], nPoints[dests[k]]);
+                        ptList[l] = nPoints[dests[k]];
+                        nPoints[dests[k]] = nPoints[dests[k]] + 1;
+                    }
                     int cnt = outgoingPolyData[dests[k]]->InsertNextCell(cellType,
-                                                           npts, ptsForThisCell);
+                                                           npts, ptList);
 #if LIB_VERSION_LE(VTK,8,1,0)
                     outgoingPolyData[dests[k]]->GetCellData()->CopyData(inCD, i, cnt);
 #else
@@ -486,88 +525,13 @@ vtkParallelImageSpaceRedistributor::RequestData(
             }
         }
     }
+    delete [] ptList;
     visitTimer->StopTimer(TH_finddestinations, "finddestinations");
 
     //
     // Done with our xformed points, so delete that memory
     //
     delete[] xformedpts;
-
-    //
-    // We have to figure out which points we need.  We don't want to
-    // send all of the points, since we don't need them all and that
-    // will just slow things down.
-    //
-    int TH_removeUnusedPoints = visitTimer->StartTimer();
-    for (int i = 0 ; i < size ; i++)
-    {
-        if (outgoingCellCount[i] <= 0)
-            continue;
-
-        if (outgoingCellCount[i] > 10000)  // need industrial grade algorithm
-        {
-            vtkPolyDataRelevantPointsFilter *rpf =
-                                     vtkPolyDataRelevantPointsFilter::New();
-            outgoingPolyData[i]->SetPoints(inPts);
-            outgoingPolyData[i]->GetPointData()->ShallowCopy(inPD);
-            rpf->SetInputData(outgoingPolyData[i]);
-            rpf->Update();
-            outgoingPolyData[i]->Delete();
-            outgoingPolyData[i] = rpf->GetOutput();
-            outgoingPolyData[i]->Register(NULL);
-            rpf->Delete();
-        }
-        else // just duplicate points ... it will be much faster.
-        {
-            vtkPolyData *opd    = outgoingPolyData[i]; // ease of reference
-            vtkPointData *outPD = opd->GetPointData();
-            vtkPoints *newPts   = vtkPoints::New(inPts->GetDataType());
-            newPts->SetNumberOfPoints(outgoingPointCount[i]);
-            opd->GetPointData()->CopyAllocate(inPD,outgoingPointCount[i]);
-            cellArrays[0] = opd->GetVerts();
-            cellArrays[1] = opd->GetLines();
-            cellArrays[2] = opd->GetPolys();
-            cellArrays[3] = opd->GetStrips();
-#if LIB_VERSION_LE(VTK,8,1,0)
-            vtkIdType curPt = 0;
-            for (int j = 0 ; j < 4 ; j++)
-            {
-                vtkIdType ncells = cellArrays[j]->GetNumberOfCells();
-                vtkIdType *cellPts = cellArrays[j]->GetPointer();
-                for (vtkIdType c=0; c<ncells; c++)
-                {
-                    vtkIdType npts = *cellPts;
-                    cellPts++;
-                    for (vtkIdType k = 0 ; k < npts ; k++)
-                    {
-                        vtkIdType oldPt = *cellPts;
-                        *cellPts = curPt;
-#else
-            vtkIdType curPt = 0;
-            for (int j = 0 ; j < 4 ; j++)
-            {
-                auto cellIter = vtk::TakeSmartPointer(cellArrays[j]->NewIterator());
-                for (cellIter->GoToFirstCell(); !cellIter->IsDoneWithTraversal(); cellIter->GoToNextCell())
-                {
-                    vtkIdType npts;
-                    const vtkIdType *cellPts;
-                    cellIter->GetCurrentCell(npts, cellPts);
-                    for (vtkIdType k = 0 ; k < npts ; k++)
-                    {
-                        vtkIdType oldPt = *cellPts;
-#endif
-                        newPts->SetPoint(curPt, inPts->GetPoint(oldPt));
-                        outPD->CopyData(inPD, oldPt, curPt);
-                        cellPts++;
-                        curPt++;
-                    }
-                }
-            }
-            opd->SetPoints(newPts);
-            newPts->Delete();
-        }
-    }
-    visitTimer->StopTimer(TH_removeUnusedPoints, "Removing unused points");
 
     //
     // Convert data to strings so we can send them to other processors

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -30,6 +30,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Enabled "Tunnel data connections through SSH" in the LLNL RZ host profiles where it was missing.</li>
   <li>Removed the obsolete LLNL host profiles for RZTopaz, Surface and Vulcan.</li>
   <li>Fixed a bug where the LLNL host profiles for Boraxo, Dane and Ruby didn't get installed in some situations.</li>
+  <li>Fixed a bug with rendering transparent surfaces with scalable rendering resulting in images with black horizontal bars or missing surface fragments.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/tests/rendering/transparency.py
+++ b/src/test/tests/rendering/transparency.py
@@ -160,4 +160,34 @@ pcAtts.opacity = 0.25
 SetPlotOptions(pcAtts)
 Test("transparency_13")
 
+# Test transparency with 3d multi block data
+DeleteAllPlots()
+OpenDatabase(silo_data_path("multi_curv3d.silo"))
+
+AddPlot("Pseudocolor", "d")
+pcAtts.SetOpacityType(pcAtts.Constant)
+pcAtts.opacity = 0.25
+SetPlotOptions(pcAtts)
+DrawPlots()
+v = View3DAttributes()
+v.viewNormal = (0.432843, 0.303466, 0.848855)
+v.focus = (0, 2.5, 15)
+v.viewUp = (-0.0787945, 0.950767, -0.299721)
+v.viewAngle = 30
+v.parallelScale = 16.0078
+v.nearPlane = -32.0156
+v.farPlane = 32.0156
+v.imagePan = (0, 0)
+v.imageZoom = 1
+v.perspective = 1
+v.eyeAngle = 2
+v.centerOfRotationSet = 0
+v.centerOfRotation = (0, 2.5, 15)
+v.axis3DScaleFlag = 0
+v.axis3DScales = (1, 1, 1)
+v.shear = (0, 0, 1)
+v.windowValid = 1
+SetView3D(v)
+Test("transparency_14")
+
 Exit()

--- a/test/baseline/rendering/transparency/transparency_14.png
+++ b/test/baseline/rendering/transparency/transparency_14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a33f32aef9c21e290191e0c6926e0b98e6a238a19856fb02ea260a761316f0df
+size 8290


### PR DESCRIPTION
### Description

Resolves #19498

Fixed a bug with rendering transparent surfaces with scalable rendering resulting in images with black horizontal bars or missing surface fragments.

The bug was in `vtkParallelImageSpaceRedistributor`. The distributor worked by forming a `vtkPolyData` object for the data to ship to each processor. The code set the number of points in the `vtkPolyData` object too small. When the `vtkPolyData` objects were all merged into a single object, the points got corrupted and the object had index references outside the range of points. I restructured how the `vktPolyData` objects for each processor are formed and in the process fixed the issue.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I tested it with 2 processors with `multi_curv3d.silo` in scalable rendering mode. When run with the old version, portions of the mesh were missing. The new version looked ok.

The ticket also referenced 3 user data sets that exhibited this bug. Here are the results of running the new version on each data set.
1) The first was a merged mili data set and portions of the filled boundary plot were white in color. This had nothing to do with this bug and was unaffected by the change.
2) The second was a decomposed mili data set and the issue was fixed with the change.
3) The third was a silo restart file and the issue was fixed with the change.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
