### PR TITLE
Update patch for vtkRectilinearGridReader.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1078,15 +1078,15 @@ function apply_vtk9_vtkRectilinearGridReader_patch
        }
 +      // if the coordinates have been reached, should be no reason
 +      // to keep reading
-+      else if (!strncmp(line, "x_coordinate", 12))
++      else if (strncmp(this->LowerCase(line), "x_coordinate", 12) == 0)
 +      {
 +        break;
 +      }
-+      else if (!strncmp(line, "y_coordinate", 12))
++      else if (strncmp(this->LowerCase(line), "y_coordinate", 12) == 0)
 +      {
 +        break;
 +      }
-+      else if (!strncmp(line, "z_coordinate", 12))
++      else if (strncmp(this->LowerCase(line), "z_coordinate", 12) == 0)
 +      {
 +        break;
 +      }

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1052,32 +1052,47 @@ function apply_vtk9_vtkRectilinearGridReader_patch
   # patch vtkRectilinearGridReader.cxx, per this issue:
   # https://gitlab.kitware.com/vtk/vtk/-/issues/18447
    patch -p0 << \EOF
-*** IO/Legacy/vtkRectilinearGridReader.cxx.orig	Thu Jan 27 10:55:12 2022
---- IO/Legacy/vtkRectilinearGridReader.cxx	Thu Jan 27 11:01:04 2022
-***************
-*** 95,101 ****
-          break;
-        }
-  
-!       if (!strncmp(this->LowerCase(line), "dimensions", 10) && !dimsRead)
-        {
-          int dim[3];
-          if (!(this->Read(dim) && this->Read(dim + 1) && this->Read(dim + 2)))
---- 95,108 ----
-          break;
-        }
-  
-!       // Have to read field data because it may be binary.
-!       if (!strncmp(this->LowerCase(line), "field", 5))
-!       {
-!         vtkFieldData* fd = this->ReadFieldData();
-!         fd->Delete();
-!       }
-! 
-!       else if (!strncmp(this->LowerCase(line), "dimensions", 10) && !dimsRead)
-        {
-          int dim[3];
-          if (!(this->Read(dim) && this->Read(dim + 1) && this->Read(dim + 2)))
+--- IO/Legacy/vtkRectilinearGridReader.cxx.orig	2024-06-05 14:21:59.105807000 -0700
++++ IO/Legacy/vtkRectilinearGridReader.cxx	2024-06-05 14:26:30.561802000 -0700
+@@ -95,7 +95,16 @@
+         break;
+       }
+ 
+-      if (!strncmp(this->LowerCase(line), "dimensions", 10) && !dimsRead)
++      // If data file is binary and there FieldData is present, it
++      // must be read here, otherwise a ReadString will fail and the
++      // loop will terminate before reading dimensions.
++      if (!strncmp(this->LowerCase(line), "field", 5))
++      {
++        vtkFieldData* fd = this->ReadFieldData();
++        fd->Delete();
++      }
++
++      else if (!strncmp(this->LowerCase(line), "dimensions", 10) && !dimsRead)
+       {
+         int dim[3];
+         if (!(this->Read(dim) && this->Read(dim + 1) && this->Read(dim + 2)))
+@@ -127,6 +136,20 @@
+ 
+         dimsRead = true;
+       }
++      // if the coordinates have been reached, should be no reason
++      // to keep reading
++      else if (!strncmp(line, "x_coordinate", 12))
++      {
++        break;
++      }
++      else if (!strncmp(line, "y_coordinate", 12))
++      {
++        break;
++      }
++      else if (!strncmp(line, "z_coordinate", 12))
++      {
++        break;
++      }
+     }
+   }
+ 
 EOF
     if [[ $? != 0 ]] ; then
         warn "vtk patch for vtkRectilinearGridReader.cxx failed."

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1059,7 +1059,7 @@ function apply_vtk9_vtkRectilinearGridReader_patch
        }
  
 -      if (!strncmp(this->LowerCase(line), "dimensions", 10) && !dimsRead)
-+      // If data file is binary and there FieldData is present, it
++      // If data file is binary and FieldData is present, it
 +      // must be read here, otherwise a ReadString will fail and the
 +      // loop will terminate before reading dimensions.
 +      if (!strncmp(this->LowerCase(line), "field", 5))


### PR DESCRIPTION
### Description
The previous patch prevented a bug when reading binary rectilinear grids with FieldData (not cell or point associated). Because the section of code where the patch was applied loops over every single line in the file, the test on 'field' in the SCALARS line caused an error.
There is no reason to loop over the entire file in this method, so I added to the patch a way to early terminate the loop

Resolves #19549

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I ran build_visit to ensure the patch was applied correctly.
I built VisIt against the new VTK and ran the regression suite on pascal with success.

I ran VisIt, opened rect3d.silo, created a scalar expression named 'field' and plotted it successfully.

I opened the sample file from the bug ticket with VisIt and plotted 'Fields/e/x' successfully.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
