### PR TITLE
Fix qt6 build issues when qt6 on system

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Removed the obsolete LLNL host profiles for RZTopaz, Surface and Vulcan.</li>
   <li>Fixed a bug where the LLNL host profiles for Boraxo, Dane and Ruby didn't get installed in some situations.</li>
   <li>Fixed a bug with rendering transparent surfaces with scalable rendering resulting in images with black horizontal bars or missing surface fragments.</li>
+  <li>Fixed issues with build_visit when using gcc-13 and when Qt6 is present on the system.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -439,19 +439,10 @@ function build_qt6_tools
     fi
 
     cd ${QT6_TOOLS_BUILD_DIR}
-    copts="-DQt6_DIR:PATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6"
-    copts="${copts} -DCMAKE_INSTALL_PREFIX:PATH=${QT6_INSTALL_DIR}"
-    copts="${copts} -DCMAKE_CXX_STANDARD:STRING=17"
-    copts="${copts} -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON"
-    info "qt6 tools options: $copts"
-    info "cmake_install ${CMAKE_INSTALL}"
-    info "cmake_command ${CMAKE_COMMAND}"
-    qt6_path="${CMAKE_INSTALL}:$PATH"
-    info "qt6 tools path: $qt6_path"
    
     info "Configuring Qt6 tools . . . "
-    env PATH="${qt6_path}" CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
-        ${CMAKE_COMMAND} ${copts} ../${QT6_TOOLS_SOURCE_DIR}
+    env CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
+        ${QT6_INSTALL_DIR}/bin/qt-configure-module  ../${QT6_TOOLS_SOURCE_DIR}
 
     info "Building Qt6 tools . . . "
     ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
@@ -492,19 +483,10 @@ function build_qt6_svg
     fi
 
     cd ${QT6_SVG_BUILD_DIR}
-    copts="-DQt6_DIR:PATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6"
-    copts="${copts} -DCMAKE_INSTALL_PREFIX:PATH=${QT6_INSTALL_DIR}"
-    copts="${copts} -DCMAKE_CXX_STANDARD:STRING=17"
-    copts="${copts} -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON"
-    info "qt6 svg options: $copts"
-    info "cmake_install ${CMAKE_INSTALL}"
-    info "cmake_command ${CMAKE_COMMAND}"
-    qt6_path="${CMAKE_INSTALL}:$PATH"
-    info "qt6 svg path: $qt6_path"
 
     info "Configuring Qt6 svg . . . "
-    env PATH="${qt6_path}" CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
-        ${CMAKE_COMMAND} ${copts} ../${QT6_SVG_SOURCE_DIR} 
+    env CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
+        ${QT6_INSTALL_DIR}/bin/qt-configure-module  ../${QT6_SVG_SOURCE_DIR}
 
     info "Building Qt6 svg . . . "
     ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -2912,6 +2912,9 @@ function build_vtk
                     vopts="${vopts} -DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES"
                     if [[ "$DO_QT6" == "yes" ]]; then
                         vopts="${vopts} -DQt6_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6"
+                        vopts="${vopts} -DQt6CoreTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6CoreTools"
+                        vopts="${vopts} -DQt6GuiTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6GuiTools"
+                        vopts="${vopts} -DQt6WidgetsTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6WidgetsTools"
                     else
                         vopts="${vopts} -DQt5_DIR:FILEPATH=${QT_INSTALL_DIR}/lib/cmake/Qt5"
                     fi
@@ -2921,6 +2924,9 @@ function build_vtk
                         vopts="${vopts} -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT6_INSTALL_DIR}/bin/qmake"
                         vopts="${vopts} -DVTK_QT_VERSION=6"
                         vopts="${vopts} -DCMAKE_PREFIX_PATH=${QT6_INSTALL_DIR}/lib/cmake"
+                        vopts="${vopts} -DQt6CoreTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6CoreTools"
+                        vopts="${vopts} -DQt6GuiTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6GuiTools"
+                        vopts="${vopts} -DQt6WidgetsTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6WidgetsTools"
                     else
                         vopts="${vopts} -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_BIN_DIR}/qmake"
                         vopts="${vopts} -DVTK_QT_VERSION=5"


### PR DESCRIPTION
### Description

Modified the builds of qttools and qtsvg to use qt-configure-module for configuring instead of CMake.

There were issues building Qt 6 if there was a version installed on the system:
qttools would pick up some of the qtbase modules from the system instead of using the ones pointed to by Qt6_DIR passed to CMake.

Add use of Qt6CoreTools_DIR, Qt6GuiTools_DIR, and Qt6WidgetsTools_DIR to ensure that VTK utilizes only the Qt6 modules from the Qt6 that build_visit points to and not mix with other versions that might be on the system

Resolves build issues reported by customer building on Fedora40, where Qt 6.7.1 was installed in the system.

I updated the release notes with this change, and also previous changes I made for gcc 13.

### Type of change

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [X] Other~~ <!-- please explain with a note below -->
build_visit issues

### How Has This Been Tested?

Updated a fedora40 container to have Qt6 installed in the system, similar to what customer reported, then ran build_visit and verified Qt6 tools and svg compiled and installed correctly utilizing the qtbase modules created by build_visit, and ensured same for VTK.

Also ran build_visit on pascal with success.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
