### PR TITLE
Fix qt6 build issues when qt6 on system (#19618)

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -31,6 +31,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Removed the obsolete LLNL host profiles for RZTopaz, Surface and Vulcan.</li>
   <li>Fixed a bug where the LLNL host profiles for Boraxo, Dane and Ruby didn't get installed in some situations.</li>
   <li>Fixed a bug with rendering transparent surfaces with scalable rendering resulting in images with black horizontal bars or missing surface fragments.</li>
+  <li>Fixed issues with build_visit when using gcc-13 and when Qt6 is present on the system.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -439,19 +439,10 @@ function build_qt6_tools
     fi
 
     cd ${QT6_TOOLS_BUILD_DIR}
-    copts="-DQt6_DIR:PATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6"
-    copts="${copts} -DCMAKE_INSTALL_PREFIX:PATH=${QT6_INSTALL_DIR}"
-    copts="${copts} -DCMAKE_CXX_STANDARD:STRING=17"
-    copts="${copts} -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON"
-    info "qt6 tools options: $copts"
-    info "cmake_install ${CMAKE_INSTALL}"
-    info "cmake_command ${CMAKE_COMMAND}"
-    qt6_path="${CMAKE_INSTALL}:$PATH"
-    info "qt6 tools path: $qt6_path"
    
     info "Configuring Qt6 tools . . . "
-    env PATH="${qt6_path}" CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
-        ${CMAKE_COMMAND} ${copts} ../${QT6_TOOLS_SOURCE_DIR}
+    env CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
+        ${QT6_INSTALL_DIR}/bin/qt-configure-module  ../${QT6_TOOLS_SOURCE_DIR}
 
     info "Building Qt6 tools . . . "
     ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
@@ -492,19 +483,10 @@ function build_qt6_svg
     fi
 
     cd ${QT6_SVG_BUILD_DIR}
-    copts="-DQt6_DIR:PATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6"
-    copts="${copts} -DCMAKE_INSTALL_PREFIX:PATH=${QT6_INSTALL_DIR}"
-    copts="${copts} -DCMAKE_CXX_STANDARD:STRING=17"
-    copts="${copts} -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON"
-    info "qt6 svg options: $copts"
-    info "cmake_install ${CMAKE_INSTALL}"
-    info "cmake_command ${CMAKE_COMMAND}"
-    qt6_path="${CMAKE_INSTALL}:$PATH"
-    info "qt6 svg path: $qt6_path"
 
     info "Configuring Qt6 svg . . . "
-    env PATH="${qt6_path}" CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
-        ${CMAKE_COMMAND} ${copts} ../${QT6_SVG_SOURCE_DIR} 
+    env CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
+        ${QT6_INSTALL_DIR}/bin/qt-configure-module  ../${QT6_SVG_SOURCE_DIR}
 
     info "Building Qt6 svg . . . "
     ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1477,6 +1477,9 @@ function build_vtk
                 vopts="${vopts} -DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES"
                 if [[ "$DO_QT6" == "yes" ]]; then
                     vopts="${vopts} -DQt6_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6"
+                    vopts="${vopts} -DQt6CoreTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6CoreTools"
+                    vopts="${vopts} -DQt6GuiTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6GuiTools"
+                    vopts="${vopts} -DQt6WidgetsTools_DIR:FILEPATH=${QT6_INSTALL_DIR}/lib/cmake/Qt6WidgetsTools"
                 else
                     vopts="${vopts} -DQt5_DIR:FILEPATH=${QT_INSTALL_DIR}/lib/cmake/Qt5"
                 fi


### PR DESCRIPTION
* Modified the builds of qttools and qtsvg to use qt-configure-module for configuring instead of CMake. There were issues building Qt 6 if there was a version installed on the sytstem. qttools would pick up some of the qtbase modules from the system instead of using the ones pointed to by Qt6_DIR passed to CMake.

* Add use of Qt6CoreTools_DIR, Qt6GuiTools_DIR, and Qt6WidgetsTools_DIR to ensure that VTK utilizes only the Qt6 modules from the Qt6 that build_visit points to and not mix with other versions that might be on the system.

* Update release notes with recent fixes to build_visit.





