### PR TITLE
Fix launcher after moving version info to new header

### DIFF
--- a/src/bin/frontendlauncher.py
+++ b/src/bin/frontendlauncher.py
@@ -234,16 +234,25 @@ if os.path.exists(visitdir + "exe"):
     ver = ""
 
     # The version that we use for plugins. Since we have a development
-    # version, let's try to get the version from the VERSION file.
+    # version, let's try to get the version from various files it might
+    # be in. The files we look in here have grown as we've moved where
+    # we store VisIt version information.
     visitpluginver = ""
     VERSIONFILE = visitdir + "VERSION"
     VISIT_CONFIG_H = visitdir + "include" + os.path.sep + "visit-config.h"
+    VISIT_VERSION_H = visitdir + "include" + os.path.sep + "visit-version.h"
     if os.path.exists(VERSIONFILE):
         visitpluginver = open(VERSIONFILE).readlines()[0][:-1]
-    elif os.path.exists(VISIT_CONFIG_H):
+    if not visitpluginver and os.path.exists(VISIT_CONFIG_H):
         tok = "#define VISIT_VERSION"
         vline = [x for x in open(VISIT_CONFIG_H).readlines() if x.find(tok) == 0]
-        visitpluginver = vline[0][23:-2]
+        if vline:
+            visitpluginver = vline[0][23:-2]
+    if not visitpluginver and os.path.exists(VISIT_VERSION_H):
+        tok = "#define VISIT_VERSION"
+        vline = [x for x in open(VISIT_VERSION_H).readlines() if x.find(tok) == 0]
+        if vline:
+            visitpluginver = vline[0][23:-2]
 
     # We want to make sure we know if we are trying to launch a public
     # version from under a development version.  Keep track of this.

--- a/src/bin/frontendlauncher.py
+++ b/src/bin/frontendlauncher.py
@@ -234,9 +234,9 @@ if os.path.exists(visitdir + "exe"):
     ver = ""
 
     # The version that we use for plugins. Since we have a development
-    # version, let's try to get the version from various files it might
-    # be in. The files we look in here have grown as we've moved where
-    # we store VisIt version information.
+    # version, let's try to get the VisIt version from various files it might
+    # be in. The file cases we try here have grown as we've moved where we
+    # store VisIt version information.
     visitpluginver = ""
     VERSIONFILE = visitdir + "VERSION"
     VISIT_CONFIG_H = visitdir + "include" + os.path.sep + "visit-config.h"


### PR DESCRIPTION
### Description

Resolves #19643 

### Type of change

So, I *added* a new case to check for version info but I also adjusted the *existing* logic. The existing logic was if/elif and I made it if...if...if. So, it keeps walking through the if cases if `visitpluginver` remains false. I also had to protect the lines that read `vline[0][23:-2]` with whether `vline` is populated or not.

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Manually on my build and install

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
