### PR TITLE
Ensure layout switches to diff value during macOS screen blank hack

### DIFF
--- a/src/viewer/core/ViewerWindowManager.C
+++ b/src/viewer/core/ViewerWindowManager.C
@@ -4514,8 +4514,9 @@ ViewerWindowManager::SetWindowLayout(const int windowLayout)
     if (windowLayout == -5 && count < 2)
     {
         static int origlo = layout;
+        static int tmplo = layout==2?1:2;
         if (count == 0)
-            SetWindowLayout(2);
+            SetWindowLayout(tmplo);
         else if (count == 1)
             SetWindowLayout(origlo);
         count++;


### PR DESCRIPTION
On macOS, we sometimes get a blank viewer window. We momentarily switch layouts to fix this. 

The original code switched into layout 2 (from 1) and back. But, that won't work if VisIt is started up in layout 2.

This fixes that by switching to a layout 2 (if not already in 2) or layout 1 (if in 2) and then back.