### PR TITLE
Make qwt optional and allow use of system Qwt

### DIFF
--- a/src/CMake/FindQwt.cmake
+++ b/src/CMake/FindQwt.cmake
@@ -11,11 +11,10 @@
 #   Kathleen Biagas, Thu Feb  8 08:30:19 PST 2018
 #   Set QWT_LIBRARY to full path, for use in target_link_libraries.
 #
+#   Kathleen Biagas, Wed July 17, 2024
+#   Allow QWT to be optional.
+#
 #*****************************************************************************
-
-if(NOT EXISTS ${VISIT_QWT_DIR})
-    message(FATAL_ERROR "Qwt installation directory is not specified or does not exist")
-endif()
 
 if(APPLE)
     if(VISIT_STATIC)
@@ -29,9 +28,10 @@ else()
     SET_UP_THIRD_PARTY(QWT LIBS qwt)
 endif()
 
-if(NOT QWT_FOUND)
-    message(FATAL_ERROR "Qwt installation could not be used.")
+if(QWT_FOUND)
+    set(QWT_LIBRARY ${QWT_LIBRARY_DIR}/${QWT_LIB} CACHE FILEPATH "full path to qwt library" FORCE)
+else()
+    message(STATUS "Qwt installation could not be used.")
 endif()
 
-SET(QWT_LIBRARY ${QWT_LIBRARY_DIR}/${QWT_LIB} CACHE FILEPATH "full path to qwt library" FORCE)
 

--- a/src/CMake/FindQwt.cmake
+++ b/src/CMake/FindQwt.cmake
@@ -12,26 +12,55 @@
 #   Set QWT_LIBRARY to full path, for use in target_link_libraries.
 #
 #   Kathleen Biagas, Wed July 17, 2024
-#   Allow QWT to be optional.
+#   Allow QWT to be optional, and allow use of system version via
+#   new VISIT_USE_SYTEM_QWT option.
 #
 #*****************************************************************************
 
-if(APPLE)
-    if(VISIT_STATIC)
-        SET_UP_THIRD_PARTY(QWT LIBS qwt)
+if(VISIT_USE_SYSTEM_QWT)
+   find_path(QWT_INCLUDE_DIR qwt.h
+             PATH_SUFFIXES include
+                           include/qt6
+                           include/qt6/qwt)
+
+    find_library(QWT_LIBRARY
+             NAMES qwt qwt-qt6
+             PATH_SUFFIXES lib lib64)
+
+    find_package_handle_standard_args(QWT DEFAULT_MSG
+        QWT_INCLUDE_DIR
+        QWT_LIBRARY)
+
+    if(QWT_FOUND)
+        message(STATUS "Qwt include: ${QWT_INCLUDE_DIR}")
+        message(STATUS "Qwt library: ${QWT_LIBRARY}")
     else()
-        SET_UP_THIRD_PARTY(QWT
-            INCDIR lib/qwt.framework/Versions/Current/Headers
-            LIBS qwt)
+        message(STATUS "Qwt could not be found in the system.")
+    endif()
+
+elseif(VISIT_QWT_DIR)
+    if(APPLE)
+        if(VISIT_STATIC)
+            SET_UP_THIRD_PARTY(QWT LIBS qwt)
+        else()
+            SET_UP_THIRD_PARTY(QWT
+                INCDIR lib/qwt.framework/Versions/Current/Headers
+                LIBS qwt)
+        endif()
+    else()
+        SET_UP_THIRD_PARTY(QWT LIBS qwt)
+    endif()
+
+    if(QWT_FOUND)
+        set(QWT_LIBRARY ${QWT_LIBRARY_DIR}/${QWT_LIB} CACHE FILEPATH "full path to qwt library" FORCE)
+    else()
+        message(STATUS "Qwt installation (${VISIT_QWT_DIR}) could not be used.")
     endif()
 else()
-    SET_UP_THIRD_PARTY(QWT LIBS qwt)
+    message(STATUS "Qwt not requested.")
 endif()
 
 if(QWT_FOUND)
-    set(QWT_LIBRARY ${QWT_LIBRARY_DIR}/${QWT_LIB} CACHE FILEPATH "full path to qwt library" FORCE)
-else()
-    message(STATUS "Qwt installation could not be used.")
+    set(HAVE_QWT TRUE CACHE BOOL "Have Qwt library")
 endif()
-
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -41,6 +41,10 @@
 #   Kathleen Biagas, Tue May 5, 2023
 #   Disable qt6 forcing of defines for UNICODE.
 #
+#   Kathleen Biagas, Thu Jul 18, 2024
+#   QWT is now optional, so make StripChart classes dependent upon
+#   it being found.
+#
 #****************************************************************************
 
 SET(GUILIB_SOURCES
@@ -209,7 +213,7 @@ if(QWT_FOUND)
     list(APPEND GUILIB_SOURCES
         QvisStripChart.C
         QvisStripChartMgr.C
-        QvisStripChartTabWidget.C
+        QvisStripChartTabWidget.C)
 endif()
 
 IF (NOT WIN32)
@@ -254,9 +258,6 @@ ENDIF(VISIT_STATIC)
 
 #***************************** The gui library *******************************
 ADD_LIBRARY(gui ${GUILIB_SOURCES})
-if(QWT_FOUND)
-    target_compile_definitions(gui PUBLIC HAVE_QWT)
-endif()
 
 if(QT_VERSION VERSION_GREATER_EQUAL "6.2.0")
     qt6_disable_unicode_defines(gui)
@@ -283,7 +284,8 @@ ${GUI_QT_LIBS}
 )
 
 if(QWT_FOUND)
-    target_include_directories(gui ${QWT_INCLUDE_DIR})
+    target_compile_definitions(gui PUBLIC HAVE_QWT)
+    target_include_directories(gui PUBLIC ${QWT_INCLUDE_DIR})
     target_link_libraries(gui ${QWT_LIBRARY})
 endif()
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -181,9 +181,6 @@ QvisSimulationMessageWindow.C
 QvisSimulationWindow.C
 QvisSourceManagerWidget.C
 QvisSpectrumBar.C
-QvisStripChart.C
-QvisStripChartMgr.C
-QvisStripChartTabWidget.C
 QvisSubsetPanelItem.C
 QvisSubsetPanelWidget.C
 QvisSubsetWindow.C
@@ -208,6 +205,13 @@ WidgetDataNode.C
 mini3D.C
 )
 
+if(QWT_FOUND)
+    list(APPEND GUILIB_SOURCES
+        QvisStripChart.C
+        QvisStripChartMgr.C
+        QvisStripChartTabWidget.C
+endif()
+
 IF (NOT WIN32)
     # This keeps comm's exceptions visible when using -fvisibility=hidden
     ADD_DEFINITIONS(-DCOMM_EXPORTS)
@@ -225,9 +229,7 @@ ${VISIT_SOURCE_DIR}/viewer/proxy
 ${VISIT_SOURCE_DIR}/viewer/rpc
 ${VISIT_SOURCE_DIR}/winutil
 ${VISIT_SOURCE_DIR}/third_party_builtin
-${QWT_INCLUDE_DIR}
 )
-LINK_DIRECTORIES(${LIBRARY_OUTPUT_DIRECTORY} )
 
 SET(GUI_QT_LIBS
 ${QT_QTUITOOLS_LIBRARY}
@@ -252,6 +254,9 @@ ENDIF(VISIT_STATIC)
 
 #***************************** The gui library *******************************
 ADD_LIBRARY(gui ${GUILIB_SOURCES})
+if(QWT_FOUND)
+    target_compile_definitions(gui PUBLIC HAVE_QWT)
+endif()
 
 if(QT_VERSION VERSION_GREATER_EQUAL "6.2.0")
     qt6_disable_unicode_defines(gui)
@@ -261,8 +266,11 @@ set_target_properties(gui PROPERTIES AUTOMOC ON)
 
 IF (WIN32)
     SET_TARGET_PROPERTIES(gui PROPERTIES OUTPUT_NAME guilib)
-    SET_TARGET_PROPERTIES(gui PROPERTIES COMPILE_DEFINITIONS QWT_DLL)
+    if(QWT_FOUND)
+        SET_TARGET_PROPERTIES(gui PROPERTIES COMPILE_DEFINITIONS QWT_DLL)
+    endif()
 ENDIF (WIN32)
+
 TARGET_LINK_LIBRARIES(gui 
 viewerrpc
 viewerproxy
@@ -272,8 +280,12 @@ mdserverproxy
 avtdbatts
 winutil
 ${GUI_QT_LIBS}
-${QWT_LIBRARY}
 )
+
+if(QWT_FOUND)
+    target_include_directories(gui ${QWT_INCLUDE_DIR})
+    target_link_libraries(gui ${QWT_LIBRARY})
+endif()
 
 IF(APPLE)
     SET_TARGET_PROPERTIES(gui 

--- a/src/gui/QvisSimulationWindow.C
+++ b/src/gui/QvisSimulationWindow.C
@@ -89,7 +89,9 @@ QvisSimulationWindow::QvisSimulationWindow(EngineList *engineList,
     uiValues = NULL;
     CustomUIWindow = NULL;
     uiLoader = new QvisUiLoader;
+#ifdef HAVE_QWT
     stripChartMgr = 0;
+#endif
     simMessages = 0;
 }
 
@@ -123,7 +125,9 @@ QvisSimulationWindow::~QvisSimulationWindow()
     if (uiValues)
         uiValues->Detach(this);
 
+#ifdef HAVE_QWT
     delete stripChartMgr;
+#endif
 }
 
 // ****************************************************************************
@@ -1244,6 +1248,7 @@ QvisSimulationWindow::UpdateWindow(bool doAll)
             clearMessages();
           }
 
+#ifdef HAVE_QWT
           else if(uiValues->GetName() == "STRIP_CHART_CLEAR_ALL")
           {
             stripChartMgr->clearAll();
@@ -1317,6 +1322,7 @@ QvisSimulationWindow::UpdateWindow(bool doAll)
 
             stripChartMgr->addDataPoints(chart, curve, npts, x, y);
           }
+#endif
           else if(CustomUIWindow != 0)
           {
             UpdateUIComponent(CustomUIWindow,
@@ -2365,7 +2371,9 @@ QvisSimulationWindow::closeEngine()
                              QMessageBox::Ok | QMessageBox::Cancel) ==
         QMessageBox::Ok)
     {
+#ifdef HAVE_QWT
         stripChartMgr->clearAll();
+#endif
 
         // Close the engine.
         GetViewerMethods()->CloseComputeEngine(host, sim);
@@ -2492,8 +2500,10 @@ QvisSimulationWindow::executePushButtonCommand(const QString &btncmd)
                                QMessageBox::Ok | QMessageBox::Cancel) ==
           QMessageBox::Cancel)
         return;
+#ifdef HAVE_QWT
       else
         stripChartMgr->clearAll();
+#endif
     }
 
     QString cmd(btncmd);

--- a/src/gui/QvisSimulationWindow.C
+++ b/src/gui/QvisSimulationWindow.C
@@ -16,9 +16,11 @@
 
 #include <QvisSimulationCommandWindow.h>
 #include <QvisSimulationMessageWindow.h>
-#include <QvisStripChartMgr.h>
-#include <QvisStripChartTabWidget.h>
-#include <QvisStripChart.h>
+#ifdef HAVE_QWT
+  #include <QvisStripChartMgr.h>
+  #include <QvisStripChartTabWidget.h>
+  #include <QvisStripChart.h>
+#endif
 #include <QvisNotepadArea.h>
 #include <QvisUiLoader.h>
 #include <SimCommandSlots.h>
@@ -237,11 +239,13 @@ QvisSimulationWindow::CreateWindowContents()
         tr("Messages"), notepadAux);
     simMessages->post();
 
+#ifdef HAVE_QWT
     // Create the strip chart manager and post it to the notepad.
     int index = GetEngineListIndex(activeEngine);
     stripChartMgr =
       new QvisStripChartMgr(this, GetViewerProxy(), engines, index, notepadAux);
     stripChartMgr->post();
+#endif
 
     // Make sure we show the commands page.
     notepadAux->showPage(simCommands);
@@ -483,8 +487,9 @@ QvisSimulationWindow::CreateCustomUIWindow()
         }
 
         simCommands->setCustomButtonEnabled(false);
-
+#ifdef HAVE_QWT
         clearStripCharts();
+#endif
 
         return;
     }
@@ -1030,7 +1035,9 @@ QvisSimulationWindow::UpdateWindow(bool doAll)
           }
 
           clearMessages();
+#ifdef HAVE_QWT
           clearStripCharts();
+#endif
         }
 
         // Add the engines to the widget.
@@ -1826,6 +1833,7 @@ QvisSimulationWindow::clearMessages()
 // Modifications:
 //
 // ****************************************************************************
+#ifdef HAVE_QWT
 void
 QvisSimulationWindow::clearStripCharts()
 {
@@ -1838,6 +1846,7 @@ QvisSimulationWindow::clearStripCharts()
         stripChartMgr->setCurveTitle(i, j, "" );
     }
 }
+#endif
 
 // ****************************************************************************
 // Method: QvisSimulationWindow::MakeKey
@@ -2254,7 +2263,9 @@ QvisSimulationWindow::selectEngine(int index)
 {
     // Clear the message and strip charts.
     clearMessages();
+#ifdef HAVE_QWT
     clearStripCharts();
+#endif
 
     // Get the new active engine.
     activeEngine = MakeKey(engines->GetEngineName()[index],
@@ -2627,6 +2638,7 @@ QvisSimulationWindow::executeStopCommand(const QString &value)
 //    command string.
 //
 // ****************************************************************************
+#ifdef HAVE_QWT
 void
 QvisSimulationWindow::setStripChartVar(const QString &value)
 {
@@ -2641,3 +2653,4 @@ QvisSimulationWindow::setStripChartVar(const QString &value)
     QString args(QString("triggered();%1;QMenu;Simulations;%2").arg(cmd).arg(value));
     GetViewerMethods()->SendSimulationCommand(host, sim, cmd.toStdString(), args.toStdString());
 }
+#endif

--- a/src/gui/QvisSimulationWindow.h
+++ b/src/gui/QvisSimulationWindow.h
@@ -28,7 +28,9 @@ class QTreeWidget;
 
 class QvisSimulationCommandWindow;
 class QvisSimulationMessageWindow;
+#ifdef HAVE_QWT
 class QvisStripChartMgr;
+#endif
 class QvisUiLoader;
 
 class EngineList;
@@ -132,7 +134,9 @@ private slots:
     void interruptEngine();
     void selectEngine(int index);
     void clearMessages();
+#ifdef HAVE_QWT
     void clearStripCharts();
+#endif
     void clearCache();
     void showCustomUIWindow();
     void executePushButtonCommand(const QString &cmd);
@@ -142,7 +146,9 @@ private slots:
     void executeStepCommand(const QString &value);
 
 public:
+#ifdef HAVE_QWT
     void setStripChartVar(const QString &value);
+#endif
 
 private:
     EngineList           *engines;
@@ -164,7 +170,9 @@ private:
     QPushButton        *clearCacheButton;
     QWidget            *CustomUIWindow;
     QvisUiLoader       *uiLoader;
+#ifdef HAVE_QWT
     QvisStripChartMgr  *stripChartMgr;
+#endif
     QvisSimulationCommandWindow  *simCommands;
     QvisSimulationMessageWindow  *simMessages;
 

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -71,6 +71,9 @@
 /* Define if you have Conduit. */
 #cmakedefine HAVE_CONDUIT
 
+/* Define if you have Qwt. */
+#cmakedefine HAVE_QWT 
+
 
 /*******************************************************************************
  * Header file checks

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -50,7 +50,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Updated Conduit to 0.9.2.</li>
   <li>Docker containers were added for RockyLinux (RHEL compatible).</li>
-  <li>Qwt is now optional. Add --qwt to the build_visit command line to build qwt. Add --system-qwt to have VisIt attempt to find and use a system version of Qwt.  Add --alt-qwt-dir /path/to/qwt/install to use a pre-built version of Qwt installed somewhere else.</li>
+  <li>Qwt is now optional. Historically, it has only ever been needed for advanced GUI features of LibSimV2 interface. Add <code>--qwt</code> to the build_visit command line to build qwt. Add <code>--system-qwt</code> to have VisIt attempt to find and use a system version of Qwt.  Add <code>--alt-qwt-dir /path/to/qwt/install</code> to use a pre-built version of Qwt installed somewhere else.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -49,7 +49,8 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.4.2</font></b></p>
 <ul>
   <li>Updated Conduit to 0.9.2.</li>
-  <li>Docker containers were added for RockyLinux (RHEL compatible).
+  <li>Docker containers were added for RockyLinux (RHEL compatible).</li>
+  <li>Qwt is now optional. Add --qwt to the build_visit command line to build qwt. Add --system-qwt to have VisIt attempt to find and use a system version of Qwt.  Add --alt-qwt-dir /path/to/qwt/install to use a pre-built version of Qwt installed somewhere else.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -7,7 +7,6 @@
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
             <lib name="qt6"/>
             <lib name="qt"/>
-            <lib name="qwt"/>
             <lib name="zlib"/>
         </required>
 
@@ -44,6 +43,7 @@
             <lib name="ospray"/>
             <lib name="pidx"/>
             <lib name="pyside"/>
+            <lib name="qwt"/>
             <lib name="silo"/>
             <lib name="stripack"/>
             <lib name="szip"/>
@@ -60,7 +60,6 @@
             <lib name="vtk"/> <!-- <lib name="vtk" reqdeps="cmake vtk" optdeps="qt mesagl"/> -->
             <lib name="qt6"/>
             <lib name="qt"/>
-            <lib name="qwt"/>
             <lib name="zlib"/>
         </group>
 
@@ -91,6 +90,7 @@
             <lib name="ospray"/>
             <lib name="pidx"/>
             <lib name="pyside"/>
+            <lib name="qwt"/>
             <lib name="silo"/>
             <lib name="szip"/>
             <lib name="tbb"/>
@@ -103,7 +103,6 @@
             <lib name="no-python"/>
             <lib name="no-qt6" />
             <lib name="no-qt" />
-            <lib name="no-qwt" />
             <lib name="no-vtk"/>
             <lib name="no-zlib"/>
         </group>
@@ -195,7 +194,6 @@
             <lib name="vtk"/>
             <lib name="qt6"/>
             <lib name="qt"/>
-            <lib name="qwt"/>
             <lib name="zlib"/>
         </required>
 
@@ -212,6 +210,7 @@
             <lib name="mpich"/>
             <lib name="osmesa"/>
             <lib name="pyqt"/>
+            <lib name="qwt"/>
             <lib name="uintah"/>
             <lib name="damaris"/>
             <lib name="xercesc"/>
@@ -225,7 +224,6 @@
             <lib name="vtk"/>
             <lib name="qt6"/>
             <lib name="qt"/>
-            <lib name="qwt"/>
             <lib name="zlib"/>
         </group>
 
@@ -234,6 +232,7 @@
             <lib name="hdf5"/>
             <lib name="netcdf"/>
             <lib name="mpich"/>
+            <lib name="qwt"/>
             <lib name="szip"/>
             <lib name="uintah"/>
             <lib name="damaris"/>
@@ -247,7 +246,6 @@
             <lib name="no-python"/>
             <lib name="no-qt6" />
             <lib name="no-qt" />
-            <lib name="no-qwt" />
             <lib name="no-vtk"/>
             <lib name="no-zlib"/>
         </group>

--- a/src/tools/dev/scripts/run-build-visit
+++ b/src/tools/dev/scripts/run-build-visit
@@ -176,7 +176,7 @@ then
    export PATH=/usr/gapps/gcc/gcc-9.1/bin:$PATH
    env CC=/usr/gapps/gcc/gcc-9.1/bin/gcc CXX=/usr/gapps/gcc/gcc-9.1/bin/g++ \
    ./$build_visit_script --group ${dest_group} --required --optional --parallel \
-    --mpich --mesagl --uintah --vtk9 --no-adios2 --no-moab --no-visit --makeflags -j4 \
+    --mpich --mesagl --uintah --vtk9 --qwt --no-adios2 --no-moab --no-visit --makeflags -j4 \
     --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.mesagl
    # just in case perms
@@ -208,7 +208,7 @@ then
    export PATH=/usr/gapps/gcc/gcc-9.1/bin:$PATH
    env CC=/usr/gapps/gcc/gcc-9.1/bin/gcc CXX=/usr/gapps/gcc/gcc-9.1/bin/g++ \
    ./$build_visit_script --group ${dest_group} --skip-opengl-context-check --required --optional \
-    --parallel --mpich --osmesa --uintah --vtk9 --no-adios2 --no-moab --no-visit --makeflags -j4 \
+    --parallel --mpich --osmesa --uintah --vtk9 --qwt --no-adios2 --no-moab --no-visit --makeflags -j4 \
     --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.opengl
    # just in case perms
@@ -238,7 +238,7 @@ then
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/include \
        ./$build_visit_script --group ${dest_group} --required --optional --mesagl --uintah --parallel\
-       --qt6 --no-pyside --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
+       --qt6 --qwt --no-pyside --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.poodle
    # just in case perms
    echo "changing permissions of ${dest_dir}"
@@ -269,7 +269,7 @@ then
        PAR_INCLUDE=-I/usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/include \
        ./${build_visit_script} --group ${dest_group} --required --optional --mesagl --uintah \
        --no-gdal --no-openexr --no-embree --no-ispc --no-tbb --no-pidx \
-       --no-ospray --parallel --qt --vtk9 --no-pyside --no-visit --no-boost --makeflags -j16 \
+       --no-ospray --parallel --qt --qwt --vtk9 --no-pyside --no-visit --no-boost --makeflags -j16 \
        --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.lassen
    # just in case perms
@@ -299,7 +299,7 @@ then
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/include \
        ./$build_visit_script --group ${dest_group} --required --optional --mesagl --uintah --parallel\
-        --qt6 --no-pyside --no-gdal --no-visit --makeflags -j20 \
+        --qt6 --qwt --no-pyside --no-gdal --no-visit --makeflags -j20 \
         --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.rzwhippet
    # just in case perms
@@ -329,7 +329,7 @@ then
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/include \
        ./$build_visit_script --group ${dest_group} --required --optional --mesagl --uintah --parallel \
-       --qt6 --no-pyside --no-gdal --no-visit --makeflags -j16 --thirdparty-path ${dest_dir} 
+       --qt6 --qwt --no-pyside --no-gdal --no-visit --makeflags -j16 --thirdparty-path ${dest_dir} 
    mv ${build_visit_script}_log ${build_visit_script}_log.rztopaz
    # just in case perms
    echo "changing permissions of ${dest_dir}"
@@ -358,7 +358,7 @@ then
        PAR_COMPILER_CXX=/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/include \
        ./$build_visit_script --group ${dest_group} --required --optional --mesagl --uintah --parallel \
-       --qt6 --no-pyside --no-gdal --no-uintah --no-visit --makeflags -j24 --thirdparty-path ${dest_dir} 
+       --qt6 --qwt --no-pyside --no-gdal --no-uintah --no-visit --makeflags -j24 --thirdparty-path ${dest_dir} 
    mv ${build_visit_script}_log ${build_visit_script}_log.rzvernal
    # just in case perms
    echo "changing permissions of ${dest_dir}"
@@ -394,7 +394,7 @@ then
        PAR_INCLUDE=-I/opt/cray/pe/mpt/7.7.20/gni/mpich-gnu/8.2/include \
        PAR_LIBS="-L/opt/cray/pe/mpt/7.7.20/gni/mpich-gnu/8.2/lib -Wl,-rpath=/opt/cray/pe/mpt/7.7.20/gni/mpich-gnu/8.2/lib -lmpich" \
        ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
-       --no-adios --no-adios2 --no-mili --no-pyside --qt510 --no-visit \
+       --no-adios --no-adios2 --no-mili --no-pyside --qt510 --qwt --no-visit \
        --makeflags -j16 --thirdparty-path ${dest_dir}
    mv ${build_visit_script}_log ${build_visit_script}_log.trinity
    # just in case perms


### PR DESCRIPTION
### Description

Resolves #19548

* Updated modules.xml to move qwt out of the required lists and into optional.

* Added `--system-qwt` to the bv_qwt.sh command-line options. It writes `option(VISIT_USE_SYSTEM_QWT "Use system version of Qwt" ON)` to the host config-site file, and nothing else. Modified logic to ensure downloads don't happen if --system-qwt or --alt-qwt-dir are used.

* Added `--qwt` to the build_visit invocations in `run-build-visit`

* Modified gui so that StripChart related classes are only included in the build if Qwt is Found.
* Modified Simulation window to have StripChart related logic bracked by #ifdef HAVE_QWT ... #endif

* Modified FindQwt to use CMake's  `find_path` and `find_library` logic if VISIT_USE_SYSTEM_QWT is set. The PATH_SUFFIXES used are those I found helpful on Fedora 40. Removed FATAL_ERROR messages if Qwt not found.
* Updated release notes.

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->
Develop/build changes.

### How Has This Been Tested?
build_visit_tests:
* I ran build_visit without any qwt references to ensure no qwt files downloaded, and no references to QWT added to the host config-site file.

* I ran build_visit with --system-qwt to ensure no qwt files downloaded and the new VISIT_USE_SYSTEM_QWT line was added to the config-site file.

* I ran build_visit with --alt-qwt-dir /path/to/visits/341/qwt  (I used full path to qwt already build for visit 3.4.1) and ensured no qwt files were downloaded, and the correct entry was made to the config-site file.

* I ran build_visit with --qwt to enure qwt properly downloaded and built

visit build tests:
* Modified poodle config-site file to contain no QWT entries. VisIt built correctly and gui ran with no errors.

* I ran the Fedora40 container, installed qwt-qt6, and modified the config-site file there to contain VISIT_USE_SYSTEM_QWT entry.  CMake correctly found the header files and library. 


### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
