### PR TITLE
Fix label for unknown zones in zonetype label expression

### DIFF
--- a/src/avt/Expressions/General/avtZoneTypeLabelExpression.C
+++ b/src/avt/Expressions/General/avtZoneTypeLabelExpression.C
@@ -76,6 +76,9 @@ avtZoneTypeLabelExpression::~avtZoneTypeLabelExpression()
 //    Made val 8 characters long to avoid a compiler error on Power 9 systems
 //    with gcc.
 //
+//    Mark C. Miller, Wed Jul 24 09:17:46 PDT 2024
+//    Make default value 'unk' instead of '" ? "'
+//
 // ****************************************************************************
 
 #define SET_VAL(STR) strncpy(val, #STR, sizeof(val))
@@ -97,7 +100,7 @@ avtZoneTypeLabelExpression::DeriveVariable(vtkDataSet *in_ds, int currentDomains
         // loop body.
         //
         char val[8];
-        SET_VAL(" ? ");
+        SET_VAL(unk);
         switch (in_ds->GetCellType(i))
         {
             // 2D cell types, lower case letters

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -33,6 +33,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with rendering transparent surfaces with scalable rendering resulting in images with black horizontal bars or missing surface fragments.</li>
   <li>Fixed issues with build_visit when using gcc-13 and when Qt6 is present on the system.</li>
   <li>Fixed bug with Volume plot when SILRestriction applied, and when Composite rendering caused problem when a different RendererType used directly afterwards.</li>
+  <li>Fixed a bug in zonetype-label expression where unknown zone types would render a weird symbol, <code>&quot;?</code>.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -104,7 +104,7 @@ function check_minimum_compiler_version()
         echo "apple clang version $VERSION"
         testvercomp $VERSION 5.0 '<'
         if [[ $? == 0 ]] ; then
-            echo "Need clang++ version >= 0.0"
+            echo "Need clang++ version >= 5.0"
             exit 1
         fi
     elif [[ "$CXX_COMPILER" == "clang++" ]] ; then 


### PR DESCRIPTION
### Description

Resolves #19523  

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
