### PR TITLE
Disable SEG msg

### DIFF
--- a/src/avt/DBAtts/MetaData/avtDatabaseMetaData.C
+++ b/src/avt/DBAtts/MetaData/avtDatabaseMetaData.C
@@ -7547,7 +7547,10 @@ avtDatabaseMetaData::GetSEGWarningString() const
 void
 avtDatabaseMetaData::IssueSEGWarningMessage() const
 {
+#if 0
+    // Disabled this warning message July 24, 2024
     IssueWarning(GetSEGWarningString());
+#endif
 }
 
 // ****************************************************************************

--- a/src/avt/DBAtts/MetaData/avtDatabaseMetaData.code
+++ b/src/avt/DBAtts/MetaData/avtDatabaseMetaData.code
@@ -3985,7 +3985,10 @@ Definition:
 void
 avtDatabaseMetaData::IssueSEGWarningMessage() const
 {
+#if 0
+    // Disabled this warning message July 24, 2024
     IssueWarning(GetSEGWarningString());
+#endif
 }
 
 Function: ShouldDisableSEG

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -2260,3 +2260,9 @@ It will cause expressions in its list to be evaluated at the time of it's own ex
 
 Automatic expressions
 ~~~~~~~~~~~~~~~~~~~~~
+
+For databases with small numbers of variables, VisIt_ will create several convenient expressions automatically.
+For example, for every *vector* variable, it will create vector magnitude expressions.
+However, for databases with a large number of variables (say more than 1000), this process of *speculative* expression generation can become onerous and a performance issue.
+So, it is disabled for databases for large numbers of variables.
+If users encounter a situation where speculative expression generation was skipped and they really, really want it and are willing to suffer through whatever the associated performance cost may be, they can exit VisIt_ and set an environment variable, ``VISIT_FORCE_SPECULATIVE_EXPRESSION_GENERATION`` and re-launch VisIt_ with that variable set.

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -2257,7 +2257,6 @@ In cases where an expression involves the *output* of an operator, or the operat
 The :ref:`DeferExpression operator` is designed for this purpose.
 It will cause expressions in its list to be evaluated at the time of it's own execution in the pipeline.
 
-
 Automatic expressions
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/doc/using_visit/Quantitative/Expressions.rst
+++ b/src/doc/using_visit/Quantitative/Expressions.rst
@@ -2265,4 +2265,5 @@ For databases with small numbers of variables, VisIt_ will create several conven
 For example, for every *vector* variable, it will create vector magnitude expressions.
 However, for databases with a large number of variables (say more than 1000), this process of *speculative* expression generation can become onerous and a performance issue.
 So, it is disabled for databases for large numbers of variables.
-If users encounter a situation where speculative expression generation was skipped and they really, really want it and are willing to suffer through whatever the associated performance cost may be, they can exit VisIt_ and set an environment variable, ``VISIT_FORCE_SPECULATIVE_EXPRESSION_GENERATION`` and re-launch VisIt_ with that variable set.
+If users encounter a situation where speculative expression generation was skipped and they really, really want it and are willing to suffer through whatever the associated performance cost may be, they can exit VisIt_ and set an environment variable, ``VISIT_FORCE_SPECULATIVE_EXPRESSION_GENERATION`` and re-launch VisIt_ with that variable set to a non-zero integer value.
+If a user is running client/server, this environment variable will need to be set on both client and server.

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -34,6 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed issues with build_visit when using gcc-13 and when Qt6 is present on the system.</li>
   <li>Fixed bug with Volume plot when SILRestriction applied, and when Composite rendering caused problem when a different RendererType used directly afterwards.</li>
   <li>Fixed a bug in zonetype-label expression where unknown zone types would render a weird symbol, <code>&quot;?</code>.</li>
+  <li>Disabled warning message regarding skipping of speculative expression generation for databases with many variables.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -34,7 +34,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed issues with build_visit when using gcc-13 and when Qt6 is present on the system.</li>
   <li>Fixed bug with Volume plot when SILRestriction applied, and when Composite rendering caused problem when a different RendererType used directly afterwards.</li>
   <li>Fixed a bug in zonetype-label expression where unknown zone types would render a weird symbol, <code>&quot;?</code>.</li>
-  <li>Disabled warning message regarding skipping of speculative expression generation for databases with many variables.</li>
+  <li>Disabled warning message regarding skipping of speculative expression generation for databases with many variables. For more information, read our documentation about <a href="https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/using_visit/Quantitative/Expressions.html#automatic-expressions">automatic expressions</a>.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/viewer/core/actions/DatabaseActions.C
+++ b/src/viewer/core/actions/DatabaseActions.C
@@ -245,10 +245,13 @@ DatabaseActionBase::OpenDatabaseHelper(const std::string &entireDBName,
                                                                forcedFileType);
     if (mdptr != NULL)
     {
+#if 0
+        // Disabled this warning message July 24, 2024
         if (mdptr->ShouldDisableSEG(Environment::exists(mdptr->GetSEGEnvVarName())))
         {
             GetViewerMessaging()->Warning(mdptr->GetSEGWarningString());
         }
+#endif
 
         avtDatabaseMetaData md(*mdptr);
 


### PR DESCRIPTION
### Description

Resolves #19424 <!-- If this PR is unrelated to a ticket, please erase this line -->

This just disables the error message itself. One can still override the behavior with the env. variable.

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other: disables error message regarding speculative expression generation (SEG)

### How Has This Been Tested?

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
