### PR TITLE
Bugfix/biagas/replace minmax macros

### DIFF
--- a/src/avt/Database/Ghost/StructuredBoundary.C
+++ b/src/avt/Database/Ghost/StructuredBoundary.C
@@ -6,10 +6,8 @@
 #include <VisItException.h>
 #include <vtkStructuredGrid.h>
 
+#include <algorithm>
 #include <vector>
-
-#define BNDMIN(A,B) (((A) < (B)) ? (A) : (B))
-#define BNDMAX(A,B) (((A) > (B)) ? (A) : (B))
 
 // ****************************************************************************
 //  Function:  CalculateIndex
@@ -28,9 +26,9 @@
 inline static int
 CalculateIndex(int *e, int *d, int i, int j, int k)
 {
-    i = BNDMIN(BNDMAX(i, e[0]), e[1]);
-    j = BNDMIN(BNDMAX(j, e[2]), e[3]);
-    k = BNDMIN(BNDMAX(k, e[4]), e[5]);
+    i = std::min(std::max(i, e[0]), e[1]);
+    j = std::min(std::max(j, e[2]), e[3]);
+    k = std::min(std::max(k, e[4]), e[5]);
     if (d[2] == 1)
         return                  (j-e[2]) *d[0] + (i-e[0]);
     else
@@ -56,9 +54,9 @@ Boundary::SetExtents(int e[6])
     oldndims[0]    = e[1] - e[0] + 1;
     oldndims[1]    = e[3] - e[2] + 1;
     oldndims[2]    = e[5] - e[4] + 1;
-    oldzdims[0]    = BNDMAX(e[1] - e[0], 1);
-    oldzdims[1]    = BNDMAX(e[3] - e[2], 1);
-    oldzdims[2]    = BNDMAX(e[5] - e[4], 1);
+    oldzdims[0]    = std::max(e[1] - e[0], 1);
+    oldzdims[1]    = std::max(e[3] - e[2], 1);
+    oldzdims[2]    = std::max(e[5] - e[4], 1);
 
     oldnpts        = oldndims[0] * oldndims[1] * oldndims[2];
     oldncells      = oldzdims[0] * oldzdims[1] * oldzdims[2];
@@ -71,11 +69,11 @@ Boundary::SetExtents(int e[6])
     oldnextents[5] = e[5];
 
     oldzextents[0] = e[0];
-    oldzextents[1] = BNDMAX(e[1]-1, e[0]);
+    oldzextents[1] = std::max(e[1]-1, e[0]);
     oldzextents[2] = e[2];
-    oldzextents[3] = BNDMAX(e[3]-1, e[2]);
+    oldzextents[3] = std::max(e[3]-1, e[2]);
     oldzextents[4] = e[4];
-    oldzextents[5] = BNDMAX(e[5]-1, e[4]);
+    oldzextents[5] = std::max(e[5]-1, e[4]);
 
     expand[0]      = 0;
     expand[1]      = 0;
@@ -134,9 +132,9 @@ Boundary::AddNeighbor(int d, int mi, int o[3], int e[6],
     n.ndims[0]   = e[1] - e[0] + 1;
     n.ndims[1]   = e[3] - e[2] + 1;
     n.ndims[2]   = e[5] - e[4] + 1;
-    n.zdims[0]   = BNDMAX(e[1] - e[0], 1);
-    n.zdims[1]   = BNDMAX(e[3] - e[2], 1);
-    n.zdims[2]   = BNDMAX(e[5] - e[4], 1);
+    n.zdims[0]   = std::max(e[1] - e[0], 1);
+    n.zdims[1]   = std::max(e[3] - e[2], 1);
+    n.zdims[2]   = std::max(e[5] - e[4], 1);
     n.npts       = n.ndims[0] * n.ndims[1] * n.ndims[2];
     n.ncells     = n.zdims[0] * n.zdims[1] * n.zdims[2];
 
@@ -148,11 +146,11 @@ Boundary::AddNeighbor(int d, int mi, int o[3], int e[6],
     n.nextents[5] = e[5];
 
     n.zextents[0] = e[0];
-    n.zextents[1] = BNDMAX(e[1]-1, e[0]);
+    n.zextents[1] = std::max(e[1]-1, e[0]);
     n.zextents[2] = e[2];
-    n.zextents[3] = BNDMAX(e[3]-1, e[2]);
+    n.zextents[3] = std::max(e[3]-1, e[2]);
     n.zextents[4] = e[4];
-    n.zextents[5] = BNDMAX(e[5]-1, e[4]);
+    n.zextents[5] = std::max(e[5]-1, e[4]);
 
     n.type = NONE;
     // ---- I ----

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -28,6 +28,7 @@
 #include <DebugStream.h>
 #include <VisItException.h>
 
+#include <algorithm>
 #include <set>
 #include <map>
 
@@ -864,10 +865,6 @@ avtUnstructuredDomainBoundaries::ExchangeMaterial(vector<int>    domainNum,
 //
 // ****************************************************************************
 
-#ifndef MIN
-#define MIN(A,B) ((A)>(B)?(B):(A))
-#endif
-
 vector<avtMaterial*>
 avtUnstructuredDomainBoundaries::ExchangeMixedMaterials(vector<int> domainNum,
                                                      vector<avtMaterial*> mats)
@@ -910,23 +907,23 @@ avtUnstructuredDomainBoundaries::ExchangeMixedMaterials(vector<int> domainNum,
         //
         int         *new_matlist  = new int[newNCells];
         const int   *old_matlist  = mats[i]->GetMatlist();
-        memcpy(new_matlist, old_matlist, sizeof(int)*MIN(oldNCells,newNCells));
+        memcpy(new_matlist, old_matlist, sizeof(int)*std::min(oldNCells,newNCells));
 
         int         *new_mix_next = new int[newMixlen];
         const int   *old_mix_next = mats[i]->GetMixNext();
-        memcpy(new_mix_next, old_mix_next, sizeof(int)*MIN(oldMixlen,newMixlen));
+        memcpy(new_mix_next, old_mix_next, sizeof(int)*std::min(oldMixlen,newMixlen));
 
         int         *new_mix_mat  = new int[newMixlen];
         const int   *old_mix_mat  = oldMat->GetMixMat();
-        memcpy(new_mix_mat, old_mix_mat, sizeof(int)*MIN(oldMixlen,newMixlen));
+        memcpy(new_mix_mat, old_mix_mat, sizeof(int)*std::min(oldMixlen,newMixlen));
 
         float       *new_mix_vf   = new float[newMixlen];
         const float *old_mix_vf   = oldMat->GetMixVF();
-        memcpy(new_mix_vf, old_mix_vf, sizeof(float)*MIN(oldMixlen,newMixlen));
+        memcpy(new_mix_vf, old_mix_vf, sizeof(float)*std::min(oldMixlen,newMixlen));
 
         int         *new_mix_zone = new int[newMixlen];
         const int   *old_mix_zone = oldMat->GetMixZone();
-        memcpy(new_mix_zone, old_mix_zone, sizeof(int)*MIN(oldMixlen,newMixlen));
+        memcpy(new_mix_zone, old_mix_zone, sizeof(int)*std::min(oldMixlen,newMixlen));
 
         //
         // Now copy over the ghost information.  By iterating over the

--- a/src/avt/Expressions/General/avtResradExpression.C
+++ b/src/avt/Expressions/General/avtResradExpression.C
@@ -215,6 +215,7 @@ avtResradExpression::DoOperation(vtkDataArray *in1, vtkDataArray *in2,
 
 #include <stdlib.h>
 #include <math.h>
+#include <algorithm>
 
 #define NPG   200
 #define NGPS  2000
@@ -224,13 +225,6 @@ avtResradExpression::DoOperation(vtkDataArray *in1, vtkDataArray *in2,
 #define RES(k,j)    res[((j)+8)*(NRES+NRES+1)+((k)+8)]
 #define VAR(i,j)    var[((j)-1)*nxvar+((i)-1)]
 #define NEWVAR(i,j) newvar[((j)-1)*nxvar+((i)-1)]
-
-#ifndef MIN
-#define MIN(a,b) ((a < b) ? a : b)
-#endif
-#ifndef MAX
-#define MAX(a,b) ((a > b) ? a : b)
-#endif
 
 static double    res[(NRES+NRES+1)*(NRES+NRES+1)];
 static int       kx [NPG], jy [NPG];
@@ -392,11 +386,11 @@ varres (T *var, T *newvar, int nxvar, int nyvar, int reflflag,
       * Calculate resolution effect on var
       */
      for (jj = -jext; jj <= jext; jj++) {
-          j2 = MIN (nyvar, nyvar - jj);
+          j2 = std::min(nyvar, nyvar - jj);
 
           for (kk = -kext; kk <= kext; kk++) {
-               k1 = MAX (1, 1 - kk);
-               k2 = MIN (nxvar, nxvar - kk);
+               k1 = std::max(1, 1 - kk);
+               k2 = std::min(nxvar, nxvar - kk);
 
                for (j = 1; j <= j2; j++) {
                     jm = j + jj;

--- a/src/avt/Filters/avtOSPRayCommon.h
+++ b/src/avt/Filters/avtOSPRayCommon.h
@@ -279,12 +279,6 @@ namespace ospray {
 #ifndef CLAMP
 # define CLAMP(x, l, h) (x > l ? x < h ? x : h : l)
 #endif
-#ifndef M_MIN
-# define M_MIN(x, r) (x < r ? x : r)
-#endif
-#ifndef M_MAX
-# define M_MAX(x, r) (x > r ? x : r)
-#endif
 
 // ostreams customized for ospray
 #ifdef ospout

--- a/src/avt/Filters/avtValueImageCompositer.C
+++ b/src/avt/Filters/avtValueImageCompositer.C
@@ -6,11 +6,6 @@
 //                       avtValueImageCompositer.C                           //
 // ************************************************************************* //
 
-// Just to be sure, on Windows.
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-
 #include <algorithm>
 #include <cmath>
 #ifdef PARALLEL

--- a/src/avt/Filters/avtWholeImageCompositerWithZ.C
+++ b/src/avt/Filters/avtWholeImageCompositerWithZ.C
@@ -6,11 +6,6 @@
 //                       avtWholeImageCompositerWithZ.C                      //
 // ************************************************************************* //
 
-// Just to be sure, on Windows.
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-
 #include <algorithm>
 #include <cmath>
 #ifdef PARALLEL

--- a/src/avt/MIR/Base/MIR.C
+++ b/src/avt/MIR/Base/MIR.C
@@ -27,14 +27,11 @@
 #include <InvalidVariableException.h>
 #include <TimingsManager.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 using std::string;
 using std::vector;
-
-
-#define STDMIN(A, B) (((A)<(B)) ? (A) : (B))
-#define STDMAX(A, B) (((A)>(B)) ? (A) : (B))
 
 
 // ****************************************************************************

--- a/src/avt/MIR/Base/MIR.C
+++ b/src/avt/MIR/Base/MIR.C
@@ -27,7 +27,6 @@
 #include <InvalidVariableException.h>
 #include <TimingsManager.h>
 
-#include <algorithm>
 #include <string>
 #include <vector>
 using std::string;

--- a/src/avt/MIR/Tet/TetMIR.C
+++ b/src/avt/MIR/Tet/TetMIR.C
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <math.h>
+#include <algorithm>
 
 #include <string>
 using std::string;
@@ -40,10 +41,6 @@ using std::vector;
 #include <ImproperUseException.h>
 #include <InvalidVariableException.h>
 #include <TimingsManager.h>
-
-
-#define STDMIN(A, B) (((A)<(B)) ? (A) : (B))
-#define STDMAX(A, B) (((A)>(B)) ? (A) : (B))
 
 
 #include "VisItArray.h"
@@ -2557,10 +2554,10 @@ TetMIR::MergeTets(TetList &tetlist, WedgeList &wedgelist,
                const Tet &tet1, const Tet &tet2,
                int forcedMat)
 {
-    float tet1max = STDMAX(STDMAX(tet1.node[0].vf,tet1.node[1].vf),STDMAX(tet1.node[2].vf,tet1.node[3].vf));
-    float tet1min = STDMIN(STDMIN(tet1.node[0].vf,tet1.node[1].vf),STDMIN(tet1.node[2].vf,tet1.node[3].vf));
-    float tet2max = STDMAX(STDMAX(tet2.node[0].vf,tet2.node[1].vf),STDMAX(tet2.node[2].vf,tet2.node[3].vf));
-    float tet2min = STDMIN(STDMIN(tet2.node[0].vf,tet2.node[1].vf),STDMIN(tet2.node[2].vf,tet2.node[3].vf));
+    float tet1max = std::max(std::max(tet1.node[0].vf,tet1.node[1].vf),std::max(tet1.node[2].vf,tet1.node[3].vf));
+    float tet1min = std::min(std::min(tet1.node[0].vf,tet1.node[1].vf),std::min(tet1.node[2].vf,tet1.node[3].vf));
+    float tet2max = std::max(std::max(tet2.node[0].vf,tet2.node[1].vf),std::max(tet2.node[2].vf,tet2.node[3].vf));
+    float tet2min = std::min(std::min(tet2.node[0].vf,tet2.node[1].vf),std::min(tet2.node[2].vf,tet2.node[3].vf));
 
     if (tet1min >= tet2max)
     {
@@ -2618,10 +2615,10 @@ TetMIR::MergeTris(TriList &trilist, int c, int npts, const vtkIdType *c_ptr,
                const MaterialTriangle &mattri, const Tri &tri1,const Tri &tri2,
                int forcedMat)
 {
-    float tri1max = STDMAX(STDMAX(tri1.node[0].vf,tri1.node[1].vf),tri1.node[2].vf);
-    float tri1min = STDMIN(STDMIN(tri1.node[0].vf,tri1.node[1].vf),tri1.node[2].vf);
-    float tri2max = STDMAX(STDMAX(tri2.node[0].vf,tri2.node[1].vf),tri2.node[2].vf);
-    float tri2min = STDMIN(STDMIN(tri2.node[0].vf,tri2.node[1].vf),tri2.node[2].vf);
+    float tri1max = std::max(std::max(tri1.node[0].vf,tri1.node[1].vf),tri1.node[2].vf);
+    float tri1min = std::min(std::min(tri1.node[0].vf,tri1.node[1].vf),tri1.node[2].vf);
+    float tri2max = std::max(std::max(tri2.node[0].vf,tri2.node[1].vf),tri2.node[2].vf);
+    float tri2min = std::min(std::min(tri2.node[0].vf,tri2.node[1].vf),tri2.node[2].vf);
 
     if (tri1min >= tri2max)
     {

--- a/src/avt/MIR/Tet/Tetrahedralizer.C
+++ b/src/avt/MIR/Tet/Tetrahedralizer.C
@@ -7,11 +7,9 @@
 #include <vtkCell.h>
 #include <VisItException.h>
 
+#include <algorithm>
 #include <vector>
 using std::vector;
-
-#define MIN(A,B)  (((A) < (B)) ? (A) : (B))
-#define SWAP(A,B) { int swtmp; swtmp=A; A=B; B=swtmp; }
 
 // ****************************************************************************
 //  Constructor: Tetrahedralizer::Tetrahedralizer
@@ -129,12 +127,12 @@ Tetrahedralizer::GetLowTetNodesForVox(int nnodes,const vtkIdType *nodes, vtkIdTy
     bool invert = ((flipx + flipy + flipz) % 2) == 0;
 
     // which diagonals will the tets cross...
-    int diagx0 = MIN(nodes[map[1]],nodes[map[6]]);
-    int diagx1 = MIN(nodes[map[2]],nodes[map[5]]);
-    int diagy0 = MIN(nodes[map[1]],nodes[map[3]]);
-    int diagy1 = MIN(nodes[map[2]],nodes[map[0]]);
-    int diagz0 = MIN(nodes[map[6]],nodes[map[3]]);
-    int diagz1 = MIN(nodes[map[5]],nodes[map[0]]);
+    int diagx0 = std::min(nodes[map[1]],nodes[map[6]]);
+    int diagx1 = std::min(nodes[map[2]],nodes[map[5]]);
+    int diagy0 = std::min(nodes[map[1]],nodes[map[3]]);
+    int diagy1 = std::min(nodes[map[2]],nodes[map[0]]);
+    int diagz0 = std::min(nodes[map[6]],nodes[map[3]]);
+    int diagz1 = std::min(nodes[map[5]],nodes[map[0]]);
 
     int diagx = (diagx0 < diagx1) ? 0 : 1;
     int diagy = (diagy0 < diagy1) ? 0 : 1;
@@ -231,12 +229,12 @@ Tetrahedralizer::GetLowTetNodesForHex(int nnodes,const vtkIdType *nodes, vtkIdTy
     bool invert = ((flipx + flipy + flipz) % 2) == 0;
 
     // which diagonals will the tets cross...
-    int diagx0 = MIN(nodes[map[1]],nodes[map[6]]);
-    int diagx1 = MIN(nodes[map[2]],nodes[map[5]]);
-    int diagy0 = MIN(nodes[map[1]],nodes[map[3]]);
-    int diagy1 = MIN(nodes[map[2]],nodes[map[0]]);
-    int diagz0 = MIN(nodes[map[6]],nodes[map[3]]);
-    int diagz1 = MIN(nodes[map[2]],nodes[map[7]]);
+    int diagx0 = std::min(nodes[map[1]],nodes[map[6]]);
+    int diagx1 = std::min(nodes[map[2]],nodes[map[5]]);
+    int diagy0 = std::min(nodes[map[1]],nodes[map[3]]);
+    int diagy1 = std::min(nodes[map[2]],nodes[map[0]]);
+    int diagz0 = std::min(nodes[map[6]],nodes[map[3]]);
+    int diagz1 = std::min(nodes[map[2]],nodes[map[7]]);
 
     int diagx = (diagx0 < diagx1) ? 0 : 1;
     int diagy = (diagy0 < diagy1) ? 0 : 1;
@@ -328,8 +326,8 @@ Tetrahedralizer::GetLowTetNodesForWdg(int nnodes,const vtkIdType *nodes, vtkIdTy
     bool invert = (flip % 2) == 0;
 
     // which diagonals will the tets cross...
-    int diag0  = MIN(nodes[map[2]],nodes[map[4]]);
-    int diag1  = MIN(nodes[map[1]],nodes[map[5]]);
+    int diag0  = std::min(nodes[map[2]],nodes[map[4]]);
+    int diag1  = std::min(nodes[map[1]],nodes[map[5]]);
 
     int diag   = (diag0 < diag1) ? 0 : 1;
 

--- a/src/avt/Math/avtMatrix.C
+++ b/src/avt/Math/avtMatrix.C
@@ -5,9 +5,7 @@
 #include "avtMatrix.h"
 #include <avtVector.h>
 #include <math.h>
-
-#define MAX(a,b) ((a)>(b) ? (a) : (b))
-#define MIN(a,b) ((a)>(b) ? (b) : (a))
+#include <algorithm>
 
 avtMatrix::avtMatrix()
 {
@@ -403,7 +401,7 @@ avtMatrix::MakeTrackball(double p1x,double p1y,  double p2x, double p2y,
 
     // Figure how much to rotate around that axis.
     t = (p2 - p1).norm();
-    t = MIN(MAX(t, -1.0), 1.0);
+    t = std::min(std::max(t, -1.0), 1.0);
     phi = -2.0*asin(t/(2.0*RADIUS));
 
     axis *= sin(phi/2.0);

--- a/src/avt/Math/avtTrackball.C
+++ b/src/avt/Math/avtTrackball.C
@@ -3,6 +3,7 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 #include "avtTrackball.h"
+#include <algorithm>
 
 //
 // Use a Witch of Agnesi for a trackball.
@@ -187,16 +188,10 @@ avtTrackball::PerformRotation(const avtVector &s1, const avtVector &s2)
         rot_axis = constrainAxis;
     }
 
-#define TRACKBALL_MIN(A,B) (((A)<(B)) ? (A) : (B))
-#define TRACKBALL_MAX(A,B) (((A)>(B)) ? (A) : (B))
-
     // Figure how much to rotate around that axis.
     double d = (p2 - p1).norm();
-    d = TRACKBALL_MAX(0.,TRACKBALL_MIN(1.,d));
+    d = std::max(0.,std::min(1.,d));
     double phi = 2.0 * asin(d / (2.0 * AGNESI_RADIUS));
-
-#undef TRACKBALL_MIN
-#undef TRACKBALL_MAX
 
     // Create the quaternion and the rotation matrix
     q = avtQuaternion(rot_axis, phi * scale);

--- a/src/avt/Pipeline/Data/avtIntervalTree.C
+++ b/src/avt/Pipeline/Data/avtIntervalTree.C
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 #include <cmath>
+#include <algorithm>
 
 #ifdef PARALLEL
 #include <mpi.h>
@@ -25,14 +26,6 @@
 
 #include <vtkCellIntersections.h>
 #include <vtkVisItUtility.h>
-
-
-//
-// Macros
-//
-
-#define MIN(X, Y)  ((X) < (Y) ? (X) : (Y))
-#define MAX(X, Y)  ((X) > (Y) ? (X) : (Y))
 
 
 //
@@ -695,10 +688,10 @@ avtIntervalTree::SetIntervals()
         for (int k = 0 ; k < nDims ; k++)
         {
             nodeExtents[parent*vectorSize + 2*k] =
-                      MIN(nodeExtents[(i-1)*vectorSize + 2*k],
+                      std::min(nodeExtents[(i-1)*vectorSize + 2*k],
                           nodeExtents[i*vectorSize + 2*k]);
             nodeExtents[parent*vectorSize + 2*k + 1] =
-                      MAX(nodeExtents[(i-1)*vectorSize + 2*k + 1],
+                      std::max(nodeExtents[(i-1)*vectorSize + 2*k + 1],
                           nodeExtents[i*vectorSize + 2*k + 1]);
         }
         if (accelerateSizeQueries)

--- a/src/avt/VisWindow/Tools/VisitSphereTool.C
+++ b/src/avt/VisWindow/Tools/VisitSphereTool.C
@@ -17,6 +17,7 @@
 #include <vtkTextProperty.h>
 
 #include <avtVector.h>
+#include <algorithm>
 
 #define SPHERE_SIZE 1.
 
@@ -81,8 +82,7 @@ VisitSphereTool::VisitSphereTool(VisWindowToolProxy &p) :
     double dXd2 = 0.5 * (bounds[1] - bounds[0]);
     double dYd2 = 0.5 * (bounds[3] - bounds[2]);
     double dZd2 = 0.5 * (bounds[5] - bounds[4]);
-#define spMIN(A,B) (((A)<(B))?(A):(B))
-    double rad = spMIN(spMIN(dXd2, dYd2), dZd2);
+    double rad = std::min(std::min(dXd2, dYd2), dZd2);
     Interface.SetOrigin(bounds[0] + dXd2,
                         bounds[2] + dYd2,
                         bounds[4] + dZd2);

--- a/src/common/plugin/PluginManager.C
+++ b/src/common/plugin/PluginManager.C
@@ -505,16 +505,13 @@ PluginManager::GetPluginList(vector<pair<string,string> > &libs)
             if (filename == "." || filename == "..")
                 continue;
 
-#define PLUGIN_MAX(A,B) (((A) < (B)) ? (B) : (A))
-
             // Ignore it if it does not end in the correct extension
-            if (filename.length() < (size_t)PLUGIN_MAX((1 + prefixLen),extLen) ||
+            if (filename.length() < (size_t)std::max((1 + prefixLen),extLen) ||
                 !(filename.substr(filename.length()-extLen,extLen) == ext))
             {
                 continue;
             }
 
-#undef PLUGIN_MAX
             // It is a valid library name so add it to the list.
             tmp[dir].push_back(files[dir][f]);
         }

--- a/src/common/state/ColorControlPointList.C
+++ b/src/common/state/ColorControlPointList.C
@@ -1217,8 +1217,6 @@ ColorControlPointList::FieldsEqual(int index_, const AttributeGroup *rhs) const
 //
 // ****************************************************************************
 
-#define EVAL_MIN(A,B) (((A)<(B))?(A):(B))
-#define EVAL_MAX(A,B) (((A)>(B))?(A):(B))
 
 float
 ColorControlPointList::EvalCubicSpline(float t, const float *allX, const float *allY, int n) const
@@ -1239,10 +1237,10 @@ ColorControlPointList::EvalCubicSpline(float t, const float *allX, const float *
 
     // Identify the 4 indices, 2 before and 1 after, around the one seleced.
     int idx[4];
-    idx[0] = EVAL_MAX(i-2, 0);
-    idx[1] = EVAL_MAX(i-1, 0);
+    idx[0] = std::max(i-2, 0);
+    idx[1] = std::max(i-1, 0);
     idx[2] = i;
-    idx[3] = EVAL_MIN(i+1, n-1);
+    idx[3] = std::min(i+1, n-1);
 
     // Obtain the x and y values for these 4 points.
     float X[4], Y[4];

--- a/src/common/state/ColorControlPointList.code
+++ b/src/common/state/ColorControlPointList.code
@@ -72,10 +72,7 @@ Definition:
 // Modifications:
 //
 // ****************************************************************************
-
-#define EVAL_MIN(A,B) (((A)<(B))?(A):(B))
-#define EVAL_MAX(A,B) (((A)>(B))?(A):(B))
-
+#include <algorithm>
 float
 ColorControlPointList::EvalCubicSpline(float t, const float *allX, const float *allY, int n) const
 {
@@ -95,10 +92,10 @@ ColorControlPointList::EvalCubicSpline(float t, const float *allX, const float *
 
     // Identify the 4 indices, 2 before and 1 after, around the one seleced.
     int idx[4];
-    idx[0] = EVAL_MAX(i-2, 0);
-    idx[1] = EVAL_MAX(i-1, 0);
+    idx[0] = std::max(i-2, 0);
+    idx[1] = std::max(i-1, 0);
     idx[2] = i;
-    idx[3] = EVAL_MIN(i+1, n-1);
+    idx[3] = std::min(i+1, n-1);
 
     // Obtain the x and y values for these 4 points.
     float X[4], Y[4];

--- a/src/databases/DDCMD/object.C
+++ b/src/databases/DDCMD/object.C
@@ -5,8 +5,6 @@
 #endif
 
 #define MAXKEYWORDS 4096
-#define MAX(A, B) ((A) > (B) ? (A) : (B))
-#define MIN(A, B) ((A) < (B) ? (A) : (B))
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -14,6 +12,7 @@
 #include <ctype.h>
 #include "object.h"
 #include "error.h"
+#include <algorithm>
 
 #ifdef WIN32
 #define strtok_r(s,sep,lasts) (*(lasts)=strtok((s),(sep)))
@@ -79,7 +78,7 @@ int object_get(OBJECT*object, char *name, void *ptr, int type, int length, char 
     FIELD f;
     f = object_parse(object, name, type, dvalue);
     if (f.n == 0 || length <= 0) return 0;
-    l = MIN(f.n, length);
+    l = std::min(f.n, length);
     memmove(ptr, f.v, l*f.element_size);
     return f.n;
 }

--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -54,6 +54,7 @@
 #include <cstdlib> // for qsort
 #include <cstdarg>
 
+#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>
@@ -2113,11 +2114,6 @@ avtExodusFileFormat::AddVar(avtDatabaseMetaData *md, char const *vname,
 //    instead of just variables the plugin is responsible for serving up.
 // ****************************************************************************
 
-#ifdef MAX
-#undef MAX
-#endif
-#define MAX(A,B) ((A)>(B)?(A):(B))
-
 void
 avtExodusFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md,
     int timeState)
@@ -2167,7 +2163,7 @@ avtExodusFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md,
             continue;
         }
 
-        topologicalDimension = MAX(topologicalDimension,
+        topologicalDimension = std::max(topologicalDimension,
             ExodusElemTypeAtt2TopoDim(connect_elem_type_attval, spatialDimension));
         delete [] connect_elem_type_attval;
     }

--- a/src/databases/Tecplot/avtTecplotFileFormat.C
+++ b/src/databases/Tecplot/avtTecplotFileFormat.C
@@ -9,6 +9,7 @@
 #include <avtTecplotFileFormat.h>
 
 #include <stdlib.h>
+#include <algorithm>
 #include <string>
 
 #include <vtkPointData.h>
@@ -34,10 +35,6 @@
 
 using std::string;
 using std::vector;
-#ifndef MAX
-#define MAX(a,b) ((a)>(b)?(a):(b))
-#endif
-
 
 #if defined(_MSC_VER) || !defined(HAVE_STRTOF) || !defined(HAVE_STRTOF_PROTOTYPE)
 #ifndef strtof
@@ -606,37 +603,37 @@ avtTecplotFileFormat::ParseElements(int numElements, const string &elemType)
     {
         nelempts = 8;
         idtype = VTK_HEXAHEDRON;
-        topologicalDimension = MAX(topologicalDimension, 3);
+        topologicalDimension = std::max(topologicalDimension, 3);
     }
     else if (elemType == "TRIANGLE" || elemType == "FETRIANGLE")
     {
         nelempts = 3;
         idtype = VTK_TRIANGLE;
-        topologicalDimension = MAX(topologicalDimension, 2);
+        topologicalDimension = std::max(topologicalDimension, 2);
     }
     else if (elemType == "QUADRILATERAL" || elemType == "FEQUADRILATERAL")
     {
         nelempts = 4;
         idtype = VTK_QUAD;
-        topologicalDimension = MAX(topologicalDimension, 2);
+        topologicalDimension = std::max(topologicalDimension, 2);
     }
     else if (elemType == "TETRAHEDRON" || elemType == "FETETRAHEDRON")
     {
         nelempts = 4;
         idtype = VTK_TETRA;
-        topologicalDimension = MAX(topologicalDimension, 3);
+        topologicalDimension = std::max(topologicalDimension, 3);
     }
     else if (elemType == "LINESEG" || elemType == "FELINESEG")
     {
         nelempts = 2;
         idtype = VTK_LINE;
-        topologicalDimension = MAX(topologicalDimension, 1);
+        topologicalDimension = std::max(topologicalDimension, 1);
     }
     else if (elemType == "POINT" || elemType == "FEPOINT" || elemType == "")
     {
         nelempts = 1;
         idtype = VTK_VERTEX;
-        topologicalDimension = MAX(topologicalDimension, 0);
+        topologicalDimension = std::max(topologicalDimension, 0);
     }
     else
     {
@@ -868,11 +865,11 @@ avtTecplotFileFormat::ParseBLOCK(int numI, int numJ, int numK)
     int numNodes = numI * numJ * numK;
 
     if (numJ==1 && numK==1)
-        topologicalDimension = MAX(topologicalDimension, 1);
+        topologicalDimension = std::max(topologicalDimension, 1);
     else if (numK==1)
-        topologicalDimension = MAX(topologicalDimension, 2);
+        topologicalDimension = std::max(topologicalDimension, 2);
     else
-        topologicalDimension = MAX(topologicalDimension, 3);
+        topologicalDimension = std::max(topologicalDimension, 3);
 
     int numElementsI = (numI <= 1) ? 1 : numI-1;
     int numElementsJ = (numJ <= 1) ? 1 : numJ-1;
@@ -951,7 +948,7 @@ avtTecplotFileFormat::ParsePOINT(int numI, int numJ, int numK)
     else
         topologicalDimensionOfZone = 3;
 
-    topologicalDimension = MAX(topologicalDimension, topologicalDimensionOfZone);
+    topologicalDimension = std::max(topologicalDimension, topologicalDimensionOfZone);
 
     int numElementsI = (numI <= 1) ? 1 : numI-1;
     int numElementsJ = (numJ <= 1) ? 1 : numJ-1;

--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -32,8 +32,6 @@
 
 #include <DebugStream.h>
 
-#define STDMIN(A,B) (((A)<(B)) ? (A) : (B))
-#define STDMAX(A,B) (((A)<(B)) ? (B) : (A))
 
 // ****************************************************************************
 //  Expression Lists

--- a/src/gui/QvisSaveMovieWizard.C
+++ b/src/gui/QvisSaveMovieWizard.C
@@ -3928,9 +3928,6 @@ QvisSaveMovieWizard::page4_viewportActivated(const QString &name)
         page4_UpdateViews(PAGE4_LIST | PAGE4_PROPERTIES);
 }
 
-#define MIN_VAL(A,B) (((A) < (B)) ? (A) : (B))
-#define MAX_VAL(A,B) (((A) > (B)) ? (A) : (B))
-
 // ****************************************************************************
 // Method: QvisSaveMovieWizard::page4_lowerLeftChanged
 //
@@ -3959,14 +3956,14 @@ QvisSaveMovieWizard::page4_lowerLeftChanged(double x, double y)
         upper_right[0], upper_right[1]))
     {
         lower_left[0] = x;
-        float tmp = MIN_VAL(lower_left[0], upper_right[0]);
-        lower_left[0] = MIN_VAL(tmp, lower_left[0]);
-        upper_right[0] = MAX_VAL(tmp, upper_right[0]);
+        float tmp = std::min(lower_left[0], upper_right[0]);
+        lower_left[0] = std::min(tmp, lower_left[0]);
+        upper_right[0] = std::max(tmp, upper_right[0]);
 
         lower_left[1] = y;
-        tmp = MIN_VAL(lower_left[1], upper_right[1]);
-        lower_left[1] = MIN_VAL(tmp, lower_left[1]);
-        upper_right[1] = MAX_VAL(tmp, upper_right[1]);
+        tmp = std::min(lower_left[1], upper_right[1]);
+        lower_left[1] = std::min(tmp, lower_left[1]);
+        upper_right[1] = std::max(tmp, upper_right[1]);
 
         // Store the modified coordinates back into the viewport.
         if(templateSpec->ViewportSetCoordinates(
@@ -4006,14 +4003,14 @@ QvisSaveMovieWizard::page4_upperRightChanged(double x, double y)
         upper_right[0], upper_right[1]))
     {
         upper_right[0] = x;
-        float tmp = MAX_VAL(lower_left[0], upper_right[0]);
-        lower_left[0] = MIN_VAL(tmp, lower_left[0]);
-        upper_right[0] = MAX_VAL(tmp, upper_right[0]);
+        float tmp = std::max(lower_left[0], upper_right[0]);
+        lower_left[0] = std::min(tmp, lower_left[0]);
+        upper_right[0] = std::max(tmp, upper_right[0]);
 
         upper_right[1] = y;
-        tmp = MIN_VAL(lower_left[1], upper_right[1]);
-        lower_left[1] = MIN_VAL(tmp, lower_left[1]);
-        upper_right[1] = MAX_VAL(tmp, upper_right[1]);
+        tmp = std::min(lower_left[1], upper_right[1]);
+        lower_left[1] = std::min(tmp, lower_left[1]);
+        upper_right[1] = std::max(tmp, upper_right[1]);
 
         // Store the modified coordinates back into the viewport.
         if(templateSpec->ViewportSetCoordinates(
@@ -4024,9 +4021,6 @@ QvisSaveMovieWizard::page4_upperRightChanged(double x, double y)
         }
     }
 }
-
-#undef MIN_VAL
-#undef MAX_VAL
 
 void
 QvisSaveMovieWizard::page4_compositingModeChanged(int value)

--- a/src/gui/QvisSpectrumBar.C
+++ b/src/gui/QvisSpectrumBar.C
@@ -3,6 +3,7 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 #include <stdlib.h> // for qsort
+#include <algorithm>  // std::min, std::max
 #include <QvisSpectrumBar.h>
 
 #include <QKeyEvent>
@@ -1609,9 +1610,6 @@ QvisSpectrumBar::drawSpectrum(QPainter &paint)
 //
 // ****************************************************************************
 
-#define EVAL_MIN(A,B) (((A)<(B))?(A):(B))
-#define EVAL_MAX(A,B) (((A)>(B))?(A):(B))
-
 float
 QvisSpectrumBar::evalCubicSpline(float t, const float *allX, const float *allY, int n) const
 {
@@ -1624,10 +1622,10 @@ QvisSpectrumBar::evalCubicSpline(float t, const float *allX, const float *allY, 
         if(allX[i] >= t)
             break;
     int idx[4];
-    idx[0] = EVAL_MAX(i-2, 0);
-    idx[1] = EVAL_MAX(i-1, 0);
+    idx[0] = std::max(i-2, 0);
+    idx[1] = std::max(i-1, 0);
     idx[2] = i;
-    idx[3] = EVAL_MIN(i+1, n-1);
+    idx[3] = std::min(i+1, n-1);
     float X[4], Y[4];
     for(int j = 0; j < 4; ++j)
     {

--- a/src/operators/Extrude/avtExtrudeFilter.C
+++ b/src/operators/Extrude/avtExtrudeFilter.C
@@ -27,6 +27,8 @@
 #include <ImproperUseException.h>
 #include <InvalidCellTypeException.h>
 
+#include <algorithm>
+
 // ****************************************************************************
 //  Method: avtExtrudeFilter constructor
 //
@@ -1340,15 +1342,12 @@ avtExtrudeFilter::ExtrudeExtents(double *dbounds) const
     offset.normalize();
     offset *= atts.GetLength();
 
-#define eMIN(A,B) (((A)<(B)) ? (A) : (B))
-#define eMAX(A,B) (((A)>(B)) ? (A) : (B))
-
-    dbounds[0] = eMIN(dbounds[0], dbounds[0] + offset.x * minScalar);
-    dbounds[1] = eMAX(dbounds[1], dbounds[1] + offset.x * maxScalar);
-    dbounds[2] = eMIN(dbounds[2], dbounds[2] + offset.y * minScalar);
-    dbounds[3] = eMAX(dbounds[3], dbounds[3] + offset.y * maxScalar);
-    dbounds[4] = eMIN(dbounds[4], dbounds[4] + offset.z * minScalar);
-    dbounds[5] = eMAX(dbounds[5], dbounds[5] + offset.z * maxScalar);
+    dbounds[0] = std::min(dbounds[0], dbounds[0] + offset.x * minScalar);
+    dbounds[1] = std::max(dbounds[1], dbounds[1] + offset.x * maxScalar);
+    dbounds[2] = std::min(dbounds[2], dbounds[2] + offset.y * minScalar);
+    dbounds[3] = std::max(dbounds[3], dbounds[3] + offset.y * maxScalar);
+    dbounds[4] = std::min(dbounds[4], dbounds[4] + offset.z * minScalar);
+    dbounds[5] = std::max(dbounds[5], dbounds[5] + offset.z * maxScalar);
 }
 
 // ****************************************************************************

--- a/src/operators/ExtrudeStacked/avtExtrudeStackedFilter.C
+++ b/src/operators/ExtrudeStacked/avtExtrudeStackedFilter.C
@@ -31,6 +31,8 @@
 #include <ImproperUseException.h>
 #include <InvalidCellTypeException.h>
 
+#include <algorithm>
+
 // Adapted from the original extrude operator.
 
 // ****************************************************************************
@@ -2228,13 +2230,10 @@ avtExtrudeStackedFilter::ExtrudeExtents(double *dbounds) const
     offset.normalize();
     offset *= atts.GetLength();
 
-#define eMIN(A,B) (((A)<(B)) ? (A) : (B))
-#define eMAX(A,B) (((A)>(B)) ? (A) : (B))
-
-    dbounds[0] = eMIN(dbounds[0], dbounds[0] + offset.x * scalarMin);
-    dbounds[1] = eMAX(dbounds[1], dbounds[1] + offset.x * scalarMax);
-    dbounds[2] = eMIN(dbounds[2], dbounds[2] + offset.y * scalarMin);
-    dbounds[3] = eMAX(dbounds[3], dbounds[3] + offset.y * scalarMax);
-    dbounds[4] = eMIN(dbounds[4], dbounds[4] + offset.z * scalarMin);
-    dbounds[5] = eMAX(dbounds[5], dbounds[5] + offset.z * scalarMax);
+    dbounds[0] = std::min(dbounds[0], dbounds[0] + offset.x * scalarMin);
+    dbounds[1] = std::max(dbounds[1], dbounds[1] + offset.x * scalarMax);
+    dbounds[2] = std::min(dbounds[2], dbounds[2] + offset.y * scalarMin);
+    dbounds[3] = std::max(dbounds[3], dbounds[3] + offset.y * scalarMax);
+    dbounds[4] = std::min(dbounds[4], dbounds[4] + offset.z * scalarMin);
+    dbounds[5] = std::max(dbounds[5], dbounds[5] + offset.z * scalarMax);
 }

--- a/src/plots/Volume/VolumeFunctions.C
+++ b/src/plots/Volume/VolumeFunctions.C
@@ -30,17 +30,11 @@
 #include <InvalidLimitsException.h>
 #include <ImproperUseException.h>
 #include <string>
+#include <algorithm>
 
 const double PI = atan(1.0)*4.0;
 
 #define NO_DATA_VALUE -1e+37
-
-#ifndef MAX
-#define MAX(a,b) ((a) > (b) ? (a) : (b))
-#endif
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif
 
 // ****************************************************************************
 //  Method: VolumeGetRange
@@ -784,18 +778,18 @@ VolumeGradient_Sobel(vtkRectilinearGrid  *grid, vtkDataArray *opac,
                     for (int c=0; c<3; c++)
                     {
                         int kk = k-1+c;
-                        kk = MAX(0, MIN(nz-1, kk));
+                        kk = std::max(0, std::min(nz-1, kk));
                         int kny = kk * ny;
                         for (int b=0; b<3; b++)
                         {
                             int jj = j-1+b;
-                            jj = MAX(0, MIN(ny-1, jj));
+                            jj = std::max(0, std::min(ny-1, jj));
                             int row = (kny + jj) * nx;
 
                             for (int a=0; a<3; a++)
                             {
                                 int ii = i-1+a;
-                                ii = MAX(0, MIN(nx-1, ii));
+                                ii = std::max(0, std::min(nx-1, ii));
 
                                 float val = fopac[row + ii];
                                 if (val < NO_DATA_VALUE)
@@ -831,18 +825,18 @@ VolumeGradient_Sobel(vtkRectilinearGrid  *grid, vtkDataArray *opac,
                     for (int c=0; c<3; c++)
                     {
                         int kk = k-1+c;
-                        kk = MAX(0, MIN(nz-1, kk));
+                        kk = std::max(0, std::min(nz-1, kk));
                         int kny = kk * ny;
                         for (int b=0; b<3; b++)
                         {
                             int jj = j-1+b;
-                            jj = MAX(0, MIN(ny-1, jj));
+                            jj = std::max(0, std::min(ny-1, jj));
                             int row = (kny + jj) * nx;
 
                             for (int a=0; a<3; a++)
                             {
                                 int ii = i-1+a;
-                                ii = MAX(0, MIN(nx-1, ii));
+                                ii = std::max(0, std::min(nx-1, ii));
 
                                 float val = opac->GetTuple1(row + ii);
                                 if (val < NO_DATA_VALUE)
@@ -1034,7 +1028,7 @@ VolumeCalculateGradient_SPH(vtkDataSet *ds, vtkDataArray *opac,
                 r[2] = p[2] - r[2];
                 h = r[0]*r[0]+r[1]*r[1]+r[2]*r[2];
                 h = sqrt(h);
-                hmax = MAX(h,hmax);
+                hmax = std::max(h,hmax);
                 //cout<<"hmax is now: "<<hmax<<endl;
             }
             //calculate the gradient

--- a/src/plots/Volume/avtDefaultRenderer.C
+++ b/src/plots/Volume/avtDefaultRenderer.C
@@ -25,15 +25,10 @@ VTK_MODULE_INIT(vtkRenderingOSPRay);
 #include <DebugStream.h>
 #include <ImproperUseException.h>
 
+#include <algorithm>
+
 #ifndef NO_DATA_VALUE
 #define NO_DATA_VALUE -1e+37
-#endif
-
-#ifndef MAX
-#define MAX(a,b) ((a) > (b) ? (a) : (b))
-#endif
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
 // ****************************************************************************
@@ -337,7 +332,7 @@ avtDefaultRenderer::Render(
             transFunc->AddRGBPoint(i, rgba[rgbIdx] / 255.f,
                 rgba[rgbIdx + 1] / 255.f,
                 rgba[rgbIdx + 2] / 255.f);
-            opacity->AddPoint(i, MAX(0.0, MIN(1.0, curOp)));
+            opacity->AddPoint(i, std::max(0.0, std::min(1.0, curOp)));
         }
 
         //

--- a/src/plots/VolumeVTK9/avtVolumeRenderer.C
+++ b/src/plots/VolumeVTK9/avtVolumeRenderer.C
@@ -40,13 +40,6 @@
   #define NO_DATA_VALUE -1e+37
 #endif
 
-#ifndef MAX
-#define MAX(a,b) ((a) > (b) ? (a) : (b))
-#endif
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif
-
 // #define LOCAL_DEBUG std::cerr << __LINE__ << "  " << mName
 #define LOCAL_DEBUG debug5 << mName
 

--- a/src/third_party_builtin/tess2/sweep.C
+++ b/src/third_party_builtin/tess2/sweep.C
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <setjmp.h>        /* longjmp */
+#include <algorithm>
 
 #include "mesh.h"
 #include "geom.h"
@@ -79,9 +80,6 @@ extern void DebugEvent( TESStesselator *tess );
 *   its associated vertex.  (This says that these edges exist only
 *   when it is necessary.)
 */
-
-#define MAX(x,y)    ((x) >= (y) ? (x) : (y))
-#define MIN(x,y)    ((x) <= (y) ? (x) : (y))
 
 /* When we merge two edges into one, we need to compute the combined
 * winding of the new edge.
@@ -582,8 +580,8 @@ static int CheckForIntersect( TESStesselator *tess, ActiveRegion *regUp )
 
     if( orgUp == orgLo ) return FALSE;    /* right endpoints are the same */
 
-    tMinUp = MIN( orgUp->t, dstUp->t );
-    tMaxLo = MAX( orgLo->t, dstLo->t );
+    tMinUp = std::min( orgUp->t, dstUp->t );
+    tMaxLo = std::max( orgLo->t, dstLo->t );
     if( tMinUp > tMaxLo ) return FALSE;    /* t ranges do not overlap */
 
     if( VertLeq( orgUp, orgLo )) {
@@ -597,10 +595,10 @@ static int CheckForIntersect( TESStesselator *tess, ActiveRegion *regUp )
 
     tesedgeIntersect( dstUp, orgUp, dstLo, orgLo, &isect );
     /* The following properties are guaranteed: */
-    if(!( MIN( orgUp->t, dstUp->t ) <= isect.t )) return FALSE;
-    if(!( isect.t <= MAX( orgLo->t, dstLo->t ))) return FALSE;
-    if(!( MIN( dstLo->s, dstUp->s ) <= isect.s )) return FALSE;
-    if(!( isect.s <= MAX( orgLo->s, orgUp->s ))) return FALSE;
+    if(!( std::min( orgUp->t, dstUp->t ) <= isect.t )) return FALSE;
+    if(!( isect.t <= std::max( orgLo->t, dstLo->t ))) return FALSE;
+    if(!( std::min( dstLo->s, dstUp->s ) <= isect.s )) return FALSE;
+    if(!( isect.s <= std::max( orgLo->s, orgUp->s ))) return FALSE;
 
     if( VertLeq( &isect, tess->event )) {
         /* The intersection point lies slightly to the left of the sweep line,
@@ -1201,7 +1199,7 @@ static int InitPriorityQ( TESStesselator *tess )
         vertexCount++;
     }
     /* Make sure there is enough space for sentinels. */
-    vertexCount += MAX( 8, tess->alloc.extraVertices );
+    vertexCount += std::max( 8, tess->alloc.extraVertices );
 
     pq = tess->pq = pqNewPriorityQ( &tess->alloc, vertexCount, (int (*)(PQkey, PQkey)) tesvertLeq );
     if (pq == NULL) return 0;

--- a/src/third_party_builtin/verdict/V_HexMetric.C
+++ b/src/third_party_builtin/verdict/V_HexMetric.C
@@ -29,6 +29,7 @@
 #include "V_GaussIntegration.h"
 #include "verdict_defines.h"
 #include <memory.h>
+#include <algorithm>
 
 //! the average volume of a hex
 VERDICT_REAL verdict_hex_size = 0;
@@ -423,13 +424,13 @@ VERDICT_REAL hex_edge_length(int max_min, VERDICT_REAL coordinates[][3])
   if(max_min == 0)
   {
     for( i = 1; i<12; i++) 
-      _edge = VERDICT_MIN( _edge, edge[i] ); 
+      _edge = std::min( _edge, edge[i] ); 
     return (VERDICT_REAL)_edge;
   }  
   else
   {
     for( i = 1; i<12; i++) 
-      _edge = VERDICT_MAX( _edge, edge[i] );
+      _edge = std::max( _edge, edge[i] );
     return (VERDICT_REAL)_edge;
   }
   
@@ -474,13 +475,13 @@ VERDICT_REAL diag_length(int max_min, VERDICT_REAL coordinates[][3])
   if(max_min == 0 )  //Return min diagonal
   { 
     for( i = 1; i<4; i++)
-      diagonal = VERDICT_MIN( diagonal, diag[i] );
+      diagonal = std::min( diagonal, diag[i] );
     return (VERDICT_REAL)diagonal;
   }
   else          //Return max diagonal
   {
     for( i = 1; i<4; i++)
-      diagonal = VERDICT_MAX( diagonal, diag[i] );
+      diagonal = std::max( diagonal, diag[i] );
     return (VERDICT_REAL)diagonal;  
   }
 
@@ -600,15 +601,15 @@ C_FUNC_DEF VERDICT_REAL v_hex_aspect (int /*num_nodes*/, VERDICT_REAL coordinate
   double mag_efg2 = efg2.length();
   double mag_efg3 = efg3.length();
   
-  aspect_12 = safe_ratio( VERDICT_MAX( mag_efg1, mag_efg2 ) , VERDICT_MIN( mag_efg1, mag_efg2 ) );
-  aspect_13 = safe_ratio( VERDICT_MAX( mag_efg1, mag_efg3 ) , VERDICT_MIN( mag_efg1, mag_efg3 ) );
-  aspect_23 = safe_ratio( VERDICT_MAX( mag_efg2, mag_efg3 ) , VERDICT_MIN( mag_efg2, mag_efg3 ) );
+  aspect_12 = safe_ratio( std::max( mag_efg1, mag_efg2 ) , std::min( mag_efg1, mag_efg2 ) );
+  aspect_13 = safe_ratio( std::max( mag_efg1, mag_efg3 ) , std::min( mag_efg1, mag_efg3 ) );
+  aspect_23 = safe_ratio( std::max( mag_efg2, mag_efg3 ) , std::min( mag_efg2, mag_efg3 ) );
 
-  aspect = VERDICT_MAX( aspect_12, VERDICT_MAX( aspect_13, aspect_23 ) );
+  aspect = std::max( aspect_12, std::max( aspect_13, aspect_23 ) );
 
   if( aspect > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( aspect, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( aspect, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( aspect, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( aspect, -VERDICT_DBL_MAX );
  
 }
 
@@ -639,11 +640,11 @@ C_FUNC_DEF VERDICT_REAL v_hex_skew( int /*num_nodes*/, VERDICT_REAL coordinates[
   skew_2 = fabs(efg1 % efg3);
   skew_3 = fabs(efg2 % efg3);
 
-  double skew = (VERDICT_MAX( skew_1, VERDICT_MAX( skew_2, skew_3 ) ));
+  double skew = (std::max( skew_1, std::max( skew_2, skew_3 ) ));
 
   if( skew > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( skew, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( skew, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( skew, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( skew, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -664,15 +665,15 @@ C_FUNC_DEF VERDICT_REAL v_hex_taper( int /*num_nodes*/, VERDICT_REAL coordinates
   VerdictVector efg13 = calc_hex_efg( 13, node_pos);
   VerdictVector efg23 = calc_hex_efg( 23, node_pos);
 
-  double taper_1 = fabs( safe_ratio( efg12.length(), VERDICT_MIN( efg1.length(), efg2.length())));
-  double taper_2 = fabs( safe_ratio( efg13.length(), VERDICT_MIN( efg1.length(), efg3.length())));
-  double taper_3 = fabs( safe_ratio( efg23.length(), VERDICT_MIN( efg2.length(), efg3.length())));
+  double taper_1 = fabs( safe_ratio( efg12.length(), std::min( efg1.length(), efg2.length())));
+  double taper_2 = fabs( safe_ratio( efg13.length(), std::min( efg1.length(), efg3.length())));
+  double taper_3 = fabs( safe_ratio( efg23.length(), std::min( efg2.length(), efg3.length())));
 
-  double taper = (VERDICT_REAL)VERDICT_MAX(taper_1, VERDICT_MAX(taper_2, taper_3));  
+  double taper = (VERDICT_REAL)std::max(taper_1, std::max(taper_2, taper_3));  
 
   if( taper > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( taper, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( taper, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( taper, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( taper, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -693,8 +694,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_volume( int /*num_nodes*/, VERDICT_REAL coordinate
   volume = (VERDICT_REAL) (efg1 % (efg2 * efg3))/64.0;
 
   if( volume > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( volume, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( volume, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( volume, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( volume, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -712,8 +713,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_stretch( int /*num_nodes*/, VERDICT_REAL coordinat
   double stretch = HEX_STRETCH_SCALE_FACTOR * safe_ratio(min_edge, max_diag);
 
   if( stretch > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( stretch, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( stretch, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( stretch, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( stretch, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -751,8 +752,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_diagonal_ratio( int /*num_nodes*/, VERDICT_REAL co
   double diagonal = safe_ratio( min_diag, max_diag);
 
   if( diagonal > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( diagonal, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( diagonal, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( diagonal, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( diagonal, -VERDICT_DBL_MAX );
 }
 
 #define SQR(x) ((x) * (x))
@@ -1120,8 +1121,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_oddy( int /*num_nodes*/, VERDICT_REAL coordinates[
   if ( current_oddy > oddy ) { oddy = current_oddy; }
   
   if( oddy > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( oddy, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( oddy, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( oddy, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( oddy, -VERDICT_DBL_MAX );
 
 }
 
@@ -1221,8 +1222,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_condition( int /*num_nodes*/, VERDICT_REAL coordin
   condition /= 3.0;
 
   if( condition > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( condition, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( condition, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( condition, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( condition, -VERDICT_DBL_MAX );
 
 }
 
@@ -1322,8 +1323,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_jacobian( int /*num_nodes*/, VERDICT_REAL coordina
   if ( current_jacobian < jacobian ) { jacobian = current_jacobian; }
 
   if( jacobian > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( jacobian, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( jacobian, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( jacobian, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( jacobian, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -1560,8 +1561,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_scaled_jacobian( int /*num_nodes*/, VERDICT_REAL c
     temp_norm_jac = jacobi;
 
   if( min_norm_jac> 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_norm_jac, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_norm_jac, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_norm_jac, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_norm_jac, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -1600,7 +1601,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths;
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(1,0,0):
@@ -1622,7 +1623,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(1,1,0):
@@ -1644,7 +1645,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(0,1,0):
@@ -1666,7 +1667,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(0,0,1):
@@ -1688,7 +1689,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(1,0,1):
@@ -1710,7 +1711,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(1,1,1):
@@ -1732,7 +1733,7 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
 
   // J(0,1,1):
@@ -1754,14 +1755,14 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( det < VERDICT_DBL_MIN ) { return 0; }
 
   shear = det / lengths; 
-  min_shear = VERDICT_MIN( shear, min_shear );
+  min_shear = std::min( shear, min_shear );
 
   if( min_shear <= VERDICT_DBL_MIN )
     min_shear = 0;
   
   if( min_shear > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_shear, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_shear, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_shear, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_shear, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -1906,8 +1907,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_shape( int /*num_nodes*/, VERDICT_REAL coordinates
     min_shape = 0;
 
   if( min_shape > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_shape, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_shape, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_shape, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_shape, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -2017,14 +2018,14 @@ C_FUNC_DEF VERDICT_REAL v_hex_relative_size_squared( int /*num_nodes*/, VERDICT_
   {
     tau = det_sum / ( 8*detw);
 
-    tau = VERDICT_MIN( tau, 1.0/tau); 
+    tau = std::min( tau, 1.0/tau); 
 
     size = tau*tau; 
   }
 
   if( size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( size, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -2040,8 +2041,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_shape_and_size( int num_nodes, VERDICT_REAL coordi
   double shape_size = size * shape;
 
   if( shape_size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( shape_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( shape_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( shape_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( shape_size, -VERDICT_DBL_MAX );
 
 }
 
@@ -2060,8 +2061,8 @@ C_FUNC_DEF VERDICT_REAL v_hex_shear_and_size( int num_nodes, VERDICT_REAL coordi
   double shear_size = shear * size; 
 
   if( shear_size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( shear_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( shear_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( shear_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( shear_size, -VERDICT_DBL_MAX );
 
 }
 
@@ -2525,11 +2526,11 @@ C_FUNC_DEF void v_hex_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       double mag_efg2 = efg2.length();
       double mag_efg3 = efg3.length();
       
-      aspect_12 = safe_ratio( VERDICT_MAX( mag_efg1, mag_efg2 ) , VERDICT_MIN( mag_efg1, mag_efg2 ) );
-      aspect_13 = safe_ratio( VERDICT_MAX( mag_efg1, mag_efg3 ) , VERDICT_MIN( mag_efg1, mag_efg3 ) );
-      aspect_23 = safe_ratio( VERDICT_MAX( mag_efg2, mag_efg3 ) , VERDICT_MIN( mag_efg2, mag_efg3 ) );
+      aspect_12 = safe_ratio( std::max( mag_efg1, mag_efg2 ) , std::min( mag_efg1, mag_efg2 ) );
+      aspect_13 = safe_ratio( std::max( mag_efg1, mag_efg3 ) , std::min( mag_efg1, mag_efg3 ) );
+      aspect_23 = safe_ratio( std::max( mag_efg2, mag_efg3 ) , std::min( mag_efg2, mag_efg3 ) );
 
-      metric_vals->aspect = (VERDICT_REAL)VERDICT_MAX( aspect_12, VERDICT_MAX( aspect_13, aspect_23 ) );
+      metric_vals->aspect = (VERDICT_REAL)std::max( aspect_12, std::max( aspect_13, aspect_23 ) );
     }
     
     if(metrics_request_flag & V_HEX_SKEW)
@@ -2551,7 +2552,7 @@ C_FUNC_DEF void v_hex_quality( int num_nodes, VERDICT_REAL coordinates[][3],
         double skewy = fabs(vec1 % vec3);
         double skewz = fabs(vec2 % vec3);
 
-        metric_vals->skew = (VERDICT_REAL)(VERDICT_MAX( skewx, VERDICT_MAX( skewy, skewz ) ));
+        metric_vals->skew = (VERDICT_REAL)(std::max( skewx, std::max( skewy, skewz ) ));
       }
     }
   
@@ -2561,11 +2562,11 @@ C_FUNC_DEF void v_hex_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       VerdictVector efg13 = calc_hex_efg( 13, node_pos);
       VerdictVector efg23 = calc_hex_efg( 23, node_pos);
 
-      double taperx = fabs( safe_ratio( efg12.length(), VERDICT_MIN( efg1.length(), efg2.length())));
-      double tapery = fabs( safe_ratio( efg13.length(), VERDICT_MIN( efg1.length(), efg3.length())));
-      double taperz = fabs( safe_ratio( efg23.length(), VERDICT_MIN( efg2.length(), efg3.length())));
+      double taperx = fabs( safe_ratio( efg12.length(), std::min( efg1.length(), efg2.length())));
+      double tapery = fabs( safe_ratio( efg13.length(), std::min( efg1.length(), efg3.length())));
+      double taperz = fabs( safe_ratio( efg23.length(), std::min( efg2.length(), efg3.length())));
       
-      metric_vals->taper = (VERDICT_REAL)VERDICT_MAX(taperx, VERDICT_MAX(tapery, taperz));  
+      metric_vals->taper = (VERDICT_REAL)std::max(taperx, std::max(tapery, taperz));  
     }
   }
   
@@ -2982,7 +2983,7 @@ C_FUNC_DEF void v_hex_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       if(det_sum > VERDICT_DBL_MIN && rel_size_error != VERDICT_TRUE)
       {
         double tau = det_sum / ( 8 * detw );
-        metric_vals->relative_size_squared = (VERDICT_REAL)VERDICT_MIN( tau*tau, 1.0/tau/tau);
+        metric_vals->relative_size_squared = (VERDICT_REAL)std::min( tau*tau, 1.0/tau/tau);
       }
       else
         metric_vals->relative_size_squared = 0.0;
@@ -3022,7 +3023,7 @@ C_FUNC_DEF void v_hex_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       static const double HEX_STRETCH_SCALE_FACTOR = sqrt(3.0);
       double min_edge=length_squared[0];
       for(int j=1; j<12; j++)
-        min_edge = VERDICT_MIN(min_edge, length_squared[j]);
+        min_edge = std::min(min_edge, length_squared[j]);
 
       double max_diag = diag_length(1, coordinates);
         
@@ -3046,104 +3047,104 @@ C_FUNC_DEF void v_hex_quality( int num_nodes, VERDICT_REAL coordinates[][3],
   //take care of any overflow problems
   //aspect
   if( metric_vals->aspect > 0 )
-    metric_vals->aspect = (VERDICT_REAL) VERDICT_MIN( metric_vals->aspect, VERDICT_DBL_MAX );
+    metric_vals->aspect = (VERDICT_REAL) std::min( metric_vals->aspect, VERDICT_DBL_MAX );
   else
-    metric_vals->aspect = (VERDICT_REAL) VERDICT_MAX( metric_vals->aspect, -VERDICT_DBL_MAX );
+    metric_vals->aspect = (VERDICT_REAL) std::max( metric_vals->aspect, -VERDICT_DBL_MAX );
 
   //skew
   if( metric_vals->skew > 0 )
-    metric_vals->skew = (VERDICT_REAL) VERDICT_MIN( metric_vals->skew, VERDICT_DBL_MAX );
+    metric_vals->skew = (VERDICT_REAL) std::min( metric_vals->skew, VERDICT_DBL_MAX );
   else
-    metric_vals->skew = (VERDICT_REAL) VERDICT_MAX( metric_vals->skew, -VERDICT_DBL_MAX );
+    metric_vals->skew = (VERDICT_REAL) std::max( metric_vals->skew, -VERDICT_DBL_MAX );
 
   //taper
   if( metric_vals->taper > 0 )
-    metric_vals->taper = (VERDICT_REAL) VERDICT_MIN( metric_vals->taper, VERDICT_DBL_MAX );
+    metric_vals->taper = (VERDICT_REAL) std::min( metric_vals->taper, VERDICT_DBL_MAX );
   else
-    metric_vals->taper = (VERDICT_REAL) VERDICT_MAX( metric_vals->taper, -VERDICT_DBL_MAX );
+    metric_vals->taper = (VERDICT_REAL) std::max( metric_vals->taper, -VERDICT_DBL_MAX );
 
   //volume
   if( metric_vals->volume > 0 )
-    metric_vals->volume = (VERDICT_REAL) VERDICT_MIN( metric_vals->volume, VERDICT_DBL_MAX );
+    metric_vals->volume = (VERDICT_REAL) std::min( metric_vals->volume, VERDICT_DBL_MAX );
   else
-    metric_vals->volume = (VERDICT_REAL) VERDICT_MAX( metric_vals->volume, -VERDICT_DBL_MAX );
+    metric_vals->volume = (VERDICT_REAL) std::max( metric_vals->volume, -VERDICT_DBL_MAX );
 
   //stretch
   if( metric_vals->stretch > 0 )
-    metric_vals->stretch = (VERDICT_REAL) VERDICT_MIN( metric_vals->stretch, VERDICT_DBL_MAX );
+    metric_vals->stretch = (VERDICT_REAL) std::min( metric_vals->stretch, VERDICT_DBL_MAX );
   else
-    metric_vals->stretch = (VERDICT_REAL) VERDICT_MAX( metric_vals->stretch, -VERDICT_DBL_MAX );
+    metric_vals->stretch = (VERDICT_REAL) std::max( metric_vals->stretch, -VERDICT_DBL_MAX );
 
   //diagonal ratio
   if( metric_vals->diagonal_ratio > 0 )
-    metric_vals->diagonal_ratio = (VERDICT_REAL) VERDICT_MIN( metric_vals->diagonal_ratio, VERDICT_DBL_MAX );
+    metric_vals->diagonal_ratio = (VERDICT_REAL) std::min( metric_vals->diagonal_ratio, VERDICT_DBL_MAX );
   else
-    metric_vals->diagonal_ratio = (VERDICT_REAL) VERDICT_MAX( metric_vals->diagonal_ratio, -VERDICT_DBL_MAX );
+    metric_vals->diagonal_ratio = (VERDICT_REAL) std::max( metric_vals->diagonal_ratio, -VERDICT_DBL_MAX );
 
   //dimension
   if( metric_vals->dimension > 0 )
-    metric_vals->dimension = (VERDICT_REAL) VERDICT_MIN( metric_vals->dimension, VERDICT_DBL_MAX );
+    metric_vals->dimension = (VERDICT_REAL) std::min( metric_vals->dimension, VERDICT_DBL_MAX );
   else
-    metric_vals->dimension = (VERDICT_REAL) VERDICT_MAX( metric_vals->dimension, -VERDICT_DBL_MAX );
+    metric_vals->dimension = (VERDICT_REAL) std::max( metric_vals->dimension, -VERDICT_DBL_MAX );
 
   //oddy
   if( metric_vals->oddy > 0 )
-    metric_vals->oddy = (VERDICT_REAL) VERDICT_MIN( metric_vals->oddy, VERDICT_DBL_MAX );
+    metric_vals->oddy = (VERDICT_REAL) std::min( metric_vals->oddy, VERDICT_DBL_MAX );
   else
-    metric_vals->oddy = (VERDICT_REAL) VERDICT_MAX( metric_vals->oddy, -VERDICT_DBL_MAX );
+    metric_vals->oddy = (VERDICT_REAL) std::max( metric_vals->oddy, -VERDICT_DBL_MAX );
 
   //condition
   if( metric_vals->condition > 0 )
-    metric_vals->condition = (VERDICT_REAL) VERDICT_MIN( metric_vals->condition, VERDICT_DBL_MAX );
+    metric_vals->condition = (VERDICT_REAL) std::min( metric_vals->condition, VERDICT_DBL_MAX );
   else
-    metric_vals->condition = (VERDICT_REAL) VERDICT_MAX( metric_vals->condition, -VERDICT_DBL_MAX );
+    metric_vals->condition = (VERDICT_REAL) std::max( metric_vals->condition, -VERDICT_DBL_MAX );
 
   //jacobian
   if( metric_vals->jacobian > 0 )
-    metric_vals->jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->jacobian, VERDICT_DBL_MAX );
+    metric_vals->jacobian = (VERDICT_REAL) std::min( metric_vals->jacobian, VERDICT_DBL_MAX );
   else
-    metric_vals->jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->jacobian, -VERDICT_DBL_MAX );
+    metric_vals->jacobian = (VERDICT_REAL) std::max( metric_vals->jacobian, -VERDICT_DBL_MAX );
 
   //scaled_jacobian
   if( metric_vals->scaled_jacobian > 0 )
-    metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
+    metric_vals->scaled_jacobian = (VERDICT_REAL) std::min( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
   else
-    metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
+    metric_vals->scaled_jacobian = (VERDICT_REAL) std::max( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
 
   //shear
   if( metric_vals->shear > 0 )
-    metric_vals->shear = (VERDICT_REAL) VERDICT_MIN( metric_vals->shear, VERDICT_DBL_MAX );
+    metric_vals->shear = (VERDICT_REAL) std::min( metric_vals->shear, VERDICT_DBL_MAX );
   else
-    metric_vals->shear = (VERDICT_REAL) VERDICT_MAX( metric_vals->shear, -VERDICT_DBL_MAX );
+    metric_vals->shear = (VERDICT_REAL) std::max( metric_vals->shear, -VERDICT_DBL_MAX );
 
   //shape
   if( metric_vals->shape > 0 )
-    metric_vals->shape = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape, VERDICT_DBL_MAX );
+    metric_vals->shape = (VERDICT_REAL) std::min( metric_vals->shape, VERDICT_DBL_MAX );
   else
-    metric_vals->shape = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape, -VERDICT_DBL_MAX );
+    metric_vals->shape = (VERDICT_REAL) std::max( metric_vals->shape, -VERDICT_DBL_MAX );
 
   //relative_size_squared
   if( metric_vals->relative_size_squared > 0 )
-    metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MIN( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
+    metric_vals->relative_size_squared = (VERDICT_REAL) std::min( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
   else
-    metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MAX( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
+    metric_vals->relative_size_squared = (VERDICT_REAL) std::max( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
 
   //shape_and_size
   if( metric_vals->shape_and_size > 0 )
-    metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape_and_size, VERDICT_DBL_MAX );
+    metric_vals->shape_and_size = (VERDICT_REAL) std::min( metric_vals->shape_and_size, VERDICT_DBL_MAX );
   else
-    metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
+    metric_vals->shape_and_size = (VERDICT_REAL) std::max( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
 
   //shear_and_size
-  if( metric_vals->shear_and_size > 0 ) metric_vals->shear_and_size = (VERDICT_REAL) VERDICT_MIN( metric_vals->shear_and_size, VERDICT_DBL_MAX );
+  if( metric_vals->shear_and_size > 0 ) metric_vals->shear_and_size = (VERDICT_REAL) std::min( metric_vals->shear_and_size, VERDICT_DBL_MAX );
   else
-    metric_vals->shear_and_size = (VERDICT_REAL) VERDICT_MAX( metric_vals->shear_and_size, -VERDICT_DBL_MAX );
+    metric_vals->shear_and_size = (VERDICT_REAL) std::max( metric_vals->shear_and_size, -VERDICT_DBL_MAX );
   
   //distortion
   if( metric_vals->distortion > 0 )
-    metric_vals->distortion = (VERDICT_REAL) VERDICT_MIN( metric_vals->distortion, VERDICT_DBL_MAX );
+    metric_vals->distortion = (VERDICT_REAL) std::min( metric_vals->distortion, VERDICT_DBL_MAX );
   else
-    metric_vals->distortion = (VERDICT_REAL) VERDICT_MAX( metric_vals->distortion, -VERDICT_DBL_MAX );
+    metric_vals->distortion = (VERDICT_REAL) std::max( metric_vals->distortion, -VERDICT_DBL_MAX );
 
 }
 

--- a/src/third_party_builtin/verdict/V_QuadMetric.C
+++ b/src/third_party_builtin/verdict/V_QuadMetric.C
@@ -29,7 +29,7 @@
 #include "verdict_defines.h"
 #include "V_GaussIntegration.h"
 #include <memory.h>
-
+#include <algorithm>
 
 //! the average area of a quad
 VERDICT_REAL verdict_quad_size = 0;
@@ -320,11 +320,11 @@ C_FUNC_DEF VERDICT_REAL v_quad_aspect( int /*num_nodes*/, VERDICT_REAL coordinat
   if( len1 < VERDICT_DBL_MIN || len2 < VERDICT_DBL_MIN )
     return (VERDICT_REAL)VERDICT_DBL_MAX;
 
-  double aspect = VERDICT_MAX( len1 / len2, len2 / len1 );
+  double aspect = std::max( len1 / len2, len2 / len1 );
 
   if( aspect > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( aspect, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( aspect, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( aspect, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( aspect, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -349,7 +349,7 @@ C_FUNC_DEF VERDICT_REAL v_quad_skew( int /*num_nodes*/, VERDICT_REAL coordinates
 
   double skew = fabs( principle_axes[0] % principle_axes[1] );
 
-  return (VERDICT_REAL) VERDICT_MIN( skew, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::min( skew, VERDICT_DBL_MAX );
 }
 
 /*! 
@@ -374,13 +374,13 @@ C_FUNC_DEF VERDICT_REAL v_quad_taper( int /*num_nodes*/, VERDICT_REAL coordinate
   lengths[1] = principle_axes[1].length();
 
   //get min length
-  lengths[0] = VERDICT_MIN( lengths[0], lengths[1] );
+  lengths[0] = std::min( lengths[0], lengths[1] );
 
   if( lengths[0] < VERDICT_DBL_MIN )
     return VERDICT_DBL_MAX;
 
   double taper = cross_derivative.length()/ lengths[0];
-  return (VERDICT_REAL) VERDICT_MIN( taper, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::min( taper, VERDICT_DBL_MAX );
 
 }
 
@@ -408,12 +408,12 @@ C_FUNC_DEF VERDICT_REAL v_quad_warpage( int /*num_nodes*/, VERDICT_REAL coordina
     return (VERDICT_REAL) VERDICT_DBL_MIN;
 
   double warpage = pow( 
-    VERDICT_MIN( corner_normals[0]%corner_normals[2],
+    std::min( corner_normals[0]%corner_normals[2],
                  corner_normals[1]%corner_normals[3]), 3 );
 
   if( warpage > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( warpage, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( warpage, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( warpage, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( warpage, -VERDICT_DBL_MAX );
 
 }
 
@@ -431,8 +431,8 @@ C_FUNC_DEF VERDICT_REAL v_quad_area( int /*num_nodes*/, VERDICT_REAL coordinates
   double area = 0.25 * (corner_areas[0] + corner_areas[1] + corner_areas[2] + corner_areas[3]);
 
   if( area  > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( area, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( area, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( area, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( area, -VERDICT_DBL_MAX );
 
 }
 
@@ -465,19 +465,19 @@ C_FUNC_DEF VERDICT_REAL v_quad_stretch( int /*num_nodes*/, VERDICT_REAL coordina
   static const double QUAD_STRETCH_FACTOR = sqrt(2.0);
 
   // 'diag02' is now the max diagonal of the quad
-  diag02 = VERDICT_MAX( diag02, diag13 );
+  diag02 = std::max( diag02, diag13 );
 
   if( diag02 < VERDICT_DBL_MIN )
     return (VERDICT_REAL) VERDICT_DBL_MAX;
   else
   {
     double stretch = (VERDICT_REAL) ( QUAD_STRETCH_FACTOR *
-                           sqrt( VERDICT_MIN(
-                                  VERDICT_MIN( lengths_squared[0], lengths_squared[1] ),
-                                  VERDICT_MIN( lengths_squared[2], lengths_squared[3] ) ) /
+                           sqrt( std::min(
+                                  std::min( lengths_squared[0], lengths_squared[1] ),
+                                  std::min( lengths_squared[2], lengths_squared[3] ) ) /
                                 diag02 ));
 
-    return (VERDICT_REAL) VERDICT_MIN( stretch, VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( stretch, VERDICT_DBL_MAX );
   }
 }
 
@@ -534,16 +534,16 @@ C_FUNC_DEF VERDICT_REAL v_quad_maximum_angle( int /*num_nodes*/, VERDICT_REAL co
     return 0.0;  
 
   angle = acos( -(edges[0] % edges[1])/(length[0]*length[1]) );
-  max_angle = VERDICT_MAX(angle, max_angle);
+  max_angle = std::max(angle, max_angle);
 
   angle = acos( -(edges[1] % edges[2])/(length[1]*length[2]) );
-  max_angle = VERDICT_MAX(angle, max_angle);
+  max_angle = std::max(angle, max_angle);
 
   angle = acos( -(edges[2] % edges[3])/(length[2]*length[3]) );
-  max_angle = VERDICT_MAX(angle, max_angle);
+  max_angle = std::max(angle, max_angle);
 
   angle = acos( -(edges[3] % edges[0])/(length[3]*length[0]) );
-  max_angle = VERDICT_MAX(angle, max_angle);
+  max_angle = std::max(angle, max_angle);
 
   max_angle = max_angle *180.0/VERDICT_PI;
 
@@ -558,8 +558,8 @@ C_FUNC_DEF VERDICT_REAL v_quad_maximum_angle( int /*num_nodes*/, VERDICT_REAL co
   } 
 
   if( max_angle  > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( max_angle, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( max_angle, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( max_angle, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( max_angle, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -614,22 +614,22 @@ C_FUNC_DEF VERDICT_REAL v_quad_minimum_angle( int /*num_nodes*/, VERDICT_REAL co
     return 360.0;  
 
   angle = acos( -(edges[0] % edges[1])/(length[0]*length[1]) );
-  min_angle = VERDICT_MIN(angle, min_angle);
+  min_angle = std::min(angle, min_angle);
 
   angle = acos( -(edges[1] % edges[2])/(length[1]*length[2]) );
-  min_angle = VERDICT_MIN(angle, min_angle);
+  min_angle = std::min(angle, min_angle);
 
   angle = acos( -(edges[2] % edges[3])/(length[2]*length[3]) );
-  min_angle = VERDICT_MIN(angle, min_angle);
+  min_angle = std::min(angle, min_angle);
 
   angle = acos( -(edges[3] % edges[0])/(length[3]*length[0]) );
-  min_angle = VERDICT_MIN(angle, min_angle);
+  min_angle = std::min(angle, min_angle);
 
   min_angle = min_angle *180.0/VERDICT_PI;
 
   if( min_angle  > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_angle, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_angle, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_angle, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_angle, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -666,12 +666,12 @@ C_FUNC_DEF VERDICT_REAL v_quad_oddy( int /*num_nodes*/, VERDICT_REAL coordinates
     else 
       cur_oddy = ( (g11-g22)*(g11-g22) + 4.*g12*g12 ) / 2. / g;
   
-    max_oddy = VERDICT_MAX(max_oddy, cur_oddy);
+    max_oddy = std::max(max_oddy, cur_oddy);
   }
   
   if( max_oddy  > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( max_oddy, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( max_oddy, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( max_oddy, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( max_oddy, -VERDICT_DBL_MAX );
 }
 
 
@@ -711,14 +711,14 @@ C_FUNC_DEF VERDICT_REAL v_quad_condition( int /*num_nodes*/, VERDICT_REAL coordi
     else 
       condition = ( xxi % xxi + xet % xet ) / areas[i];
     
-    max_condition = VERDICT_MAX(max_condition, condition);
+    max_condition = std::max(max_condition, condition);
   }
   
   max_condition /= 2;
 
   if( max_condition > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( max_condition, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( max_condition, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( max_condition, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( max_condition, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -735,11 +735,11 @@ C_FUNC_DEF VERDICT_REAL v_quad_jacobian( int /*num_nodes*/, VERDICT_REAL coordin
   double areas[4]; 
   signed_corner_areas( areas, coordinates );
 
-  double jacobian = VERDICT_MIN( VERDICT_MIN( areas[0], areas[1] ), 
-                                 VERDICT_MIN( areas[2], areas[3] ) );
+  double jacobian = std::min( std::min( areas[0], areas[1] ), 
+                                 std::min( areas[2], areas[3] ) );
   if( jacobian > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( jacobian, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( jacobian, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( jacobian, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( jacobian, -VERDICT_DBL_MAX );
 
 }
 
@@ -774,20 +774,20 @@ C_FUNC_DEF VERDICT_REAL v_quad_scaled_jacobian( int /*num_nodes*/, VERDICT_REAL 
 
 
   scaled_jac = corner_areas[0] / (length[0] * length[3]);
-  min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+  min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
   scaled_jac = corner_areas[1] / (length[1] * length[0]);
-  min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+  min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
   scaled_jac = corner_areas[2] / (length[2] * length[1]);
-  min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+  min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
   scaled_jac = corner_areas[3] / (length[3] * length[2]);
-  min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+  min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
   if( min_scaled_jac > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_scaled_jac, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_scaled_jac, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_scaled_jac, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_scaled_jac, -VERDICT_DBL_MAX );
 
 }
 
@@ -803,7 +803,7 @@ C_FUNC_DEF VERDICT_REAL v_quad_shear( int /*num_nodes*/, VERDICT_REAL coordinate
   if( scaled_jacobian <= VERDICT_DBL_MIN )
     return 0.0;
   else
-    return (VERDICT_REAL) VERDICT_MIN( scaled_jacobian, VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( scaled_jacobian, VERDICT_DBL_MAX );
 }
 
 /*!
@@ -833,16 +833,16 @@ C_FUNC_DEF VERDICT_REAL v_quad_shape( int /*num_nodes*/, VERDICT_REAL coordinate
     return 0.0;  
 
   shape = corner_areas[0] / (length_squared[0] + length_squared[3]);
-  min_shape = VERDICT_MIN( shape, min_shape );
+  min_shape = std::min( shape, min_shape );
 
   shape = corner_areas[1] / (length_squared[1] + length_squared[0]);
-  min_shape = VERDICT_MIN( shape, min_shape );
+  min_shape = std::min( shape, min_shape );
 
   shape = corner_areas[2] / (length_squared[2] + length_squared[1]);
-  min_shape = VERDICT_MIN( shape, min_shape );
+  min_shape = std::min( shape, min_shape );
 
   shape = corner_areas[3] / (length_squared[3] + length_squared[2]);
-  min_shape = VERDICT_MIN( shape, min_shape );
+  min_shape = std::min( shape, min_shape );
 
   min_shape *= 2;
 
@@ -850,8 +850,8 @@ C_FUNC_DEF VERDICT_REAL v_quad_shape( int /*num_nodes*/, VERDICT_REAL coordinate
     min_shape = 0;
 
   if( min_shape > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_shape, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_shape, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_shape, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_shape, -VERDICT_DBL_MAX );
 
 }
 
@@ -878,14 +878,14 @@ C_FUNC_DEF VERDICT_REAL v_quad_relative_size_squared( int /*num_nodes*/, VERDICT
       
     if ( w11 > VERDICT_DBL_MIN )
     {
-      rel_size = VERDICT_MIN( w11, 1/w11 );
+      rel_size = std::min( w11, 1/w11 );
       rel_size *= rel_size;
     }
   }
   
   if( rel_size  > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( rel_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( rel_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( rel_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( rel_size, -VERDICT_DBL_MAX );
 
 }
 
@@ -903,8 +903,8 @@ C_FUNC_DEF VERDICT_REAL v_quad_shape_and_size( int num_nodes, VERDICT_REAL coord
   double shape_and_size = shape * size;
   
   if( shape_and_size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( shape_and_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( shape_and_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( shape_and_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( shape_and_size, -VERDICT_DBL_MAX );
 
 }
 
@@ -922,8 +922,8 @@ C_FUNC_DEF VERDICT_REAL v_quad_shear_and_size( int num_nodes, VERDICT_REAL coord
   double shear_and_size = shear * size;
 
   if( shear_and_size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( shear_and_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( shear_and_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( shear_and_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( shear_and_size, -VERDICT_DBL_MAX );
 
 }
 
@@ -978,7 +978,7 @@ C_FUNC_DEF VERDICT_REAL v_quad_distortion( int num_nodes, VERDICT_REAL coordinat
 
          sign_jacobian = (face_normal % ( first * second )) > 0? 1.:-1.;
          cur_jacobian = sign_jacobian*(first * second).length();
-         distortion = VERDICT_MIN(distortion, cur_jacobian);
+         distortion = std::min(distortion, cur_jacobian);
       }
       element_area = (first*second).length()/2.0;
       distortion /= element_area;
@@ -1218,7 +1218,7 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       {
         metric_vals->minimum_angle = VERDICT_DBL_MAX;
         for(int i = 0; i<4; i++)
-          metric_vals->minimum_angle = VERDICT_MIN(angles[i], metric_vals->minimum_angle);
+          metric_vals->minimum_angle = std::min(angles[i], metric_vals->minimum_angle);
         metric_vals->minimum_angle *= 180.0 / VERDICT_PI;
       }
       // if largest angle, find the largest angle
@@ -1226,7 +1226,7 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       {
         metric_vals->maximum_angle = 0.0;
         for(int i = 0; i<4; i++)
-          metric_vals->maximum_angle = VERDICT_MAX(angles[i], metric_vals->maximum_angle);
+          metric_vals->maximum_angle = std::max(angles[i], metric_vals->maximum_angle);
         metric_vals->maximum_angle *= 180.0 / VERDICT_PI;
 
         if( areas[0] < 0 || areas[1] < 0 || 
@@ -1255,13 +1255,13 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
         if( len1 < VERDICT_DBL_MIN || len2 < VERDICT_DBL_MIN )
           metric_vals->aspect = VERDICT_DBL_MAX;
         else
-          metric_vals->aspect = VERDICT_MAX( len1 / len2, len2 / len1 );
+          metric_vals->aspect = std::max( len1 / len2, len2 / len1 );
       }
     
       // calculate the taper
       if(metrics_request_flag & V_QUAD_TAPER)
       {
-        double min_length = VERDICT_MIN( len1, len2 );
+        double min_length = std::min( len1, len2 );
 
         VerdictVector cross_derivative = edges[1] + edges[3]; 
 
@@ -1302,7 +1302,7 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     if( avg_area < VERDICT_DBL_MIN )
       metric_vals->relative_size_squared = 0.0;
     else
-      metric_vals->relative_size_squared =  pow( VERDICT_MIN( 
+      metric_vals->relative_size_squared =  pow( std::min( 
                                               metric_vals->area/avg_area,  
                                               avg_area/metric_vals->area ), 2 );
   }
@@ -1310,9 +1310,9 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
   // calculate the jacobian
   if(metrics_request_flag & V_QUAD_JACOBIAN)
   {
-    metric_vals->jacobian = VERDICT_MIN(
-                              VERDICT_MIN( areas[0], areas[1] ),
-                              VERDICT_MIN( areas[2], areas[3] ) );
+    metric_vals->jacobian = std::min(
+                              std::min( areas[0], areas[1] ),
+                              std::min( areas[2], areas[3] ) );
   }
 
   if( metrics_request_flag & ( V_QUAD_SCALED_JACOBIAN | V_QUAD_SHEAR | V_QUAD_SHEAR_AND_SIZE ) )
@@ -1330,16 +1330,16 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     else
     {
       scaled_jac = areas[0] / (lengths[0] * lengths[3]);
-      min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+      min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
       scaled_jac = areas[1] / (lengths[1] * lengths[0]);
-      min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+      min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
       scaled_jac = areas[2] / (lengths[2] * lengths[1]);
-      min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+      min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
       scaled_jac = areas[3] / (lengths[3] * lengths[2]);
-      min_scaled_jac = VERDICT_MIN( scaled_jac, min_scaled_jac );
+      min_scaled_jac = std::min( scaled_jac, min_scaled_jac );
 
       metric_vals->scaled_jacobian = min_scaled_jac;
      
@@ -1381,22 +1381,22 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
         diff = (lengths[0]*lengths[0]) - (lengths[1]*lengths[1]);
         dot_prod = edges[0]%edges[1];
         oddy = ((diff*diff) + 4*dot_prod*dot_prod ) / (2*length_squared[1]);
-        max_oddy = VERDICT_MAX( oddy, max_oddy );
+        max_oddy = std::max( oddy, max_oddy );
 
         diff = (lengths[1]*lengths[1]) - (lengths[2]*lengths[2]);
         dot_prod = edges[1]%edges[2];
         oddy = ((diff*diff) + 4*dot_prod*dot_prod ) / (2*length_squared[2]);
-        max_oddy = VERDICT_MAX( oddy, max_oddy );
+        max_oddy = std::max( oddy, max_oddy );
 
         diff = (lengths[2]*lengths[2]) - (lengths[3]*lengths[3]);
         dot_prod = edges[2]%edges[3];
         oddy = ((diff*diff) + 4*dot_prod*dot_prod ) / (2*length_squared[3]);
-        max_oddy = VERDICT_MAX( oddy, max_oddy );
+        max_oddy = std::max( oddy, max_oddy );
 
         diff = (lengths[3]*lengths[3]) - (lengths[0]*lengths[0]);
         dot_prod = edges[3]%edges[0];
         oddy = ((diff*diff) + 4*dot_prod*dot_prod ) / (2*length_squared[0]);
-        max_oddy = VERDICT_MAX( oddy, max_oddy );
+        max_oddy = std::max( oddy, max_oddy );
 
         metric_vals->oddy = max_oddy;
       }
@@ -1412,7 +1412,7 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       else 
       {
         metric_vals->warpage = pow( 
-                             VERDICT_MIN( corner_normals[0]%corner_normals[2],
+                             std::min( corner_normals[0]%corner_normals[2],
                                           corner_normals[1]%corner_normals[3]), 3 ); 
       }
     }
@@ -1435,15 +1435,15 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     static const double QUAD_STRETCH_FACTOR = sqrt(2.0);
 
     // 'diag02' is now the max diagonal of the quad
-    diag02 = VERDICT_MAX( diag02, diag13 );
+    diag02 = std::max( diag02, diag13 );
 
     if( diag02 < VERDICT_DBL_MIN )
       metric_vals->stretch = VERDICT_DBL_MAX; 
     else
       metric_vals->stretch =  QUAD_STRETCH_FACTOR *
-                              VERDICT_MIN(
-                                VERDICT_MIN( lengths[0], lengths[1] ),
-                                VERDICT_MIN( lengths[2], lengths[3] ) ) /
+                              std::min(
+                                std::min( lengths[0], lengths[1] ),
+                                std::min( lengths[2], lengths[3] ) ) /
                               sqrt(diag02);
   }
 
@@ -1468,16 +1468,16 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       double max_condition = 0.0, condition;
 
       condition = (lengths_squared[0] + lengths_squared[3])/areas[0];
-      max_condition = VERDICT_MAX( max_condition, condition ); 
+      max_condition = std::max( max_condition, condition ); 
 
       condition = (lengths_squared[1] + lengths_squared[0])/areas[1];
-      max_condition = VERDICT_MAX( max_condition, condition ); 
+      max_condition = std::max( max_condition, condition ); 
      
       condition = (lengths_squared[2] + lengths_squared[1])/areas[2];
-      max_condition = VERDICT_MAX( max_condition, condition ); 
+      max_condition = std::max( max_condition, condition ); 
 
       condition = (lengths_squared[3] + lengths_squared[2])/areas[3];
-      max_condition = VERDICT_MAX( max_condition, condition ); 
+      max_condition = std::max( max_condition, condition ); 
 
       metric_vals->condition = 0.5*max_condition;
       metric_vals->shape =  2/max_condition;
@@ -1487,22 +1487,22 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
   if(metrics_request_flag & V_QUAD_AREA )
   {
     if( metric_vals->area > 0 ) 
-      metric_vals->area = (VERDICT_REAL) VERDICT_MIN( metric_vals->area, VERDICT_DBL_MAX );
-    metric_vals->area = (VERDICT_REAL) VERDICT_MAX( metric_vals->area, -VERDICT_DBL_MAX );
+      metric_vals->area = (VERDICT_REAL) std::min( metric_vals->area, VERDICT_DBL_MAX );
+    metric_vals->area = (VERDICT_REAL) std::max( metric_vals->area, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_ASPECT )
   {
     if( metric_vals->aspect > 0 ) 
-      metric_vals->aspect = (VERDICT_REAL) VERDICT_MIN( metric_vals->aspect, VERDICT_DBL_MAX );
-    metric_vals->aspect = (VERDICT_REAL) VERDICT_MAX( metric_vals->aspect, -VERDICT_DBL_MAX );
+      metric_vals->aspect = (VERDICT_REAL) std::min( metric_vals->aspect, VERDICT_DBL_MAX );
+    metric_vals->aspect = (VERDICT_REAL) std::max( metric_vals->aspect, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_CONDITION )
   {
     if( metric_vals->condition > 0 ) 
-      metric_vals->condition = (VERDICT_REAL) VERDICT_MIN( metric_vals->condition, VERDICT_DBL_MAX );
-    metric_vals->condition = (VERDICT_REAL) VERDICT_MAX( metric_vals->condition, -VERDICT_DBL_MAX );
+      metric_vals->condition = (VERDICT_REAL) std::min( metric_vals->condition, VERDICT_DBL_MAX );
+    metric_vals->condition = (VERDICT_REAL) std::max( metric_vals->condition, -VERDICT_DBL_MAX );
   }
 
   // calculate distortion
@@ -1511,57 +1511,57 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     metric_vals->distortion = v_quad_distortion(num_nodes, coordinates);
 
     if( metric_vals->distortion > 0 ) 
-      metric_vals->distortion = (VERDICT_REAL) VERDICT_MIN( metric_vals->distortion, VERDICT_DBL_MAX );
-    metric_vals->distortion = (VERDICT_REAL) VERDICT_MAX( metric_vals->distortion, -VERDICT_DBL_MAX );
+      metric_vals->distortion = (VERDICT_REAL) std::min( metric_vals->distortion, VERDICT_DBL_MAX );
+    metric_vals->distortion = (VERDICT_REAL) std::max( metric_vals->distortion, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_JACOBIAN )
   {
     if( metric_vals->jacobian > 0 ) 
-      metric_vals->jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->jacobian, VERDICT_DBL_MAX );
-    metric_vals->jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->jacobian, -VERDICT_DBL_MAX );
+      metric_vals->jacobian = (VERDICT_REAL) std::min( metric_vals->jacobian, VERDICT_DBL_MAX );
+    metric_vals->jacobian = (VERDICT_REAL) std::max( metric_vals->jacobian, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_MAXIMUM_ANGLE )
   {
     if( metric_vals->maximum_angle > 0 ) 
-      metric_vals->maximum_angle = (VERDICT_REAL) VERDICT_MIN( metric_vals->maximum_angle, VERDICT_DBL_MAX );
-    metric_vals->maximum_angle = (VERDICT_REAL) VERDICT_MAX( metric_vals->maximum_angle, -VERDICT_DBL_MAX );
+      metric_vals->maximum_angle = (VERDICT_REAL) std::min( metric_vals->maximum_angle, VERDICT_DBL_MAX );
+    metric_vals->maximum_angle = (VERDICT_REAL) std::max( metric_vals->maximum_angle, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_MINIMUM_ANGLE )
   {
     if( metric_vals->minimum_angle > 0 ) 
-      metric_vals->minimum_angle = (VERDICT_REAL) VERDICT_MIN( metric_vals->minimum_angle, VERDICT_DBL_MAX );
-    metric_vals->minimum_angle = (VERDICT_REAL) VERDICT_MAX( metric_vals->minimum_angle, -VERDICT_DBL_MAX );
+      metric_vals->minimum_angle = (VERDICT_REAL) std::min( metric_vals->minimum_angle, VERDICT_DBL_MAX );
+    metric_vals->minimum_angle = (VERDICT_REAL) std::max( metric_vals->minimum_angle, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_ODDY )
   {
     if( metric_vals->oddy > 0 ) 
-      metric_vals->oddy = (VERDICT_REAL) VERDICT_MIN( metric_vals->oddy, VERDICT_DBL_MAX );
-    metric_vals->oddy = (VERDICT_REAL) VERDICT_MAX( metric_vals->oddy, -VERDICT_DBL_MAX );
+      metric_vals->oddy = (VERDICT_REAL) std::min( metric_vals->oddy, VERDICT_DBL_MAX );
+    metric_vals->oddy = (VERDICT_REAL) std::max( metric_vals->oddy, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_RELATIVE_SIZE_SQUARED )
   {
     if( metric_vals->relative_size_squared> 0 ) 
-      metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MIN( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
-    metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MAX( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
+      metric_vals->relative_size_squared = (VERDICT_REAL) std::min( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
+    metric_vals->relative_size_squared = (VERDICT_REAL) std::max( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_SCALED_JACOBIAN )
   {
     if( metric_vals->scaled_jacobian> 0 ) 
-      metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
-    metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
+      metric_vals->scaled_jacobian = (VERDICT_REAL) std::min( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
+    metric_vals->scaled_jacobian = (VERDICT_REAL) std::max( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_SHEAR )
   {
     if( metric_vals->shear > 0 ) 
-      metric_vals->shear = (VERDICT_REAL) VERDICT_MIN( metric_vals->shear, VERDICT_DBL_MAX );
-    metric_vals->shear = (VERDICT_REAL) VERDICT_MAX( metric_vals->shear, -VERDICT_DBL_MAX );
+      metric_vals->shear = (VERDICT_REAL) std::min( metric_vals->shear, VERDICT_DBL_MAX );
+    metric_vals->shear = (VERDICT_REAL) std::max( metric_vals->shear, -VERDICT_DBL_MAX );
   }
 
   // calculate shear and size
@@ -1571,15 +1571,15 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     metric_vals->shear_and_size = metric_vals->shear * metric_vals->relative_size_squared;
 
     if( metric_vals->shear_and_size > 0 ) 
-      metric_vals->shear_and_size = (VERDICT_REAL) VERDICT_MIN( metric_vals->shear_and_size, VERDICT_DBL_MAX );
-    metric_vals->shear_and_size = (VERDICT_REAL) VERDICT_MAX( metric_vals->shear_and_size, -VERDICT_DBL_MAX );
+      metric_vals->shear_and_size = (VERDICT_REAL) std::min( metric_vals->shear_and_size, VERDICT_DBL_MAX );
+    metric_vals->shear_and_size = (VERDICT_REAL) std::max( metric_vals->shear_and_size, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_SHAPE )
   {
     if( metric_vals->shape > 0 ) 
-      metric_vals->shape = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape, VERDICT_DBL_MAX );
-    metric_vals->shape = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape, -VERDICT_DBL_MAX );
+      metric_vals->shape = (VERDICT_REAL) std::min( metric_vals->shape, VERDICT_DBL_MAX );
+    metric_vals->shape = (VERDICT_REAL) std::max( metric_vals->shape, -VERDICT_DBL_MAX );
   }
 
   // calculate shape and size
@@ -1589,36 +1589,36 @@ C_FUNC_DEF void v_quad_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     metric_vals->shape_and_size = metric_vals->shape * metric_vals->relative_size_squared;
 
     if( metric_vals->shape_and_size > 0 ) 
-      metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape_and_size, VERDICT_DBL_MAX );
-    metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
+      metric_vals->shape_and_size = (VERDICT_REAL) std::min( metric_vals->shape_and_size, VERDICT_DBL_MAX );
+    metric_vals->shape_and_size = (VERDICT_REAL) std::max( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_SKEW )
   {
     if( metric_vals->skew > 0 ) 
-      metric_vals->skew = (VERDICT_REAL) VERDICT_MIN( metric_vals->skew, VERDICT_DBL_MAX );
-    metric_vals->skew = (VERDICT_REAL) VERDICT_MAX( metric_vals->skew, -VERDICT_DBL_MAX );
+      metric_vals->skew = (VERDICT_REAL) std::min( metric_vals->skew, VERDICT_DBL_MAX );
+    metric_vals->skew = (VERDICT_REAL) std::max( metric_vals->skew, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_STRETCH )
   {
     if( metric_vals->stretch > 0 ) 
-      metric_vals->stretch = (VERDICT_REAL) VERDICT_MIN( metric_vals->stretch, VERDICT_DBL_MAX );
-    metric_vals->stretch = (VERDICT_REAL) VERDICT_MAX( metric_vals->stretch, -VERDICT_DBL_MAX );
+      metric_vals->stretch = (VERDICT_REAL) std::min( metric_vals->stretch, VERDICT_DBL_MAX );
+    metric_vals->stretch = (VERDICT_REAL) std::max( metric_vals->stretch, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_TAPER )
   {
     if( metric_vals->taper > 0 ) 
-      metric_vals->taper = (VERDICT_REAL) VERDICT_MIN( metric_vals->taper, VERDICT_DBL_MAX );
-    metric_vals->taper = (VERDICT_REAL) VERDICT_MAX( metric_vals->taper, -VERDICT_DBL_MAX );
+      metric_vals->taper = (VERDICT_REAL) std::min( metric_vals->taper, VERDICT_DBL_MAX );
+    metric_vals->taper = (VERDICT_REAL) std::max( metric_vals->taper, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_QUAD_WARPAGE )
   {
     if( metric_vals->warpage > 0 ) 
-      metric_vals->warpage = (VERDICT_REAL) VERDICT_MIN( metric_vals->warpage, VERDICT_DBL_MAX );
-    metric_vals->warpage = (VERDICT_REAL) VERDICT_MAX( metric_vals->warpage, -VERDICT_DBL_MAX );
+      metric_vals->warpage = (VERDICT_REAL) std::min( metric_vals->warpage, VERDICT_DBL_MAX );
+    metric_vals->warpage = (VERDICT_REAL) std::max( metric_vals->warpage, -VERDICT_DBL_MAX );
   }
 
 }

--- a/src/third_party_builtin/verdict/V_TetMetric.C
+++ b/src/third_party_builtin/verdict/V_TetMetric.C
@@ -28,6 +28,7 @@
 #include "VerdictVector.h"
 #include "V_GaussIntegration.h"
 #include <memory.h>
+#include <algorithm>
 
 //! the average volume of a tet
 VERDICT_REAL verdict_tet_size = 0;
@@ -186,8 +187,8 @@ C_FUNC_DEF VERDICT_REAL v_tet_aspect_beta( int /*num_nodes*/, VERDICT_REAL coord
     aspect_ratio = numerator.length() * area_sum / (108*volume*volume); 
     
     if( aspect_ratio > 0 )
-      return (VERDICT_REAL) VERDICT_MIN( aspect_ratio, VERDICT_DBL_MAX );
-    return (VERDICT_REAL) VERDICT_MAX( aspect_ratio, -VERDICT_DBL_MAX );
+      return (VERDICT_REAL) std::min( aspect_ratio, VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::max( aspect_ratio, -VERDICT_DBL_MAX );
   }
 
 }
@@ -378,7 +379,7 @@ C_FUNC_DEF VERDICT_REAL v_tet_shape( int /*num_nodes*/, VERDICT_REAL coordinates
   if ( den < VERDICT_DBL_MIN ) 
     return (VERDICT_REAL)0.0;
     
-  return (VERDICT_REAL)VERDICT_MAX( num/den, 0 );
+  return (VERDICT_REAL)std::max( num/den, 0.0 );
 }
 
 
@@ -660,7 +661,7 @@ C_FUNC_DEF void v_tet_quality( int num_nodes, VERDICT_REAL coordinates[][3],
     if( den < VERDICT_DBL_MIN )
       metric_vals->shape = (VERDICT_REAL)0.0;
     else
-      metric_vals->shape = (VERDICT_REAL)VERDICT_MAX( num/den, 0 );
+      metric_vals->shape = (VERDICT_REAL)std::max( num/den, 0.0 );
   }
   
   // calculate the relative size of the tet
@@ -680,7 +681,7 @@ C_FUNC_DEF void v_tet_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       else
       {
         tmp *= tmp;
-        metric_vals->relative_size_squared = (VERDICT_REAL)VERDICT_MIN(tmp, 1/tmp);
+        metric_vals->relative_size_squared = (VERDICT_REAL)std::min(tmp, 1/tmp);
       }
     }
   }
@@ -757,71 +758,71 @@ C_FUNC_DEF void v_tet_quality( int num_nodes, VERDICT_REAL coordinates[][3],
   if(metrics_request_flag & V_TET_ASPECT_BETA )
   {
     if( metric_vals->aspect_beta > 0 ) 
-      metric_vals->aspect_beta = (VERDICT_REAL) VERDICT_MIN( metric_vals->aspect_beta, VERDICT_DBL_MAX );
-    metric_vals->aspect_beta = (VERDICT_REAL) VERDICT_MAX( metric_vals->aspect_beta, -VERDICT_DBL_MAX );
+      metric_vals->aspect_beta = (VERDICT_REAL) std::min( metric_vals->aspect_beta, VERDICT_DBL_MAX );
+    metric_vals->aspect_beta = (VERDICT_REAL) std::max( metric_vals->aspect_beta, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_ASPECT_GAMMA)
   {
     if( metric_vals->aspect_gamma > 0 ) 
-      metric_vals->aspect_gamma = (VERDICT_REAL) VERDICT_MIN( metric_vals->aspect_gamma, VERDICT_DBL_MAX );
-    metric_vals->aspect_gamma = (VERDICT_REAL) VERDICT_MAX( metric_vals->aspect_gamma, -VERDICT_DBL_MAX );
+      metric_vals->aspect_gamma = (VERDICT_REAL) std::min( metric_vals->aspect_gamma, VERDICT_DBL_MAX );
+    metric_vals->aspect_gamma = (VERDICT_REAL) std::max( metric_vals->aspect_gamma, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_VOLUME)
   {
     if( metric_vals->volume > 0 ) 
-      metric_vals->volume = (VERDICT_REAL) VERDICT_MIN( metric_vals->volume, VERDICT_DBL_MAX );
-    metric_vals->volume = (VERDICT_REAL) VERDICT_MAX( metric_vals->volume, -VERDICT_DBL_MAX );
+      metric_vals->volume = (VERDICT_REAL) std::min( metric_vals->volume, VERDICT_DBL_MAX );
+    metric_vals->volume = (VERDICT_REAL) std::max( metric_vals->volume, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_CONDITION)
   {
     if( metric_vals->condition > 0 ) 
-      metric_vals->condition = (VERDICT_REAL) VERDICT_MIN( metric_vals->condition, VERDICT_DBL_MAX );
-    metric_vals->condition = (VERDICT_REAL) VERDICT_MAX( metric_vals->condition, -VERDICT_DBL_MAX );
+      metric_vals->condition = (VERDICT_REAL) std::min( metric_vals->condition, VERDICT_DBL_MAX );
+    metric_vals->condition = (VERDICT_REAL) std::max( metric_vals->condition, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_JACOBIAN)
   {
     if( metric_vals->jacobian > 0 ) 
-      metric_vals->jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->jacobian, VERDICT_DBL_MAX );
-    metric_vals->jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->jacobian, -VERDICT_DBL_MAX );
+      metric_vals->jacobian = (VERDICT_REAL) std::min( metric_vals->jacobian, VERDICT_DBL_MAX );
+    metric_vals->jacobian = (VERDICT_REAL) std::max( metric_vals->jacobian, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_SCALED_JACOBIAN)
   {
     if( metric_vals->scaled_jacobian > 0 ) 
-      metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
-    metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
+      metric_vals->scaled_jacobian = (VERDICT_REAL) std::min( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
+    metric_vals->scaled_jacobian = (VERDICT_REAL) std::max( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_SHAPE)
   {
     if( metric_vals->shape > 0 ) 
-      metric_vals->shape = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape, VERDICT_DBL_MAX );
-    metric_vals->shape = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape, -VERDICT_DBL_MAX );
+      metric_vals->shape = (VERDICT_REAL) std::min( metric_vals->shape, VERDICT_DBL_MAX );
+    metric_vals->shape = (VERDICT_REAL) std::max( metric_vals->shape, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_RELATIVE_SIZE_SQUARED)
   {
     if( metric_vals->relative_size_squared > 0 ) 
-      metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MIN( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
-    metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MAX( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
+      metric_vals->relative_size_squared = (VERDICT_REAL) std::min( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
+    metric_vals->relative_size_squared = (VERDICT_REAL) std::max( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_SHAPE_AND_SIZE)
   {
     if( metric_vals->shape_and_size > 0 ) 
-      metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape_and_size, VERDICT_DBL_MAX );
-    metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
+      metric_vals->shape_and_size = (VERDICT_REAL) std::min( metric_vals->shape_and_size, VERDICT_DBL_MAX );
+    metric_vals->shape_and_size = (VERDICT_REAL) std::max( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
   }
 
   if(metrics_request_flag & V_TET_DISTORTION)
   {
     if( metric_vals->distortion > 0 ) 
-      metric_vals->distortion = (VERDICT_REAL) VERDICT_MIN( metric_vals->distortion, VERDICT_DBL_MAX );
-    metric_vals->distortion = (VERDICT_REAL) VERDICT_MAX( metric_vals->distortion, -VERDICT_DBL_MAX );
+      metric_vals->distortion = (VERDICT_REAL) std::min( metric_vals->distortion, VERDICT_DBL_MAX );
+    metric_vals->distortion = (VERDICT_REAL) std::max( metric_vals->distortion, -VERDICT_DBL_MAX );
   }
 
 

--- a/src/third_party_builtin/verdict/V_TriMetric.C
+++ b/src/third_party_builtin/verdict/V_TriMetric.C
@@ -30,6 +30,7 @@
 #include "VerdictVector.h"
 #include <memory.h>
 #include <stddef.h>
+#include <algorithm>
 
 // the average area of a tri
 VERDICT_REAL verdict_tri_size = 0;
@@ -110,8 +111,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_aspect( int /*num_nodes*/, VERDICT_REAL coordinate
  
   double aspect = (VERDICT_REAL)(srms / (two_times_root_of_3 * (areaX2)));
   if( aspect > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( aspect, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( aspect, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( aspect, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( aspect, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -137,8 +138,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_area( int /*num_nodes*/, VERDICT_REAL coordinates[
   // return the magnitude of the vector divided by two
   double area = 0.5 * tmp.length();
   if( area > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( area, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( area, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( area, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( area, -VERDICT_DBL_MAX );
   
 }
 
@@ -205,8 +206,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_minimum_angle( int /*num_nodes*/, VERDICT_REAL coo
     min_angle = sides[0].interior_angle(sides[3]);
 
   if( min_angle > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( min_angle, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( min_angle, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( min_angle, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( min_angle, -VERDICT_DBL_MAX );
   
 }
 
@@ -275,8 +276,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_maximum_angle( int /*num_nodes*/, VERDICT_REAL coo
     max_angle = sides[0].interior_angle(sides[3]);
 
   if( max_angle > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( max_angle, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( max_angle, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( max_angle, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( max_angle, -VERDICT_DBL_MAX );
   
 }
 
@@ -306,7 +307,7 @@ C_FUNC_DEF VERDICT_REAL v_tri_condition( int /*num_nodes*/, VERDICT_REAL coordin
     return (VERDICT_REAL)VERDICT_DBL_MAX;
 
   double condition = (VERDICT_REAL)( ((v1%v1) + (v2%v2) - (v1%v2)) / (areax2*rt3) );
-  return (VERDICT_REAL)VERDICT_MIN( condition, VERDICT_DBL_MAX );
+  return (VERDICT_REAL)std::min( condition, VERDICT_DBL_MAX );
 }
 
 /*!
@@ -337,8 +338,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_scaled_jacobian( int /*num_nodes*/, VERDICT_REAL c
   jacobian = cross.length();
 
   double max_edge_length_product = 0.0;
-  max_edge_length_product = VERDICT_MAX( edge[0].length()*edge[1].length(),
-                            VERDICT_MAX( edge[1].length()*edge[2].length(), 
+  max_edge_length_product = std::max( edge[0].length()*edge[1].length(),
+                            std::max( edge[1].length()*edge[2].length(), 
                                          edge[0].length()*edge[2].length() ) ); 
 
   if( max_edge_length_product < VERDICT_DBL_MIN )
@@ -364,8 +365,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_scaled_jacobian( int /*num_nodes*/, VERDICT_REAL c
   }
 
   if( jacobian > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( jacobian, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( jacobian, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( jacobian, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( jacobian, -VERDICT_DBL_MAX );
 
 }
 
@@ -386,8 +387,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_shape( int num_nodes, VERDICT_REAL coordinates[][3
     shape = (1 / condition);
 
   if( shape > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( shape, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( shape, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( shape, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( shape, -VERDICT_DBL_MAX );
 }
 
 /*!
@@ -424,11 +425,11 @@ C_FUNC_DEF VERDICT_REAL v_tri_relative_size_squared( int /*num_nodes*/, VERDICT_
     
   double size = pow( deta/detw, 2 );
   
-  double rel_size = VERDICT_MIN(size, 1.0/size );  
+  double rel_size = std::min(size, 1.0/size );  
 
   if( rel_size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( rel_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( rel_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( rel_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( rel_size, -VERDICT_DBL_MAX );
   
 }
 
@@ -447,8 +448,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_shape_and_size( int num_nodes, VERDICT_REAL coordi
   double shape_and_size = size * shape;
 
   if( shape_and_size > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( shape_and_size, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( shape_and_size, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( shape_and_size, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( shape_and_size, -VERDICT_DBL_MAX );
 
 }
 
@@ -643,8 +644,8 @@ C_FUNC_DEF VERDICT_REAL v_tri_distortion( int num_nodes, VERDICT_REAL coordinate
       distortion *=1.;
    
   if( distortion > 0 )
-    return (VERDICT_REAL) VERDICT_MIN( distortion, VERDICT_DBL_MAX );
-  return (VERDICT_REAL) VERDICT_MAX( distortion, -VERDICT_DBL_MAX );
+    return (VERDICT_REAL) std::min( distortion, VERDICT_DBL_MAX );
+  return (VERDICT_REAL) std::max( distortion, -VERDICT_DBL_MAX );
 }
 
 
@@ -878,7 +879,7 @@ C_FUNC_DEF void v_tri_quality( int num_nodes, VERDICT_REAL coordinates[][3],
       // square the size
       size *= size;
       // value ranges between 0 to 1
-      metric_vals->relative_size_squared = (VERDICT_REAL)VERDICT_MIN(size, 1.0/size );
+      metric_vals->relative_size_squared = (VERDICT_REAL)std::min(size, 1.0/size );
     }
   }
 
@@ -895,54 +896,54 @@ C_FUNC_DEF void v_tri_quality( int num_nodes, VERDICT_REAL coordinates[][3],
 
   //take care of any over-flow problems
   if( metric_vals->aspect > 0 )
-    metric_vals->aspect = (VERDICT_REAL) VERDICT_MIN( metric_vals->aspect, VERDICT_DBL_MAX );\
+    metric_vals->aspect = (VERDICT_REAL) std::min( metric_vals->aspect, VERDICT_DBL_MAX );\
   else
-    metric_vals->aspect = (VERDICT_REAL) VERDICT_MAX( metric_vals->aspect, -VERDICT_DBL_MAX );
+    metric_vals->aspect = (VERDICT_REAL) std::max( metric_vals->aspect, -VERDICT_DBL_MAX );
 
   if( metric_vals->area > 0 )
-    metric_vals->area = (VERDICT_REAL) VERDICT_MIN( metric_vals->area, VERDICT_DBL_MAX );
+    metric_vals->area = (VERDICT_REAL) std::min( metric_vals->area, VERDICT_DBL_MAX );
   else
-    metric_vals->area = (VERDICT_REAL) VERDICT_MAX( metric_vals->area, -VERDICT_DBL_MAX );
+    metric_vals->area = (VERDICT_REAL) std::max( metric_vals->area, -VERDICT_DBL_MAX );
 
   if( metric_vals->minimum_angle > 0 )
-    metric_vals->minimum_angle = (VERDICT_REAL) VERDICT_MIN( metric_vals->minimum_angle, VERDICT_DBL_MAX );
+    metric_vals->minimum_angle = (VERDICT_REAL) std::min( metric_vals->minimum_angle, VERDICT_DBL_MAX );
   else
-    metric_vals->minimum_angle = (VERDICT_REAL) VERDICT_MAX( metric_vals->minimum_angle, -VERDICT_DBL_MAX );
+    metric_vals->minimum_angle = (VERDICT_REAL) std::max( metric_vals->minimum_angle, -VERDICT_DBL_MAX );
 
   if( metric_vals->maximum_angle > 0 )
-    metric_vals->maximum_angle = (VERDICT_REAL) VERDICT_MIN( metric_vals->maximum_angle, VERDICT_DBL_MAX );
+    metric_vals->maximum_angle = (VERDICT_REAL) std::min( metric_vals->maximum_angle, VERDICT_DBL_MAX );
   else
-    metric_vals->maximum_angle = (VERDICT_REAL) VERDICT_MAX( metric_vals->maximum_angle , -VERDICT_DBL_MAX );
+    metric_vals->maximum_angle = (VERDICT_REAL) std::max( metric_vals->maximum_angle , -VERDICT_DBL_MAX );
 
   if( metric_vals->condition > 0 )
-    metric_vals->condition = (VERDICT_REAL) VERDICT_MIN( metric_vals->condition, VERDICT_DBL_MAX );
+    metric_vals->condition = (VERDICT_REAL) std::min( metric_vals->condition, VERDICT_DBL_MAX );
   else
-    metric_vals->condition = (VERDICT_REAL) VERDICT_MAX( metric_vals->condition, -VERDICT_DBL_MAX );
+    metric_vals->condition = (VERDICT_REAL) std::max( metric_vals->condition, -VERDICT_DBL_MAX );
 
   if( metric_vals->shape > 0 )
-    metric_vals->shape = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape, VERDICT_DBL_MAX );
+    metric_vals->shape = (VERDICT_REAL) std::min( metric_vals->shape, VERDICT_DBL_MAX );
   else
-    metric_vals->shape = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape, -VERDICT_DBL_MAX );
+    metric_vals->shape = (VERDICT_REAL) std::max( metric_vals->shape, -VERDICT_DBL_MAX );
 
   if( metric_vals->scaled_jacobian > 0 )
-    metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MIN( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
+    metric_vals->scaled_jacobian = (VERDICT_REAL) std::min( metric_vals->scaled_jacobian, VERDICT_DBL_MAX );
   else
-    metric_vals->scaled_jacobian = (VERDICT_REAL) VERDICT_MAX( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
+    metric_vals->scaled_jacobian = (VERDICT_REAL) std::max( metric_vals->scaled_jacobian, -VERDICT_DBL_MAX );
 
   if( metric_vals->relative_size_squared > 0 )
-    metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MIN( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
+    metric_vals->relative_size_squared = (VERDICT_REAL) std::min( metric_vals->relative_size_squared, VERDICT_DBL_MAX );
   else
-    metric_vals->relative_size_squared = (VERDICT_REAL) VERDICT_MAX( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
+    metric_vals->relative_size_squared = (VERDICT_REAL) std::max( metric_vals->relative_size_squared, -VERDICT_DBL_MAX );
 
   if( metric_vals->shape_and_size > 0 )
-    metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MIN( metric_vals->shape_and_size, VERDICT_DBL_MAX );
+    metric_vals->shape_and_size = (VERDICT_REAL) std::min( metric_vals->shape_and_size, VERDICT_DBL_MAX );
   else
-    metric_vals->shape_and_size = (VERDICT_REAL) VERDICT_MAX( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
+    metric_vals->shape_and_size = (VERDICT_REAL) std::max( metric_vals->shape_and_size, -VERDICT_DBL_MAX );
 
   if( metric_vals->distortion > 0 )
-    metric_vals->distortion = (VERDICT_REAL) VERDICT_MIN( metric_vals->distortion, VERDICT_DBL_MAX );
+    metric_vals->distortion = (VERDICT_REAL) std::min( metric_vals->distortion, VERDICT_DBL_MAX );
   else
-    metric_vals->distortion = (VERDICT_REAL) VERDICT_MAX( metric_vals->distortion, -VERDICT_DBL_MAX );
+    metric_vals->distortion = (VERDICT_REAL) std::max( metric_vals->distortion, -VERDICT_DBL_MAX );
 }
 
 

--- a/src/third_party_builtin/verdict/verdict_defines.h
+++ b/src/third_party_builtin/verdict/verdict_defines.h
@@ -32,9 +32,6 @@
 enum VerdictBoolean { VERDICT_FALSE = 0, VERDICT_TRUE = 1} ;
 
 
-#define VERDICT_MIN(a,b)  ( (a) < (b) ? (a) : (b) )
-#define VERDICT_MAX(a,b)  ( (a) > (b) ? (a) : (b) )
-
 inline double  determinant(double a,
     double b,
     double c,

--- a/src/tools/data/DataManualExamples/Simulations/patch.C
+++ b/src/tools/data/DataManualExamples/Simulations/patch.C
@@ -394,18 +394,16 @@ patches_abut(const score_patch_info &p0, const score_patch_info &p1)
 // Modifications:
 //   
 // ****************************************************************************
-#define MIN(A,B) (((A)<(B)) ? (A) : (B))
-#define MAX(A,B) (((A)>(B)) ? (A) : (B))
 
 static score_patch_info
 patch_add(const score_patch_info &p0, const score_patch_info &p1)
 {
     score_patch_info s;
 
-    s.startx = MIN(p0.startx, p1.startx);
-    s.endx = MAX(p0.endx, p1.endx);
-    s.starty = MIN(p0.starty, p1.starty);
-    s.endy = MAX(p0.endy, p1.endy);
+    s.startx = std::min(p0.startx, p1.startx);
+    s.endx = std::max(p0.endx, p1.endx);
+    s.starty = std::min(p0.starty, p1.starty);
+    s.endy = std::max(p0.endy, p1.endy);
 
     return s;
 }

--- a/src/tools/data/datagen/multi_test.C
+++ b/src/tools/data/datagen/multi_test.C
@@ -23,6 +23,7 @@
 
 #include <silo.h>
 
+#include <algorithm>
 #include <map>
 #include <vector>
 using std::map;
@@ -40,9 +41,6 @@ using std::vector;
 #define STRLEN          256 
 #define MIXMAX          20000       // Maximum length of the mixed arrays
 #define MAXMATNO        3
-
-#define MIN(x, y) (x) < (y) ? (x) : (y)
-#define MAX(x, y) (x) > (y) ? (x) : (y)
 
 #define ALLOC_N(T,N)    ((T*)calloc((N),sizeof(T)))
 #define FREE(M)         if(M){free(M);(M)=NULL;}
@@ -2165,16 +2163,16 @@ build_block_ucd3d(DBfile *dbfile, char dirnames[MAXBLOCKS][STRLEN],
         // Now extract the data for this block.
         //
         imin = (block % nblocks_x) * delta_x - 1;
-        imax = MIN(imin + delta_x + 3, NX + 1);
-        imin = MAX(imin, 0);
+        imax = std::min(imin + delta_x + 3, NX + 1);
+        imin = std::max(imin, 0);
         nx = imax - imin;
         jmin = ((block % (nblocks_x * nblocks_y)) / nblocks_x) * delta_y - 1;
-        jmax = MIN(jmin + delta_y + 3, NY + 1);
-        jmin = MAX(jmin, 0);
+        jmax = std::min(jmin + delta_y + 3, NY + 1);
+        jmin = std::max(jmin, 0);
         ny = jmax - jmin;
         kmin = (block / (nblocks_x * nblocks_y)) * delta_z - 1;
-        kmax = MIN(kmin + delta_z + 3, NZ + 1);
-        kmin = MAX(kmin, 0);
+        kmax = std::min(kmin + delta_z + 3, NZ + 1);
+        kmin = std::max(kmin, 0);
         nz = kmax - kmin;
 
         for (k = 0, n_z = kmin; n_z < kmax; k++, n_z++)

--- a/src/tools/dev/clipeditor/Matrix.C
+++ b/src/tools/dev/clipeditor/Matrix.C
@@ -5,9 +5,7 @@
 #include "Matrix.h"
 #include "Vector.h"
 #include <math.h>
-
-#define MAX(a,b) ((a)>(b) ? (a) : (b))
-#define MIN(a,b) ((a)>(b) ? (b) : (a))
+#include <algorithm>
 
 Matrix::Matrix()
 {
@@ -291,7 +289,7 @@ Matrix::CreateTrackball(float p1x,float p1y,  float p2x, float p2y)
 
     // Figure how much to rotate around that axis.
     t = (p2 - p1).norm();
-    t = MIN(MAX(t, -1.0), 1.0);
+    t = std::min(std::max(t, -1.0), 1.0);
     phi = -2.0*asin(t/(2.0*RADIUS));
 
     axis *= sin(phi/2.0);

--- a/src/viewer/main/ui/PlotAndOperatorActionsUI.C
+++ b/src/viewer/main/ui/PlotAndOperatorActionsUI.C
@@ -38,9 +38,7 @@
 
 #include <DebugStream.h>
 #include <InvalidExpressionException.h>
-
-#define VMAX(A,B) (((A) > (B)) ? (A) : (B))
-
+#include <algorithm>
 //
 // Include icons
 //
@@ -397,8 +395,8 @@ AddPlotActionUI::AddPlotActionUI(ViewerActionLogic *L) : ViewerActionUIMultiple(
                     }
 
                     // Find the maximum pixmap width and height
-                    maxPixmapWidth = VMAX(maxPixmapWidth, pix.width());
-                    maxPixmapHeight = VMAX(maxPixmapHeight, pix.height());
+                    maxPixmapWidth = std::max(maxPixmapWidth, pix.width());
+                    maxPixmapHeight = std::max(maxPixmapHeight, pix.height());
 
                     // Add a choice for plot so that it has an icon.
                     QString tip(tr("Add %1 plot").arg(menuName));


### PR DESCRIPTION
### Description

Resolves #19564 

Removed #define MIN (and variants thereof)
Removed #define MAX (and variants thereof)

Replaced uses of the various MIN and MAX macros with std::min and std::max respectively.

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other

### How Has This Been Tested?

Compiled successfully on Windows, Linux. Regression suite ran successfully on pascal.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
