### PR TITLE
Ensure perspective mode gets restored from config-site files.

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Blueprint writer now correctly puts the right cycle number in file names.</li>
   <li>Fixed a bug in zonetype-label expression where unknown zone types would render a weird symbol, <code>&quot;?</code>.</li>
   <li>Disabled warning message regarding skipping of speculative expression generation for databases with many variables. For more information, read our documentation about <a href="https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/using_visit/Quantitative/Expressions.html#automatic-expressions">automatic expressions</a>.</li>
+  <li>Fixed a bug where perspective mode set to `off` in config files would not be restored correctly.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/viewer/core/ViewerWindowManager.C
+++ b/src/viewer/core/ViewerWindowManager.C
@@ -4973,6 +4973,10 @@ ViewerWindowManager::UpdateGlobalAtts() const
 //    Jeremy Meredith, Mon Feb  4 13:33:29 EST 2008
 //    Added remaining support for axis array window modality.
 //
+//    Kathleen Biagas, Thu Aug 15, 2024
+//    Ensure perspective (if changed) is set in WindowInformation by adding
+//    WINDOWINFO_WINDOWFLAGS to the flags sent to UpdateWindowInformation.
+//
 // ****************************************************************************
 
 void
@@ -4988,6 +4992,7 @@ ViewerWindowManager::UpdateViewAtts(int windowIndex, bool updateCurve,
     if(index == activeWindow || windows[index]->GetViewIsLocked())
     {
         bool haveNotified = false;
+        int flags = WINDOWINFO_WINMODEONLY;
 
         //
         // Set the curve attributes from the window's view.
@@ -5014,6 +5019,14 @@ ViewerWindowManager::UpdateViewAtts(int windowIndex, bool updateCurve,
         //
         if(update3d)
         {
+            // ensure that if perspective has changed, the perspective flag
+            // in WindowInformation will be updated as well.  This ensures the
+            // toggle button on the toolbar will reflect the current state and
+            // that the setting will get save/restored correctly in configs.
+            if(GetViewerState()->GetWindowInformation()->GetPerspective() !=
+                view3d.perspective)
+                flags |= WINDOWINFO_WINDOWFLAGS;
+
             view3d.SetToView3DAttributes(GetViewerState()->GetView3DAttributes());
             GetViewerState()->GetView3DAttributes()->Notify();
             haveNotified = true;
@@ -5030,7 +5043,7 @@ ViewerWindowManager::UpdateViewAtts(int windowIndex, bool updateCurve,
         }
 
         if(haveNotified)
-            UpdateWindowInformation(WINDOWINFO_WINMODEONLY, index);
+            UpdateWindowInformation(flags, index);
     }
 
     //


### PR DESCRIPTION
### Description

Resolves #18777 

In ViewerWindowManager::UpdateViewAtts, added check for whether the view3D perspective matches what is stored in WindowInformation, and if not add WINDOWINFO_WINDOWFLAGS to the flags sent to UpdateWindowInformation.
This ensures the 'perspective ' toggle button in the ViewerWindow gets updated, so that it matches the value of the checkbox from View3DAttributes windows, and also ensures that the flag is fully saved to and restored from the config setting file.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Opened View window, change to 3D tab, turned off perspective. Saved settings.  Restarted VisIt, perspective is still off.


### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
