### PR TITLE
Replace `WIN32` preprocessor check with `_WIN32`.

### DIFF
--- a/src/CMake/TestSocklenT.c
+++ b/src/CMake/TestSocklenT.c
@@ -2,7 +2,7 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/types.h>
 #include <sys/socket.h>
 #endif

--- a/src/avt/Database/Database/avtDatabase.C
+++ b/src/avt/Database/Database/avtDatabase.C
@@ -57,7 +57,7 @@ ConvertSlashes(char *str)
     size_t len = strlen(str);
     for (size_t i = 0; i < len; ++i)
     {
-#ifndef WIN32
+#ifndef _WIN32
         if (str[i] == '\\')
             str[i] = '/';
 #else

--- a/src/avt/Expressions/Math/avtBinaryModuloExpression.C
+++ b/src/avt/Expressions/Math/avtBinaryModuloExpression.C
@@ -8,7 +8,7 @@
 
 #include <avtBinaryModuloExpression.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <math.h>
 #else
 #include <cmath>

--- a/src/avt/Pipeline/Pipeline/avtDebugDumpOptions.C
+++ b/src/avt/Pipeline/Pipeline/avtDebugDumpOptions.C
@@ -170,7 +170,7 @@ avtDebugDumpOptions::SetDumpDirectory(const string &odir)
             res_dir += slash;
 
         // make sure the dir exists!
-#ifdef WIN32
+#ifdef _WIN32
         DWORD resAttrs = GetFileAttributes(res_dir.c_str());
         if (resAttrs == INVALID_FILE_ATTRIBUTES)
             invalidDir = true;

--- a/src/avt/PythonFilters/avtPythonFilterEnvironment.C
+++ b/src/avt/PythonFilters/avtPythonFilterEnvironment.C
@@ -288,7 +288,7 @@ avtPythonFilterEnvironment::UnwrapVTKObject(PyObject *obj,
 
     PyObject *py_addy_int = pyi->GetGlobalObject("_vtkaddy");
 
-#ifdef WIN32
+#ifdef _WIN32
     if(py_addy_int == NULL)
         return NULL;
 

--- a/src/avt/Queries/Queries/avtFlattenQuery.C
+++ b/src/avt/Queries/Queries/avtFlattenQuery.C
@@ -26,7 +26,7 @@
 #include <cstdint>
 #include <cstring>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -218,7 +218,7 @@ avtFlattenQuery::SetInputParams(const MapNode &params)
         }
     }
 
-#ifndef WIN32
+#ifndef _WIN32
     if(params.HasEntry("useSharedMemory"))
     {
         const MapNode *useShm = params.GetEntry("useSharedMemory");
@@ -821,7 +821,7 @@ avtFlattenQuery::BuildOutputInfo(const intVector &varNComps, const intVector &va
 void
 avtFlattenQuery::WriteSharedMemory() const
 {
-#ifndef WIN32
+#ifndef _WIN32
     int fd = shm_open(pimpl->sharedMemoryName.c_str(),
                         O_CREAT | O_RDWR | O_EXCL,
                         S_IREAD | S_IWRITE);

--- a/src/common/comm/RemoteProcess.C
+++ b/src/common/comm/RemoteProcess.C
@@ -767,7 +767,7 @@ RemoteProcess::SingleThreadedAcceptSocket()
 //
 // ****************************************************************************
 
-#if defined(WIN32)
+#if defined(_WIN32)
 DWORD WINAPI threaded_accept_callback(LPVOID data)
 #else
 static void *threaded_accept_callback(void *data)
@@ -874,7 +874,7 @@ RemoteProcess::MultiThreadedAcceptSocket()
 
     debug5 << mName << "Creating new accept thread" << endl;
     bool validThread = true;
-#if defined(WIN32)
+#if defined(_WIN32)
     // Create the thread Windows style.
     DWORD  Id;
     HANDLE tid;
@@ -946,7 +946,7 @@ RemoteProcess::MultiThreadedAcceptSocket()
                 noDescriptor = (cb.desc == -1);
                 noProcessError = (cb.Errno == 0 && childDied[GetProcessId()] == false);
                 MUTEX_UNLOCK(cb.mutex);
-#ifdef WIN32
+#ifdef _WIN32
                 Sleep(1);
 #elif defined(__linux__)
                 sched_yield();
@@ -961,7 +961,7 @@ RemoteProcess::MultiThreadedAcceptSocket()
             if(cb.alive)
             {
                 debug5 << mName << "Terminating the accept thread." << endl;
-#if defined(WIN32)
+#if defined(_WIN32)
                 TerminateThread(tid, 0);
                 CloseHandle(tid);
 #else

--- a/src/common/comm/SocketBridge.C
+++ b/src/common/comm/SocketBridge.C
@@ -658,7 +658,7 @@ ForwardData(FILE *log, int read_fd, int write_fd, char *buff, int buffSize)
     DEBUG_SOCKETS_CODE(const char *mName = "ForwardData: ";)
     DEBUG_SOCKETS(fprintf(log, "%s begin\n", mName);
             fprintf(log, "%sread(%d): buffSize=%d\n", mName, read_fd, buffSize);)
-#ifndef WIN32
+#ifndef _WIN32
     int nread = read(read_fd, buff, buffSize);
 #else
     int nread = _read(read_fd, buff, buffSize);

--- a/src/common/misc/DebugStreamFull.C
+++ b/src/common/misc/DebugStreamFull.C
@@ -553,7 +553,7 @@ DebugStreamFull::open(const char *progname, bool clobber, bool buffer_debug)
 {
     char filename[256];
 
-#ifdef WIN32
+#ifdef _WIN32
     // On windows, we always use pids, so won't need to rename, and thus
     // don't need to prepend a letter.
     sprintf(filename, "%s.%d.thr", progname, level);
@@ -633,7 +633,7 @@ DebugStreamFull::open(const char *progname, bool clobber, bool buffer_debug)
 {
     char filename[256];
 
-#ifdef WIN32
+#ifdef _WIN32
     // On windows, we always use pids, so won't need to rename, and thus
     // don't need to prepend a letter.
     sprintf(filename, "%s.%d", progname, level);

--- a/src/common/misc/FileFunctions.C
+++ b/src/common/misc/FileFunctions.C
@@ -479,7 +479,7 @@ FileFunctions::FilteredPath(const std::string &path)
     size_t state = 0;
     size_t start = 0;
     std::string filteredPath;
-#ifdef WIN32
+#ifdef _WIN32
     bool isUNC = false;
     if (path.substr(0,2) == "\\\\")
     {
@@ -544,7 +544,7 @@ FileFunctions::FilteredPath(const std::string &path)
         {
             filteredPath = "";
             size_t start = 0;
-#ifdef WIN32
+#ifdef _WIN32
             if (isUNC)
             {
                 filteredPath = "\\\\";
@@ -1224,7 +1224,7 @@ std::string
 FileFunctions::ComposeDatabaseName(const std::string &host,
     const std::string &db)
 {
-#ifdef WIN32
+#ifdef _WIN32
     if (db.substr(0,2) == "\\\\")
         return db;
 #endif

--- a/src/common/misc/InstallationFunctions.C
+++ b/src/common/misc/InstallationFunctions.C
@@ -80,7 +80,7 @@ GetDefaultConfigFile(const char *filename, const char *home)
     const char *configFileName;
     int  filenameLength;
 
-#ifdef WIN32
+#ifdef _WIN32
     // If the filename is enclosed in quotes, do no prepend the home directory.
     if (filename != NULL && (filename[0] == '\'' || filename[0] == '\"'))
     {

--- a/src/common/misc/VisItInit.C
+++ b/src/common/misc/VisItInit.C
@@ -347,7 +347,7 @@ VisItInit::Initialize(int &argc, char *argv[], int r, int n, bool strip, bool si
                 msg = "GIT version is unknown!";
             else
                 msg = "Built from version "  +  visitcommon::GITVersion();
-#if defined(WIN32) && defined(VISIT_WINDOWS_APPLICATION)
+#if defined(_WIN32) && defined(VISIT_WINDOWS_APPLICATION)
             MessageBox(NULL, LPCSTR(msg.c_str()), LPCSTR(""), MB_ICONINFORMATION | MB_OK);
 #else
             cerr << msg << endl;
@@ -360,7 +360,7 @@ VisItInit::Initialize(int &argc, char *argv[], int r, int n, bool strip, bool si
     RemovePrependedDirs(argv[0], progname_wo_dir);
     strcpy(executableName, progname_wo_dir);
     strcpy(componentName, progname_wo_dir);
-#ifdef WIN32
+#ifdef _WIN32
     // On windows, we want timings and log files to go in user's directory,
     // not install directory, because users may not have write permissions.
     std::string homedir = GetUserVisItDirectory();

--- a/src/common/state/GlobalAttributes.C
+++ b/src/common/state/GlobalAttributes.C
@@ -115,7 +115,7 @@ void GlobalAttributes::Init()
     createTimeDerivativeExpressions = true;
     createVectorMagnitudeExpressions = true;
     newPlotsInheritSILRestriction = true;
-#ifdef WIN32
+#ifdef _WIN32
     userDirForSessionFiles = true;
 #else
     userDirForSessionFiles = false;

--- a/src/common/state/GlobalAttributes.code
+++ b/src/common/state/GlobalAttributes.code
@@ -1,5 +1,5 @@
 Initialization: userDirForSessionFiles
-#ifdef WIN32
+#ifdef _WIN32
     userDirForSessionFiles = true;
 #else
     userDirForSessionFiles = false;

--- a/src/common/utility/StringHelpers_test.C
+++ b/src/common/utility/StringHelpers_test.C
@@ -17,7 +17,7 @@ using std::string;
 static string slash_swap_for_os(string const in)
 {
     string out = in;
-#ifdef WIN32
+#ifdef _WIN32
     for (size_t i = 0; i < in.size(); i++)
         if (in[i] == '/') out[i] = '\\';
 #endif
@@ -250,7 +250,7 @@ int main(int argc, char **argv)
     CHECK_BASENAME_WITH_SUFFIX("/foo/bar/gorfo.txt",  "gorfo.txt", "gorfo.txt");
     CHECK_BASENAME_WITH_SUFFIX("/foo/bar/gorfo.txt",  "",          "gorfo.txt");
 
-#ifdef WIN32
+#ifdef _WIN32
     // test with unix-style path separators
     CHECK_PATHNAMES("C:/usr/lib",    "C:/usr",        "lib");
     CHECK_PATHNAMES("D:/usr/",       "D:/usr",        "");

--- a/src/common/utility/SysCall.h
+++ b/src/common/utility/SysCall.h
@@ -10,7 +10,7 @@
 #define VISIT_SYSCALL_H
 
 #include <cerrno>
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #else
 #include <sys/select.h>

--- a/src/databases/ANSYS/avtANSYSFileFormat.C
+++ b/src/databases/ANSYS/avtANSYSFileFormat.C
@@ -175,7 +175,7 @@ int
 get_errno()
 {
    int eno = 0;
-#ifdef WIN32
+#ifdef _WIN32
     _get_errno(&eno);
 #else
     eno = errno;

--- a/src/databases/BOV/avtBOVFileFormat.C
+++ b/src/databases/BOV/avtBOVFileFormat.C
@@ -926,7 +926,7 @@ avtBOVFileFormat::GetVar(int dom, const char *var)
     char filename[1024];
     sprintf(filename, file_pattern.c_str(), dom);
     char qual_filename[1024];
-#ifdef WIN32
+#ifdef _WIN32
     if (PathIsRelative(filename))
 #else
     if (filename[0] != '/')

--- a/src/databases/Blueprint/avtBlueprintWriter.C
+++ b/src/databases/Blueprint/avtBlueprintWriter.C
@@ -33,7 +33,7 @@
 #include <DebugStream.h>
 #include <ImproperUseException.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <direct.h>
 #endif
 

--- a/src/databases/Claw/avtClawFileFormat.C
+++ b/src/databases/Claw/avtClawFileFormat.C
@@ -28,7 +28,7 @@
 #include <InvalidVariableException.h>
 #include <ImproperUseException.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <dirent.h>
 #include <unistd.h>
 #else
@@ -329,13 +329,13 @@ ReadTimeStepHeader(string rootDir, string fileName, TimeHeader_t *hdr)
     char buf[2048];
     string fullFileName = rootDir + VISIT_SLASH_STRING + fileName;
     int fd =
-#ifndef WIN32
+#ifndef _WIN32
         open(fullFileName.c_str(), O_RDONLY);
 #else
         ::_open(fullFileName.c_str(), _O_RDONLY|_O_BINARY);
 #endif
     int nread = 
-#ifndef WIN32
+#ifndef _WIN32
         read(fd, buf, sizeof(buf)-1);
 #else
         ::_read(fd, buf, sizeof(buf)-1);
@@ -547,7 +547,7 @@ ReadGridHeaders(string rootDir, string fileName, const TimeHeader_t *thdr,
     //char buf[2048];
     string fullFileName = rootDir + VISIT_SLASH_STRING + fileName;
     int fd =
-#ifndef WIN32
+#ifndef _WIN32
         open(fullFileName.c_str(), O_RDONLY);
 #else
         ::_open(fullFileName.c_str(), _O_RDONLY|_O_BINARY);
@@ -1218,7 +1218,7 @@ avtClawFileFormat::GetVar(int timeState, int domain, const char *varname)
     char *buf = new char[dsLength+1];
     string fullFileName = rootDir + VISIT_SLASH_STRING + gridFilenames[timeState];
     int fd =
-#ifndef WIN32
+#ifndef _WIN32
         open(fullFileName.c_str(), O_RDONLY);
 #else
         ::_open(fullFileName.c_str(), _O_RDONLY|_O_BINARY);
@@ -1232,7 +1232,7 @@ avtClawFileFormat::GetVar(int timeState, int domain, const char *varname)
     }
     lseek(fd, dsOffset, SEEK_SET);
     int nread =
-#ifndef WIN32
+#ifndef _WIN32
         read(fd, buf, dsLength);
 #else
         ::_read(fd, buf, dsLength);

--- a/src/databases/DDCMD/object.C
+++ b/src/databases/DDCMD/object.C
@@ -14,7 +14,7 @@
 #include "error.h"
 #include <algorithm>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define strtok_r(s,sep,lasts) (*(lasts)=strtok((s),(sep)))
 #define strcasecmp stricmp
 #endif

--- a/src/databases/Exodus/avtExodusFileFormat.C
+++ b/src/databases/Exodus/avtExodusFileFormat.C
@@ -231,7 +231,7 @@ static void fill_tmp_suffixes(int n, ...)
     va_end(ap);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 #define strcasecmp stricmp
 #endif
 

--- a/src/databases/H5Part/avtH5PartWriter.C
+++ b/src/databases/H5Part/avtH5PartWriter.C
@@ -47,7 +47,7 @@
 #include <avtParallel.h>
 #endif
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/src/databases/Nek5000/avtNek5000FileFormat.C
+++ b/src/databases/Nek5000/avtNek5000FileFormat.C
@@ -7,7 +7,7 @@
 // ************************************************************************* //
 
 #include <avtNek5000FileFormat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <direct.h>

--- a/src/databases/S3D/avtS3DFileFormat.C
+++ b/src/databases/S3D/avtS3DFileFormat.C
@@ -34,7 +34,7 @@
 using     std::string;
 using     std::vector;
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdio.h>
 #define F_SLASH_STRING "/"
 #define B_SLASH_STRING "\\"
@@ -54,7 +54,7 @@ using     std::vector;
 static string
 parse_dirname(char *wholePath)
 {
-#ifndef WIN32
+#ifndef _WIN32
     return string(dirname(wholePath));
 #else
     string wholePathString(wholePath);
@@ -102,7 +102,7 @@ CreateStringFromDouble(double ts)
     char temp[256];
     snprintf(temp,256,"%1.3E",ts);
     string tempStr(temp);
-#ifdef WIN32
+#ifdef _WIN32
     size_t off = tempStr.find("E+0");
     if (off < tempStr.size())
     {

--- a/src/databases/SAS/avtSASFileFormat.h
+++ b/src/databases/SAS/avtSASFileFormat.h
@@ -11,7 +11,7 @@
 
 #include <avtMTMDFileFormat.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #define OPEN    ::_open
 #define CLOSE   ::_close

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -900,7 +900,7 @@ avtSiloFileFormat::OpenFile(const char *n, bool skipGlobalInfo)
     // do not treat it as relative to the toc file. This permits root
     // files to have multi-block objects with absolute path names.
     //
-#ifdef WIN32
+#ifdef _WIN32
     // Example "C:\foo\bar"
     if (strlen(n) > 2 && n[1] == ':' && n[2] == VISIT_SLASH_CHAR)
 #else

--- a/src/databases/Silo/avtSiloWriter.C
+++ b/src/databases/Silo/avtSiloWriter.C
@@ -203,7 +203,7 @@ static string oldCompressionParams;
 // DBCreate from working with PDB driver because that driver is
 // designed to detect attempts to apply compression and fail if so.
 //
-#if !defined(WIN32) && defined(SILO_VERSION_GE)
+#if !defined(_WIN32) && defined(SILO_VERSION_GE)
 #if SILO_VERSION_GE(4,7,0) && !SILO_VERSION_GE(4,7,1)
 typedef struct SILO_Globals_copy_t {
     long dataReadMask;
@@ -247,7 +247,7 @@ SaveAndSetSiloLibState(int driver, bool checkSums, string compressionParams)
         if (compressionParams != "" && !myRank)
             cerr << "Compression supported only on HDF5 driver" << endl;
         oldFriendlyHDFNames = DBSetFriendlyHDF5Names(0);
-#if !defined(WIN32) && !SILO_VERSION_GE(4,7,1)
+#if !defined(_WIN32) && !SILO_VERSION_GE(4,7,1)
         DBSetCompression("");
         // Hack to work-around bug in Silo lib
         SILO_Globals.enableCompression = 0;
@@ -269,7 +269,7 @@ RestoreSiloLibState()
 #if defined(SILO_VERSION_GE)
 #if SILO_VERSION_GE(4,7,0)
     DBSetFriendlyHDF5Names(oldFriendlyHDFNames);
-#if !defined (WIN32) && !SILO_VERSION_GE(4,7,1)
+#if !defined (_WIN32) && !SILO_VERSION_GE(4,7,1)
     DBSetCompression(oldCompressionParams.c_str());
     // Hack to work-around bug in Silo lib
     SILO_Globals.enableCompression = 0;

--- a/src/databases/Tecplot/TecplotFile.C
+++ b/src/databases/Tecplot/TecplotFile.C
@@ -34,7 +34,7 @@
 #define TECPLOT_VERSION_7X(v) (v >= TECPLOT_71 && v <= 79)
 #define TECPLOT_VERSION_104GE(v) (v >= TECPLOT_104)
 
-#ifdef WIN32
+#ifdef _WIN32
 #define FSEEK _fseeki64
 #define FTELL _ftelli64
 #else

--- a/src/databases/VTK/avtVTKWriter.C
+++ b/src/databases/VTK/avtVTKWriter.C
@@ -31,7 +31,7 @@
 #include <FileFunctions.h>
 
 #include <DBOptionsAttributes.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <direct.h>
 #endif
 
@@ -122,7 +122,7 @@ avtVTKWriter::OpenFile(const string &stemname, int nb)
     {
        // we want the basename without the extension to use as a sub-dir name
        mbDirName = FileFunctions::Basename(stem);
-#ifdef WIN32
+#ifdef _WIN32
        _mkdir(stem.c_str());
 #else
        mkdir(stem.c_str(), 0777);

--- a/src/databases/ZipWrapper/avtZipWrapperFileFormatInterface.C
+++ b/src/databases/ZipWrapper/avtZipWrapperFileFormatInterface.C
@@ -14,7 +14,7 @@
 #include <vector>
 
 #include <sys/stat.h>
-#ifdef WIN32
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -307,7 +307,7 @@ avtZipWrapperFileFormatInterface::Initialize(int procNum, int procCount,
     // Decide on root temporary directory
     if (tmpDir == "$TMPDIR" && procNum == 0)
     {
-#ifdef WIN32
+#ifdef _WIN32
         if (!Environment::get("TMP").empty())
             tmpDir = Environment::get("TMP");
         else if (!Environment::get("TEMP").empty())
@@ -392,7 +392,7 @@ avtZipWrapperFileFormatInterface::Initialize(int procNum, int procCount,
     // Make the temporary directory
     // (will have different name on mdserver and engine)
     errno = 0;
-#ifdef WIN32
+#ifdef _WIN32
     if(_mkdir(tmpDir.c_str()) != 0 && errno != EEXIST)
 #else
     if (mkdir(tmpDir.c_str(), 0777) != 0 && errno != EEXIST)
@@ -424,7 +424,7 @@ void
 avtZipWrapperFileFormatInterface::Finalize()
 {
     errno = 0;
-#ifdef WIN32
+#ifdef _WIN32
     if (_rmdir(tmpDir.c_str()) != 0 && errno != ENOENT)
 #else
     if (rmdir(tmpDir.c_str()) != 0 && errno != ENOENT)
@@ -716,7 +716,7 @@ avtZipWrapperFileFormatInterface::GetRealInterface(int ts, int dom, bool dontCac
     string dcmd = decompCmd;
     if (dcmd == "")
     {
-#ifdef WIN32
+#ifdef _WIN32
         if(PathFileExists("C:\\Program Files\\7-zip\\7z.exe"))
         {
             dcmd = "\"C:\\Program Files\\7-zip\\7z.exe\" x -y";
@@ -769,7 +769,7 @@ avtZipWrapperFileFormatInterface::GetRealInterface(int ts, int dom, bool dontCac
     while (ntries>0)
     {
         // Wait a bit.
-#ifdef WIN32
+#ifdef _WIN32
         Sleep(1);
 #else
         struct timespec ts = {0, 1000000000/2}; // 1/2-second
@@ -804,7 +804,7 @@ avtZipWrapperFileFormatInterface::GetRealInterface(int ts, int dom, bool dontCac
         debug5 << "It looks like an existing decompression attempt has hung. But, proceeding anyway." << endl;
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     // no 'touch' command on Windows, so create the empty .lck file first
     char tmpcmd[1024];
     // Create full path

--- a/src/databases/ffp/avtffpFileFormat.C
+++ b/src/databases/ffp/avtffpFileFormat.C
@@ -14,7 +14,7 @@
 
 #include <avtffpFileFormat.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <dlfcn.h>
@@ -68,7 +68,7 @@ static trlistp_t _trlistp = 0;
 static int InitLibStripack()
 {
     static char const * const envar = "VISIT_FFP_STRIPACK_PATH";
-#ifdef WIN32
+#ifdef _WIN32
     HINSTANCE libh = NULL;
     if (Environment::exists(envar))
         libh = LoadLibrary(Environment::get(envar).c_str());

--- a/src/databases/lata/Lata_tools.h
+++ b/src/databases/lata/Lata_tools.h
@@ -36,7 +36,7 @@
 
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #define __BIG_ENDIAN    111
 #define __LITTLE_ENDIAN 121
 #define __BYTE_ORDER __LITTLE_ENDIAN

--- a/src/databases/paraDIS/RC_cpp_lib/timer.h
+++ b/src/databases/paraDIS/RC_cpp_lib/timer.h
@@ -88,7 +88,7 @@ class timer
   }
 
   static double GetExactSeconds(void) {
-#ifndef WIN32
+#ifndef _WIN32
     struct timeval t; 
     gettimeofday(&t, NULL); 
     return t.tv_sec + (double)t.tv_usec/1000000.0; 

--- a/src/databases/paraDIS/paraDIS_lib/paradis.C
+++ b/src/databases/paraDIS/paraDIS_lib/paradis.C
@@ -15,7 +15,7 @@
 #include "paradis_version.h"
 //#include "visit_writer.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #  include <dirent.h>
 #else
 #  include <direct.h>
@@ -3085,7 +3085,7 @@ namespace paraDIS {
   //===========================================================================
   bool DataSet::Mkdir(const char *dirname) {
     dbprintf(3, "Mkdir(%s)",dirname); 
-#ifndef WIN32
+#ifndef _WIN32
     DIR *dir = opendir(dirname); 
     if (!dir)
       {
@@ -4496,7 +4496,7 @@ namespace paraDIS {
 
     uint32_t numMetaArms = 0, numArms = 0, totalArms = Arm::mArms.size(); 
     STARTPROGRESS(); 
-#ifndef WIN32
+#ifndef _WIN32
     dbprintf(4, "FindMetaArms: %s\n", datestring()); 
 #endif
     for (vector<Arm*>::iterator currentArm = Arm::mArms.begin(); currentArm != Arm::mArms.end(); ++currentArm, ++numArms) {

--- a/src/databases/paraDIS/parallelParaDIS.C
+++ b/src/databases/paraDIS/parallelParaDIS.C
@@ -28,7 +28,7 @@
 #include <avtDatabaseMetaData.h>
 #include <avtMaterial.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdio.h>
 #define F_SLASH_STRING "/"
 #define B_SLASH_STRING "\\"
@@ -36,7 +36,7 @@
 #else
 #include <libgen.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #include <direct.h> /* for _getcwd */
 #define getcwd _getcwd
 #else
@@ -60,7 +60,7 @@ using namespace std;
 static string
 parse_dirname(char *wholePath)
 {
-#ifndef WIN32
+#ifndef _WIN32
     return string(dirname(wholePath)) + "/";
 #else
     string wholePathString(wholePath);
@@ -635,7 +635,7 @@ bool ParallelData:: ParseMetaDataFile(void) {
   } else {
     cwd = string(buf) + "/"; 
   }
-#ifndef WIN32
+#ifndef _WIN32
   if (mMetaDataFileName[0] != '/' )
 #else
   if (mMetaDataFileName.size() > 1 && mMetaDataFileName[1] != ':' )

--- a/src/databases/paraDIS_tecplot/RC_c_lib/fileutils.c
+++ b/src/databases/paraDIS_tecplot/RC_c_lib/fileutils.c
@@ -1,7 +1,7 @@
 #include "fileutils.h"
 #include <stdlib.h>
 #include <string.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <dirent.h>
 #endif
 #include <sys/stat.h>
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 
 /* return 0 on success, perr, or -1 (internal failure) value on failure */
-#ifndef WIN32
+#ifndef _WIN32
 int mkdir_recursive(const char *targetdir){
   char parentdir[1024]; 
   char *lastslash = NULL;

--- a/src/databases/paraDIS_tecplot/RC_c_lib/fileutils.h
+++ b/src/databases/paraDIS_tecplot/RC_c_lib/fileutils.h
@@ -10,7 +10,7 @@ extern "C" {
 /* utilities to deal with files and directories */
 
 size_t fread_loop(void *bufp, size_t elemSize, size_t elems2Read, FILE *fp);
-#ifndef WIN32
+#ifndef _WIN32
 int mkdir_recursive(const char *dirname); 
 #endif
 

--- a/src/databases/paraDIS_tecplot/RC_c_lib/signals.c
+++ b/src/databases/paraDIS_tecplot/RC_c_lib/signals.c
@@ -2,7 +2,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef WIN32
+#ifdef _WIN32
 #  include <winsock2.h>
 #else
 #  include <netdb.h>
@@ -52,7 +52,7 @@ int GettingSignaled(void)
   setsignal(SIGTERM, handler);
   setsignal(SIGABRT, handler);
 
-#ifndef WIN32
+#ifndef _WIN32
   setsignal(SIGCHLD, handler);
   setsignal(SIGHUP, SIG_IGN);
   setsignal(SIGPIPE, handler);
@@ -80,7 +80,7 @@ int GettingSignaled(void)
   /*fclose(stderr);*/
   i=30;
   while (i--){
-#ifndef WIN32
+#ifndef _WIN32
     int err = usleep (999999);
     if (err) {
       fprintf(stderr, "child sleep err %d\n", err);

--- a/src/databases/paraDIS_tecplot/RC_cpp_lib/pathutil.h
+++ b/src/databases/paraDIS_tecplot/RC_cpp_lib/pathutil.h
@@ -1,7 +1,7 @@
 #include "stringutil.h"
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #  include <direct.h>
 #  define WINDOWS_LEAN_AND_MEAN
 #  include <windows.h>

--- a/src/databases/paraDIS_tecplot/RC_cpp_lib/timer.h
+++ b/src/databases/paraDIS_tecplot/RC_cpp_lib/timer.h
@@ -68,7 +68,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #include <sys/timeb.h>
 #include <Winsock2.h>
 #endif
@@ -91,7 +91,7 @@ class timer
   double acc_time;
   double time_per_tick; 
   bool mUseWallTime; 
-#ifndef WIN32
+#ifndef _WIN32
   double getExactSeconds(void) {
     struct timeval t; 
     gettimeofday(&t, NULL); 

--- a/src/databases/sw4img/avtsw4imgFileFormat.C
+++ b/src/databases/sw4img/avtsw4imgFileFormat.C
@@ -32,7 +32,7 @@
 
 using namespace std;
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #define OPEN  ::_open
 #define CLOSE ::_close

--- a/src/databases/volimage/avtvolimageFileFormat.C
+++ b/src/databases/volimage/avtvolimageFileFormat.C
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #define OPEN  ::_open
 #define CLOSE ::_close

--- a/src/gui/QualifiedFilename.C
+++ b/src/gui/QualifiedFilename.C
@@ -372,7 +372,7 @@ QualifiedFilename::SetFromString(const std::string &str)
 std::string
 QualifiedFilename::FullName() const
 {
-#ifdef WIN32
+#ifdef _WIN32
     if (path.substr(0,2) == "\\\\")
     {
         std::string temp(path);

--- a/src/gui/QvisCommandWindow.C
+++ b/src/gui/QvisCommandWindow.C
@@ -1007,7 +1007,7 @@ QvisCommandWindow::macroUpdateClicked()
            // Tell the CLI to source the file so we get our macros back with
            // the changes that have been put into place.
            QString command("ClearMacros()\nSource(\"%1\")\n");
-#ifdef WIN32
+#ifdef _WIN32
            // On windows, the path-string passed to the python commands needs
            // to have it's back-slash's converted.
            rcFileName.replace("\\", "/");

--- a/src/gui/QvisFileWindowBase.C
+++ b/src/gui/QvisFileWindowBase.C
@@ -1777,7 +1777,7 @@ QvisFileWindowBase::changeDirectory(QListWidgetItem *item)
                     if(newPath.size() == 0)
                         newPath = separator;
                 }
-#ifdef WIN32
+#ifdef _WIN32
                 if (newPath.substr(0,2) == "\\\\")
                 {
                     // need to determine if we are attempting to access root

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -1458,7 +1458,7 @@ QvisGUIApplication::HandleSynchronize(int val)
         if(GetViewerState()->GetGlobalAttributes()->GetUserDirForSessionFiles())
             sessionDir = GetUserVisItDirectory();
         else
-#ifndef WIN32
+#ifndef _WIN32
             sessionDir = QString(QDir(".").absolutePath() + VISIT_SLASH_STRING).toStdString();
 #else
             sessionDir = fileServer->GetPath();
@@ -4603,7 +4603,7 @@ QvisGUIApplication::SaveSessionAs()
     }
     else
     {
-#ifdef WIN32
+#ifdef _WIN32
         if (sessionDir.substr(0,2) == "\\\\")
             defaultFile = QString("%1visit%2.session")
                 .arg(sessionDir.c_str())
@@ -5132,7 +5132,7 @@ QvisGUIApplication::RestoreSessionFile(const QString &s,
 
         // If the file could not be opened then try and prepend the
         // VisIt directory to it.
-#ifndef WIN32
+#ifndef _WIN32
         if(node == 0)
         {
             if(guifilename[0] != VISIT_SLASH_CHAR)
@@ -7000,7 +7000,7 @@ QvisGUIApplication::PrintWindow()
     QPrintDialog printDialog(printer, mainWin);
     if(printDialog.exec() == QDialog::Accepted)
     {
-#ifdef WIN32
+#ifdef _WIN32
         // If printer->outputFileName is NOT NULL, then 'Print to file' was
         // chosen and the outputFileName set to 'FILE:'.  Not a very helpful
         // name, and default location will be '%HOMEDRIVE%', eg "C:\"

--- a/src/gui/QvisVisItUpdate.C
+++ b/src/gui/QvisVisItUpdate.C
@@ -678,7 +678,7 @@ QvisVisItUpdate::determineLatestDownload(bool error)
                 maxVersion = it.key();
                 for(int i = 0; i < it.value().size(); ++i)
                 {
-#ifdef WIN32
+#ifdef _WIN32
                     if(it.value()[i].contains(".exe") &&
                        !it.value()[i].contains("visitdev"))
 #else
@@ -714,7 +714,7 @@ QvisVisItUpdate::determineLatestDownload(bool error)
 
             latestVersion = maxUsableVersion;
             downloads.clear();
-#ifndef WIN32
+#ifndef _WIN32
             int slash = installationFile.lastIndexOf("/");
             if(slash != -1)
             {

--- a/src/sim/V2/ddtsim/mpicompat/openmpi/mpi.h
+++ b/src/sim/V2/ddtsim/mpicompat/openmpi/mpi.h
@@ -94,7 +94,7 @@
 #define ompi_fortran_integer_t int
 
 #ifndef OMPI_DECLSPEC
-#if defined(WIN32)
+#if defined(_WIN32)
 #define OMPI_DECLSPEC __declspec(dllimport)
 #else
 #define OMPI_DECLSPEC

--- a/src/tools/data/datagen/multidir.C
+++ b/src/tools/data/datagen/multidir.C
@@ -12,7 +12,7 @@
 
 #include "QuadMesh.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 // What's the header for getcwd
 #else
 #include <unistd.h>
@@ -90,7 +90,7 @@ public:
 std::string
 GetCurrentDirectory()
 {
-#ifdef WIN32
+#ifdef _WIN32
     cerr << "GetCurrentDirectory not implemented" << endl;
     // For now...
     return std::string();
@@ -123,7 +123,7 @@ GetCurrentDirectory()
 void
 GotoDirectory(const std::string &dirname)
 {
-#ifdef WIN32
+#ifdef _WIN32
     cerr << "GotoDirectory not implemented" << endl;
 #else
     if ( (mkdir(dirname.c_str(), S_IRWXU) && (errno!=EEXIST))

--- a/src/tools/dev/xml/GenerateCMake.h
+++ b/src/tools/dev/xml/GenerateCMake.h
@@ -1256,7 +1256,7 @@ class CMakeGeneratorPlugin : public Plugin
 
         QString guilibname("gui");
         QString viewerlibname("viewer");
-#ifdef WIN32
+#ifdef _WIN32
         if (! using_dev)
         {
             // when calling from an installed version, cmake doesn't know that

--- a/src/tools/dev/xml/main.C
+++ b/src/tools/dev/xml/main.C
@@ -108,7 +108,7 @@ Open(const QString &name_withoutpath)
     bool alreadyexists = false;
     QFile *file = new QFile(name);
     if (clobber)
-#ifdef WIN32
+#ifdef _WIN32
         file->open(QIODevice::WriteOnly);
 #else
         file->open(QIODevice::WriteOnly | QIODevice::Text);
@@ -117,7 +117,7 @@ Open(const QString &name_withoutpath)
     {
         if (!file->exists())
         {
-#ifdef WIN32
+#ifdef _WIN32
             file->open(QIODevice::WriteOnly);
 #else
             file->open(QIODevice::WriteOnly | QIODevice::Text);

--- a/src/tools/dev/xml/main.h
+++ b/src/tools/dev/xml/main.h
@@ -11,7 +11,7 @@ QString     Endl("\n");
 
 #include <BJHash.h>
 #include <stdio.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/src/tools/third_party/mpeg2encode/mpeg2enc.c
+++ b/src/tools/third_party/mpeg2encode/mpeg2enc.c
@@ -168,7 +168,7 @@ char *fname;
   int h,m,s,f;
   FILE *fd;
   char line[256];
-#ifdef WIN32
+#ifdef _WIN32
   char *commentBegin = NULL;
   int len = 0;
 #endif
@@ -185,7 +185,7 @@ char *fname;
   }
 
   result = fgets(id_string,254,fd);
-#ifndef WIN32
+#ifndef _WIN32
   result = fgets(line,254,fd); sscanf(line,"%s",tplorg);
 #else
   result = fgets(line,254,fd); 
@@ -199,7 +199,7 @@ char *fname;
   result = fgets(line,254,fd); sscanf(line,"%s",tplref);
   result = fgets(line,254,fd); sscanf(line,"%s",iqname);
   result = fgets(line,254,fd); sscanf(line,"%s",niqname);
-#ifndef WIN32
+#ifndef _WIN32
   result = fgets(line,254,fd); sscanf(line,"%s",statname);
 #else
   result = fgets(line,254,fd); 

--- a/src/viewer/core/ViewerStateManager.C
+++ b/src/viewer/core/ViewerStateManager.C
@@ -987,7 +987,7 @@ ViewerStateManager::BuildSourceMap(DataNode *viewerNode, const stringVector &sou
             }
             // Ensure we save a fully host-qualified name.
             FileFunctions::SplitHostDatabase(source, tmpHost, tmpDB);
-#ifdef WIN32
+#ifdef _WIN32
             if (tmpDB.substr(0,2) == "\\\\")
                 sourceToDB[std::string(tmp)] = tmpDB;
             else
@@ -1332,7 +1332,7 @@ CleanHostProfileCallback(void *,
         (base.substr(base.length()-4) != ".xml" &&
          base.substr(base.length()-4) != ".XML"))
         return;
-#ifdef WIN32
+#ifdef _WIN32
     _unlink(file.c_str());
 #else
     unlink(file.c_str());

--- a/src/viewer/core/ViewerWindowManager.C
+++ b/src/viewer/core/ViewerWindowManager.C
@@ -1692,7 +1692,7 @@ ViewerWindowManager::SaveWindow(int windowIndex)
                        "use the name \"visit\" as the base for the files "
                        "to be saved."));
             }
-#ifdef WIN32
+#ifdef _WIN32
             else
             {
                 // need to check if our filename contains a path:

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -2174,7 +2174,7 @@ ViewerSubject::ReadConfigFiles(int argc, char **argv)
                  !GetViewerProperties()->GetNoConfig())
         {
             specifiedConfig = true;
-#ifndef WIN32
+#ifndef _WIN32
             GetViewerProperties()->SetConfigurationFileName(argv[i+1]);
 #else
             string tmp = argv[i+1];
@@ -2500,7 +2500,7 @@ ViewerSubject::ProcessCommandLine(int argc, char **argv)
         {
             // Make sure the -config flag and the filename that follows it is
             // not passed along to other components.
-#ifndef WIN32
+#ifndef _WIN32
             ++i;
 #else
             i+=nConfigArgs;

--- a/src/viewer/main/VisItViewer.C
+++ b/src/viewer/main/VisItViewer.C
@@ -470,7 +470,7 @@ VisItViewer::Setup()
     {
 
         std::string pluginDir(GetVisItHome());
-#ifndef WIN32
+#ifndef _WIN32
         pluginDir += "/plugins";
 #endif
 

--- a/src/visit_vtk/full/vtkVisItStreamLine.C
+++ b/src/visit_vtk/full/vtkVisItStreamLine.C
@@ -34,7 +34,7 @@ vtkStandardNewMacro(vtkVisItStreamLine);
 #define VTK_START_FROM_POSITION 0
 #define VTK_START_FROM_LOCATION 1
 
-#ifdef WIN32
+#ifdef _WIN32
 // JRC 21Jul2010: this hack no longer needed, as vtk patch
 // now export StreamArray
 #ifndef VTK_STREAM_ARRAY_EXPORTED

--- a/src/visitpy/cli/cli.C
+++ b/src/visitpy/cli/cli.C
@@ -36,7 +36,7 @@
 #include <string>
 #include <vector>
 
-#ifdef WIN32
+#ifdef _WIN32
   #define VISITCLI_API __declspec(dllimport)
 
   #define BEGINSWITHQUOTE(A) (A[0] == '\'' || A[0] == '\"')
@@ -216,7 +216,7 @@ main(int argc, char *argv[])
     bool sleep_mode = false;
     std::string run_code = "";
 
-#ifdef WIN32
+#ifdef _WIN32
     char tmpArg[512];
 #endif
 
@@ -249,7 +249,7 @@ main(int argc, char *argv[])
                 fprintf(stderr,"Warning: clamping debug level to 5\n");
             }
         }
-#ifdef WIN32
+#ifdef _WIN32
         else if((strcmp(argv[i], "-s") == 0 && (i+1 < argc)) ||
                 (strcmp(argv[i], "-o") == 0 && (i+1 < argc)) ||
                 (strcmp(argv[i], "-runcode") == 0 && (i+1 < argc)))
@@ -426,7 +426,7 @@ main(int argc, char *argv[])
 
         else if(strcmp(argv[i], "-minimized") == 0)
         {
-#ifdef WIN32
+#ifdef _WIN32
             HWND console = GetConsoleWindow();
             if(console != NULL)
                 ShowWindow(console, SW_MINIMIZE);
@@ -434,7 +434,7 @@ main(int argc, char *argv[])
         }
         else if(strcmp(argv[i], "-hide_window") == 0)
         {
-#ifdef WIN32
+#ifdef _WIN32
             HWND console = GetConsoleWindow();
             if(console != NULL)
                 ShowWindow(console, SW_HIDE);
@@ -726,7 +726,7 @@ main(int argc, char *argv[])
             }
             PyRun_SimpleString(command.str().c_str());
             
-#ifdef WIN32
+#ifdef _WIN32
              delete [] loadFile;
 #endif
         }
@@ -746,7 +746,7 @@ main(int argc, char *argv[])
             
             cli_runscript(runFile);
 
-#ifdef WIN32
+#ifdef _WIN32
              delete [] runFile;
 #endif
         }
@@ -788,7 +788,7 @@ main(int argc, char *argv[])
     }
     ENDTRY
 
-#ifdef WIN32
+#ifdef _WIN32
     // cleanup allocs that were necessary for windows (runFile may be used in argv_py_style)
     if(runFile !=0)
         delete [] runFile;

--- a/src/visitpy/common/PyTable.C
+++ b/src/visitpy/common/PyTable.C
@@ -22,7 +22,7 @@
 #include <string>
 
 // For shared memory access
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -100,7 +100,7 @@ public:
             << ", isMemMapped=" << isMemMapped << std::endl;
         if(isMemMapped)
         {
-    #ifndef WIN32
+    #ifndef _WIN32
             if(ptr)
             {
                 munmap(ptr, len);
@@ -435,7 +435,7 @@ LoadFromSharedMemory(const std::string &shmName,
                      std::array<void*, 2> &outPtrs)
 {
     outPtrs[0] = outPtrs[1] = nullptr;
-#ifndef WIN32
+#ifndef _WIN32
     debug5 << "Loading flatten data from shared memory." << std::endl;
     int fd = shm_open(shmName.c_str(), O_RDWR, 0);
     if(fd == -1)

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -5943,7 +5943,7 @@ visit_SetCloneWindowOnFirstRef(PyObject *self, PyObject *args)
 // Modifications:
 //
 // ****************************************************************************
-#ifdef WIN32
+#ifdef _WIN32
 #define strcasecmp stricmp
 #endif
 STATIC PyObject *
@@ -20018,7 +20018,7 @@ cli_runscript(const char *fileName)
         if(fp)
         {
             std::string fn(fileName);
-#ifdef WIN32
+#ifdef _WIN32
             std::replace(fn.begin(), fn.end(), '\\', '/');
 #endif
             // book keeping for source stack


### PR DESCRIPTION
### Description

Make the macro usage consistent across all of VisIt.

### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other~~ <!-- please explain with a note below -->
code consistency

### How Has This Been Tested?

compiled and ran tests on Windows with success.


### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

