### PR TITLE
Fix hang saving an image with transparent geometry with scalable rendering. (#19729)

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -68,6 +68,14 @@ bool VisWinRendering::stereoEnabled = false;
 
 #if LIB_VERSION_LE(VTK,8,1,0)
 #else
+//
+// vtkBackgroundPass is no longer used. It was previously used in
+// PostProcessScreenCapture to copy the composited image to the image
+// before rendering the foreground annotations. I'm leaving it here in
+// case we ever need it again and as an example of a render pass and
+// using an OpenGL shader in VTK.
+//
+
 // For vtkBackgroundPass
 #include <vtkOpenGLQuadHelper.h>
 #include <vtkOpenGLRenderUtilities.h>
@@ -1935,6 +1943,11 @@ VisWinRendering::BackgroundReadback(bool doViewportOnly)
 //    the vtkBackgroundPass render pass (at the top of this file) to
 //    accomplish this. The old mechanism no longer worked with VTK9.
 //
+//    Eric Brugger, Thu Aug  8 15:33:43 PDT 2024
+//    Switch back to using the old method to set the pixel data with
+//    SetPixelData and SetRGBACharPixelData, except writing to the back
+//    buffer instead of the front buffer.
+//
 // ****************************************************************************
 
 avtImage_p
@@ -1965,7 +1978,6 @@ VisWinRendering::PostProcessScreenCapture(avtImage_p input,
     writer->Delete();
 #endif
 
-#if LIB_VERSION_LE(VTK,8,1,0)
     // temporarily remove canvas and background renderers
     vtkRenderWindow *renWin = GetRenderWindow();
     renWin->RemoveRenderer(canvas);
@@ -1974,43 +1986,20 @@ VisWinRendering::PostProcessScreenCapture(avtImage_p input,
     // set pixel data
     unsigned char *pixels = input->GetImage().GetRGBBuffer();
     int nChannels = input->GetImage().GetNumberOfColorChannels();
+#if LIB_VERSION_LE(VTK,8,1,0)
     if(nChannels == 4)
         renWin->SetRGBACharPixelData(c0, r0, c0+w-1, r0+h-1, pixels, /*front=*/1);
     else
         renWin->SetPixelData(c0, r0, c0+w-1, r0+h-1, pixels, /*front=*/1);
+#else
+    if(nChannels == 4)
+        renWin->SetRGBACharPixelData(c0, r0, c0+w-1, r0+h-1, pixels, /*back=*/0);
+    else
+        renWin->SetPixelData(c0, r0, c0+w-1, r0+h-1, pixels, /*back=*/0);
+#endif
 
     // render (foreground layer only)
     RenderRenderWindow();
-#else
-    // Get the render window.
-    vtkRenderWindow *renWin = GetRenderWindow();
-
-    // Create a renderer that uses the vtkBackgroundPass to render the
-    // composited image.
-    vtkRenderer *imageRenderer = vtkRenderer::New();
-    vtkBackgroundPass *imagePass = vtkBackgroundPass::New();
-    unsigned char *pixels = input->GetImage().GetRGBBuffer();
-    int nChannels = input->GetImage().GetNumberOfColorChannels();
-    imagePass->SetBackground(nChannels, c0, r0, w, h, pixels);
-    imageRenderer->SetPass(imagePass);
-    imageRenderer->SetLayer(1);
-    imageRenderer->SetBackground(1., 1., 1.);
-
-    // Replace the canvas with the image.
-    renWin->RemoveRenderer(canvas);
-    renWin->AddRenderer(imageRenderer);
-
-    // Render.
-    renWin->Render();
-
-    // Restore the canvas.
-    renWin->RemoveRenderer(imageRenderer);
-    renWin->AddRenderer(canvas);
-
-    // Clean up the image renderer.
-    imagePass->Delete();
-    imageRenderer->Delete();
-#endif
 
     // Capture the whole image now.
     GetCaptureRegion(r0, c0, w, h, false);
@@ -2048,11 +2037,10 @@ VisWinRendering::PostProcessScreenCapture(avtImage_p input,
 
     im->Delete();
 
-#if LIB_VERSION_LE(VTK,8,1,0)
     // add canvas and background renderers back in
     renWin->AddRenderer(background);
     renWin->AddRenderer(canvas);
-#endif
+
     return output;
 }
 

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Blueprint writer now correctly puts the right cycle number in file names.</li>
   <li>Fixed a bug in zonetype-label expression where unknown zone types would render a weird symbol, <code>&quot;?</code>.</li>
   <li>Disabled warning message regarding skipping of speculative expression generation for databases with many variables. For more information, read our documentation about <a href="https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/using_visit/Quantitative/Expressions.html#automatic-expressions">automatic expressions</a>.</li>
+  <li>Fixed a bug where saving an image with transparent geometry would hang when using scalable rendering.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/test/skip.json
+++ b/src/test/skip.json
@@ -137,7 +137,7 @@
                     {"category":"queries","file":"xrayimage.py","cases":["NonSquare_Pixels_Ray_trace_setup_1","NonSquare_Pixels_Ray_trace_setup_2","NonSquare_Pixels_Ray_trace_setup_3","NonSquare_Pixels_Ray_trace_setup_4","NonSquare_Pixels_Ray_trace_setup_5","NonSquare_Pixels_Ray_trace_setup_6","NonSquare_Pixels_Ray_trace_setup_8"]},
                     {"category":"rendering","file":"compositing.py","cases":["compositing_01"]},
                     {"category":"rendering","file":"pixeldata.py","cases":["pixeldata_0_00","pixeldata_0_01","pixeldata_0_02","pixeldata_0_03","pixeldata_0_04","pixeldata_0_06"]},
-                    {"category":"rendering","file":"transparency.py"},
+                    {"category":"rendering","file":"transparency.py", "cases":["transparency_01","transparency_02","transparency_03","transparency_04","transparency_05","transparency_06","transparency_07","transparency_09","transparency_11"]},
                     {"category":"session","file":"rect3d-contour.py","cases":["rect3d-contour00"]},
                     {"category":"session","file":"simplekeyframe.py"},
                     {"platform":"win","category":"hybrid","file":"field_operators.py","cases":["field_op_04"]},


### PR DESCRIPTION
### Description

This is a merge from develop to the 3.4RC. It is the same change, but I added some conditional code to handle the VTK 8.1 case.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran the test `rendering/transparent.py` in `scalable,parallel,icet` mode. It ran successfully.

I also ran the following script manually to verify that saving an image with transparent geometry didn't hang.
```
OpenDatabase("localhost:/usr/gapps/visit/data/multi_ucd3d.silo", 0)

# Turn off annotations.
a = AnnotationAttributes()
a.userInfoFlag = 0
a.databaseInfoFlag = 0
SetAnnotationAttributes(a)

# Create an transparent plot.
AddPlot("Subset", "domains(mesh1)", 1, 0)
s = SubsetAttributes()
s.opacity = 0.403922
SetPlotOptions(s)

# Turn on scalable rendering.
r = RenderingAttributes()
r.scalableActivationMode = r.Always
SetRenderingAttributes(r)

# Set the view.
View3DAtts = View3DAttributes()
View3DAtts.viewNormal = (0.281187, 0.666153, 0.690778)
View3DAtts.focus = (0, 2.5, 10)
View3DAtts.viewUp = (-0.285935, 0.745284, -0.602323)
View3DAtts.viewAngle = 30
View3DAtts.parallelScale = 11.4564
View3DAtts.nearPlane = -22.9129
View3DAtts.farPlane = 22.9129
View3DAtts.imagePan = (0, 0)
View3DAtts.imageZoom = 1
View3DAtts.perspective = 1
View3DAtts.eyeAngle = 2
View3DAtts.centerOfRotationSet = 0
View3DAtts.centerOfRotation = (0, 2.5, 10)
View3DAtts.axis3DScaleFlag = 0
View3DAtts.axis3DScales = (1, 1, 1)
View3DAtts.shear = (0, 0, 1)
View3DAtts.windowValid = 1
SetView3D(View3DAtts)

# Draw the plot.
DrawPlots()

# Save the window.
s = SaveWindowAttributes()
s.width = 512
s.height = 512
s.format = s.PNG
s.resConstraint = s.NoConstraint
SetSaveWindowAttributes(s)
SaveWindow()
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
