### PR TITLE
Fix bug rendering both opaque and transparent geometry with scalable rendering. (#19732)

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -1630,10 +1630,17 @@ VisWinRendering::ScreenRender(avtImageType imgT,
             unsigned char *rgbbuf = input->GetImage().GetRGBBuffer();
             int nchan = input->GetImage().GetNumberOfColorChannels();
 
+#if LIB_VERSION_LE(VTK,8,1,0)
+            if (nchan == 3)
+                renWin->SetPixelData(r0,c0,w-1,h-1,rgbbuf, 1);
+            else
+                renWin->SetRGBACharPixelData(r0,c0,w-1,h-1, rgbbuf, 1);
+#else
             if (nchan == 3)
                 renWin->SetPixelData(r0,c0,w-1,h-1,rgbbuf, 0);
             else
                 renWin->SetRGBACharPixelData(r0,c0,w-1,h-1, rgbbuf, 0);
+#endif
 
             glDepthMask(GL_TRUE);
         }

--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -1504,6 +1504,11 @@ VisWinRendering::GetCaptureRegion(int& r0, int& c0, int& w, int& h,
 //    that's why these things are conditionally compiled. They'll need to
 //    be changed to render passes for VTK 8.
 //
+//    Eric Brugger, Fri Aug  9 13:45:49 PDT 2024
+//    Change the calls to SetPixelData and SetRGBACharPixelData to write
+//    to the back buffer instead of the front buffer. The behavior changed
+//    with VTK9.
+//
 // ****************************************************************************
 
 void
@@ -1626,9 +1631,9 @@ VisWinRendering::ScreenRender(avtImageType imgT,
             int nchan = input->GetImage().GetNumberOfColorChannels();
 
             if (nchan == 3)
-                renWin->SetPixelData(r0,c0,w-1,h-1,rgbbuf, 1);
+                renWin->SetPixelData(r0,c0,w-1,h-1,rgbbuf, 0);
             else
-                renWin->SetRGBACharPixelData(r0,c0,w-1,h-1, rgbbuf, 1);
+                renWin->SetRGBACharPixelData(r0,c0,w-1,h-1, rgbbuf, 0);
 
             glDepthMask(GL_TRUE);
         }

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -37,6 +37,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Blueprint writer now correctly puts the right cycle number in file names.</li>
   <li>Fixed a bug in zonetype-label expression where unknown zone types would render a weird symbol, <code>&quot;?</code>.</li>
   <li>Disabled warning message regarding skipping of speculative expression generation for databases with many variables. For more information, read our documentation about <a href="https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/using_visit/Quantitative/Expressions.html#automatic-expressions">automatic expressions</a>.</li>
+  <li>Fixed a bug where the opaque geometry in an image containing both opaque and transparent geometry wouldn't be rendered poperly when rendered using scalable rendering.</li>
   <li>Fixed a bug where saving an image with transparent geometry would hang when using scalable rendering.</li>
   <li>Fixed a bug where perspective mode set to `off` in config files would not be restored correctly.</li>
 </ul>

--- a/src/test/tests/rendering/transparency.py
+++ b/src/test/tests/rendering/transparency.py
@@ -40,8 +40,12 @@
 #   Mark C. Miller, Wed Jan 20 07:37:11 PST 2010
 #   Added ability to swtich between Silo's HDF5 and PDB data.
 #
-#    Kathleen Biagas, Mon Dec 19 15:45:38 PST 2016
-#    Use FilledBoundary plot for materials instead of Subset.
+#   Kathleen Biagas, Mon Dec 19 15:45:38 PST 2016
+#   Use FilledBoundary plot for materials instead of Subset.
+#
+#   Eric Brugger, Fri Aug  9 13:45:49 PDT 2024
+#   Added a test of combining opaque and transparent plots from
+#   multi_ucd3d.silo.
 #
 # ----------------------------------------------------------------------------
 
@@ -189,5 +193,49 @@ v.shear = (0, 0, 1)
 v.windowValid = 1
 SetView3D(v)
 Test("transparency_14")
+
+# Test both opaque and transparent plots with 3d multi block data
+DeleteAllPlots()
+OpenDatabase("localhost:/usr/gapps/visit/data/multi_ucd3d.silo", 0)
+
+AddPlot("Subset", "mesh1", 1, 1)
+s = SubsetAttributes()
+s.colorType = s.ColorBySingleColor
+s.singleColor = (153, 153, 153, 255)
+SetPlotOptions(s)
+AddOperator("Slice", 1)
+SliceAtts = SliceAttributes()
+SliceAtts.originType = SliceAtts.Intercept
+SliceAtts.originIntercept = 2.5
+SliceAtts.project2d = 0
+SetOperatorOptions(SliceAtts, 0, 1)
+
+AddPlot("Subset", "domains(mesh1)", 1, 0)
+s = SubsetAttributes()
+s.opacity = 0.403922
+SetPlotOptions(s)
+
+DrawPlots()
+v = GetView3D()
+v.viewNormal = (0.281187, 0.666153, 0.690778)
+v.focus = (0, 2.5, 10)
+v.viewUp = (-0.285935, 0.745284, -0.602323)
+v.viewAngle = 30
+v.parallelScale = 11.4564
+v.nearPlane = -22.9129
+v.farPlane = 22.9129
+v.imagePan = (0, 0)
+v.imageZoom = 1
+v.perspective = 1
+v.eyeAngle = 2
+v.centerOfRotationSet = 0
+v.centerOfRotation = (0, 2.5, 10)
+v.axis3DScaleFlag = 0
+v.axis3DScales = (1, 1, 1)
+v.shear = (0, 0, 1)
+v.windowValid = 1
+SetView3D(v)
+
+Test("transparency_15")
 
 Exit()

--- a/test/baseline/rendering/transparency/transparency_15.png
+++ b/test/baseline/rendering/transparency/transparency_15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1369c269d9b05b7a1616f73197bc0bf31c4a7d3992747dafca8d7d0481549d6c
+size 11486


### PR DESCRIPTION
### Description

This is a merge from develop to the 3.4RC. It is the same change, but I added some conditional code to handle the VTK 8.1 case.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran the test `rendering/transparent.py` in `scalable,parallel,icet` mode. It ran successfully.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
