### PR TITLE
Always search for hdf5_hl so it will be installed with VisIt. (#19762)

### DIFF
--- a/src/CMake/FindHDF5.cmake
+++ b/src/CMake/FindHDF5.cmake
@@ -13,6 +13,9 @@
 #   Kathleen Biagas, Thu Jan 9 18:47:21 PDT 2014
 #   Add patch from John Cary for hdf5 without 'dll' suffix on name.
 #
+#   Kathleen Biagas, Wed July 31, 2024
+#   Add hdf5_hl to search on Linux.
+#
 #****************************************************************************/
 
 # Use the HDF5_DIR hint from the config-site .cmake file
@@ -39,8 +42,8 @@ IF(WIN32)
     endif()
   endif()
 ELSE()
-  SET_UP_THIRD_PARTY(HDF5 LIBS hdf5)
+  SET_UP_THIRD_PARTY(HDF5 LIBS hdf5 hdf5_hl)
   IF(VISIT_PARALLEL)
-      SET_UP_THIRD_PARTY(HDF5_MPI LIBS hdf5_mpi)
+      SET_UP_THIRD_PARTY(HDF5_MPI LIBS hdf5_mpi hdf5_mpi_hl)
   ENDIF(VISIT_PARALLEL)
 ENDIF()

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -53,6 +53,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The <code>VISIT_VERSION_GE()</code> macro useful in detecting the VisIt version being used at compile time has been made public in its own header file, <code>visit-version.h</code>, which is found in <code>VISIT_INSTALL/include/visit/include</code>.</li>
   <li>The Blueprint writer lets users specify Blueprint write options.</li>
   <li>The expression system now supports the <code>%</code> binary modulo operator. The <code>mod()</code> expression function is still supported but has been generalized to use the <code>fmod()</code> function from the C/C++ math library as does the new <code>%</code> binary operator.</li>
+  <li>Fixed bug where hdf5_hl library wouldn't always be installed with VisIt.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #19692

Merge from 3.4RC

### Type of change


* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Compiled and installed Visit without NETCDF (which pulls in hdf5_hl as a dependency).
hdf5_hl was installed, resolving the MOAB/MFEM dependencies.


### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
