### PR TITLE
expression editor read only tweaks

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -757,12 +757,16 @@ QvisExpressionsWindow::SetStandardEditorReadOnly(bool read_only)
 {
     if(read_only)
     {
+        nameEditLabel->setText(tr("Name (Read Only)"));
+        nameEdit->setReadOnly(true);
         stdDefinitionEdit->setTextInteractionFlags(Qt::TextSelectableByMouse |
                                                    Qt::TextSelectableByKeyboard );
         stdDefinitionEditLabel->setText(tr("Definition (Read Only)"));
     }
     else
     {
+        nameEditLabel->setText(tr("Name"));
+        nameEdit->setReadOnly(false);
         stdDefinitionEdit->setTextInteractionFlags(Qt::TextEditable);
         stdDefinitionEditLabel->setText(tr("Definition"));
     }
@@ -1025,7 +1029,6 @@ QvisExpressionsWindow::UpdateWindowSensitivity()
         read_only = true;
     }
 
-    nameEdit->setEnabled(enable && !read_only);
     delButton->setEnabled(enable && !read_only);
 
     typeList->setEnabled(enable && !read_only);

--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -738,6 +738,40 @@ QvisExpressionsWindow::CreateStandardEditor()
 }
 
 // ****************************************************************************
+// Method: QvisExpressionsWindow::SetStandardEditorReadOnly()
+//
+// Purpose:
+//   Sets interaction of widgets according to if we are in a read only mode.
+//   We still want to be able to copy text even if read only.
+//
+//
+// Programmer: Cyrus Harrison
+// Creation:   Fri Aug 23 10:00:47 PDT 2024
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+QvisExpressionsWindow::SetStandardEditorReadOnly(bool read_only)
+{
+    if(read_only)
+    {
+        stdDefinitionEdit->setTextInteractionFlags(Qt::TextSelectableByMouse |
+                                                   Qt::TextSelectableByKeyboard );
+        stdDefinitionEditLabel->setText(tr("Definition (Read Only)"));
+    }
+    else
+    {
+        stdDefinitionEdit->setTextInteractionFlags(Qt::TextEditable);
+        stdDefinitionEditLabel->setText(tr("Definition"));
+    }
+
+    stdInsertFunctionButton->setEnabled(!read_only);
+    stdInsertVariableButton->setEnabled(!read_only);
+}
+
+// ****************************************************************************
 // Method: QvisExpressionsWindow::CreatePythonFilterEditor()
 //
 // Purpose:
@@ -970,12 +1004,16 @@ QvisExpressionsWindow::UpdateWindowSingleItem()
 //    Capture currentIndex before setting enablement of the tabs, then reset
 //    it afterwards.
 //
+//    Cyrus Harrison, Thu Aug 22 14:27:14 PDT 2024
+//    Set text editing modes for the editor widgets, don't fully disable them.
+//
 // ****************************************************************************
 
 void
 QvisExpressionsWindow::UpdateWindowSensitivity()
 {
     bool enable = true;
+    bool read_only = false;
     int index = exprListBox->currentRow();
 
     if (index <  0)
@@ -984,15 +1022,18 @@ QvisExpressionsWindow::UpdateWindowSensitivity()
     }
     else if ((*exprList)[indexMap[index]].GetFromDB())
     {
-        enable = false;
+        read_only = true;
     }
 
+    nameEdit->setEnabled(enable && !read_only);
+    delButton->setEnabled(enable && !read_only);
 
-    nameEdit->setEnabled(enable);
-    delButton->setEnabled(enable);
+    typeList->setEnabled(enable && !read_only);
+    notHidden->setEnabled(enable && !read_only);
 
-    typeList->setEnabled(enable);
-    notHidden->setEnabled(enable);
+    SetStandardEditorReadOnly(read_only);
+    // we don't have db defined python exprs
+    editorTabs->setTabVisible(1,!read_only);
 
     // calling setTableEnbled with a value of false seems to change the
     // current index, so capture that information and reset it after.
@@ -1001,7 +1042,8 @@ QvisExpressionsWindow::UpdateWindowSensitivity()
     editorTabs->setTabEnabled(1, enable && pyExprActive);
     editorTabs->setCurrentIndex(ci);
     editorTabs->update();
-    
+
+
     this->update();
 }
 

--- a/src/gui/QvisExpressionsWindow.h
+++ b/src/gui/QvisExpressionsWindow.h
@@ -111,6 +111,7 @@ class GUI_API QvisExpressionsWindow : public QvisPostableWindowObserver
     QString QuoteVariable(const QString &);
 
     void    CreateStandardEditor();
+    void    SetStandardEditorReadOnly(bool read_only);
     void    CreatePythonFilterEditor();
     void    UpdatePythonExpression();
     bool    ParsePythonExpression(const QString &, QString &, QString &);


### PR DESCRIPTION
### Description

Resolves #19720

Changes presentation of db or auto gen expressions so their definitions can be copied, along with a few other adjustments. 

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

UI Change
### How Has This Been Tested?

Tested on macOS, we should test on other platforms and discuss changes in a project meeting. 


### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
