### PR TITLE
add support for SLURM_NPROCS to visit_utils.engine

### DIFF
--- a/src/visitpy/visit_utils/src/engine.py
+++ b/src/visitpy/visit_utils/src/engine.py
@@ -53,8 +53,9 @@ def open(**kwargs):
 
       engine.open(method="slurm")
 
-    This reads the SLURM_JOB_NUM_NODES and SLURM_CPUS_ON_NODE 
-    env vars and uses these values to launch with srun.
+    This reads the SLURM_NPROCS or (SLURM_JOB_NUM_NODES and
+    SLURM_CPUS_ON_NODE) env vars and uses these values to launch
+    with srun.
 
     If you already have a lsf batch allocation, you can use:
 
@@ -83,15 +84,17 @@ def open(**kwargs):
         args["method"] = host.launch_method(args["part"])
     elif kwargs["method"] == "slurm":
         args["host"] = hostname(False)
-        if "SLURM_JOB_NUM_NODES" in os.environ:
+        if "SLURM_NPROCS" in os.environ:
+            nprocs = int(os.environ["SLURM_NPROCS"])
+        elif "SLURM_JOB_NUM_NODES" in os.environ:
             nnodes = int(os.environ["SLURM_JOB_NUM_NODES"])
             ppn    = int(os.environ["SLURM_CPUS_ON_NODE"])
+            args["ppn"]      = ppn
             nprocs = ppn * nnodes
         else:
             raise VisItException("engine.open(method='slurm') requires "
-                                 "SLURM_JOB_NUM_NODES and SLURM_CPUS_ON_NODE env vars")
+                                 "SLURM_NPROCS OR (SLURM_JOB_NUM_NODES and SLURM_CPUS_ON_NODE) env vars")
         args["nprocs"]   = nprocs
-        args["ppn"]      = ppn
         kwargs["method"] = "srun"
     elif kwargs["method"] == "lsf":
         args["host"] = hostname(False)


### PR DESCRIPTION
### Description

Resolves #19435 

Updates `visit_utils.engine` to support `SLURM_NPROCS` env var. 

This is important b/c folks want to use the number of tasks requested, which may be different from the number of cores on a node. 


### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

WHIP### How Has This Been Tested?

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
