### PR TITLE
cmake: make sure visit bin items have proper cmake dep

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -63,6 +63,10 @@
 #  Kathleen Biagas, Tue Jan 31, 2023
 #  Change how files are copied on Windows.
 #
+#  Cyrus Harrison, Fri Aug 23 14:17:16 PDT 2024
+#  Use custom command to copy bin files so that cmake keeps them
+#  up-to-date in `/bin` when the source files are modified.
+#
 #****************************************************************************
 
 #-----------------------------------------------------------------------------
@@ -118,11 +122,20 @@ if(NOT WIN32)
     # otherwise.
     #
     # this is copying to build dir
+    set(__all_visit_bin_build_dir_items)
     foreach(VISIT_BIN_ITEM ${VISIT_BIN_FILES} internallauncher makemovie.py makemoviemain.py visitcinema.py visitcinemamain.py visitdiff.py)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy
-                                ${CMAKE_CURRENT_SOURCE_DIR}/${VISIT_BIN_ITEM}
-                                ${CMAKE_CURRENT_BINARY_DIR}/${VISIT_BIN_ITEM})
+        # use custom command so cmake captures the dependency, triggering
+        # a copy whenever the source files change
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${VISIT_BIN_ITEM}
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/${VISIT_BIN_ITEM}
+                                   ${CMAKE_CURRENT_BINARY_DIR}/${VISIT_BIN_ITEM}
+                           MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${VISIT_BIN_ITEM})
+        list(APPEND __all_visit_bin_build_dir_items ${CMAKE_CURRENT_BINARY_DIR}/${VISIT_BIN_ITEM})
     endforeach()
+
+    add_custom_target(visit_bin_exec_items ALL DEPENDS ${__all_visit_bin_build_dir_items})
+    unset(__all_visit_bin_build_dir_items)
 
     file(MAKE_DIRECTORY ${VISIT_EXECUTABLE_DIR})
     configure_file(makemili_driver_ser ${VISIT_EXECUTABLE_DIR} COPYONLY)


### PR DESCRIPTION
### Description

Resolves #19647


Changes cmake logic used to copy `/bin` items, such as internallauncher for non windows systems. 

Uses custom command and a custom target to make sure the copy action will trigger if source files change. 


### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

cmake build system cahnge

### How Has This Been Tested?

Tested on macOS, verified that a modified internallauncher was picked and copied to bin

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
