### PR TITLE
Add patch for vtkOpenGLPolyDataMapper. (#19771)

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -54,6 +54,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The Blueprint writer lets users specify Blueprint write options.</li>
   <li>The expression system now supports the <code>%</code> binary modulo operator. The <code>mod()</code> expression function is still supported but has been generalized to use the <code>fmod()</code> function from the C/C++ math library as does the new <code>%</code> binary operator.</li>
   <li>Fixed bug where hdf5_hl library wouldn't always be installed with VisIt.</li>
+  <li>Fixed bug with Pseudocolor plots of datasets with very large or small extents being rendered black.</li>
 </ul>
 
 <a name="Dev_changes"></a>
@@ -63,6 +64,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Docker containers were added for RockyLinux (RHEL compatible).</li>
   <li>Qwt is now optional. Historically, it has only ever been needed for advanced GUI features of LibSimV2 interface. Add <code>--qwt</code> to the build_visit command line to build qwt. Add <code>--system-qwt</code> to have VisIt attempt to find and use a system version of Qwt.  Add <code>--alt-qwt-dir /path/to/qwt/install</code> to use a pre-built version of Qwt installed somewhere else.</li>
   <li>Added ICE-T support for Windows builds.</li>
+  <li>Fixed bug where printing the build_visit log file location prepended extra paths.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -145,6 +145,36 @@ function bv_vtk_ensure
 # *************************************************************************** #
 #                            Function 6, build_vtk                            #
 # *************************************************************************** #
+function apply_vtk9_vtkopenglpolydatamapper_patch
+{
+  # patch that allows extra large extents datasets to be rendered correctly
+   patch -p0 << \EOF
+--- Rendering/OpenGL2/vtkOpenGLPolyDataMapper.cxx.orig    2024-08-23 08:45:54.157974000 -0700
++++ Rendering/OpenGL2/vtkOpenGLPolyDataMapper.cxx 2024-08-23 08:57:58.918823000 -0700
+@@ -2241,9 +2241,12 @@
+     }
+     else // not lines, so surface
+     {
++      // The partial derivatives are scaled by the inverse of fwidth
++      // to avoid overflow or underflow in the following computations.
+       vtkShaderProgram::Substitute(FSSource, "//VTK::UniformFlow::Impl",
+-        "vec3 fdx = dFdx(vertexVC.xyz);\n"
+-        "  vec3 fdy = dFdy(vertexVC.xyz);\n"
++        "float scale = 1.0/length(fwidth(vertexVC.xyz));\n"
++        "  vec3 fdx = dFdx(vertexVC.xyz)*scale;\n"
++        "  vec3 fdy = dFdy(vertexVC.xyz)*scale;\n"
+         "  //VTK::UniformFlow::Impl\n" // For further replacements
+       );
+
+EOF
+
+    if [[ $? != 0 ]] ; then
+      warn "patch allowing VTK to build with g++-13 failed."
+      return 1
+    fi
+
+}
+
 function apply_vtk9_gcc13_patch
 {
   # patches that allows VTK9 to be built g++-13
@@ -1304,6 +1334,10 @@ function apply_vtk_patch
         return 1
     fi
 
+    apply_vtk9_vtkopenglpolydatamapper_patch
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
 
     return 0
 }

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -189,11 +189,7 @@ function error
              "the VisIt project via https://visit-help.llnl.gov. You may "\
              "need to compress the ${LOG_FILE} using a program like gzip "\
              "so it will fit within the size limits for attachments."
-        if [[ -n "$START_DIR" ]]; then
-            info "Log file full path: " ${START_DIR}/${LOG_FILE}
-        else
-            info "Log file full path: " $(pwd)/${LOG_FILE}
-        fi
+        info "Log file full path: " ${LOG_FILE}
     fi
     exit 1
 }


### PR DESCRIPTION
### Description

Merge from 3.4RC

Add patch (from Kitware) for vtkOpenGLPolyDataMapper, which scales vertex normals to prevent overflow/underflow for datasets with very large or small extents.

Resolves #19480.

Removed logic that prepended a path to the LOG_FILE when printing out its 'full path'. LOG_FILE itself already contains full path.

Resolves #19599.


### Type of change

* [X Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?
Built VTK, build visit against new vtk,, drew the #19480 dataset correctly.
Also tested the log file location by deliberately forcing an error in build_visit to produce the message that points to the logfile. The location pointed no longer has extra path information.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
