### PR TITLE
Fix pick auxiliary data identifiers

### DIFF
--- a/src/avt/Queries/Pick/avtPickQuery.C
+++ b/src/avt/Queries/Pick/avtPickQuery.C
@@ -2061,7 +2061,7 @@ avtPickQuery::GetElementIdByLabel(const std::string &elementLabel,
     avtDataObject_p dataObject = this->GetInput();
     VoidRefList result;
     void * args = NULL;
-    const char * type ="AUXILIARY_DATA_IDENTIFIERS";
+    const char * type = AUXILIARY_DATA_IDENTIFIERS;
     TRY
     {
         dataObject->GetOriginatingSource()->GetVariableAuxiliaryData(type, args, contract_p, result);

--- a/src/avt/Queries/Pick/avtPickQuery.C
+++ b/src/avt/Queries/Pick/avtPickQuery.C
@@ -2036,6 +2036,10 @@ avtPickQuery::ExtractZonePickHighlights(const int &zoneId,
 //
 //  Programmer: Matt Larsen
 //  Creation:   May 4, 2017
+// 
+//  Modifications:
+//    Justin Privitera, Fri Aug 30 11:44:59 PDT 2024
+//    Removed quotes from AUXILIARY_DATA_IDENTIFIERS.
 //
 // ****************************************************************************
 bool

--- a/src/databases/BATL/avtBATLFileFormat.C
+++ b/src/databases/BATL/avtBATLFileFormat.C
@@ -2841,6 +2841,10 @@ avtBATLFileFormat::BuildDomainNesting()
 //    Paul D. Stewart, July 16, 2012
 //    allow reading of DATA_DATA extents to fail silently for files without
 //    DATA_DATA extents.
+// 
+//    Justin Privitera, Fri Aug 30 12:01:44 PDT 2024
+//    Removed quotes from AUXILIARY_DATA_SPATIAL_EXTENTS and 
+//    AUXILIARY_DATA_DATA_EXTENTS.
 // ****************************************************************************
 void *
 avtBATLFileFormat::GetAuxiliaryData(const char *var, int dom,
@@ -2853,7 +2857,7 @@ avtBATLFileFormat::GetAuxiliaryData(const char *var, int dom,
     void *retval = 0;
     if (numBlocks == 0)
         return NULL;
-    if (strcmp(type, "AUXILIARY_DATA_SPATIAL_EXTENTS") == 0)
+    if (strcmp(type, AUXILIARY_DATA_SPATIAL_EXTENTS) == 0)
     {
         debug5 << "DATA_SPATIAL_EXTENTS" << endl;
         avtIntervalTree *itree = new avtIntervalTree(numBlocks, 3);
@@ -2875,7 +2879,7 @@ avtBATLFileFormat::GetAuxiliaryData(const char *var, int dom,
 
         retval = (void *)itree;
     }
-    else if (strcmp(type, "AUXILIARY_DATA_DATA_EXTENTS") == 0 )
+    else if (strcmp(type, AUXILIARY_DATA_DATA_EXTENTS) == 0 )
     {
         debug5 << "DATA_DATA called" << endl;
         // Read the number of domains for the mesh.


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

This fixes the pick.py test.
Removes the quotes from the AUXILIARY_DATA_IDENTIFIERS to match the mili plugin fix #19782 

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran rzhound toss4 all pick tests pass.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
