### PR TITLE
Add a couple of parallel mode pixeldata tests to the skip list.

### DIFF
--- a/src/test/skip.json
+++ b/src/test/skip.json
@@ -71,7 +71,7 @@
                     {"category":"queries","file":"avg_value.py","cases":["avg_value_02"]},
                     {"category":"queries","file":"pick.py","cases":["Pick2D","Pick3DTo2D","PickAMR","PickBox","PickIndexSelect","PickSamrai_01","PickSamrai_05"]},
                     {"category":"rendering","file":"bigdata.py","cases":["bigdata_01"]},
-                    {"category":"rendering","file":"pixeldata.py","cases":["pixeldata_0_05","pixeldata_0_07","pixeldata_0_08","pixeldata_0_09","pixeldata_0_10","pixeldata_0_11"]},
+                    {"category":"rendering","file":"pixeldata.py","cases":["pixeldata_0_04","pixeldata_0_05","pixeldata_0_06","pixeldata_0_07","pixeldata_0_08","pixeldata_0_09","pixeldata_0_10","pixeldata_0_11"]},
                     {"platform":"win", "category":"databases","file":"ffp.py","cases":["ffp_03"]},
                     {"platform":"win","category":"hybrid","file":"field_operators.py","cases":["field_op_04"]},
                     {"platform":"win","category":"plots","file": "contour.py","cases":["contour_lineStyle01"]},


### PR DESCRIPTION
### Description

Added a couple of `rendering/pixeldata` tests to the skip list in parallel mode. The two tests that started failing were testing the alpha values of images saved in png format with images with transparent geometry. The results were always wrong, but they had a mode specific baseline image that was wrong that has changed to a new wrong image.

### Type of change

* [X] Other - Skip list update for failing tests.

### How Has This Been Tested?

I ran the `rendering/pixeldata` tests in parallel mode and the appropriate tests were skipped and the test passed.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
