### PR TITLE
Re-enable VTKm support. (#19795)

### DIFF
--- a/src/CMake/FindVTKm.cmake
+++ b/src/CMake/FindVTKm.cmake
@@ -28,6 +28,10 @@
 #   the var is always defined, but may be empty. The new test will return
 #   return true only if the var is not empty. This fixes the case where
 #   VISIT_VTKM_DIR hasn't been set by config-site file.
+#
+#   Eric Brugger, Wed Sep  4 10:31:31 PT 2024
+#   Modified the logic to also install static libraries. I also fixed a
+#   bug that prevented installing dependent libraries.
 # 
 #****************************************************************************/
 
@@ -60,7 +64,7 @@ IF (VISIT_VTKM_DIR)
    # ever change to shared libraries, this may be needed.
    function(get_lib_loc_and_install _lib)
        get_target_property(ttype ${_lib} TYPE)
-       if (ttype STREQUAL "INTERFACE_LIBRARY" OR ttype STREQUAL "STATIC_LIBRARY")
+       if (ttype STREQUAL "INTERFACE_LIBRARY")
            return()
        endif()
        get_target_property(i_loc ${_lib} IMPORTED_LOCATION)
@@ -83,6 +87,7 @@ IF (VISIT_VTKM_DIR)
        if(VTKM_LL_DEP)
            foreach(ll_dep ${VTKM_LL_DEP})
                # only process libraries that start with vtkm
+	       string(SUBSTRING ${ll_dep} 0 4 ll_dep_prefix)
                if ("${ll_dep_prefix}" STREQUAL "vtkm")
                    # don't process duplicates
                    if (NOT ${ll_dep} IN_LIST VTKM_INT_LL AND

--- a/src/CMake/SetUpThirdParty.cmake
+++ b/src/CMake/SetUpThirdParty.cmake
@@ -45,6 +45,9 @@
 #   Kathleen Biagas, Thu May 2, 2024
 #   Add '*.inl' to acceptable patterns when installing headers.
 #
+#   Eric Brugger, Wed Sep  4 10:31:31 PDT 2024
+#   I re-enabled vtkm.
+#
 #****************************************************************************/
 
 # ==============================================
@@ -634,9 +637,7 @@ if(NOT VISIT_BUILD_MINIMAL_PLUGINS OR VISIT_SELECTED_DATABASE_PLUGINS)
 
     include(${VISIT_SOURCE_DIR}/CMake/FindPIDX.cmake)
 
-    if(VTK_VERSION VERSION_EQUAL "8.1.0")
-        include(${VISIT_SOURCE_DIR}/CMake/FindVTKm.cmake)
-    endif()
+    include(${VISIT_SOURCE_DIR}/CMake/FindVTKm.cmake)
 
     include(${VISIT_SOURCE_DIR}/CMake/FindGFortran.cmake)
 endif()

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -59,6 +59,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The <code>VISIT_VERSION_GE()</code> macro useful in detecting the VisIt version being used at compile time has been made public in its own header file, <code>visit-version.h</code>, which is found in <code>VISIT_INSTALL/include/visit/include</code>.</li>
   <li>The Blueprint writer lets users specify Blueprint write options.</li>
   <li>The expression system now supports the <code>%</code> binary modulo operator. The <code>mod()</code> expression function is still supported but has been generalized to use the <code>fmod()</code> function from the C/C++ math library as does the new <code>%</code> binary operator.</li>
+  <li>Re-enabled support for using VTKm, which was removed in the 3.4.0 release.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
Merge from develop to the 3.4RC.

### Description

Resolves #18628
Resolves #17985

I re-enabled calling `FindVTKm.cmake` in `SetUpThirdParty.cmake`. I modified `FindVTKm.cmake` to install static libraries as well as dynamic libraries. I also fixed a bug that prevented the dependent libraries from getting installed.

I then modified some code to work with VTK 9 due to changes to `vtkCellArray`.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built a distribution and installed it on rzgenie. I checked the directory `visit/3.4.9/linux-x86_64/archive` to see if the VTKm libraries were installed there. I found the following:

```
ls visit/3.4.9/linux-x86_64/archives/
libadiosread.a	      libvtkm_cont-1.9.a
libadiosread_nompi.a  libvtkm_filter_clean_grid-1.9.a
libAdvBase.a	      libvtkm_filter_connected_components-1.9.a
libAdvDocIO.a	      libvtkm_filter_contour-1.9.a
libAdvFileIO.a	      libvtkm_filter_core-1.9.a
libbox2D.a	      libvtkm_filter_density_estimate-1.9.a
libbox3D.a	      libvtkm_filter_entity_extraction-1.9.a
libcfitsio.a	      libvtkm_filter_field_conversion-1.9.a
libH5Part.a	      libvtkm_filter_field_transform-1.9.a
libHalf.a	      libvtkm_filter_flow-1.9.a
libIceTCore.a	      libvtkm_filter_geometry_refinement-1.9.a
libIceTGL.a	      libvtkm_filter_image_processing-1.9.a
libIceTMPI.a	      libvtkm_filter_mesh_info-1.9.a
libIex.a	      libvtkm_filter_multi_block-1.9.a
libIlmImf.a	      libvtkm_filter_resampling-1.9.a
libIlmThread.a	      libvtkm_filter_scalar_topology-1.9.a
libImath.a	      libvtkm_filter_vector_analysis-1.9.a
libmili.a	      libvtkm_filter_zfp-1.9.a
libnetcdf.a	      libvtkm_worklet-1.9.a
libnetcdf_c++.a
```
This shows that all the VTKm filter libraries and their dependencies were installed.

I then ran VisIt with `-debug 5` and turned on VTKm support and created a Contour plot of d. The plot was correct. I then checked the `A.engine_ser.5.vlog` file to check if it used VTKm. I found the following:

```
About to execute contour filter.  10 isovalues are: 0.100579, 0.174478, 0.248377, 0.322276, 0.396175, 0.470075, 0.543974, 0.617873, 0.691772, 0.765671,
converting dataset from VTK to VTKm...
avtDataObjectToDatastFilter converting ugrids to polydata in postex.
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
converting dataset from VTKm to VTK...
Xfer::Update: Sending: opcode=27, name=NonBlockingRPC::CompletionData (from ExecuteRPC)
Xfer::Update: Sending: opcode=27, name=NonBlockingRPC::CompletionData (from ExecuteRPC)
Done executing avtContourFilter
```

This shows that the original data set was converted to VTKm to use with the VTKm contour filter and then each contour generated was converted back to VTK for further processing.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
