### PR TITLE
Update the changed vtkm baselines. (#19820)

### DIFF
--- a/test/baseline/hybrid/vtkm/vtkm_curv3d_01a.png
+++ b/test/baseline/hybrid/vtkm/vtkm_curv3d_01a.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49975d30821652c20b447cf30cb326cf9186f3bea6169726a40e04f28143dffc
+oid sha256:15a790e9a93acaf34f08946fa637877f92a07b905ea13c6cc1b657d3da6fb3f3
 size 10432

--- a/test/baseline/hybrid/vtkm/vtkm_curv3d_03.png
+++ b/test/baseline/hybrid/vtkm/vtkm_curv3d_03.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69f059d219f34b6b00cc82cc1a7755975d90ef1609896b0e9ac0acab57a2ca4a
-size 7203
+oid sha256:3b16d6633f9a29c010617607ff71d9be6fdd14ae7bdd87f8fcad58edd72f9dae
+size 7205

--- a/test/baseline/hybrid/vtkm/vtkm_curv3d_10.png
+++ b/test/baseline/hybrid/vtkm/vtkm_curv3d_10.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60df5c00d1c76c45d73c4ef4e138efc66d30c102fbd06a91e94c09cc1ade3ab6
-size 8994
+oid sha256:e1d49875254a1d29581fc67c3650bd53cf370f902635e1ac61fe262d2f2eead9
+size 8988

--- a/test/baseline/hybrid/vtkm/vtkm_globe_02.png
+++ b/test/baseline/hybrid/vtkm/vtkm_globe_02.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2ae1facebd3581d1aea745c955543b08c1cb569c48428fe12e7b275f5f006d0
-size 14592
+oid sha256:eeb37193ad3420e87c19f736f3d402f3eca7623a86eb42d251d990ea41236e5e
+size 14702

--- a/test/baseline/hybrid/vtkm/vtkm_globe_03.png
+++ b/test/baseline/hybrid/vtkm/vtkm_globe_03.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3c712e9c9581324451e6952b5debe1f42041869e52151cadc4dff411555d4ef
-size 6590
+oid sha256:34877939c95484cb3bc6033b3b6f40966d1124ecd3d090d5edac1db5b1806042
+size 6596

--- a/test/baseline/hybrid/vtkm/vtkm_rect3d_01.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect3d_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18cfbc6d865056236a5f1daf2b5cf8e3a3667f749d8ff289bcdc423a9213c31b
+oid sha256:25524b3b6d9a280e2bc33cbf38a827c73512cbe2e7a19ec27df04d4bc11d2373
 size 28956

--- a/test/baseline/hybrid/vtkm/vtkm_rect3d_01a.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect3d_01a.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:757f17aff57dc143c64d0bd5423646612107ba55f7a9bdf724452da04860f2f3
-size 42351
+oid sha256:2535083a7128316c3ae9576e1da645f64ecc2a10193e0000bfac84aed0c6e65e
+size 42346

--- a/test/baseline/hybrid/vtkm/vtkm_rect3d_03.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect3d_03.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4afc4d95f00d532320d607c76dd9cd2beef0fcc4c777560a2cf70d0fd0246db
+oid sha256:f257f83d3285e5ae0dfb6669c739d4225d37bff71c64a50ef882bf3044c17556
 size 7522

--- a/test/baseline/hybrid/vtkm/vtkm_rect3d_05.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect3d_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c37226b5fa013806c907f63d0e5cb2f30e1d8207d4846e302550c57f6ba52524
-size 43680
+oid sha256:dedbfcf996523f4f3929224abea1c5ca21e14db549a81d913ae9e2b9a19ccf1c
+size 43681

--- a/test/baseline/hybrid/vtkm/vtkm_rect3d_10.png
+++ b/test/baseline/hybrid/vtkm/vtkm_rect3d_10.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:548b1b8a33acc0c5b91c0713b687aebb018d5d10129fbb81f690f2c9e9d5414e
-size 15473
+oid sha256:4d2cf1a78366e094ab79749a1d4b05a070855752674eaf85061b3c4fec821f44
+size 15410

--- a/test/baseline/hybrid/vtkm/vtkm_ucd3d_01.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd3d_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58b77e1a045612a3ae19a400037c184d11646263a2b7a7034c34947a5e4e3150
-size 11061
+oid sha256:3b593cf7bc8e03a7a287202eded7e5a393a29ffd9d149432cf059d55d7b17bb2
+size 11049

--- a/test/baseline/hybrid/vtkm/vtkm_ucd3d_03.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd3d_03.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb79d7a4fa7797365bb9ef2953182ee136186f10d99cdb105a9a1d58d42366a2
-size 7598
+oid sha256:8c8394be15234c0faccf9dda6c897f33558b1a218e030665055207468afb0baa
+size 7602

--- a/test/baseline/hybrid/vtkm/vtkm_ucd3d_04.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd3d_04.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e118b33093cf06b144173b9d8093a7a51f45d136218127fadc933f20a8c2f02d
-size 10846
+oid sha256:2d5ba551aedc36c9f05d31bd99d2fc1d94a78eefd526ec1f51dabfe9aa7aebd9
+size 10832

--- a/test/baseline/hybrid/vtkm/vtkm_ucd3d_05.png
+++ b/test/baseline/hybrid/vtkm/vtkm_ucd3d_05.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94719d0b046e36d021ea4b32f9304f527c0295007ea0ea6ef21695b32e44b60e
-size 16132
+oid sha256:0ac5e1b03eebee2c2fa5060fe0673343f450b0a742a79c0abaa97c055715a0e6
+size 16116


### PR DESCRIPTION
Merge from develop to the 3.4RC.

### Description

I updated the VTK-m baseline images that changed when VTK-m was re-enabled. The existing baseline images matched the results from running without VTK-m since VTK-m was disabled. The changes to the updated images were imperceptible visually and in many cases were either a single or several pixel difference.

### Type of change

* [X] Other - Update baseline images.

### How Has This Been Tested?

I built develop on `pascal` and ran the VTK-m tests. I added new baselines for any failed tests. I then ran the test suite again and all the tests passed.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
