### PR TITLE
Fix optional-qwt so simulations using StripChart callbacks won't crash.

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -45,6 +45,11 @@
 #   QWT is now optional, so make StripChart classes dependent upon
 #   it being found.
 #
+#   Kathleen Biagas, Tue Sep 17, 2024
+#   Add QvisStripChartMgr.C QvisStripChartTabWidget.C back to the build
+#   even if QWT isn't found. This will preserve the ability for simulations
+#   to use the StripChart callbacks and not crash.
+#
 #****************************************************************************
 
 SET(GUILIB_SOURCES
@@ -185,6 +190,8 @@ QvisSimulationMessageWindow.C
 QvisSimulationWindow.C
 QvisSourceManagerWidget.C
 QvisSpectrumBar.C
+QvisStripChartMgr.C
+QvisStripChartTabWidget.C
 QvisSubsetPanelItem.C
 QvisSubsetPanelWidget.C
 QvisSubsetWindow.C
@@ -211,9 +218,7 @@ mini3D.C
 
 if(QWT_FOUND)
     list(APPEND GUILIB_SOURCES
-        QvisStripChart.C
-        QvisStripChartMgr.C
-        QvisStripChartTabWidget.C)
+        QvisStripChart.C)
 endif()
 
 IF (NOT WIN32)

--- a/src/gui/QvisSimulationWindow.C
+++ b/src/gui/QvisSimulationWindow.C
@@ -16,11 +16,9 @@
 
 #include <QvisSimulationCommandWindow.h>
 #include <QvisSimulationMessageWindow.h>
-#ifdef HAVE_QWT
-  #include <QvisStripChartMgr.h>
-  #include <QvisStripChartTabWidget.h>
-  #include <QvisStripChart.h>
-#endif
+#include <QvisStripChartMgr.h>
+#include <QvisStripChart.h> // for MAX_STRIP_CHART_VARS
+#include <QvisStripChartTabWidget.h> // for MAX_STRIP_CHARTS
 #include <QvisNotepadArea.h>
 #include <QvisUiLoader.h>
 #include <SimCommandSlots.h>
@@ -89,9 +87,7 @@ QvisSimulationWindow::QvisSimulationWindow(EngineList *engineList,
     uiValues = NULL;
     CustomUIWindow = NULL;
     uiLoader = new QvisUiLoader;
-#ifdef HAVE_QWT
     stripChartMgr = 0;
-#endif
     simMessages = 0;
 }
 
@@ -125,9 +121,7 @@ QvisSimulationWindow::~QvisSimulationWindow()
     if (uiValues)
         uiValues->Detach(this);
 
-#ifdef HAVE_QWT
     delete stripChartMgr;
-#endif
 }
 
 // ****************************************************************************
@@ -243,13 +237,11 @@ QvisSimulationWindow::CreateWindowContents()
         tr("Messages"), notepadAux);
     simMessages->post();
 
-#ifdef HAVE_QWT
     // Create the strip chart manager and post it to the notepad.
     int index = GetEngineListIndex(activeEngine);
     stripChartMgr =
       new QvisStripChartMgr(this, GetViewerProxy(), engines, index, notepadAux);
     stripChartMgr->post();
-#endif
 
     // Make sure we show the commands page.
     notepadAux->showPage(simCommands);
@@ -491,9 +483,7 @@ QvisSimulationWindow::CreateCustomUIWindow()
         }
 
         simCommands->setCustomButtonEnabled(false);
-#ifdef HAVE_QWT
         clearStripCharts();
-#endif
 
         return;
     }
@@ -1039,9 +1029,7 @@ QvisSimulationWindow::UpdateWindow(bool doAll)
           }
 
           clearMessages();
-#ifdef HAVE_QWT
           clearStripCharts();
-#endif
         }
 
         // Add the engines to the widget.
@@ -1248,7 +1236,6 @@ QvisSimulationWindow::UpdateWindow(bool doAll)
             clearMessages();
           }
 
-#ifdef HAVE_QWT
           else if(uiValues->GetName() == "STRIP_CHART_CLEAR_ALL")
           {
             stripChartMgr->clearAll();
@@ -1322,7 +1309,6 @@ QvisSimulationWindow::UpdateWindow(bool doAll)
 
             stripChartMgr->addDataPoints(chart, curve, npts, x, y);
           }
-#endif
           else if(CustomUIWindow != 0)
           {
             UpdateUIComponent(CustomUIWindow,
@@ -1839,7 +1825,6 @@ QvisSimulationWindow::clearMessages()
 // Modifications:
 //
 // ****************************************************************************
-#ifdef HAVE_QWT
 void
 QvisSimulationWindow::clearStripCharts()
 {
@@ -1852,7 +1837,6 @@ QvisSimulationWindow::clearStripCharts()
         stripChartMgr->setCurveTitle(i, j, "" );
     }
 }
-#endif
 
 // ****************************************************************************
 // Method: QvisSimulationWindow::MakeKey
@@ -2269,9 +2253,7 @@ QvisSimulationWindow::selectEngine(int index)
 {
     // Clear the message and strip charts.
     clearMessages();
-#ifdef HAVE_QWT
     clearStripCharts();
-#endif
 
     // Get the new active engine.
     activeEngine = MakeKey(engines->GetEngineName()[index],
@@ -2371,9 +2353,7 @@ QvisSimulationWindow::closeEngine()
                              QMessageBox::Ok | QMessageBox::Cancel) ==
         QMessageBox::Ok)
     {
-#ifdef HAVE_QWT
         stripChartMgr->clearAll();
-#endif
 
         // Close the engine.
         GetViewerMethods()->CloseComputeEngine(host, sim);
@@ -2500,10 +2480,8 @@ QvisSimulationWindow::executePushButtonCommand(const QString &btncmd)
                                QMessageBox::Ok | QMessageBox::Cancel) ==
           QMessageBox::Cancel)
         return;
-#ifdef HAVE_QWT
       else
         stripChartMgr->clearAll();
-#endif
     }
 
     QString cmd(btncmd);
@@ -2648,7 +2626,6 @@ QvisSimulationWindow::executeStopCommand(const QString &value)
 //    command string.
 //
 // ****************************************************************************
-#ifdef HAVE_QWT
 void
 QvisSimulationWindow::setStripChartVar(const QString &value)
 {
@@ -2663,4 +2640,3 @@ QvisSimulationWindow::setStripChartVar(const QString &value)
     QString args(QString("triggered();%1;QMenu;Simulations;%2").arg(cmd).arg(value));
     GetViewerMethods()->SendSimulationCommand(host, sim, cmd.toStdString(), args.toStdString());
 }
-#endif

--- a/src/gui/QvisSimulationWindow.h
+++ b/src/gui/QvisSimulationWindow.h
@@ -28,9 +28,7 @@ class QTreeWidget;
 
 class QvisSimulationCommandWindow;
 class QvisSimulationMessageWindow;
-#ifdef HAVE_QWT
 class QvisStripChartMgr;
-#endif
 class QvisUiLoader;
 
 class EngineList;
@@ -38,8 +36,6 @@ class StatusAttributes;
 class avtSimulationCommandSpecification;
 class SimulationUIValues;
 class SimCommandSlots;
-
-class QwtPlot;
 
 // ****************************************************************************
 // Class: QvisSimulationWindow
@@ -134,9 +130,7 @@ private slots:
     void interruptEngine();
     void selectEngine(int index);
     void clearMessages();
-#ifdef HAVE_QWT
     void clearStripCharts();
-#endif
     void clearCache();
     void showCustomUIWindow();
     void executePushButtonCommand(const QString &cmd);
@@ -146,9 +140,7 @@ private slots:
     void executeStepCommand(const QString &value);
 
 public:
-#ifdef HAVE_QWT
     void setStripChartVar(const QString &value);
-#endif
 
 private:
     EngineList           *engines;
@@ -170,9 +162,7 @@ private:
     QPushButton        *clearCacheButton;
     QWidget            *CustomUIWindow;
     QvisUiLoader       *uiLoader;
-#ifdef HAVE_QWT
     QvisStripChartMgr  *stripChartMgr;
-#endif
     QvisSimulationCommandWindow  *simCommands;
     QvisSimulationMessageWindow  *simMessages;
 

--- a/src/gui/QvisStripChart.h
+++ b/src/gui/QvisStripChart.h
@@ -5,12 +5,14 @@
 #ifndef QVIS_STRIPCHART_H
 #define QVIS_STRIPCHART_H
 
+#define MAX_STRIP_CHART_VARS 5
+
+#ifdef HAVE_QWT
 #include <qwt_plot.h>
 #include <qwt_plot_curve.h>
 #include <QPen>
 
 #define HISTORY 50
-#define MAX_STRIP_CHART_VARS 5
 
 class Background;
 
@@ -121,4 +123,5 @@ private:
     }
     vars[MAX_STRIP_CHART_VARS];
 };
+#endif
 #endif

--- a/src/gui/QvisStripChartMgr.C
+++ b/src/gui/QvisStripChartMgr.C
@@ -94,6 +94,9 @@ QvisStripChartMgr::CreateEntireWindow()
 // Creation:   Wed Sep 26 16:16:23 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Add message about StripChart unavailability when VisIt not built with Qwt
+//   support, and hide other StripChart widgets.
 //
 // ****************************************************************************
 void 
@@ -101,7 +104,13 @@ QvisStripChartMgr::CreateWindowContents()
 {
     stripChartTabWidget = new QvisStripChartTabWidget(central, this, 2000, 100);
     topLayout->addWidget( stripChartTabWidget);
-    
+
+#ifndef HAVE_QWT
+    QGroupBox *noStripChartsGroup = new QGroupBox(central);
+    noStripChartsGroup->setTitle(tr("VisIt was not compiled with QWT, StripChart functionality is not available"));
+    topLayout->addWidget(noStripChartsGroup);
+#endif
+
     // Create the group box 
     QGroupBox *stripChartGroup = new QGroupBox(central);
     stripChartGroup->setTitle(tr("Strip Chart Information and Controls"));
@@ -170,6 +179,10 @@ QvisStripChartMgr::CreateWindowContents()
     connect(stripChartVarButton4,SIGNAL(pressed()), this,
             SLOT(clickedStripChartVarButton4()));
     menuLayout->addWidget(stripChartVarButton4,0,4);
+
+#ifndef HAVE_QWT
+   stripChartGroup->hide();
+#endif
 
     // With Qt 5 and a C++11 compiler, the idiomatic to pass a value:    
     // connect(stripChartVar0Button, &QAction::triggered, this, [this]{ clickedStripChartVar(0); });

--- a/src/gui/QvisStripChartTabWidget.C
+++ b/src/gui/QvisStripChartTabWidget.C
@@ -3,7 +3,9 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 #include <QvisStripChartTabWidget.h>
+#ifdef HAVE_QWT
 #include <QvisStripChart.h>
+#endif
 
 #include <QScrollArea>
 #include <QInputDialog>
@@ -54,6 +56,8 @@ void QvisTabBar::mouseDoubleClickEvent(QMouseEvent *e)
 // Creation:   Friday Oct. 27, 2006
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 QvisStripChartTabWidget::QvisStripChartTabWidget( QWidget *parent,
@@ -70,6 +74,7 @@ QvisStripChartTabWidget::QvisStripChartTabWidget( QWidget *parent,
     SC_Info.resize(MAX_STRIP_CHARTS);
 
     // create the strip charts
+#ifdef HAVE_QWT
     for( unsigned int i=0; i<SC_Info.size(); ++i )
     {
         std::stringstream str;
@@ -94,6 +99,7 @@ QvisStripChartTabWidget::QvisStripChartTabWidget( QWidget *parent,
 
         addTab(sc, SC_Info[i].getName());
     }
+#endif
 
     // default to the first strip chart as current
     currentStripChart = 0;
@@ -225,12 +231,16 @@ QvisStripChartTabWidget::nameToIndex(const QString &SC_Name) const
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::pick()
 {
+#ifdef HAVE_QWT
     stripCharts[currentStripChart]->toggleDisplayMode(false);
+#endif
 }
 
 // ****************************************************************************
@@ -244,12 +254,16 @@ QvisStripChartTabWidget::pick()
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::zoom()
 {
+#ifdef HAVE_QWT
     stripCharts[currentStripChart]->toggleDisplayMode(true);
+#endif
 }
 
 // ****************************************************************************
@@ -263,12 +277,16 @@ QvisStripChartTabWidget::zoom()
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::reset()
 {
+#ifdef HAVE_QWT
     stripCharts[currentStripChart]->reset();
+#endif
 }
 
 // ****************************************************************************
@@ -282,12 +300,16 @@ QvisStripChartTabWidget::reset()
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::clear()
 {
+#ifdef HAVE_QWT
     stripCharts[currentStripChart]->clear();
+#endif
 }
 
 // ****************************************************************************
@@ -301,12 +323,16 @@ QvisStripChartTabWidget::clear()
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::clear( const unsigned int index )
 {
+#ifdef HAVE_QWT
     stripCharts[index]->clear();
+#endif
 }
 
 // ****************************************************************************
@@ -323,13 +349,17 @@ QvisStripChartTabWidget::clear( const unsigned int index )
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::setCurveTitle(const unsigned int curveIndex,
                                        const QString &newTitle)
 {
+#ifdef HAVE_QWT
     stripCharts[currentStripChart]->setCurveTitle(curveIndex, newTitle);
+#endif
 }
 
 // ****************************************************************************
@@ -346,23 +376,31 @@ QvisStripChartTabWidget::setCurveTitle(const unsigned int curveIndex,
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation blocks around QvisStripChart usage.
 //
 // ****************************************************************************
 void
 QvisStripChartTabWidget::clearAll(const unsigned int tabIndex)
 {
     // Clear the plot
+#ifdef HAVE_QWT
     stripCharts[tabIndex]->clear();
+#endif
 
     // Reset the plot name
     std::ostringstream label;
     label << "StripChart_" << tabIndex;
     setTabText(tabIndex, label.str().c_str());
+#ifdef HAVE_QWT
     stripCharts[tabIndex]->setTitle( "History" );
+#endif
 
+#ifdef HAVE_QWT
     // Clear the curves.
     for( unsigned int i=0; i<MAX_STRIP_CHART_VARS; ++i )
       stripCharts[tabIndex]->setCurveTitle( i, "" );
+#endif
 }
 
 // ****************************************************************************
@@ -379,6 +417,8 @@ QvisStripChartTabWidget::clearAll(const unsigned int tabIndex)
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation blocks around QvisStripChart usage.
 //
 // ****************************************************************************
 void
@@ -391,12 +431,16 @@ QvisStripChartTabWidget::setTabLabel(const unsigned int tabIndex,
         std::ostringstream label;
         label << "StripChart_" << tabIndex;
         setTabText(tabIndex, label.str().c_str());
+#ifdef HAVE_QWT
         stripCharts[tabIndex]->setTitle( "History" );
+#endif
     }
     else
     {
         setTabText(tabIndex, newLabel);
+#ifdef HAVE_QWT
         stripCharts[tabIndex]->setTitle( newLabel );
+#endif
     }
 }
 
@@ -415,6 +459,8 @@ QvisStripChartTabWidget::setTabLabel(const unsigned int tabIndex,
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
@@ -422,7 +468,9 @@ QvisStripChartTabWidget::setCurveTitle(const unsigned int tabIndex,
                                        const unsigned int curveIndex,
                                        const QString &newTitle)
 {
+#ifdef HAVE_QWT
     stripCharts[tabIndex]->setCurveTitle(curveIndex, newTitle);
+#endif
 }
 
 // ****************************************************************************
@@ -442,6 +490,8 @@ QvisStripChartTabWidget::setCurveTitle(const unsigned int tabIndex,
 // Creation:   Mon Oct 15 14:27:29 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
@@ -449,7 +499,9 @@ QvisStripChartTabWidget::addDataPoint( const unsigned int tabIndex,
                                        const unsigned int curveIndex,
                                        const double x, const double y )
 {
+#ifdef HAVE_QWT
     stripCharts[tabIndex]->addDataPoint(curveIndex, x, y);
+#endif
 }
 
 // ****************************************************************************
@@ -470,6 +522,8 @@ QvisStripChartTabWidget::addDataPoint( const unsigned int tabIndex,
 // Creation:   29 May 2020
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation block around QvisStripChart usage.
 //
 // ****************************************************************************
 void
@@ -478,5 +532,7 @@ QvisStripChartTabWidget::addDataPoints( const unsigned int tabIndex,
                                         const unsigned int npts,
                                         const double *x, const double *y )
 {
+#ifdef HAVE_QWT
     stripCharts[tabIndex]->addDataPoints(curveIndex, npts, x, y);
+#endif
 }

--- a/src/gui/QvisStripChartTabWidget.h
+++ b/src/gui/QvisStripChartTabWidget.h
@@ -12,7 +12,9 @@
 
 
 class QScrollArea;
+#ifdef HAVE_QWT
 class QvisStripChart;
+#endif
 
 #define MAX_STRIP_CHARTS 5
 
@@ -28,6 +30,10 @@ class QvisStripChart;
 // Creation:   Wed Aug  1 15:11:06 PDT 2007
 //
 // Modifications:
+//   Kathleen Biagas, Tue Sep 17, 2024
+//   Added conditional compilation blocks around QvisStripChart usage.
+//   Allows simulation callbacks into the StripChar gui widgets to not crash
+//   the sim, even if VisIt wasn't build with Qwt.
 //
 // ****************************************************************************
 
@@ -121,8 +127,10 @@ private:
     // index of the currently displayed strip chart
     unsigned int currentStripChart;
 
+#ifdef HAVE_QWT
     // array of maxStripCharts
     QvisStripChart *stripCharts[MAX_STRIP_CHARTS];
+#endif
     SC_NamesVector SC_Info;
 };
 #endif /* QVISSTRIPCHARTTABWIDGET */

--- a/src/include/visit-cmake.h.in
+++ b/src/include/visit-cmake.h.in
@@ -71,9 +71,6 @@
 /* Define if you have Conduit. */
 #cmakedefine HAVE_CONDUIT
 
-/* Define if you have Qwt. */
-#cmakedefine HAVE_QWT 
-
 
 /*******************************************************************************
  * Header file checks

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -66,7 +66,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Updated Conduit to 0.9.2.</li>
   <li>Docker containers were added for RockyLinux (RHEL compatible).</li>
-  <li>Qwt is now optional. Historically, it has only ever been needed for advanced GUI features of LibSimV2 interface. Add <code>--qwt</code> to the build_visit command line to build qwt. Add <code>--system-qwt</code> to have VisIt attempt to find and use a system version of Qwt.  Add <code>--alt-qwt-dir /path/to/qwt/install</code> to use a pre-built version of Qwt installed somewhere else.</li>
+  <li>Qwt is now optional, but built by default. If you encounter issues with Qwt when running build_visit, add <code>--no-qwt</code> to the build_visit command line to disable Qwt. Historically, it has only ever been needed for advanced GUI features of LibSimV2 interface. Add <code>--system-qwt</code> to have VisIt attempt to find and use a system version of Qwt.  Add <code>--alt-qwt-dir /path/to/qwt/install</code> to use a pre-built version of Qwt installed somewhere else.</li>
   <li>Added ICE-T support for Windows builds.</li>
   <li>Fixed bug where printing the build_visit log file location prepended extra paths.</li>
   <li>Fixed glitch that prevented VISIT_CXX_FLAGS defined in config-site file from being applied.</li>

--- a/src/tools/dev/scripts/bv_support/bv_qwt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qwt.sh
@@ -1,6 +1,6 @@
 function bv_qwt_initialize
 {
-    export DO_QWT="no"
+    export DO_QWT="yes"
     export USE_SYSTEM_QWT="no"
     export USE_ALT_QWT="no"
     add_extra_commandline_args "qwt" "system-qwt" 0 "Use Qwt found on system"


### PR DESCRIPTION
### Description

Resolves #19766
Also complete re-do of making Qwt optional, in consultation with @ARSanderson .
Need to leave some of the StripChart functionality in VisIt so that simulation don't crash if they use the strip chart callbacks.
Only the code that actually uses Qwt is now conditionally compiled, and a message is written to the StripChart section of the Simulation Window stating when the capability is unavailable due to VisIt not being compiled with Qwt.

Qwt will now be built by default (but not required). Updated release notes to reflect this.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Built VisIt with and without Qwt to verify the changes to the StripChart gui.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
