### PR TITLE
Add vtkm libs to Slice and Isovolume operators.

### DIFF
--- a/src/CMake/PluginVsInstall.cmake.in
+++ b/src/CMake/PluginVsInstall.cmake.in
@@ -123,6 +123,9 @@
 #   Add separate RUNTIME_OUTPUT_DIRECTORY entries for each Configuration
 #   type on Windows (VISIT_INSTALL_PLUGINS).
 #
+#   Kathleen Biagas, Wed Sep 18, 2024
+#   Added HAVE_LIBVTKM.
+# 
 #****************************************************************************/
 
 ##
@@ -360,6 +363,7 @@ set(OPENEXR_INCLUDE_DIR  ${VISIT_ROOT_INCLUDE_DIR}/openexr/OpenEXR)
 set(OPENEXR_LIBRARY_DIR  ${VISIT_LIBRARY_DIR} ${VISIT_ARCHIVE_DIR})
 set(OPENEXR_LIB @OPENEXR_LIB@)
 
+set(HAVE_LIBVTKM                 @HAVE_LIBVTKM@)
 set(VTKm_INCLUDE_DIRS  @filtered_VTKm_INCLUDE_DIRS@)
 
 include(${VISIT_ROOT_INCLUDE_DIR}/VisItMacros.cmake)

--- a/src/operators/Isovolume/CMakeLists.txt
+++ b/src/operators/Isovolume/CMakeLists.txt
@@ -81,11 +81,19 @@ ENDIF(NOT VISIT_SERVER_COMPONENTS_ONLY AND NOT VISIT_ENGINE_ONLY AND NOT VISIT_D
 
 ADD_LIBRARY(EIsovolumeOperator_ser ${LIBE_SOURCES})
 TARGET_LINK_LIBRARIES(EIsovolumeOperator_ser visitcommon avtpipeline_ser avtexpressions_ser avtfilters_ser )
+if(HAVE_LIBVTKM)
+    target_link_libraries(EIsovolumeOperator_ser  vtkm_cont vtkm_filter_core vtkm_filter_contour vtkm_filter_entity_extraction vtkm_filter_field_conversion vtkm_worklet)
+endif()
+
 SET(INSTALLTARGETS ${INSTALLTARGETS} EIsovolumeOperator_ser)
 
 IF(VISIT_PARALLEL)
     ADD_PARALLEL_LIBRARY(EIsovolumeOperator_par ${LIBE_SOURCES})
     TARGET_LINK_LIBRARIES(EIsovolumeOperator_par visitcommon avtpipeline_par avtexpressions_par avtfilters_par )
+    if(HAVE_LIBVTKM)
+        target_link_libraries(EIsovolumeOperator_par  vtkm_cont vtkm_filter_core vtkm_filter_contour vtkm_filter_entity_extraction vtkm_filter_field_conversion vtkm_worklet)
+    endif()
+
     SET(INSTALLTARGETS ${INSTALLTARGETS} EIsovolumeOperator_par)
 ENDIF(VISIT_PARALLEL)
 

--- a/src/operators/Isovolume/Isovolume.code
+++ b/src/operators/Isovolume/Isovolume.code
@@ -1,0 +1,4 @@
+Target: xml2cmake
+Condition:       HAVE_LIBVTKM
+ELinkLibraries:  vtkm_cont vtkm_filter_core vtkm_filter_contour vtkm_filter_entity_extraction vtkm_filter_field_conversion vtkm_worklet
+

--- a/src/operators/Isovolume/Isovolume.xml
+++ b/src/operators/Isovolume/Isovolume.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
   <Plugin name="Isovolume" type="operator" label="Isovolume" version="1.0" enabled="true" mdspecificcode="false" engspecificcode="false" onlyengine="false" noengine="false" iconFile="Isovolume.xpm" category="Selection">
-    <Attribute name="IsovolumeAttributes" purpose="This class contains attributes for the isovolume operator." persistent="true" keyframe="true" exportAPI="" exportInclude="">
+    <Attribute name="IsovolumeAttributes" purpose="This class contains attributes for the isovolume operator." persistent="true" keyframe="true" exportAPI="" exportInclude="" codefile="Isovolume.code">
       <CXXFLAGS>
           -I${VTKm_INCLUDE_DIRS}
       </CXXFLAGS>

--- a/src/operators/Slice/CMakeLists.txt
+++ b/src/operators/Slice/CMakeLists.txt
@@ -81,11 +81,19 @@ ENDIF(NOT VISIT_SERVER_COMPONENTS_ONLY AND NOT VISIT_ENGINE_ONLY AND NOT VISIT_D
 
 ADD_LIBRARY(ESliceOperator_ser ${LIBE_SOURCES})
 TARGET_LINK_LIBRARIES(ESliceOperator_ser visitcommon avtpipeline_ser avtexpressions_ser avtfilters_ser )
+if(HAVE_LIBVTKM)
+    target_link_libraries(ESliceOperator_ser  vtkm_cont vtkm_filter_core vtkm_filter_contour vtkm_worklet vtkm_filter_vector_analysis)
+endif()
+
 SET(INSTALLTARGETS ${INSTALLTARGETS} ESliceOperator_ser)
 
 IF(VISIT_PARALLEL)
     ADD_PARALLEL_LIBRARY(ESliceOperator_par ${LIBE_SOURCES})
     TARGET_LINK_LIBRARIES(ESliceOperator_par visitcommon avtpipeline_par avtexpressions_par avtfilters_par )
+    if(HAVE_LIBVTKM)
+        target_link_libraries(ESliceOperator_par  vtkm_cont vtkm_filter_core vtkm_filter_contour vtkm_worklet vtkm_filter_vector_analysis)
+    endif()
+
     SET(INSTALLTARGETS ${INSTALLTARGETS} ESliceOperator_par)
 ENDIF(VISIT_PARALLEL)
 

--- a/src/operators/Slice/SliceAttributes.code
+++ b/src/operators/Slice/SliceAttributes.code
@@ -391,3 +391,8 @@ SliceAttributes::SetValue(const std::string &name, const bool &value)
         retval = AttributeSubject::SetValue(name, value);
     return retval;
 }
+
+Target: xml2cmake
+Condition:       HAVE_LIBVTKM
+ELinkLibraries:  vtkm_cont vtkm_filter_core vtkm_filter_contour vtkm_worklet vtkm_filter_vector_analysis
+

--- a/src/tools/dev/xml/CMakeLists.txt
+++ b/src/tools/dev/xml/CMakeLists.txt
@@ -13,6 +13,9 @@
 #   Cyrus Harrison, Mon Dec  9 13:39:19 PST 2019
 #   Rename main files to correspond to their actual use.
 #
+#   Kathleen Biagas, Wed Sep 18, 2024 
+#   Add VTKM version to xml2cmake compile definitions.
+#
 #****************************************************************************
 
 INCLUDE_DIRECTORIES(
@@ -42,7 +45,7 @@ foreach(tool xml2atts xml2avt xml2cmake xml2info xml2java xml2python xml2sim
 endforeach()
 
 
-target_compile_definitions(xml2cmake PRIVATE VTK_MAJ=${VTK_MAJOR_VERSION} VTK_MIN=${VTK_MINOR_VERSION})
+target_compile_definitions(xml2cmake PRIVATE VTK_MAJ=${VTK_MAJOR_VERSION} VTK_MIN=${VTK_MINOR_VERSION} VTKM_SMALL=${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR})
 
 # Install the targets
 VISIT_INSTALL_TARGETS(xmltest xml2atts xml2window xml2info xml2avt xml2python xml2java xml2cmake)

--- a/src/tools/dev/xml/GenerateCMake.h
+++ b/src/tools/dev/xml/GenerateCMake.h
@@ -295,11 +295,10 @@ class CMakeGeneratorPlugin : public Plugin
         for(int i = 0; i < newlist.size(); ++i)
         {
             QString tmp(newlist[i]);
-            if(tmp.startsWith("vtkm_"))
+            if(tmp.startsWith("vtkm_") && !using_dev)
             {
-                if (!using_dev)
-                    // append the vtk version for VTK-8
-                    tmp.append(vtkmversion);
+                // append the vtkm version
+                tmp.append(vtkmversion);
             }
             libs += " " + tmp;
         }


### PR DESCRIPTION
### Description

They are conditional upon HAVE_LIBVTKM.
This resolves issues building plugins vs Install when VTKm is enabled.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Compiled on Windows/Linux and ran the pluginVsInstall tests successfully.

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
