### PR TITLE
Conditionally compile recently added vtkm related code.

### DIFF
--- a/src/tools/dev/xml/CMakeLists.txt
+++ b/src/tools/dev/xml/CMakeLists.txt
@@ -44,8 +44,11 @@ foreach(tool xml2atts xml2avt xml2cmake xml2info xml2java xml2python xml2sim
     endif()
 endforeach()
 
+target_compile_definitions(xml2cmake PRIVATE VTK_MAJ=${VTK_MAJOR_VERSION} VTK_MIN=${VTK_MINOR_VERSION})
 
-target_compile_definitions(xml2cmake PRIVATE VTK_MAJ=${VTK_MAJOR_VERSION} VTK_MIN=${VTK_MINOR_VERSION} VTKM_SMALL=${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR})
+if(HAVE_LIBVTKM)
+    target_compile_definitions(xml2cmake PRIVATE VTKM_SMALL=${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR})
+endif()
 
 # Install the targets
 VISIT_INSTALL_TARGETS(xmltest xml2atts xml2window xml2info xml2avt xml2python xml2java xml2cmake)

--- a/src/tools/dev/xml/GenerateCMake.h
+++ b/src/tools/dev/xml/GenerateCMake.h
@@ -287,6 +287,7 @@ class CMakeGeneratorPlugin : public Plugin
     void
     FilterConditionalLibs(QString &links, QString &libs)
     {
+#ifdef HAVE_LIBVTKM
         // Will convert vtkm_xxx to vtkm_xxx-version
         // otherwise will leave it alone.
         QString vtkmversion = QString("-%1").arg(VTKM_SMALL);
@@ -302,6 +303,9 @@ class CMakeGeneratorPlugin : public Plugin
             }
             libs += " " + tmp;
         }
+#else
+        libs = links;
+#endif
     }
 
     void


### PR DESCRIPTION
### Description

Fixes compile error when VTKm not available.

### Type of change

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Compiled successfully without VTKm enabled.

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
