### PR TITLE
Add logic for setting curve names in output files generated by time queries

### DIFF
--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -835,13 +835,15 @@ avtDatasetFileWriter::WriteCurveFile(const char *filename, int quality, int comp
     }
 
     vtkPoints *pts = pd->GetPoints();
+    bool useLabels = !labels.empty();
+    bool numberedCurves = line_segments.size() > 1;
     for (size_t i = 0 ; i < line_segments.size() ; i++)
     {
         // Prefer labels if present
-        if (!labels.empty())
+        if (useLabels)
             ofile() << varTag << " " << labels[i] << endl;
         // Default to generic 'curve'
-        else if (line_segments.size() > 1)
+        else if (numberedCurves)
             ofile() << varTag << " curve" << i << endl;
         else
             ofile() << varTag << " curve" << endl;

--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -371,11 +371,11 @@ avtDatasetFileWriter::WriteOBJTree(avtDataTree_p dt, int idx,
 //
 //    Kathleen Biagas, Fri Feb 22 15:39:02 PST 2013
 //    If using cd2pd, use it's ouput port as input to the geometry filter.
-// 
+//
 //    Justin Privitera, Fri Nov  3 15:25:32 PDT 2023
 //    The new arguments (writeMTL, MTLHasTex, and texFilename) are used to
 //    setup needed parameters for the upgraded vtkOBJWriter.
-// 
+//
 //    Justin Privitera, Mon Nov 27 14:57:17 PST 2023
 //    Most downstream tools expect to *wrap* textures. This means that texture
 //    coordinate 0.0 is treated identically to texture coordinate 1.0 (e.g. circular
@@ -383,7 +383,7 @@ avtDatasetFileWriter::WriteOBJTree(avtDataTree_p dt, int idx,
 //    the colors associated with these two texture coordinates, producing a color
 //    that may not be in the table. To work-around this behavior, we *pad* the color
 //    texture duplicating the minimum and maximum color pixels on each end.
-// 
+//
 //    Justin Privitera, Mon Feb 12 15:20:31 PST 2024
 //    I moved the extents calculation to the beginning to get around the bugged
 //    vtkCellDataToPointData.
@@ -394,7 +394,7 @@ void
 avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
                                    const char *fname,
                                    const char *label,
-                                   bool writeMTL, 
+                                   bool writeMTL,
                                    bool MTLHasTex,
                                    std::string texFilename)
 {
@@ -788,11 +788,18 @@ avtDatasetFileWriter::WritePLYFile(const char *filename, bool binary)
 //    Kathleen Biagas, Fri Aug 31 13:23:19 PDT 2018
 //    Use DBOptionsAttributes to determine comment style.
 //
+//    Kathleen Biagas, Wed Spe 11, 2024
+//    Use label(s), if provided, for curve name(s) in output file.
+//
 // ****************************************************************************
 
 void
 avtDatasetFileWriter::WriteCurveFile(const char *filename, int quality, int compression)
 {
+    // Get possible labels to use for curve names
+    stringVector labels;
+    GetInputDataTree()->GetAllLabels(labels);
+
     // We want it all in a single output file
     vtkDataSet *ds = GetSingleDataset();
 
@@ -830,10 +837,14 @@ avtDatasetFileWriter::WriteCurveFile(const char *filename, int quality, int comp
     vtkPoints *pts = pd->GetPoints();
     for (size_t i = 0 ; i < line_segments.size() ; i++)
     {
-        if (line_segments.size() <= 1)
-            ofile() << varTag << " curve" << endl;
-        else
+        // Prefer labels if present
+        if (!labels.empty())
+            ofile() << varTag << " " << labels[i] << endl;
+        // Default to generic 'curve'
+        else if (line_segments.size() > 1)
             ofile() << varTag << " curve" << i << endl;
+        else
+            ofile() << varTag << " curve" << endl;
 
         ofile() << std::setprecision(16);
         for (size_t j = 0 ; j < line_segments[i].size() ; j++)
@@ -1319,7 +1330,7 @@ TakeOffPolyLine(int *seg_list,int start_pt,std::vector< std::vector<int> > &ls)
 //    Removed the sprintfs for color table control point positions.  A user
 //    reported that other locales will insert commas instead of periods,
 //    causing problems for POV-Ray attempts to parse them.
-// 
+//
 //    Justin Privitera, Mon Aug 21 15:54:50 PDT 2023
 //    Changed ColorTableAttributes `names` to `colorTableNames`.
 //
@@ -2492,7 +2503,7 @@ avtDatasetFileWriter::WritePOVRayDF3File(vtkRectilinearGrid *rgrid,
 //
 // Programmer:  Dave Pugmire
 // Creation:    March  2, 2011
-// 
+//
 // Modifications:
 //    Justin Privitera, Mon Aug 21 15:54:50 PDT 2023
 //    Changed ColorTableAttributes `names` to `colorTableNames`.

--- a/src/avt/Filters/avtCurveConstructorFilter.h
+++ b/src/avt/Filters/avtCurveConstructorFilter.h
@@ -25,17 +25,17 @@
 //  Creation:   Sat Apr 20 13:01:58 PST 2002
 //
 //  Modifications:
-//    Kathleen Bonnell, Fri Jul 12 16:53:11 PDT 2002  
+//    Kathleen Bonnell, Fri Jul 12 16:53:11 PDT 2002
 //    Removed vtk filters associated with label-creation.  Now handled by
 //    the plot.
 //
 //    Kathleen Bonnell, Mon Dec 23 08:23:26 PST 2002
-//    Added UpdateDataObjectInfo. 
-//    
+//    Added UpdateDataObjectInfo.
+//
 //    Hank Childs, Fri Oct  3 11:10:29 PDT 2003
 //    Moved from /plots/Curve.  Renamed to CurveConstructorFilter.
 //
-//    Kathleen Bonnell, Tue Jun 20 16:02:38 PDT 2006 
+//    Kathleen Bonnell, Tue Jun 20 16:02:38 PDT 2006
 //    Add PostExecute and outputArray.
 //
 //    Kathleen Bonnell, Thu Mar 19 17:42:14 PDT 2009
@@ -59,10 +59,10 @@ class AVTFILTERS_API avtCurveConstructorFilter : public avtDatasetToDatasetFilte
                               avtCurveConstructorFilter();
     virtual                  ~avtCurveConstructorFilter();
 
-    virtual const char       *GetType(void)  
-                                       { return "avtCurveConstructorFilter"; };
+    virtual const char       *GetType(void)
+                                       { return "avtCurveConstructorFilter"; }
     virtual const char       *GetDescription(void)
-                                  { return "Constructing Curve"; };
+                                  { return "Constructing Curve"; }
 
   protected:
     doubleVector              outputArray;
@@ -72,8 +72,7 @@ class AVTFILTERS_API avtCurveConstructorFilter : public avtDatasetToDatasetFilte
     virtual void              Execute(void);
     virtual void              PostExecute(void);
     virtual void              VerifyInput(void);
-    avtContract_p
-                           ModifyContract(avtContract_p spec);
+    avtContract_p             ModifyContract(avtContract_p spec);
     virtual void              UpdateDataObjectInfo(void);
 };
 

--- a/src/avt/Queries/Abstract/avtDataObjectQuery.C
+++ b/src/avt/Queries/Abstract/avtDataObjectQuery.C
@@ -30,11 +30,11 @@ void                *avtDataObjectQuery::initializeProgressCallbackArgs=NULL;
 //  Programmer: Hank Childs
 //  Creation:   February 5, 2004
 //
-//  Modifications: 
+//  Modifications:
 //    Kathleen Bonnell, Wed Mar 31 15:52:54 PST 2004
 //    Initialize new member timeVarying.
 //
-//    Kathleen Bonnell, Tue May  4 14:18:26 PDT 2004 
+//    Kathleen Bonnell, Tue May  4 14:18:26 PDT 2004
 //    Initialize new member querySILR.
 //
 //    Kathleen Bonnell, Tue Jul  8 18:03:40 PDT 2008
@@ -42,6 +42,9 @@ void                *avtDataObjectQuery::initializeProgressCallbackArgs=NULL;
 //
 //    Hank Childs, Fri Dec 24 17:52:28 PST 2010
 //    Initialize parallelizingOverTime.
+//
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add 'outputCurveLabel' to timeCurveSpecs.
 //
 // ****************************************************************************
 
@@ -51,10 +54,11 @@ avtDataObjectQuery::avtDataObjectQuery()
     parallelizingOverTime = false;
     querySILR = NULL;
 
-    // derived classes should overide these as necessary 
+    // derived classes should overide these as necessary
     timeCurveSpecs["useTimeForXAxis"] = true;
     timeCurveSpecs["useVarForYAxis"] = false;
     timeCurveSpecs["nResultsToStore"] = 1;
+    timeCurveSpecs["outputCurveLabel"] = "";
 }
 
 
@@ -88,11 +92,11 @@ avtDataObjectQuery::~avtDataObjectQuery()
 //      pc      The initialize progress callback.
 //      args    The arguments to the initialize progress callback.
 //
-//  Programmer: Kathleen Bonnell 
-//  Creation:   September 27, 2002 
+//  Programmer: Kathleen Bonnell
+//  Creation:   September 27, 2002
 //
 // ****************************************************************************
- 
+
 void
 avtDataObjectQuery::RegisterInitializeProgressCallback(
                                      InitializeProgressCallback pc, void *args)
@@ -105,19 +109,19 @@ avtDataObjectQuery::RegisterInitializeProgressCallback(
 //  Method: avtDataObjectQuery::RegisterProgressCallback
 //
 //  Purpose:
-//      Registers the ProgressCallback.  This will be called during a 
-//      PerformQuery as some portion (that can be easily identified) is 
+//      Registers the ProgressCallback.  This will be called during a
+//      PerformQuery as some portion (that can be easily identified) is
 //      completed.
 //
 //  Arguments:
 //      pc      The progress callback.
 //      args    The arguments to the progress callback.
 //
-//  Programmer: Kathleen Bonnell 
-//  Creation:   September 27, 2002 
+//  Programmer: Kathleen Bonnell
+//  Creation:   September 27, 2002
 //
 // ****************************************************************************
- 
+
 void
 avtDataObjectQuery::RegisterProgressCallback(ProgressCallback pc, void *args)
 {
@@ -143,17 +147,17 @@ avtDataObjectQuery::RegisterProgressCallback(ProgressCallback pc, void *args)
 //                    with total == 0.  Also, the name of description can be
 //                    NULL.
 //
-//  Programmer:       Kathleen Bonnell 
-//  Creation:         September 27, 2002 
+//  Programmer:       Kathleen Bonnell
+//  Creation:         September 27, 2002
 //
 // ****************************************************************************
- 
+
 void
 avtDataObjectQuery::UpdateProgress(int current, int total)
 {
     if (progressCallback != NULL)
     {
-        progressCallback(progressCallbackArgs, GetType(), GetDescription(), 
+        progressCallback(progressCallbackArgs, GetType(), GetDescription(),
                          current, total);
     }
 }
@@ -163,24 +167,24 @@ avtDataObjectQuery::UpdateProgress(int current, int total)
 //  Method: avtDataObjectQuery::Init
 //
 //  Purpose:
-//      Initialize progress call back with the number of stages in the Query. 
+//      Initialize progress call back with the number of stages in the Query.
 //
-//  Programmer:       Kathleen Bonnell 
-//  Creation:         September 27, 2002 
+//  Programmer:       Kathleen Bonnell
+//  Creation:         September 27, 2002
 //
-//  Modifications: 
+//  Modifications:
 //    Kathleen Bonnell, Wed Mar 31 15:52:54 PST 2004
 //    Added nTimesteps argument.
-// 
+//
 //    Hank Childs, Thu Feb  8 14:39:07 PST 2007
 //    Do not initialize the progress callback if there is more than 1 timestep.
 //    The terminating source will do the initialization in that case.
-//    (And the QueryOverTimeFilter will call this method once for each 
-//     timestep, which means the progress will be re-initialized 
+//    (And the QueryOverTimeFilter will call this method once for each
+//     timestep, which means the progress will be re-initialized
 //     inappropriately.)
 //
 //    Hank Childs, Thu Jan 31 16:35:44 PST 2008
-//    Improve the test for whether or not to call the initialize progress 
+//    Improve the test for whether or not to call the initialize progress
 //    callback.
 //
 // ****************************************************************************
@@ -188,10 +192,10 @@ avtDataObjectQuery::UpdateProgress(int current, int total)
 void
 avtDataObjectQuery::Init(const int nTimesteps)
 {
-    if (initializeProgressCallback != NULL) 
+    if (initializeProgressCallback != NULL)
     {
         //
-        // Each filter is a stage, plus a stage for the query. 
+        // Each filter is a stage, plus a stage for the query.
         //
         int nstages = (GetNFilters() + 1) * nTimesteps;
 
@@ -206,10 +210,10 @@ avtDataObjectQuery::Init(const int nTimesteps)
 //
 //  Purpose:
 //    A stub that allows derived types not to define this.  Returns the
-//    number of filters that the query requires to be executed.  
+//    number of filters that the query requires to be executed.
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    September 27, 2002 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    September 27, 2002
 //
 // ****************************************************************************
 
@@ -223,10 +227,10 @@ avtDataObjectQuery::GetNFilters()
 //  Method: avtDataObjectQuery::ChangedInput
 //
 //  Purpose:
-//    Catches the hook from the base class that the input has changed.                             
+//    Catches the hook from the base class that the input has changed.
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    October 22, 2002 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    October 22, 2002
 //
 //  Kathleen Bonnell, Fri Jul 11 16:33:16 PDT 2003
 //  Retrieve units.
@@ -244,7 +248,7 @@ avtDataObjectQuery::ChangedInput()
     // Give the derived types an opportunity to throw an exception if they
     // don't like the input.
     //
-    VerifyInput(); 
+    VerifyInput();
 }
 
 
@@ -252,10 +256,10 @@ avtDataObjectQuery::ChangedInput()
 //  Method: avtDataObjectQuery::VerifyInput
 //
 //  Purpose:
-//    This is a chance for the derived types to verify a new input.  
+//    This is a chance for the derived types to verify a new input.
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    October 22, 2002 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    October 22, 2002
 //
 //  Modifications:
 //    Kathleen Bonnell, Fri Sep  3 08:33:47 PDT 2004
@@ -267,7 +271,7 @@ avtDataObjectQuery::ChangedInput()
 void
 avtDataObjectQuery::VerifyInput()
 {
-    if (!GetInput()->GetInfo().GetValidity().GetQueryable()) 
+    if (!GetInput()->GetInfo().GetValidity().GetQueryable())
     {
         EXCEPTION0(NonQueryableInputException);
     }
@@ -278,10 +282,10 @@ avtDataObjectQuery::VerifyInput()
 //  Method: avtDataObjectQuery::SetSILRestriction
 //
 //  Purpose:
-//    Creates a new avtSILRestriction from the passed Attributes. 
+//    Creates a new avtSILRestriction from the passed Attributes.
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    May 4, 2004 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    May 4, 2004
 //
 // ****************************************************************************
 
@@ -296,10 +300,10 @@ avtDataObjectQuery::SetSILRestriction(const SILRestrictionAttributes *silAtts)
 //  Method: avtDataObjectQuery::SetSILRestriction
 //
 //  Purpose:
-//    Creates a new avtSILRestriction from the passed restriction . 
+//    Creates a new avtSILRestriction from the passed restriction .
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    January 3, 2005 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    January 3, 2005
 //
 // ****************************************************************************
 
@@ -315,41 +319,51 @@ avtDataObjectQuery::SetSILRestriction(const avtSILRestriction_p silr)
 //
 //  Purpose:
 //    Sets some flags used by QueryOverTime.
-//    Defined here so derived types don't have to.  
-//    The default type of time curve is a Single curve using Time for 
+//    Defined here so derived types don't have to.
+//    The default type of time curve is a Single curve using Time for
 //    the X-axis.
 //
+//  Arguments:
+//    QueryAttributes, in case query needs info from the atts for
+//    for filling in the timeCurveSpecs.
+//
 //  Notes:
-//    If useTimeForXAxis is true, then nResultsToStore should be 1 unless 
+//    If useTimeForXAxis is true, then nResultsToStore should be 1 unless
 //    multiple curves are desired (not yet implemented by QOT).
 //
-//    If useTimeForXAxis is false, then nResultsToStore should be 2^n where 
-//    n is the number of curves desired. Odd-indexed results will be used 
+//    If useTimeForXAxis is false, then nResultsToStore should be 2^n where
+//    n is the number of curves desired. Odd-indexed results will be used
 //    for X-axis, even-indexed results will be used for Y Axis.
 //
 //    If useVarForYAxis is true, then the query variable and its units will
 //    be used to set the Y-axis label.
 //
-//    If useVarForYAxis is false, then the Y-axis label is the query name 
-//    or short description. 
+//    If useVarForYAxis is false, then the Y-axis label is the query name
+//    or short description.
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    January 3, 2005 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    January 3, 2005
 //
 //  Modifications:
 //    Kathleen Bonnell, Tue Jul  8 15:39:30 PDT 2008
 //    Modified to use a MapNode and added 'useVarForYAxis' element.
 //
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added QueryAttributes argument, some queries may need info from the
+//    atts for filling in new element 'outputCurveLabel'.
+//
 // ****************************************************************************
 
 const MapNode&
-avtDataObjectQuery::GetTimeCurveSpecs() 
+avtDataObjectQuery::GetTimeCurveSpecs(const QueryAttributes *)
 {
-    // The defaults are listed below, derived classes should overide 
-    // whichever of these as necessary 
+    // The defaults are listed below, derived classes should overide
+    // whichever of these as necessary
     //
     // timeCurveSpecs["useTimeForXAxis"] = true;
     // timeCurveSpecs["useVarForYAxis"] = false;
     // timeCurveSpecs["nResultsToStore"] = 1;
+    // timeCurveSpecs["outputCurveLabel"] = "";
     return timeCurveSpecs;
 }
+

--- a/src/avt/Queries/Abstract/avtDataObjectQuery.h
+++ b/src/avt/Queries/Abstract/avtDataObjectQuery.h
@@ -88,6 +88,9 @@ typedef void (*ProgressCallback)(void *, const char *, const char *,int,int);
 //    Kathleen Bonnell, Fri Jun 17 16:25:09 PDT 2011
 //    Added SetInputParams.
 //
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add QueryAttributes argument to GetTimeCurveSpecs.
+//
 // ****************************************************************************
 
 class QUERY_API avtDataObjectQuery : public virtual avtDataObjectSink
@@ -97,11 +100,11 @@ class QUERY_API avtDataObjectQuery : public virtual avtDataObjectSink
     virtual                ~avtDataObjectQuery();
 
     virtual const char     *GetType(void) = 0;
-    virtual const char     *GetDescription(void) { return NULL; };
-    virtual const char     *GetShortDescription(void) { return NULL; };
+    virtual const char     *GetDescription(void) { return NULL; }
+    virtual const char     *GetShortDescription(void) { return NULL; }
 
-    virtual void            SetInputParams(const MapNode &) {;};
-    virtual bool            OriginalData(void) { return false; };
+    virtual void            SetInputParams(const MapNode &) {;}
+    virtual bool            OriginalData(void) { return false; }
     virtual void            PerformQuery(QueryAttributes *) = 0;
     virtual std::string     GetResultMessage(void) = 0;
 
@@ -112,7 +115,7 @@ class QUERY_API avtDataObjectQuery : public virtual avtDataObjectSink
     virtual int             GetNFilters();
 
     virtual void            SetTimeVarying(bool val) { timeVarying = val;}
-    virtual const MapNode  &GetTimeCurveSpecs();
+    virtual const MapNode  &GetTimeCurveSpecs(const QueryAttributes *);
 
     void                    SetSILRestriction(const SILRestrictionAttributes *);
     void                    SetSILRestriction(const avtSILRestriction_p);
@@ -121,11 +124,11 @@ class QUERY_API avtDataObjectQuery : public virtual avtDataObjectSink
                                 { units = _units;}
 
     virtual bool            QuerySupportsTimeParallelization(void)
-                                { return false; };
+                                { return false; }
     void                    SetParallelizingOverTime(bool v)
-                                { parallelizingOverTime = v; };
+                                { parallelizingOverTime = v; }
     bool                    ParallelizingOverTime(void)
-                                { return parallelizingOverTime; };
+                                { return parallelizingOverTime; }
 
   protected:
     static InitializeProgressCallback

--- a/src/avt/Queries/Misc/avtDirectDatabaseQOTFilter.h
+++ b/src/avt/Queries/Misc/avtDirectDatabaseQOTFilter.h
@@ -3,7 +3,7 @@
 // details.  No copyright assignment is required to contribute to VisIt.
 
 // ************************************************************************* //
-//                       avtDirectDatabaseQOTFilter.h                            //
+//                   avtDirectDatabaseQOTFilter.h                            //
 // ************************************************************************* //
 
 #ifndef AVT_DIRECT_DATABASE_QOT_FILTER_H
@@ -35,7 +35,7 @@ class vtkUnstructuredGrid;
 //      but there are some significant drawbacks that must be noted:
 //
 //          1. This filter can only retrieve "original" data, meaning that
-//             the query will be performed before any other plots and filters
+//             the query will be performed before any other plots and filter
 //             are applied (excluding the expression filter).
 //          2. The QOTDataset is limited in its ability to process expressions.
 //          3. This filter cannot preserve coordinates during a QOT pick.
@@ -47,10 +47,12 @@ class vtkUnstructuredGrid;
 //  Creation:   Tue Sep 24 13:46:56 MST 2019
 //
 //  Modifications:
-//
 //    Alister Maguire, Thu Nov  5 10:00:31 PST 2020
-//    Changed VerifyAndRefineTimesteps to VerifyAndRefinePointTimesteps
+//    Changed VerifyAndRefineTimesteps to VerifyAndRefinePointTimestep
 //    and added VerifyAndRefineArrayTimesteps.
+//
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add outputLabel.
 //
 // ****************************************************************************
 
@@ -63,9 +65,9 @@ class QUERY_API avtDirectDatabaseQOTFilter : public avtQueryOverTimeFilter
     static avtFilter        *Create(const AttributeGroup*);
 
     virtual const char      *GetType(void)
-                               { return "avtDirectDatabaseQOTFilter"; };
+                               { return "avtDirectDatabaseQOTFilter"; }
     virtual const char      *GetDescription(void)
-                               { return "Querying over Time"; };
+                               { return "Querying over Time"; }
 
   protected:
     bool                     success;
@@ -73,12 +75,13 @@ class QUERY_API avtDirectDatabaseQOTFilter : public avtQueryOverTimeFilter
     bool                     useTimeForXAxis;
     bool                     useVarForYAxis;
     std::string              YLabel;
+    std::string              outputLabel;
 
     virtual void             Execute(void);
     virtual void             UpdateDataObjectInfo(void);
 
     virtual bool             ExecutionSuccessful(void)
-                               { return success; };
+                               { return success; }
 
     vtkUnstructuredGrid     *VerifyAndRefinePointTimesteps(
                                  vtkUnstructuredGrid *);

--- a/src/avt/Queries/Misc/avtDirectDatabaseQOTFilter.h
+++ b/src/avt/Queries/Misc/avtDirectDatabaseQOTFilter.h
@@ -35,7 +35,7 @@ class vtkUnstructuredGrid;
 //      but there are some significant drawbacks that must be noted:
 //
 //          1. This filter can only retrieve "original" data, meaning that
-//             the query will be performed before any other plots and filter
+//             the query will be performed before any other plots and filters
 //             are applied (excluding the expression filter).
 //          2. The QOTDataset is limited in its ability to process expressions.
 //          3. This filter cannot preserve coordinates during a QOT pick.

--- a/src/avt/Queries/Misc/avtTimeLoopQOTFilter.h
+++ b/src/avt/Queries/Misc/avtTimeLoopQOTFilter.h
@@ -26,14 +26,14 @@ class vtkRectilinearGrid;
 //  Class: avtTimeLoopQOTFilter
 //
 //  Purpose:
-//    Performs a query over time. 
+//    Performs a query over time.
 //
 //  Note: This class was previously named avtQueryOverTimeFilter. Now that
 //        there are multiple QOT filters to choose from, a base class has
 //        been created with the name avtQueryOverTimeFilter, and this class
-//        has been renamed avtTimeLoopQOTFilter. 
+//        has been renamed avtTimeLoopQOTFilter.
 //
-//  Programmer: Kathleen Bonnell 
+//  Programmer: Kathleen Bonnell
 //  Creation:   March 19, 2004
 //
 //  Modifications:
@@ -41,9 +41,9 @@ class vtkRectilinearGrid;
 //    Fixed for Windows.
 //
 //    Kathleen Bonnell, Tue May  4 14:21:37 PDT 2004
-//    Removed SilUseSet in favor of SILRestrictionAttributes. 
+//    Removed SilUseSet in favor of SILRestrictionAttributes.
 //
-//    Kathleen Bonnell, Thu Jan  6 11:12:35 PST 2005 
+//    Kathleen Bonnell, Thu Jan  6 11:12:35 PST 2005
 //    Added inheritance from avtTimeLoopFilter, which handles the stepping
 //    through time.  Removed PostExecute method.  Added CreateFinalOutput,
 //    ExecutionSuccessful (required by new inheritance).  Added qRes, times
@@ -51,9 +51,9 @@ class vtkRectilinearGrid;
 //    sucess and finalOutputCreated.
 //
 //    Kathleen Bonnell, Tue Nov  8 10:45:43 PST 2005
-//    Added CreatePolys method, and members useTimeForXAxis, nResultsToStore. 
+//    Added CreatePolys method, and members useTimeForXAxis, nResultsToStore.
 //
-//    Kathleen Bonnell, Thu Jul 27 17:43:38 PDT 2006 
+//    Kathleen Bonnell, Thu Jul 27 17:43:38 PDT 2006
 //    Curves now represented as 1D RectilinearGrid, Renamed CreatedPolys to
 //    CreateRGRid.
 //
@@ -61,9 +61,9 @@ class vtkRectilinearGrid;
 //    Try to correctly quote how many additional filters there will be
 //    for one time step.
 //
-//    Kathleen Bonnell, Wed Nov 28 16:33:22 PST 2007 
+//    Kathleen Bonnell, Wed Nov 28 16:33:22 PST 2007
 //    Added member 'label', to store a shorter y-axis label than the query
-//    name if desired. 
+//    name if desired.
 //
 //    Kathleen Bonnell, Tue Jul  8 15:48:11 PDT 2008
 //    Add useVarForYAxis.
@@ -76,12 +76,15 @@ class vtkRectilinearGrid;
 //
 //    Alister Maguire, Wed May 23 09:21:45 PDT 2018
 //    Added cacheIdx and useCache to allow plotting pick curves
-//    from cached picks. 
+//    from cached picks.
 //
 //    Alister Maguire, Mon Sep 23 11:13:48 MST 2019
-//    Changed name from avtQueryOverTimeFilter to avtTimeLoopQOTFilter, 
+//    Changed name from avtQueryOverTimeFilter to avtTimeLoopQOTFilter,
 //    and added avtQueryOverTimeFilter inheritance. Also removed methods
-//    that are now defined in avtQueryOverTimeFilter. 
+//    that are now defined in avtQueryOverTimeFilter.
+//
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Rename 'label' as 'yLabel', add 'outputLabel'.
 //
 // ****************************************************************************
 
@@ -94,8 +97,8 @@ class QUERY_API avtTimeLoopQOTFilter : public avtTimeLoopFilter,
 
     static avtFilter     *Create(const AttributeGroup*);
 
-    virtual const char   *GetType(void)  { return "avtTimeLoopQOTFilter"; };
-    virtual const char   *GetDescription(void) { return "Querying over Time"; };
+    virtual const char   *GetType(void)  { return "avtTimeLoopQOTFilter"; }
+    virtual const char   *GetDescription(void) { return "Querying over Time"; }
 
     virtual bool          FilterSupportsTimeParallelization(void);
 
@@ -104,7 +107,8 @@ class QUERY_API avtTimeLoopQOTFilter : public avtTimeLoopFilter,
     doubleVector          times;
     bool                  success;
     bool                  finalOutputCreated;
-    std::string           label;
+    std::string           yLabel;
+    std::string           outputLabel;
 
     bool                  useTimeForXAxis;
     bool                  useVarForYAxis;
@@ -116,12 +120,12 @@ class QUERY_API avtTimeLoopQOTFilter : public avtTimeLoopFilter,
     virtual void          Execute(void);
     virtual void          UpdateDataObjectInfo(void);
 
-    virtual int           AdditionalPipelineFilters(void) 
-                                            { return numAdditionalFilters; };
+    virtual int           AdditionalPipelineFilters(void)
+                                            { return numAdditionalFilters; }
 
     virtual void          CreateFinalOutput(void);
-    virtual bool          ExecutionSuccessful(void) { return success; } ;
-    avtDataTree_p         CreateTree(const doubleVector &, 
+    virtual bool          ExecutionSuccessful(void) { return success; }
+    avtDataTree_p         CreateTree(const doubleVector &,
                                      const doubleVector &,
                                      stringVector &,
                                      const bool);

--- a/src/avt/Queries/Queries/avtAverageValueQuery.C
+++ b/src/avt/Queries/Queries/avtAverageValueQuery.C
@@ -17,12 +17,12 @@ using     std::string;
 // ****************************************************************************
 //  Method: avtAverageValueQuery constructor
 //
-//  Programmer: Hank Childs 
+//  Programmer: Hank Childs
 //  Creation:   May 12, 2011
 //
 // ****************************************************************************
 
-avtAverageValueQuery::avtAverageValueQuery() 
+avtAverageValueQuery::avtAverageValueQuery()
     : avtWeightedVariableSummationQuery()
 {
     ;
@@ -32,7 +32,7 @@ avtAverageValueQuery::avtAverageValueQuery()
 // ****************************************************************************
 //  Method: avtAverageValueQuery destructor
 //
-//  Programmer: Hank Childs 
+//  Programmer: Hank Childs
 //  Creation:   May 12, 2011
 //
 // ****************************************************************************
@@ -60,4 +60,23 @@ avtAverageValueQuery::CreateVariable(avtDataObject_p inData)
     return inData;
 }
 
+// ****************************************************************************
+//  Method: avtAverageValueQuery::GetTimeCurveSpecs
+//
+//  Purpose:
+//    Override default TimeCurveSpecs
+//
+//  Programmer:  Kathleen Bigags
+//  Creation:    Sept 11, 2024
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+const MapNode&
+avtAverageValueQuery::GetTimeCurveSpecs(const QueryAttributes *qa)
+{
+    timeCurveSpecs["outputCurveLabel"] = "Average_Value_" + qa->GetVariables()[0];
+    return timeCurveSpecs;
+}
 

--- a/src/avt/Queries/Queries/avtAverageValueQuery.h
+++ b/src/avt/Queries/Queries/avtAverageValueQuery.h
@@ -23,6 +23,10 @@
 //  Programmer: Hank Childs
 //  Creation:   May 12. 2011
 //
+//  Modifications:
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add GetTimeCurveSpecs method.
+//
 // ****************************************************************************
 
 class QUERY_API avtAverageValueQuery : public avtWeightedVariableSummationQuery
@@ -31,12 +35,13 @@ class QUERY_API avtAverageValueQuery : public avtWeightedVariableSummationQuery
                          avtAverageValueQuery();
     virtual             ~avtAverageValueQuery();
 
-    virtual const char  *GetType(void)  
-                             { return "avtAverageValueQuery"; };
+    virtual const char  *GetType(void)
+                             { return "avtAverageValueQuery"; }
+    const MapNode       &GetTimeCurveSpecs(const QueryAttributes *) override;
 
   protected:
     virtual avtDataObject_p    CreateVariable(avtDataObject_p d);
-    virtual bool               CalculateAverage(void) { return true; };
+    virtual bool               CalculateAverage(void) { return true; }
 };
 
 

--- a/src/avt/Queries/Queries/avtMinMaxQuery.C
+++ b/src/avt/Queries/Queries/avtMinMaxQuery.C
@@ -1158,3 +1158,29 @@ avtMinMaxQuery::GetDefaultInputParams(MapNode &params)
 {
     params["use_actual_data"] = 1;
 }
+
+
+// ****************************************************************************
+//  Method: avtMinMaxQuwey::GetTimeCurveSpecs
+//
+//  Purpose:
+//    Override default TimeCurveSpecs
+//
+//  Programmer:  Kathleen Bigags
+//  Creation:    Sep 11, 2024
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+const MapNode&
+avtMinMaxQuery::GetTimeCurveSpecs(const QueryAttributes *qa)
+{
+    string label = "Min_";
+    if(doMax)
+        label = "Max_";
+    label += qa->GetVariables()[0];
+    timeCurveSpecs["outputCurveLabel"] = label;
+    return timeCurveSpecs;
+}
+

--- a/src/avt/Queries/Queries/avtMinMaxQuery.h
+++ b/src/avt/Queries/Queries/avtMinMaxQuery.h
@@ -25,21 +25,21 @@ class vtkDataSet;
 //  Class: avtMinMaxQuery
 //
 //  Purpose:
-//    A query that retrieves min and max information about a variable. 
+//    A query that retrieves min and max information about a variable.
 //
 //  Programmer: Kathleen Bonnell
 //  Creation:   July 23, 2003
 //
 //  Modifications:
 //    Kathleen Bonnell, Tue Feb  3 17:54:19 PST 2004
-//    Renamed from avtPlotMinMaxQuery. Made into parent class. 
+//    Renamed from avtPlotMinMaxQuery. Made into parent class.
 //
-//    Kathleen Bonnell, Wed Mar 31 16:07:50 PST 2004 
-//    Added args to constructor. 
+//    Kathleen Bonnell, Wed Mar 31 16:07:50 PST 2004
+//    Added args to constructor.
 //
-//    Kathleen Bonnell, Tue Jul  6 16:59:26 PDT 2004 
+//    Kathleen Bonnell, Tue Jul  6 16:59:26 PDT 2004
 //    Encapsulated elNum, vals, domain, coords in class MinMaxInfo.
-//    Removed CreateMinMessage, CreateMaxMessage.  
+//    Removed CreateMinMessage, CreateMaxMessage.
 //    Added InfoToString, CreateMessage, FindElement, FinalizeZoneCoord,
 //    FinalizeNodeCoord.
 //
@@ -52,6 +52,9 @@ class vtkDataSet;
 //    Kathleen Biagas, Tue Jul 26 13:48:11 PDT 2011
 //    Add GetDefaultInputParams.
 //
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add GetTimeCurveSpecs method.
+//
 // ****************************************************************************
 
 class QUERY_API avtMinMaxQuery : virtual public avtDatasetQuery
@@ -61,12 +64,14 @@ class QUERY_API avtMinMaxQuery : virtual public avtDatasetQuery
     virtual                ~avtMinMaxQuery();
 
 
-    virtual const char     *GetType(void)   
-                                { return "avtMinMaxQuery"; };
+    virtual const char     *GetType(void)
+                                { return "avtMinMaxQuery"; }
     virtual const char     *GetDescription(void)
-                                { return "Calculating min/max."; };
+                                { return "Calculating min/max."; }
 
     static  void            GetDefaultInputParams(MapNode &);
+
+    const MapNode          &GetTimeCurveSpecs(const QueryAttributes *) override;
 
   protected:
     virtual void            Execute(vtkDataSet *, const int);
@@ -74,8 +79,8 @@ class QUERY_API avtMinMaxQuery : virtual public avtDatasetQuery
     virtual void            PostExecute(void);
             void            StandardPostExecute(void);
             void            TimeVaryingPostExecute(void);
-    virtual void            VerifyInput(void);   
-            void            Preparation(avtDataObject_p);   
+    virtual void            VerifyInput(void);
+            void            Preparation(avtDataObject_p);
 
   private:
 
@@ -108,21 +113,21 @@ class QUERY_API avtMinMaxQuery : virtual public avtDatasetQuery
 
     const avtMatrix        *invTransform;
 
-    void                    GetNodeCoord(vtkDataSet *ds, const int id, 
+    void                    GetNodeCoord(vtkDataSet *ds, const int id,
                                         double coord[3]);
-    void                    GetCellCoord(vtkDataSet *ds, const int id, 
+    void                    GetCellCoord(vtkDataSet *ds, const int id,
                                         double coord[3]);
 
     void                    CreateResultMessage(const int);
 
     std::string             InfoToString(const MinMaxInfo &);
-    void                    CreateMessage(const int, const MinMaxInfo &, 
+    void                    CreateMessage(const int, const MinMaxInfo &,
                                           const MinMaxInfo &, std::string &,
                                           doubleVector &);
 
     void                    FindElement(MinMaxInfo &);
-    void                    FinalizeZoneCoord(vtkDataSet *, 
-                                              vtkDataArray *, 
+    void                    FinalizeZoneCoord(vtkDataSet *,
+                                              vtkDataArray *,
                                               MinMaxInfo &, bool);
     void                    FinalizeNodeCoord(vtkDataSet *, MinMaxInfo &);
 };

--- a/src/avt/Queries/Queries/avtTrajectoryByNode.C
+++ b/src/avt/Queries/Queries/avtTrajectoryByNode.C
@@ -136,17 +136,36 @@ avtTrajectoryByNode::PostExecute(void)
 //    Override default TimeCurveSpecs 
 //
 //  Programmer:  Kathleen Bonnell 
-//  Creation:    July 8, 2008 
+//  Creation:    July 8, 2008
 //
 //  Modifications:
+//    Kathleen Biagas, Wed Sep 11
+//    Add QueryAttributes argument. Use it to get variable and element info
+//    for outputCurveLabel.
 //
 // ****************************************************************************
 
 const MapNode&
-avtTrajectoryByNode::GetTimeCurveSpecs() 
+avtTrajectoryByNode::GetTimeCurveSpecs(const QueryAttributes *qa)
 {
     timeCurveSpecs["useTimeForXAxis"] = false;
     timeCurveSpecs["nResultsToStore"] = 2;
+
+    stringVector vars = qa->GetVariables();
+    const MapNode qip = qa->GetQueryInputParams();
+    bool global = (qip.HasEntry("use_global_id") && qip.GetEntry("use_global_id")->AsInt());
+    string n = "_node_" + std::to_string(qip.GetEntry("element")->AsInt());
+    if(global)
+        n = "_global" + n;
+    string v = "Trajectory_" + vars[0] + "_" + vars[1] + n;
+    if(qip.HasEntry("domain") && !global)
+    {
+        v += "_domain_";
+        v += std::to_string(qip.GetEntry("domain")->AsInt());
+    }
+  
+    timeCurveSpecs["outputCurveLabel"] = v;
+
     return timeCurveSpecs;
 }
 

--- a/src/avt/Queries/Queries/avtTrajectoryByNode.h
+++ b/src/avt/Queries/Queries/avtTrajectoryByNode.h
@@ -17,11 +17,11 @@
 //  Class: avtTrajectoryByNode
 //
 //  Purpose:
-//    A time query that retrieves var information about a mesh given a 
+//    A time query that retrieves var information about a mesh given a
 //    particular domain and node number.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   November 8, 2005 
+//  Creation:   November 8, 2005
 //
 //  Modifications:
 //    Kathleen Bonnell, Tue Jul  8 15:43:15 PDT 2008
@@ -29,6 +29,10 @@
 //
 //    Kathleen Biagas, Tue Jul 26 10:03:11 PDT 2011
 //    Add GetDefaultInputParams.
+//
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add QueryAttributes argument to GetTimeCurveSpecs.
+//    Addd GetShortDescription.
 //
 // ****************************************************************************
 
@@ -42,13 +46,16 @@ class QUERY_API avtTrajectoryByNode : public avtVariableByNodeQuery
     virtual const char       *GetType(void)   { return "avtTrajectoryByNode"; }
     virtual const char       *GetDescription(void)
                                { return "Retrieving var information on mesh.";}
+    virtual const char       *GetShortDescription(void)
+                              { return "Trajectory"; }
 
-    virtual const MapNode    &GetTimeCurveSpecs(); 
+
+    const MapNode    &GetTimeCurveSpecs(const QueryAttributes *) override;
 
     static void               GetDefaultInputParams(MapNode &);
 
   protected:
-    virtual void              Preparation(const avtDataAttributes &); 
+    virtual void              Preparation(const avtDataAttributes &);
     virtual void              PostExecute(void);
 };
 

--- a/src/avt/Queries/Queries/avtTrajectoryByZone.h
+++ b/src/avt/Queries/Queries/avtTrajectoryByZone.h
@@ -17,11 +17,11 @@
 //  Class: avtTrajectoryByZone
 //
 //  Purpose:
-//    A time query that retrieves var information about a mesh given a 
+//    A time query that retrieves var information about a mesh given a
 //    particular domain and zone number.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   November 8, 2005 
+//  Creation:   November 8, 2005
 //
 //  Modifications:
 //    Kathleen Bonnell, Tue Jul  8 15:41:59 PDT 2008
@@ -29,6 +29,9 @@
 //
 //    Kathleen Biagas, Tue Jul 26 10:03:42 PDT 2011
 //    Add GetDefaultInputParams.
+//
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Add QueryAttributes argument to GetTimeCurveSpecs.
 //
 // ****************************************************************************
 
@@ -42,8 +45,10 @@ class QUERY_API avtTrajectoryByZone : public avtVariableByZoneQuery
     virtual const char       *GetType(void)   { return "avtTrajectoryByZone"; }
     virtual const char       *GetDescription(void)
                               { return "Retrieving var information on mesh."; }
+    virtual const char       *GetShortDescription(void)
+                              { return "Trajectory"; }
 
-    virtual const MapNode    &GetTimeCurveSpecs(); 
+    const MapNode    &GetTimeCurveSpecs(const QueryAttributes *) override;
 
     static void               GetDefaultInputParams(MapNode &);
 

--- a/src/avt/Queries/Queries/avtVariableByNodeQuery.C
+++ b/src/avt/Queries/Queries/avtVariableByNodeQuery.C
@@ -25,7 +25,7 @@ using std::string;
 //  Purpose:
 //      Construct an avtVariableByNodeQuery object.
 //
-//  Programmer:   Kathleen Bonnell 
+//  Programmer:   Kathleen Bonnell
 //  Creation:     July 29, 2004
 //
 //  Modifications:
@@ -47,8 +47,8 @@ avtVariableByNodeQuery::avtVariableByNodeQuery()
 //  Purpose:
 //      Destruct an avtVariableByNodeQuery object.
 //
-//  Programmer:   Kathleen Bonnell 
-//  Creation:     July 29, 2004 
+//  Programmer:   Kathleen Bonnell
+//  Creation:     July 29, 2004
 //
 //  Modifications:
 //
@@ -67,17 +67,17 @@ avtVariableByNodeQuery::~avtVariableByNodeQuery()
 //  Arguments:
 //    params:     MapNode containing input.
 //
-//  Programmer:   Kathleen Biagas 
+//  Programmer:   Kathleen Biagas
 //  Creation:     June 20, 2011
 //
 //  Modifications:
 //    Kathleen Biagas, Thu Jan 10 08:12:47 PST 2013
-//    Use newer MapNode methods that check for numeric entries and retrieves 
+//    Use newer MapNode methods that check for numeric entries and retrieves
 //    to specific type.  Add error checking for size of passed vectors.
 //
 // ****************************************************************************
 
-void 
+void
 avtVariableByNodeQuery::SetInputParams(const MapNode &params)
 {
     if (params.HasEntry("vars"))
@@ -103,14 +103,14 @@ avtVariableByNodeQuery::SetInputParams(const MapNode &params)
         useGlobalId = params.GetEntry("use_global_id")->ToBool();
 }
 
- 
+
 // ****************************************************************************
 //  Method: avtVariableByNodeQuery::Preparation
 //
 //  Purpose:
-//    Sets pickAtts information from queryAtts. 
+//    Sets pickAtts information from queryAtts.
 //
-//  Programmer:   Kathleen Bonnell 
+//  Programmer:   Kathleen Bonnell
 //  Creation:     July 29, 2004
 //
 //  Modifications:
@@ -122,10 +122,10 @@ avtVariableByNodeQuery::SetInputParams(const MapNode &params)
 //
 // ****************************************************************************
 
-void 
+void
 avtVariableByNodeQuery::Preparation(const avtDataAttributes &inAtts)
 {
-    avtDataRequest_p dataRequest = 
+    avtDataRequest_p dataRequest =
         GetInput()->GetOriginatingSource()->GetFullDataRequest();
 
     pickAtts.SetTimeStep(queryAtts.GetTimeStep());
@@ -148,7 +148,7 @@ avtVariableByNodeQuery::Preparation(const avtDataAttributes &inAtts)
 //    gathered the info, to processor 0.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   July 29, 2004 
+//  Creation:   July 29, 2004
 //
 //  Modifications:
 //    Brad Whitlock, Tue Mar 13 11:26:59 PDT 2007
@@ -164,7 +164,7 @@ avtVariableByNodeQuery::Preparation(const avtDataAttributes &inAtts)
 //    a Mesh plot.
 //
 //    Kathleen Bonnell, Thu Feb  3 16:17:37 PST 2011
-//    Verify that pickvarinfo's values aren't empty before attempting to 
+//    Verify that pickvarinfo's values aren't empty before attempting to
 //    reference an element.
 //
 //    Kathleen Bonnell, Tue Mar  1 16:06:04 PST 2011
@@ -179,8 +179,8 @@ void
 avtVariableByNodeQuery::PostExecute(void)
 {
     avtPickQuery::PostExecute();
-   
-    if (PAR_Rank() == 0) 
+
+    if (PAR_Rank() == 0)
     {
         doubleVector vals;
         if (pickAtts.GetFulfilled())
@@ -192,12 +192,12 @@ avtVariableByNodeQuery::PostExecute(void)
             pickAtts.CreateOutputString(msg);
             SetResultMessage(msg.c_str());
             if (pickAtts.GetNumVarInfos() == 1)
-            { 
+            {
                 doubleVector dvals = pickAtts.GetVarInfo(0).GetValues();
                 if (dvals.size() > 0)
                 {
                     SetResultValue(dvals[dvals.size()-1]);
-                }   
+                }
                 else
                 {
                     debug3 << "Variable by Node query reports a fulfilled "
@@ -226,7 +226,7 @@ avtVariableByNodeQuery::PostExecute(void)
         }
         else
         {
-            char msg[120]; 
+            char msg[120];
             snprintf(msg, 120, "Could not retrieve information from domain "
                      " %d element %d.", domain, node);
             SetResultMessage(msg);
@@ -241,17 +241,19 @@ avtVariableByNodeQuery::PostExecute(void)
 //  Method: avtVariableByNodeQuery::GetTimeCurveSpecs
 //
 //  Purpose:
-//    Override default TimeCurveSpecs 
+//    Override default TimeCurveSpecs
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    July 8, 2008 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    July 8, 2008
 //
 //  Modifications:
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added QueryAttributes argument (currently unused here).
 //
 // ****************************************************************************
 
 const MapNode&
-avtVariableByNodeQuery::GetTimeCurveSpecs()
+avtVariableByNodeQuery::GetTimeCurveSpecs(const QueryAttributes *)
 {
     timeCurveSpecs["useVarForYAxis"] = true;
     return timeCurveSpecs;

--- a/src/avt/Queries/Queries/avtVariableByNodeQuery.h
+++ b/src/avt/Queries/Queries/avtVariableByNodeQuery.h
@@ -22,7 +22,7 @@ class vtkDataSet;
 //  Class: avtVariableByNodeQuery
 //
 //  Purpose:
-//    A query that retrieves var information about a mesh given a 
+//    A query that retrieves var information about a mesh given a
 //    particular domain and node number.
 //
 //  Programmer: Kathleen Bonnell
@@ -41,6 +41,9 @@ class vtkDataSet;
 //    Kathleen Biagas, Mon Jun 20 10:32:53 PDT 2011
 //    Added SetInputParams, removed SetNumVars, added node, domain.
 //
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added QueryAttributes argument to GetTimeCurveSpecs.
+//
 // ****************************************************************************
 
 class QUERY_API avtVariableByNodeQuery : public avtPickByNodeQuery
@@ -50,17 +53,17 @@ class QUERY_API avtVariableByNodeQuery : public avtPickByNodeQuery
     virtual                  ~avtVariableByNodeQuery();
 
 
-    virtual const char       *GetType(void)   
+    virtual const char       *GetType(void)
                               { return "avtVariableByNodeQuery"; }
     virtual const char       *GetDescription(void)
                               { return "Retrieving var information on mesh."; }
 
     virtual void              SetInputParams(const MapNode &);
 
-    virtual const MapNode    &GetTimeCurveSpecs(); 
+    const MapNode            &GetTimeCurveSpecs(const QueryAttributes *) override;
 
   protected:
-    virtual void              Preparation(const avtDataAttributes &); 
+    virtual void              Preparation(const avtDataAttributes &);
     virtual void              PostExecute(void);
 
     int node;

--- a/src/avt/Queries/Queries/avtVariableByZoneQuery.C
+++ b/src/avt/Queries/Queries/avtVariableByZoneQuery.C
@@ -25,7 +25,7 @@ using std::string;
 //  Purpose:
 //      Construct an avtVariableByZoneQuery object.
 //
-//  Programmer:   Kathleen Bonnell 
+//  Programmer:   Kathleen Bonnell
 //  Creation:     July 29, 2004
 //
 //  Modifications:
@@ -46,8 +46,8 @@ avtVariableByZoneQuery::avtVariableByZoneQuery()
 //  Purpose:
 //      Destruct an avtVariableByZoneQuery object.
 //
-//  Programmer:   Kathleen Bonnell 
-//  Creation:     July 29, 2004 
+//  Programmer:   Kathleen Bonnell
+//  Creation:     July 29, 2004
 //
 //  Modifications:
 //
@@ -66,17 +66,17 @@ avtVariableByZoneQuery::~avtVariableByZoneQuery()
 //  Arguments:
 //    params:  MapNode containing input.
 //
-//  Programmer:   Kathleen Biagas 
+//  Programmer:   Kathleen Biagas
 //  Creation:     June 20, 2011
 //
 //  Modifications:
 //    Kathleen Biagas, Thu Jan 10 08:12:47 PST 2013
-//    Use newer MapNode methods that check for numeric entries and retrieves 
+//    Use newer MapNode methods that check for numeric entries and retrieves
 //    to specific type. Add error checking for size of passed vectors.
 //
 // ****************************************************************************
 
-void 
+void
 avtVariableByZoneQuery::SetInputParams(const MapNode &params)
 {
     if (params.HasEntry("vars"))
@@ -99,14 +99,14 @@ avtVariableByZoneQuery::SetInputParams(const MapNode &params)
         EXCEPTION1(QueryArgumentException, "element");
 }
 
- 
+
 // ****************************************************************************
 //  Method: avtVariableByZoneQuery::Preparation
 //
 //  Purpose:
-//    Sets pickAtts based on queryAtts. 
+//    Sets pickAtts based on queryAtts.
 //
-//  Programmer:   Kathleen Bonnell 
+//  Programmer:   Kathleen Bonnell
 //  Creation:     July 29, 2004
 //
 //  Modifications:
@@ -118,10 +118,10 @@ avtVariableByZoneQuery::SetInputParams(const MapNode &params)
 //
 // ****************************************************************************
 
-void 
+void
 avtVariableByZoneQuery::Preparation(const avtDataAttributes &inAtts)
 {
-    avtDataRequest_p dataRequest = 
+    avtDataRequest_p dataRequest =
         GetInput()->GetOriginatingSource()->GetFullDataRequest();
 
     pickAtts.SetTimeStep(queryAtts.GetTimeStep());
@@ -143,7 +143,7 @@ avtVariableByZoneQuery::Preparation(const avtDataAttributes &inAtts)
 //    gathered the info, to processor 0.
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   July 29, 2004 
+//  Creation:   July 29, 2004
 //
 //  Modifications:
 //    Brad Whitlock, Tue Mar 13 11:26:59 PDT 2007
@@ -173,8 +173,8 @@ void
 avtVariableByZoneQuery::PostExecute(void)
 {
     avtPickQuery::PostExecute();
-   
-    if (PAR_Rank() == 0) 
+
+    if (PAR_Rank() == 0)
     {
         doubleVector vals;
         if (pickAtts.GetFulfilled())
@@ -218,7 +218,7 @@ avtVariableByZoneQuery::PostExecute(void)
         }
         else
         {
-            char msg[120]; 
+            char msg[120];
             snprintf(msg, 120, "Could not retrieve information from domain "
                      " %d element %d.", domain, zone);
             SetResultMessage(msg);
@@ -232,17 +232,19 @@ avtVariableByZoneQuery::PostExecute(void)
 //  Method: avtVariableByZoneQuery::GetTimeCurveSpecs
 //
 //  Purpose:
-//    Override default TimeCurveSpecs 
+//    Override default TimeCurveSpecs
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    July 8, 2008 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    July 8, 2008
 //
 //  Modifications:
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added QueryAttributes argument (currently unused here).
 //
 // ****************************************************************************
 
 const MapNode&
-avtVariableByZoneQuery::GetTimeCurveSpecs()
+avtVariableByZoneQuery::GetTimeCurveSpecs(const QueryAttributes *)
 {
     timeCurveSpecs["useVarForYAxis"] = true;
     return timeCurveSpecs;

--- a/src/avt/Queries/Queries/avtVariableByZoneQuery.h
+++ b/src/avt/Queries/Queries/avtVariableByZoneQuery.h
@@ -22,7 +22,7 @@ class vtkDataSet;
 //  Class: avtVariableByZoneQuery
 //
 //  Purpose:
-//    A query that retrieves var information about a mesh given a 
+//    A query that retrieves var information about a mesh given a
 //    particular domain and zone number.
 //
 //  Programmer: Kathleen Bonnell
@@ -41,6 +41,9 @@ class vtkDataSet;
 //    Kathleen Biagas, Mon Jun 20 10:31:43 PDT 2011
 //    Added SetInputParams, removed SetNumVars, added domain, zone.
 //
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added QueryAttributes argument to GetTimeCurveSpecs.
+//
 // ****************************************************************************
 
 class QUERY_API avtVariableByZoneQuery : public avtPickByZoneQuery
@@ -50,14 +53,14 @@ class QUERY_API avtVariableByZoneQuery : public avtPickByZoneQuery
     virtual                  ~avtVariableByZoneQuery();
 
 
-    virtual const char       *GetType(void)   
-                              { return "avtVariableByZoneQuery"; };
+    virtual const char       *GetType(void)
+                              { return "avtVariableByZoneQuery"; }
     virtual const char       *GetDescription(void)
                               { return "Retrieving var information on mesh."; }
 
     virtual void              SetInputParams(const MapNode &);
 
-    virtual const MapNode    &GetTimeCurveSpecs(); 
+    const MapNode            &GetTimeCurveSpecs(const QueryAttributes *) override;
 
   protected:
     virtual void                    Preparation(const avtDataAttributes &);

--- a/src/avt/Queries/Queries/avtVariableSummationQuery.C
+++ b/src/avt/Queries/Queries/avtVariableSummationQuery.C
@@ -23,8 +23,8 @@ using     std::string;
 // ****************************************************************************
 //  Method: avtVariableSummationQuery constructor
 //
-//  Programmer: Hank Childs 
-//  Creation:   February 3, 2004 
+//  Programmer: Hank Childs
+//  Creation:   February 3, 2004
 //
 //  Modifications:
 //    Kathleen Bonnell, Thu Mar  2 15:05:17 PST 2006
@@ -43,8 +43,8 @@ avtVariableSummationQuery::avtVariableSummationQuery() : avtSummationQuery()
 // ****************************************************************************
 //  Method: avtVariableSummationQuery destructor
 //
-//  Programmer: Hank Childs 
-//  Creation:   February 3, 2004 
+//  Programmer: Hank Childs
+//  Creation:   February 3, 2004
 //
 //  Modifications:
 //    Kathleen Bonnell, Thu Mar  2 15:05:17 PST 2006
@@ -76,13 +76,13 @@ avtVariableSummationQuery::~avtVariableSummationQuery()
 //    Kathleen Bonnell, Wed Jul 28 08:26:05 PDT 2004
 //    Retrieve variable's units, if available.
 //
-//    Kathleen Bonnell, Thu Jan  6 10:34:57 PST 2005 
+//    Kathleen Bonnell, Thu Jan  6 10:34:57 PST 2005
 //    Remove TRY-CATCH block in favor of testing for ValidVariable.
 //
-//    Kathleen Bonnell, Wed Apr  2 10:20:27 PDT 2008 
+//    Kathleen Bonnell, Wed Apr  2 10:20:27 PDT 2008
 //    Retrieve the varname from the dataAtts instead of DataRequest, as
 //    DataRequest may have the wrong value based on other pipelines sharing
-//    the same source. 
+//    the same source.
 //
 //    Kathleen Bonnell, Tue Jul 29 10:05:39 PDT 2008
 //    Check for ValidActiveVariable before retrieving from DatAtts.  Revert
@@ -133,7 +133,7 @@ avtVariableSummationQuery::VerifyInput(void)
 //  Purpose:
 //
 //  Programmer: Kathleen Bonnell
-//  Creation:   February 24, 2006 
+//  Creation:   February 24, 2006
 //
 //  Modifications:
 //    Kathleen Bonnell, Thu May 11 10:32:54 PDT 2006
@@ -154,19 +154,19 @@ avtVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
         cent = datts.GetCentering(variableName.c_str());
         cellData = (cent != AVT_NODECENT);
     }
-    else 
+    else
     {
         // we can't determine the centering, assume zone-centered
         cellData = true;
     }
 
-    int bDoCustomFiltering = dval.SubdivisionOccurred() || 
+    int bDoCustomFiltering = dval.SubdivisionOccurred() ||
                              ( cellData && !dval.GetOriginalZonesIntact()) ||
                              (!cellData && !dval.GetZonesPreserved());
-#ifdef PARALLEL    
+#ifdef PARALLEL
     int bAnyDoCustomFiltering;
-    
-    MPI_Allreduce(&bDoCustomFiltering, &bAnyDoCustomFiltering, 1, 
+
+    MPI_Allreduce(&bDoCustomFiltering, &bAnyDoCustomFiltering, 1,
                   MPI_INT, MPI_LOR, VISIT_MPI_COMM);
     bDoCustomFiltering = bAnyDoCustomFiltering;
 #endif
@@ -183,7 +183,7 @@ avtVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
         avtDataRequest_p oldSpec = inData->GetOriginatingSource()->
             GetGeneralContract()->GetDataRequest();
 
-        avtDataRequest_p newDS = new 
+        avtDataRequest_p newDS = new
             avtDataRequest(oldSpec, querySILR);
         newDS->SetTimestep(queryAtts.GetTimeStep());
 
@@ -195,13 +195,13 @@ avtVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
         {
             newDS->TurnNodeNumbersOn();
         }
-        else 
+        else
         {
             newDS->TurnZoneNumbersOn();
             newDS->TurnNodeNumbersOn();
         }
 
-        avtContract_p contract = 
+        avtContract_p contract =
             new avtContract(newDS, queryAtts.GetPipeIndex());
 
         avtDataObject_p temp;
@@ -211,8 +211,30 @@ avtVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
         rv->Update(contract);
         return rv;
     }
-    else 
+    else
     {
         return avtSummationQuery::ApplyFilters(inData);
     }
 }
+
+
+// ****************************************************************************
+//  Method: avtVariableSummationQuery::GetTimeCurveSpecs
+//
+//  Purpose:
+//    Override default TimeCurveSpecs
+//
+//  Programmer:  Kathleen Bigags
+//  Creation:    Sep 11, 2024
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+const MapNode&
+avtVariableSummationQuery::GetTimeCurveSpecs(const QueryAttributes *qa)
+{
+    timeCurveSpecs["outputCurveLabel"] = "Sum_" + qa->GetVariables()[0];
+    return timeCurveSpecs;
+}
+

--- a/src/avt/Queries/Queries/avtVariableSummationQuery.h
+++ b/src/avt/Queries/Queries/avtVariableSummationQuery.h
@@ -29,6 +29,9 @@ class avtCondenseDatasetFilter;
 //    Kathleen Bonnell, Thu Mar  2 15:05:17 PST 2006
 //    Add ApplyFilters() and condense filter.
 //
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added GetTimeCurveSpecs.
+//
 // ****************************************************************************
 
 class QUERY_API avtVariableSummationQuery : public avtSummationQuery
@@ -37,8 +40,10 @@ class QUERY_API avtVariableSummationQuery : public avtSummationQuery
                          avtVariableSummationQuery();
     virtual             ~avtVariableSummationQuery();
 
-    virtual const char  *GetType(void)  
-                             { return "avtVariableSummationQuery"; };
+    virtual const char  *GetType(void)
+                             { return "avtVariableSummationQuery"; }
+
+    const MapNode       &GetTimeCurveSpecs(const QueryAttributes *) override;
 
   protected:
     avtCondenseDatasetFilter   *condense;

--- a/src/avt/Queries/Queries/avtWeightedVariableSummationQuery.C
+++ b/src/avt/Queries/Queries/avtWeightedVariableSummationQuery.C
@@ -26,15 +26,15 @@ using     std::string;
 // ****************************************************************************
 //  Method: avtWeightedVariableSummationQuery constructor
 //
-//  Programmer: Hank Childs 
-//  Creation:   February 3, 2004 
+//  Programmer: Hank Childs
+//  Creation:   February 3, 2004
 //
 //  Modifications:
 //    Kathleen Bonnell, Wed Aug 10 14:05:07 PDT 2005
 //    Force only positive volumes, but allow negative values from var.
 //
 //    Kathleen Bonnell, Fri Feb  3 10:32:12 PST 2006
-//    Added revolvedVolume. 
+//    Added revolvedVolume.
 //
 //    Hank Childs, Wed Apr 28 05:27:24 PDT 2010
 //    Add support for edges (1D cross sections)
@@ -44,7 +44,7 @@ using     std::string;
 //
 // ****************************************************************************
 
-avtWeightedVariableSummationQuery::avtWeightedVariableSummationQuery() 
+avtWeightedVariableSummationQuery::avtWeightedVariableSummationQuery()
     : avtSummationQuery()
 {
     length = new avtEdgeLength;
@@ -62,7 +62,7 @@ avtWeightedVariableSummationQuery::avtWeightedVariableSummationQuery()
 
     revolvedVolume = new avtRevolvedVolume;
     revolvedVolume->SetOutputVariableName("avt_weights");
-    
+
     constExpr = new avtConstantCreatorExpression;
     constExpr->SetOutputVariableName("avt_weights");
 
@@ -76,8 +76,8 @@ avtWeightedVariableSummationQuery::avtWeightedVariableSummationQuery()
 // ****************************************************************************
 //  Method: avtWeightedVariableSummationQuery destructor
 //
-//  Programmer: Hank Childs 
-//  Creation:   February 3, 2004 
+//  Programmer: Hank Childs
+//  Creation:   February 3, 2004
 //
 //  Modifications:
 //    Kathleen Bonnell, Fri Feb  3 10:32:12 PST 2006
@@ -121,11 +121,11 @@ avtWeightedVariableSummationQuery::~avtWeightedVariableSummationQuery()
 //    Minimize work done by creating new SIL.
 //
 //    Kathleen Bonnell, Tue May  4 14:25:07 PDT 2004
-//    Set SILRestriction via member restriction, instead of SILUseSet. 
+//    Set SILRestriction via member restriction, instead of SILUseSet.
 //
-//    Kathleen Bonnell, Fri Jan  7 15:15:32 PST 2005 
-//    Rework so that both time-varying and non use artificial pipeline. 
-//    Only difference is the pipeline spec used. 
+//    Kathleen Bonnell, Fri Jan  7 15:15:32 PST 2005
+//    Rework so that both time-varying and non use artificial pipeline.
+//    Only difference is the pipeline spec used.
 //
 //    Kathleen Bonnell, Fri Feb  3 10:32:12 PST 2006
 //    Added revolvedVolume, use it when 2D data and meshcoord type is RZ or ZR.
@@ -134,16 +134,16 @@ avtWeightedVariableSummationQuery::~avtWeightedVariableSummationQuery()
 //    Add support for filters to inherit from this class and create new
 //    variables based on the mesh.
 //
-//    Kathleen Bonnell, Wed Apr  2 10:20:27 PDT 2008 
+//    Kathleen Bonnell, Wed Apr  2 10:20:27 PDT 2008
 //    Retrieve the varname from the dataAtts instead of DataRequest, as
 //    DataRequest may have the wrong value based on other pipelines sharing
-//    the same source. 
+//    the same source.
 //
-//    Kathleen Bonnell, Tue Jul 29 9:03:15 PDT 2008 
+//    Kathleen Bonnell, Tue Jul 29 9:03:15 PDT 2008
 //    For better error messages, check if there is an active variable in the
 //    data attributes, and if not then retrieve from data request.
 //
-//    Kathleen Bonnell, Tue Sep 23 08:53:03 PDT 2008 
+//    Kathleen Bonnell, Tue Sep 23 08:53:03 PDT 2008
 //    Move setting of secondary var "avt_weights" till after the contract
 //    has been set for the time-varying case.
 //
@@ -169,14 +169,14 @@ avtWeightedVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
     string varname;
     if (GetInput()->GetInfo().GetAttributes().ValidActiveVariable())
         varname = GetInput()->GetInfo().GetAttributes().GetVariableName();
-    else 
+    else
         varname = GetInput()->GetOriginatingSource()->GetFullDataRequest()->
                   GetVariable();
     varname = GetVarname(varname);
     SetSumType(varname);
 
     int topo = GetInput()->GetInfo().GetAttributes().GetTopologicalDimension();
-    
+
     if(topo == 0)
     {
         debug5 << "WeightedVariableSum using Point" << endl;
@@ -199,7 +199,7 @@ avtWeightedVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
             area->SetInput(dob);
             dob = area->GetOutput();
         }
-        else 
+        else
         {
             debug5 << "WeightedVariableSum using RevolvedVolume" << endl;
             revolvedVolume->SetInput(dob);
@@ -226,14 +226,14 @@ avtWeightedVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
     //
     // Cause our artificial pipeline to execute.
     //
-    avtContract_p contract = 
+    avtContract_p contract =
         inData->GetOriginatingSource()->GetGeneralContract();
 
-    if (timeVarying) 
-    { 
+    if (timeVarying)
+    {
         avtDataRequest_p dataRequest = GetInput()->GetOriginatingSource()
                                            ->GetFullDataRequest();
-        avtDataRequest_p newDS = new 
+        avtDataRequest_p newDS = new
             avtDataRequest(dataRequest, querySILR);
         newDS->SetTimestep(queryAtts.GetTimeStep());
 
@@ -260,12 +260,12 @@ avtWeightedVariableSummationQuery::ApplyFilters(avtDataObject_p inData)
 //      Now that we have an input, we can determine what the variable units
 //      are and tell the base class about it.
 //
-//  Programmer: Kathleen Bonnell 
-//  Creation:   July 28, 2004 
+//  Programmer: Kathleen Bonnell
+//  Creation:   July 28, 2004
 //
 //  Modifications:
-//    Kathleen Bonnell, Thu Jan  6 10:34:57 PST 2005 
-//    Remove TRY-CATCH block in favor of testing for ValidActiveVariable. 
+//    Kathleen Bonnell, Thu Jan  6 10:34:57 PST 2005
+//    Remove TRY-CATCH block in favor of testing for ValidActiveVariable.
 //
 //    Hank Childs, Thu May 11 14:13:30 PDT 2006
 //    Do not set the units if the variable doesn't match the variable of
@@ -284,7 +284,7 @@ avtWeightedVariableSummationQuery::VerifyInput(void)
 
     if (GetInput()->GetInfo().GetAttributes().ValidActiveVariable())
     {
-        std::string varname1 = 
+        std::string varname1 =
                         GetInput()->GetInfo().GetAttributes().GetVariableName();
         std::string varname2 = GetVarname(varname1);
         if (varname1 == varname2)
@@ -297,4 +297,23 @@ avtWeightedVariableSummationQuery::VerifyInput(void)
     }
 }
 
+// ****************************************************************************
+//  Method: avtWeightedVariableSummationQuery::GetTimeCurveSpecs
+//
+//  Purpose:
+//    Override default TimeCurveSpecs
+//
+//  Programmer:  Kathleen Bigags
+//  Creation:    Sep 11, 2024
+//
+//  Modifications:
+//
+// ****************************************************************************
+
+const MapNode&
+avtWeightedVariableSummationQuery::GetTimeCurveSpecs(const QueryAttributes *qa)
+{
+    timeCurveSpecs["outputCurveLabel"] = "Weighted_sum_" + qa->GetVariables()[0];
+    return timeCurveSpecs;
+}
 

--- a/src/avt/Queries/Queries/avtWeightedVariableSummationQuery.h
+++ b/src/avt/Queries/Queries/avtWeightedVariableSummationQuery.h
@@ -36,14 +36,17 @@ class     avtConstantCreatorExpression;
 //    Kathleen Bonnell, Wed Jul 28 08:50:51 PDT 2004
 //    Added VerifyInput.
 //
-//    Kathleen Bonnell, Fri Feb  3 10:32:12 PST 2006 
-//    Added revolvedVolume. 
+//    Kathleen Bonnell, Fri Feb  3 10:32:12 PST 2006
+//    Added revolvedVolume.
 //
 //    Hank Childs, Thu May 11 13:28:50 PDT 2006
 //    Added new virtual methods so that new queries can inherit from this.
 //
 //    Hank Childs, Wed Apr 28 05:25:52 PDT 2010
 //    Add support for 1D cross sections.
+//
+//    Kathleen Biagas, Wed Sep 11, 2024
+//    Added GetTimeCurveSpecs.
 //
 // ****************************************************************************
 
@@ -53,8 +56,10 @@ class QUERY_API avtWeightedVariableSummationQuery : public avtSummationQuery
                          avtWeightedVariableSummationQuery();
     virtual             ~avtWeightedVariableSummationQuery();
 
-    virtual const char  *GetType(void)  
-                             { return "avtWeightedVariableSummationQuery"; };
+    virtual const char  *GetType(void)
+                             { return "avtWeightedVariableSummationQuery"; }
+
+    const MapNode       &GetTimeCurveSpecs(const QueryAttributes *) override;
 
   protected:
     avtEdgeLength               *length;

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -62,6 +62,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>The function <code>GetDefaultFileOpenOptions</code> in the Python scripting interface was enhanced to open a metadata server if one wasn't already open.</li>
   <li>The function <code>GetExportOptions</code> in the Python scripting interface was enhanced to open a metadata server if one wasn't already open.</li>
   <li>Re-enabled support for using VTKm, which was removed in the 3.4.0 release.</li>
+  <li>Saving results of time queries to curve files now uses query name and/or variable names as curve names instead of just 'Curve'.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #19139

Mechanism uses labels set in output avtDataTree specs. When writing output curve names, if those labels are empty, will use the generic 'curve'.

Basic queries not var related will set the labels with their query name, var-related will add the var as well.

Examples:
Min_pressure
Max_pressure
3D_surface_area
Trajectory_u_v_zone_0_domain_0
Weighted_sum_pressure
Volume
Average_value_pressure


### Type of change

* ~~[ ] Bug fix~~
* [X] New feature
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

I ran time queries, saving curves to files, verified use of query and var names instead of generic 'curve'.

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

