### PR TITLE
Fix bug with operator atts displaying incorrectly after session restore. (#19874)

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -49,6 +49,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed bug with Pseudocolor plots of datasets with very large or small extents being rendered black.</li>
   <li>ChooseCenter with a mouse on Scatter plot now works.</li>
   <li>Fixed a bug in the Plaintext Reader causing reading variable names that were single-characters to fail.</li>
+  <li>Fixed a bug where the operator attribute windows will show the default attributes when displaying the attributes for an operator applied to a plot after restoring a session. The plots displayed in the visualization windows will be correct, just the attributes displayed in the attribute window will be incorrect. This happens with session files saved with releases 3.4 and 3.4.1. To fix the issue you will need to save a new session file using a newer version of VisIt. If you restored a session with a bad session file, you will need to change the attributes of any affected operators before saving the new session file.</li>
 </ul>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.4.2</font></b></p>

--- a/src/viewer/core/ViewerOperator.C
+++ b/src/viewer/core/ViewerOperator.C
@@ -570,6 +570,10 @@ ViewerOperator::NeedsRecalculation() const
 //   Eric Brugger, Wed Mar 22 16:23:12 PDT 2023
 //   Add operator keyframing.
 //   
+//   Eric Brugger, Wed Oct  2 13:41:53 PDT 2024
+//   Added logic to store the current operator attributes before storing
+//   the keyframed operator attributes.
+//
 // ****************************************************************************
 
 void
@@ -580,6 +584,11 @@ ViewerOperator::CreateNode(DataNode *parentNode)
 
     DataNode *operatorNode = new DataNode("ViewerOperator");
     parentNode->AddNode(operatorNode);
+
+    //
+    // Store the current operator attributes.
+    //
+    curOperatorAtts->CreateNode(operatorNode, true, true);
 
     //
     // Add the keyframed operator attributes.


### PR DESCRIPTION
Merge from the 3.4RC to develop.

### Description

Resolves #19623

I fixed a bug with the operator attributes displaying the default attributes for plots after restoring a session. The plots in the visualization window will be correct, just the values displayed in the attribute windows will be incorrect. This happens with session files saved with VisIt 3.4 and 3.4.1. To fix the issue, new session files will need to be saved.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I used the following steps to save a session file.

1) Open rect2d.silo
2) Create a pseudocolor plot of d.
3) Change the plot limits to 0.1 and 0.4.
4) Add a transform operator.
5) Change the X, Y and Z scale values to 5., 6. and 7.
6) Save the session.

Restart VisIt and restore the session.

I also ran the `keyframe.py` tests in the test suite.
```
./run_visit_test_suite.sh --parallel-launch srun -m "pascal,serial,trunk" ../../src/test/tests/hybrid/keyframe.py 
[[VisIt Test Suite]]
[Checking test data]
[Test data file '/usr/workspace/brugger/visit_dev_git/visit/build/testdata/silo_hdf5_test_data/globe.silo' exists.]
[Starting test suite run @ 2024:10:02:14:00:58]
[Running 1 test case]
[Using skip list file: '/usr/workspace/brugger/visit_dev_git/visit/src/test/skip.json']
[Using 1 test process]
[Launching: hybrid/keyframe.py]
+ Passed with zero differences in test file: hybrid/keyframe.py
[Test suite run complete @ 2024:10:02:14:01:37 (wall time = 39)]
++ Test suite run finished with NO errors.
[Cleanup: Waiting for delayed writes]
[Cleanup: Removing _run directory]
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
