### PR TITLE
Fix logic error in avtLineSamplerInfoQuery for loops.

### DIFF
--- a/src/avt/Queries/Queries/avtLineSamplerInfoQuery.C
+++ b/src/avt/Queries/Queries/avtLineSamplerInfoQuery.C
@@ -279,7 +279,7 @@ avtLineSamplerInfoQuery::Execute(vtkDataSet *data, const int chunk)
         vertPtr++; //Now segptr points at vtx0.
 #else
       auto verts = vtk::TakeSmartPointer(ds->GetVerts()->NewIterator());
-      for (verts->GoToFirstCell(); !verts->IsDoneWithTraversal(); verts->GoToNextCell());
+      for (verts->GoToFirstCell(); !verts->IsDoneWithTraversal(); verts->GoToNextCell())
       {
         const vtkIdType *vertPtr;
         verts->GetCurrentCell(nPts, vertPtr);
@@ -327,7 +327,7 @@ avtLineSamplerInfoQuery::Execute(vtkDataSet *data, const int chunk)
         segPtr++; //Now segptr points at vtx0.
 #else
       auto lines = vtk::TakeSmartPointer(ds->GetLines()->NewIterator());
-      for (lines->GoToFirstCell(); !lines->IsDoneWithTraversal(); lines->GoToNextCell());
+      for (lines->GoToFirstCell(); !lines->IsDoneWithTraversal(); lines->GoToNextCell())
       {
         const vtkIdType *segPtr;
         lines->GetCurrentCell(nPts, segPtr);


### PR DESCRIPTION
### Description

I noticed  `;` at end of for-loop statement. Fixed.


### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
