### PR TITLE
Fix rendering of rubber band zoom lines when zooming.

### DIFF
--- a/src/avt/VisWindow/Interactors/Zoom2D.C
+++ b/src/avt/VisWindow/Interactors/Zoom2D.C
@@ -495,10 +495,6 @@ Zoom2D::StartRubberBand(int x, int y)
         vtkRenderer *ren = proxy.GetBackground();
         ren->AddActor2D(guideLinesActor);
        
-#if 0
-        lastGuideX = x;
-        lastGuideY = y;
-#endif
         UpdateRubberBand(x,y,x,y,x,y);
     }
 }
@@ -602,10 +598,6 @@ Zoom2D::UpdateRubberBand(int aX, int aY, int lX, int lY, int nX, int nY)
         pts->SetPoint(10, (double) x1,  (double) yMin, 0.);
         pts->SetPoint(11, (double) x1,  (double) yMax, 0.);
         guideLinesMapper->RenderOverlay(ren, guideLinesActor);
-#if 0
-        lastGuideX = nX;
-        lastGuideY = nY;
-#endif
     }
 }
 
@@ -658,143 +650,6 @@ GetGuideSegment(int a, int l, int n, int &outl, int &newl)
         newl += offset;
     }
 }
-
-
-#if 0
-// ****************************************************************************
-//  Method: Zoom2D::UpdateGuideLines
-//
-//  Purpose:
-//      Updates the guide lines to new positions, with minimized flashing. 
-//      This method only updates the guide lines, assuming that guide
-//      lines already exist on the screen (to be erased if needed).
-//      Uses same naming conventions as described in DrawGuideLines.
-//
-//  Arguments:
-//      aX      The x-coordinate of the anchor in display coordinates.
-//      aY      The y-coordinate of the anchor in display coordinates.
-//      lX      The x-coordinate of the last corner in display coordinates.
-//      lY      The y-coordinate of the last corner in display coordinates.
-//      nX      The x-coordinate of the new corner in display coordinates.
-//      nY      The y-coordinate of the new corner in display coordinates.
-//
-//  Programmer: Akira Haddox 
-//  Creation:   July 3, 2003
-//
-// ****************************************************************************
-
-void
-Zoom2D::UpdateGuideLines(int aX, int aY, int lX, int lY, int nX, int nY)
-{
-    // Certain lines need to be completely erased and redrawn. Those we
-    // draw using DrawGuideLines with this array. Lines which need to be
-    // 'adjusted' (like how the rubberBand is adjusted in ZoomInteractor)
-    // are done manually in this function.
-    bool refresh[8];
-    int i;
-    for (i = 0; i < 8; ++i)
-    {
-        refresh[i] = false;
-    }
-    
-    // If any lines will be or are down on a border, or we're moving over
-    // a line, just erase and redraw. It's more work than it's worth
-    // to make it work, and it doesn't happen often enough for the flashing
-    // to be noticable.
-    if (((nX-aX)*(lX-aX) <= 0) || ((nY-aY)*(lY-aY) <= 0))
-    {
-        for (i = 0; i < 8; ++i)
-            refresh[i] = true;
-    }
-    else
-    {
-        bool cornerPartialRefresh = true;
-        // If both coordinates have changed, the following refreshes: 
-        // refresh: corner [h/v], shareX[h], shareY[v]
-        if (nX != lX && nY != lY)
-        {
-            refresh[2] = refresh[3] = refresh[4] = refresh[7] = true;
-            cornerPartialRefresh = false;
-        }
-        
-        // If the x coordinate has changed, the following refreshes:
-        // refresh: corner[v], shareY[v]
-        // partials: shareY[h], corner[h]
-        if(nX != lX)
-        {
-            refresh[3] = refresh[7] = true;
-            
-            // Partially refresh shareY[h]
-//            guideLinesMapper->SetHorizontalBias(true);
-            Zoom2D_SetLineProperties(guideLines, 2, 3, true);
-
-            int fromX, toX;
-            GetGuideSegment(aX, lX, nX, fromX, toX);
-        
-            DrawGuideLine(fromX, aY, toX, aY);
-
-            // Partially refresh corner[h]
-            if (cornerPartialRefresh)
-                DrawGuideLine(fromX, nY, toX, nY);
-        }
-       
-        // If the y coordinate has changed, the following refreshes:
-        // refresh: corner[h], shareX[h]
-        // partials: shareX[v], corner[v]
-        if(nY != lY)
-        {
-            refresh[2] = refresh[4] = true;
-            
-            // Partially refresh shareX[v]
-//            guideLinesMapper->SetHorizontalBias(false);
-            Zoom2D_SetLineProperties(guideLines, 2, 3, false);
-            int fromY, toY;
-            GetGuideSegment(aY, lY, nY, fromY, toY);
-            DrawGuideLine(aX, fromY, aX, toY);
-            
-            //Partially refresh corner[v]
-            if (cornerPartialRefresh)
-                DrawGuideLine(nX, fromY, nX, toY);
-        }
-    }
-   
-    // Completely refreshed lines
-    // Draw the new lines
-    DrawGuideLines(aX, aY, nX, nY, refresh);
-    // Erase the old lines
-    DrawGuideLines(aX, aY, lX, lY, refresh);
-}
-#endif
-
-
-#if 0
-// ****************************************************************************
-//  Method: Zoom2D::DrawAllGuideLines
-//
-//  Purpose:
-//      Draw all the guide lines without considering what may already be
-//      on the screen. Useful for initial drawing, and for erasing all
-//      lines on the screen.
-//
-//  Arguments:
-//      aX:     Anchor's x display coordinate
-//      aY:     Anchor's y display coordinate
-//      nX:     Oppossite corner's x display coordinate
-//      nY:     Oppossite corner's y display coordinate
-//
-//  Programmer: Akira Haddox 
-//  Creation:   July 3, 2003
-//
-// ****************************************************************************
-
-void
-Zoom2D::DrawAllGuideLines(int aX, int aY, int nX, int nY)
-{
-    const bool drawAll[8] = { true, true, true, true, true, true, true, true };
-    DrawGuideLines(aX, aY, nX, nY, drawAll);
-}
-#endif
-
 
 // ****************************************************************************
 //  Method: Zoom2D::DrawGuideLines

--- a/src/avt/VisWindow/Interactors/Zoom2D.C
+++ b/src/avt/VisWindow/Interactors/Zoom2D.C
@@ -63,6 +63,12 @@ Zoom2D_SetLineProperties(vtkPolyData *guideLines,
 //    the left mouse button would result in the window being stuck in pan mode
 //    if the shift key was released before the left mouse button.
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases. I also
+//    changed the cues to be four lines, two parallel to the Y axis
+//    extending from xmin to xmax and two parallel to the X axis extending
+//    from ymin to ymax.
+//
 // ****************************************************************************
 
 Zoom2D::Zoom2D(VisWindowInteractorProxy &v) : ZoomInteractor(v)
@@ -79,35 +85,21 @@ Zoom2D::Zoom2D(VisWindowInteractorProxy &v) : ZoomInteractor(v)
     LineProperties->Delete();
     Zoom2D_SetLineProperties(guideLines, 2, 3, false);
 
-#if defined(__APPLE__) || defined(_WIN32)
     vtkPoints *pts = vtkPoints::New();
-    pts->SetNumberOfPoints(12);
+    pts->SetNumberOfPoints(8);
     guideLines->SetPoints(pts);
     pts->Delete();
 
     vtkCellArray *lines  = vtkCellArray::New();
-    vtkIdType  ids[8][2] = {
-       {0, 1}, {2,3}, {4,5}, {6,7}, {8,1}, {5,9}, {10,2}, {6,11}
+    vtkIdType  ids[4][2] = {
+       {0, 1}, {2,3}, {4,5}, {6,7}
     };
-    for(int i = 0; i < 8; ++i)
+    for(int i = 0; i < 4; ++i)
         lines->InsertNextCell(2, ids[i]);
     guideLines->SetLines(lines);
     lines->Delete();
-#else
-    vtkPoints *pts = vtkPoints::New();
-    pts->SetNumberOfPoints(2);
-    guideLines->SetPoints(pts);
-    pts->Delete();
-
-    vtkCellArray *lines  = vtkCellArray::New();
-    vtkIdType  ids[2] = { 0, 1 };
-    lines->InsertNextCell(2, ids);
-    guideLines->SetLines(lines);
-    lines->Delete();
-#endif
     guideLinesMapper = proxy.CreateXorGridMapper();
     guideLinesMapper->SetInputData(guideLines);
-//    guideLinesMapper->SetDots(2, 3);
     
     guideLinesActor  = vtkActor2D::New();
     guideLinesActor->SetMapper(guideLinesMapper);
@@ -486,6 +478,12 @@ Zoom2D::OnMouseWheelBackward()
 //    Kathleen Biagas, Mon Jun 11 17:16:42 MST 2012
 //    Have windows follow the APPLE path.
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases. I also
+//    changed the cues to be four lines, two parallel to the Y axis
+//    extending from xmin to xmax and two parallel to the X axis extending
+//    from ymin to ymax.
+//
 // ****************************************************************************
 
 void
@@ -503,13 +501,11 @@ Zoom2D::StartRubberBand(int x, int y)
         vtkRenderer *ren = proxy.GetBackground();
         ren->AddActor2D(guideLinesActor);
        
+#if 0
         lastGuideX = x;
         lastGuideY = y;
-#if defined(__APPLE__) || defined(_WIN32)
-        UpdateRubberBand(x,y,x,y,x,y);
-#else
-        DrawAllGuideLines(x, y, x, y);
 #endif
+        UpdateRubberBand(x,y,x,y,x,y);
     }
 }
 
@@ -566,6 +562,12 @@ Zoom2D::EndRubberBand()
 //    Kathleen Biagas, Mon Jun 11 17:16:42 MST 2012
 //    Have windows follow the APPLE path.
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases. I also
+//    changed the cues to be four lines, two parallel to the Y axis
+//    extending from xmin to xmax and two parallel to the X axis extending
+//    from ymin to ymax.
+//
 // ****************************************************************************
 
 void
@@ -586,8 +588,6 @@ Zoom2D::UpdateRubberBand(int aX, int aY, int lX, int lY, int nX, int nY)
     // call. The rubberBand doesn't need it exactly, but we do.
     if (shouldDrawGuides)
     {
-#if defined(__APPLE__) || defined(_WIN32)
-        int x0 = (aX < nX) ? aX : nX;
         int x1 = (aX > nX) ? aX : nX;
         int y0 = (aY < nY) ? aY : nY;
         int y1 = (aY > nY) ? aY : nY;
@@ -598,23 +598,18 @@ Zoom2D::UpdateRubberBand(int aX, int aY, int lX, int lY, int nX, int nY)
         vtkViewport *ren = proxy.GetBackground();
         vtkPoints *pts = guideLines->GetPoints();
         pts->SetPoint(0, (double) xMin, (double) y0, 0.);
-        pts->SetPoint(1, (double) x0,   (double) y0, 0.);
-        pts->SetPoint(2, (double) x1,   (double) y0, 0.);
-        pts->SetPoint(3, (double) xMax, (double) y0, 0.);
-        pts->SetPoint(4, (double) xMin, (double) y1, 0.);
-        pts->SetPoint(5, (double) x0,   (double) y1, 0.);
-        pts->SetPoint(6, (double) x1,   (double) y1, 0.);
-        pts->SetPoint(7, (double) xMax, (double) y1, 0.);
-        pts->SetPoint(8, (double) x0,   (double) yMin, 0.);
-        pts->SetPoint(9, (double) x0,   (double) yMax, 0.);
-        pts->SetPoint(10, (double) x1,  (double) yMin, 0.);
-        pts->SetPoint(11, (double) x1,  (double) yMax, 0.);
+        pts->SetPoint(1, (double) xMax, (double) y0, 0.);
+        pts->SetPoint(2, (double) xMin, (double) y1, 0.);
+        pts->SetPoint(3, (double) xMax, (double) y1, 0.);
+        pts->SetPoint(4, (double) x0,   (double) yMin, 0.);
+        pts->SetPoint(5, (double) x0,   (double) yMax, 0.);
+        pts->SetPoint(6, (double) x1,   (double) yMin, 0.);
+        pts->SetPoint(7, (double) x1,   (double) yMax, 0.);
         guideLinesMapper->RenderOverlay(ren, guideLinesActor);
-#else
-        UpdateGuideLines(aX, aY, lastGuideX, lastGuideY, nX, nY);
-#endif
+#if 0
         lastGuideX = nX;
         lastGuideY = nY;
+#endif
     }
 }
 
@@ -669,6 +664,7 @@ GetGuideSegment(int a, int l, int n, int &outl, int &newl)
 }
 
 
+#if 0
 // ****************************************************************************
 //  Method: Zoom2D::UpdateGuideLines
 //
@@ -772,8 +768,10 @@ Zoom2D::UpdateGuideLines(int aX, int aY, int lX, int lY, int nX, int nY)
     // Erase the old lines
     DrawGuideLines(aX, aY, lX, lY, refresh);
 }
+#endif
 
 
+#if 0
 // ****************************************************************************
 //  Method: Zoom2D::DrawAllGuideLines
 //
@@ -799,6 +797,7 @@ Zoom2D::DrawAllGuideLines(int aX, int aY, int nX, int nY)
     const bool drawAll[8] = { true, true, true, true, true, true, true, true };
     DrawGuideLines(aX, aY, nX, nY, drawAll);
 }
+#endif
 
 
 // ****************************************************************************

--- a/src/avt/VisWindow/Interactors/Zoom2D.C
+++ b/src/avt/VisWindow/Interactors/Zoom2D.C
@@ -64,10 +64,7 @@ Zoom2D_SetLineProperties(vtkPolyData *guideLines,
 //    if the shift key was released before the left mouse button.
 //
 //    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
-//    I modified the class to use the APPLE path in all cases. I also
-//    changed the cues to be four lines, two parallel to the Y axis
-//    extending from xmin to xmax and two parallel to the X axis extending
-//    from ymin to ymax.
+//    I modified the class to use the APPLE path in all cases.
 //
 // ****************************************************************************
 
@@ -86,15 +83,15 @@ Zoom2D::Zoom2D(VisWindowInteractorProxy &v) : ZoomInteractor(v)
     Zoom2D_SetLineProperties(guideLines, 2, 3, false);
 
     vtkPoints *pts = vtkPoints::New();
-    pts->SetNumberOfPoints(8);
+    pts->SetNumberOfPoints(12);
     guideLines->SetPoints(pts);
     pts->Delete();
 
     vtkCellArray *lines  = vtkCellArray::New();
-    vtkIdType  ids[4][2] = {
-       {0, 1}, {2,3}, {4,5}, {6,7}
+    vtkIdType  ids[8][2] = {
+       {0, 1}, {2,3}, {4,5}, {6,7}, {8,1}, {5,9}, {10,2}, {6,11}
     };
-    for(int i = 0; i < 4; ++i)
+    for(int i = 0; i < 8; ++i)
         lines->InsertNextCell(2, ids[i]);
     guideLines->SetLines(lines);
     lines->Delete();
@@ -479,10 +476,7 @@ Zoom2D::OnMouseWheelBackward()
 //    Have windows follow the APPLE path.
 //
 //    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
-//    I modified the class to use the APPLE path in all cases. I also
-//    changed the cues to be four lines, two parallel to the Y axis
-//    extending from xmin to xmax and two parallel to the X axis extending
-//    from ymin to ymax.
+//    I modified the class to use the APPLE path in all cases.
 //
 // ****************************************************************************
 
@@ -563,10 +557,7 @@ Zoom2D::EndRubberBand()
 //    Have windows follow the APPLE path.
 //
 //    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
-//    I modified the class to use the APPLE path in all cases. I also
-//    changed the cues to be four lines, two parallel to the Y axis
-//    extending from xmin to xmax and two parallel to the X axis extending
-//    from ymin to ymax.
+//    I modified the class to use the APPLE path in all cases.
 //
 // ****************************************************************************
 
@@ -599,13 +590,17 @@ Zoom2D::UpdateRubberBand(int aX, int aY, int lX, int lY, int nX, int nY)
         vtkViewport *ren = proxy.GetBackground();
         vtkPoints *pts = guideLines->GetPoints();
         pts->SetPoint(0, (double) xMin, (double) y0, 0.);
-        pts->SetPoint(1, (double) xMax, (double) y0, 0.);
-        pts->SetPoint(2, (double) xMin, (double) y1, 0.);
-        pts->SetPoint(3, (double) xMax, (double) y1, 0.);
-        pts->SetPoint(4, (double) x0,   (double) yMin, 0.);
-        pts->SetPoint(5, (double) x0,   (double) yMax, 0.);
-        pts->SetPoint(6, (double) x1,   (double) yMin, 0.);
-        pts->SetPoint(7, (double) x1,   (double) yMax, 0.);
+        pts->SetPoint(1, (double) x0,   (double) y0, 0.);
+        pts->SetPoint(2, (double) x1,   (double) y0, 0.);
+        pts->SetPoint(3, (double) xMax, (double) y0, 0.);
+        pts->SetPoint(4, (double) xMin, (double) y1, 0.);
+        pts->SetPoint(5, (double) x0,   (double) y1, 0.);
+        pts->SetPoint(6, (double) x1,   (double) y1, 0.);
+        pts->SetPoint(7, (double) xMax, (double) y1, 0.);
+        pts->SetPoint(8, (double) x0,   (double) yMin, 0.);
+        pts->SetPoint(9, (double) x0,   (double) yMax, 0.);
+        pts->SetPoint(10, (double) x1,  (double) yMin, 0.);
+        pts->SetPoint(11, (double) x1,  (double) yMax, 0.);
         guideLinesMapper->RenderOverlay(ren, guideLinesActor);
 #if 0
         lastGuideX = nX;

--- a/src/avt/VisWindow/Interactors/Zoom2D.C
+++ b/src/avt/VisWindow/Interactors/Zoom2D.C
@@ -588,6 +588,7 @@ Zoom2D::UpdateRubberBand(int aX, int aY, int lX, int lY, int nX, int nY)
     // call. The rubberBand doesn't need it exactly, but we do.
     if (shouldDrawGuides)
     {
+        int x0 = (aX < nX) ? aX : nX;
         int x1 = (aX > nX) ? aX : nX;
         int y0 = (aY < nY) ? aY : nY;
         int y1 = (aY > nY) ? aY : nY;

--- a/src/avt/VisWindow/Interactors/Zoom2D.h
+++ b/src/avt/VisWindow/Interactors/Zoom2D.h
@@ -73,8 +73,10 @@ class VISWINDOW_API Zoom2D : public ZoomInteractor
     virtual void        OnMouseWheelBackward();
 
   protected:
+#if 0
     int                 lastGuideX;
     int                 lastGuideY;
+#endif
 
     vtkPolyData                 *guideLines;
     vtkPolyDataMapper2D         *guideLinesMapper;
@@ -83,9 +85,11 @@ class VISWINDOW_API Zoom2D : public ZoomInteractor
     virtual void        StartRubberBand(int, int);
     virtual void        EndRubberBand();
     virtual void        UpdateRubberBand(int, int, int, int, int, int);
+#if 0
     void                UpdateGuideLines(int, int, int, int, int, int);
     
     void                DrawAllGuideLines(int, int, int, int);
+#endif
    
     void                DrawGuideLines(int, int, int, int, const bool which[8]);
     void                DrawGuideLine(int, int, int, int);

--- a/src/avt/VisWindow/Interactors/Zoom2D.h
+++ b/src/avt/VisWindow/Interactors/Zoom2D.h
@@ -54,6 +54,9 @@ class VisWindowInteractorProxy;
 //    the left mouse button would result in the window being stuck in pan mode
 //    if the shift key was released before the left mouse button.
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases.
+//
 // ****************************************************************************
 
 class VISWINDOW_API Zoom2D : public ZoomInteractor
@@ -73,11 +76,6 @@ class VISWINDOW_API Zoom2D : public ZoomInteractor
     virtual void        OnMouseWheelBackward();
 
   protected:
-#if 0
-    int                 lastGuideX;
-    int                 lastGuideY;
-#endif
-
     vtkPolyData                 *guideLines;
     vtkPolyDataMapper2D         *guideLinesMapper;
     vtkActor2D                  *guideLinesActor;
@@ -85,11 +83,6 @@ class VISWINDOW_API Zoom2D : public ZoomInteractor
     virtual void        StartRubberBand(int, int);
     virtual void        EndRubberBand();
     virtual void        UpdateRubberBand(int, int, int, int, int, int);
-#if 0
-    void                UpdateGuideLines(int, int, int, int, int, int);
-    
-    void                DrawAllGuideLines(int, int, int, int);
-#endif
    
     void                DrawGuideLines(int, int, int, int, const bool which[8]);
     void                DrawGuideLine(int, int, int, int);

--- a/src/avt/VisWindow/Interactors/ZoomInteractor.h
+++ b/src/avt/VisWindow/Interactors/ZoomInteractor.h
@@ -55,6 +55,9 @@ class VisWindowInteractorProxy;
 //    Added two flags for when InteractorAtts 'ClampToSquare' and 
 //    'ShowGuidelines' are set. 
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases.
+//
 // ****************************************************************************
 
 class VISWINDOW_API ZoomInteractor : public VisitInteractor
@@ -86,7 +89,6 @@ class VISWINDOW_API ZoomInteractor : public VisitInteractor
     virtual void           StartRubberBand(int, int);
     virtual void           EndRubberBand();
     virtual void           UpdateRubberBand(int, int, int, int, int, int);
-    virtual void           DrawRubberBandLine(int, int, int, int);
 
     void                   SetCanvasViewport(void);
     void                   ForceCoordsToViewport(int &, int &);

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -52,6 +52,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Plaintext Reader causing reading variable names that were single-characters to fail.</li>
   <li>Fixed a bug where the operator attribute windows will show the default attributes when displaying the attributes for an operator applied to a plot after restoring a session. The plots displayed in the visualization windows will be correct, just the attributes displayed in the attribute window will be incorrect. This happens with session files saved with releases 3.4 and 3.4.1. To fix the issue you will need to save a new session file using a newer version of VisIt. If you restored a session with a bad session file, you will need to change the attributes of any affected operators before saving the new session file.</li>
 </ul>
+  <li>Fixed a bug where the rubber band lines are either broken or missing when you click and move the mouse when zooming an image using zoom mode on Linux systems.</li>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.4.2</font></b></p>
 <ul>


### PR DESCRIPTION
### Description

Resolves #19429
Resolves #19094

I fixed the rendering of rubber band zoom lines when zooming both in 2D and 3D. The code to render the rubber bands had two cases. One for Apple and Windows and one for the rest. I modified the code to always use the Apple and Windows code. I also removed any code that was no longer needed.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built the code on `rzwhippet`. I opened `curv2d.silo` and created a pseudocolor plot. Then I tested out the zoom mode verifying that the rubber band lines displayed properly. I did the same with `globe.silo` to test zooming in 3D.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
