### PR TITLE
Fix rendering of rubber band zoom lines when zooming. (#19911)

### DIFF
--- a/src/avt/VisWindow/Interactors/Zoom2D.h
+++ b/src/avt/VisWindow/Interactors/Zoom2D.h
@@ -54,6 +54,9 @@ class VisWindowInteractorProxy;
 //    the left mouse button would result in the window being stuck in pan mode
 //    if the shift key was released before the left mouse button.
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases.
+//
 // ****************************************************************************
 
 class VISWINDOW_API Zoom2D : public ZoomInteractor
@@ -73,9 +76,6 @@ class VISWINDOW_API Zoom2D : public ZoomInteractor
     virtual void        OnMouseWheelBackward();
 
   protected:
-    int                 lastGuideX;
-    int                 lastGuideY;
-
     vtkPolyData                 *guideLines;
     vtkPolyDataMapper2D         *guideLinesMapper;
     vtkActor2D                  *guideLinesActor;
@@ -83,9 +83,6 @@ class VISWINDOW_API Zoom2D : public ZoomInteractor
     virtual void        StartRubberBand(int, int);
     virtual void        EndRubberBand();
     virtual void        UpdateRubberBand(int, int, int, int, int, int);
-    void                UpdateGuideLines(int, int, int, int, int, int);
-    
-    void                DrawAllGuideLines(int, int, int, int);
    
     void                DrawGuideLines(int, int, int, int, const bool which[8]);
     void                DrawGuideLine(int, int, int, int);

--- a/src/avt/VisWindow/Interactors/ZoomInteractor.h
+++ b/src/avt/VisWindow/Interactors/ZoomInteractor.h
@@ -55,6 +55,9 @@ class VisWindowInteractorProxy;
 //    Added two flags for when InteractorAtts 'ClampToSquare' and 
 //    'ShowGuidelines' are set. 
 //
+//    Eric Brugger, Wed Oct  2 16:54:48 PDT 2024
+//    I modified the class to use the APPLE path in all cases.
+//
 // ****************************************************************************
 
 class VISWINDOW_API ZoomInteractor : public VisitInteractor
@@ -86,7 +89,6 @@ class VISWINDOW_API ZoomInteractor : public VisitInteractor
     virtual void           StartRubberBand(int, int);
     virtual void           EndRubberBand();
     virtual void           UpdateRubberBand(int, int, int, int, int, int);
-    virtual void           DrawRubberBandLine(int, int, int, int);
 
     void                   SetCanvasViewport(void);
     void                   ForceCoordsToViewport(int &, int &);

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -52,6 +52,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug in the Plaintext Reader causing reading variable names that were single-characters to fail.</li>
   <li>Fixed a bug where the operator attribute windows will show the default attributes when displaying the attributes for an operator applied to a plot after restoring a session. The plots displayed in the visualization windows will be correct, just the attributes displayed in the attribute window will be incorrect. This happens with session files saved with releases 3.4 and 3.4.1. To fix the issue you will need to save a new session file using a newer version of VisIt. If you restored a session with a bad session file, you will need to change the attributes of any affected operators before saving the new session file.</li>
 </ul>
+  <li>Fixed a bug where the rubber band lines are either broken or missing when you click and move the mouse when zooming an image using zoom mode on Linux systems.</li>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.4.2</font></b></p>
 <ul>


### PR DESCRIPTION
Merge from the 3.4RC to develop.

### Description

Resolves #19429
Resolves #19094

I fixed the rendering of rubber band zoom lines when zooming both in 2D and 3D. The code to render the rubber bands had two cases. One for Apple and Windows and one for the rest. I modified the code to always use the Apple and Windows code. I also removed any code that was no longer needed.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built the code on `rzwhippet`. I opened `curv2d.silo` and created a pseudocolor plot. Then I tested out the zoom mode verifying that the rubber band lines displayed properly. I did the same with `globe.silo` to test zooming in 3D.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
