### PR TITLE
Fix interaction mode for non-read-only Expressions editor.

### DIFF
--- a/src/gui/QvisExpressionsWindow.C
+++ b/src/gui/QvisExpressionsWindow.C
@@ -749,6 +749,10 @@ QvisExpressionsWindow::CreateStandardEditor()
 // Creation:   Fri Aug 23 10:00:47 PDT 2024
 //
 // Modifications:
+//  Kathleen Biags, Fri Oct 18, 2024
+//  Set the non-read-only Interaction flags to Qt::TextEditorInteraction,
+//  Qt docs state it is the default for a text editor and  is the same as
+//  Qt::TextEditable | Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard.
 //
 // ****************************************************************************
 
@@ -767,7 +771,7 @@ QvisExpressionsWindow::SetStandardEditorReadOnly(bool read_only)
     {
         nameEditLabel->setText(tr("Name"));
         nameEdit->setReadOnly(false);
-        stdDefinitionEdit->setTextInteractionFlags(Qt::TextEditable);
+        stdDefinitionEdit->setTextInteractionFlags(Qt::TextEditorInteraction);
         stdDefinitionEditLabel->setText(tr("Definition"));
     }
 


### PR DESCRIPTION
### Description

Resolves #19866

Changed the non-read-only `TextInteractionFlags` to `Qt::TextEditInteraction`.
Qt docs state this flag is the default for a text editor and is the same as:

`TextSelectableByMouse | TextSelectableByKeyboard | TextEditable`

### Type of change

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I tried using arrow keys to move around, and mouse to select text with success.

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.
