### PR TITLE
Allow user to type into the SIL Set selection combo box. (#19927)

### DIFF
--- a/src/gui/QvisSILSetSelector.h
+++ b/src/gui/QvisSILSetSelector.h
@@ -12,17 +12,19 @@
 #include <vectortypes.h>
 
 class QComboBox;
+class QCompleter;
+class QStringListModel;
 class QLabel;
 class SILRestrictionAttributes;
 
 // ****************************************************************************
 // Class: QvisSILSetSelector
 //
-// Purpose: 
+// Purpose:
 //   Defines QvisSILSetSelector class.
 //
-// Programmer: Kathleen Bonnell 
-// Creation:   June 6, 2007 
+// Programmer: Kathleen Bonnell
+// Creation:   June 6, 2007
 //
 // Modifications:
 //   Kathleen Bonnell, Thu Jun 14 12:18:47 PDT 2007
@@ -32,10 +34,13 @@ class SILRestrictionAttributes;
 //   Brad Whitlock, Fri Jul 18 08:35:26 PDT 2008
 //   Qt 4.
 //
+//   Kathleen Biagas, Monday Oct 21, 2024
+//   Added QCompleter and QStringListModel for use with subsetName ComboBox.
+//
 // ****************************************************************************
 
-class GUI_API QvisSILSetSelector : public QWidget, 
-                                   public SimpleObserver, 
+class GUI_API QvisSILSetSelector : public QWidget,
+                                   public SimpleObserver,
                                    public GUIBase
 {
     Q_OBJECT
@@ -70,6 +75,8 @@ class GUI_API QvisSILSetSelector : public QWidget,
     QComboBox *categoryName;
     QLabel    *subsetLabel;
     QComboBox *subsetName;
+    QCompleter *subsetNameCompleter;
+    QStringListModel *subsetNameModel;
 
     SILRestrictionAttributes *silAtts;
     QString defaultItem;

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -70,6 +70,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added species set support to the Blueprint Reader.</li>
   <li>Saving results of time queries to curve files now uses query name and/or variable names as curve names instead of just 'Curve'.</li>
   <li>Curves are now supported in Xdmf files. They are handled as 2DRectMesh objects with >1 points in X and 1 point in Y.</li>
+  <li>The OnionPeel and IndexSelect operator Windows now allow typing into the 'Set' option as well as selecting from the dropwdown box. Typing will filter the available entries to match what has been typed so far, allowing easier selection than the pulldown if there is a large number of sets. If typing is completed with text that doesn't match an available entry a Warning message will pop up.<li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves #19920.

Affects OnionPeel and IndexSelect operators.

Modified QvisSILSetSelector subsetName combobox to fill its entries from a QStringListModel. This facilitates using the same model for a QCompleter now attached to the subsetName combobox.
Modified the subsetName combobox to be editable with a 'NoInsert' policy. This allows the user to type their option without changing the values stored.
The QCompleter filters the available options to match what the user has typed so far. This allows easier selection.
The user can also simply fully type their option and hit enter or move the mouse out of the text editor when finished.
If user enters text that doesn't match an available option, a Warning message will pop up and the selection will be reset to that last used valid option.

### Type of change

* ~~[ ] Bug fix~~
* [X] New feature
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I opened a multi-domain file and ensure I could type into the Set option in OnionPeel and IndexSelect windows.
I also tried a file with multiple SIL categories, and ensure the Completer still worked after changing categories.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
