### PR TITLE
Add support for jsrun and bsub/jsrun for launching parallel jobs. (#19938)

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -234,6 +234,43 @@ class JobSubmitter_mpiexec(JobSubmitter):
         return parcmd
 
 ###############################################################################
+# Class: JobSubmitter_jsrun
+#
+# Purpose:    Launch an MPI job with jsrun
+#
+# Programmer: Eric Brugger
+# Date:       Mon Aug 26 10:54:18 PDT 2024
+#
+# Modifications:
+#
+###############################################################################
+
+class JobSubmitter_jsrun(JobSubmitter):
+    def __init__(self, launcher):
+        super(JobSubmitter_jsrun,self).__init__(launcher)
+
+    def Executable(self):
+        return ["jsrun"]
+
+    def CreateCommand(self, args, debugger):
+        nodes = self.parallel.nn
+        if nodes == None:
+            nodes = self.parallel.np
+        ppn = str(int(math.ceil(float(self.parallel.np) / float(nodes))))
+        parcmd = self.Executable()
+        parcmd = parcmd + ["--np", self.parallel.np]
+        parcmd = parcmd + ["--nrs", nodes]
+        parcmd = parcmd + ["-c", "ALL_CPUS", "-g", "ALL_GPUS"]
+        parcmd = parcmd + ["-d", "plane:%s" % ppn]
+        parcmd = parcmd + ["-b", "none", "-X", "1"]
+        if self.parallel.sublaunchargs != None:
+            parcmd = parcmd + self.parallel.sublaunchargs
+        parcmd = parcmd + self.VisItExecutable()
+        parcmd = parcmd + args
+        parcmd = debugger.CreateCommand(parcmd)
+        return parcmd
+
+###############################################################################
 # Class: JobSubmitter_lrun
 #
 # Purpose:    Launch an MPI job with lrun (LLNL's jsrun wrapper)
@@ -3883,6 +3920,9 @@ VisIt does not recognize your terminal application so it will ignore the -newcon
     #    Eric Brugger, Wed May 15 11:11:11 PDT 2024
     #    Added flux as a new job submitter.
     #
+    #    Eric Brugger, Mon Aug 26 10:54:18 PDT 2024
+    #    Added jsrun as a new job submitter.
+    #
     ############################################################################
 
     def JobSubmitterFactory(self, launch):
@@ -3904,6 +3944,8 @@ VisIt does not recognize your terminal application so it will ignore the -newcon
             return JobSubmitter_poe(self)
         elif launch == "ibrun":
             return JobSubmitter_ibrun(self)
+        elif launch == "jsrun":
+            return JobSubmitter_jsrun(self)
         elif launch == "lrun":
             return JobSubmitter_lrun(self)
         elif launch == "prun":

--- a/src/gui/QvisHostProfileWindow.C
+++ b/src/gui/QvisHostProfileWindow.C
@@ -1164,6 +1164,10 @@ QvisHostProfileWindow::CreateParallelSettingsGroup()
 //   Eric Brugger, Tue May 21 13:35:51 PDT 2024
 //   Add flux.
 //
+//   Eric Brugger, Mon Aug 26 10:54:18 PDT 2024
+//   Add jsrun, bsub/jsrun. Moved "bsub/mpirun", "flux/batch" and "flux/run"
+//   in the list, since they were in the wrong location.
+//
 // ****************************************************************************
 
 QWidget *
@@ -1184,9 +1188,9 @@ QvisHostProfileWindow::CreateLaunchSettingsGroup()
     launchMethod->addItem(tr("(default)"));
     launchMethod->addItem("aprun");
     launchMethod->addItem("bsub");
-    launchMethod->addItem("bsub/mpirun");
     launchMethod->addItem("dmpirun");
     launchMethod->addItem("ibrun");
+    launchMethod->addItem("jsrun");
     launchMethod->addItem("mpiexec");
     launchMethod->addItem("mpirun");
     launchMethod->addItem("msub");
@@ -1198,6 +1202,10 @@ QvisHostProfileWindow::CreateLaunchSettingsGroup()
     launchMethod->addItem("WindowsHPC");
     launchMethod->addItem("yod");
     launchMethod->addItem("lrun");
+    launchMethod->addItem("bsub/jsrun");
+    launchMethod->addItem("bsub/mpirun");
+    launchMethod->addItem("flux/batch");
+    launchMethod->addItem("flux/run");
     launchMethod->addItem("msub/aprun");
     launchMethod->addItem("msub/srun");
     launchMethod->addItem("psub/mpirun");
@@ -1213,8 +1221,6 @@ QvisHostProfileWindow::CreateLaunchSettingsGroup()
     launchMethod->addItem("sbatch/mpiexec");
     launchMethod->addItem("sbatch/mpirun");
     launchMethod->addItem("sbatch/srun");
-    launchMethod->addItem("flux/batch");
-    launchMethod->addItem("flux/run");
     connect(launchMethod, SIGNAL(currentTextChanged(const QString &)),
             this, SLOT(launchMethodChanged(const QString &)));
     launchCheckBox = new QCheckBox(tr("Parallel launch method"), currentGroup);

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -71,6 +71,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Saving results of time queries to curve files now uses query name and/or variable names as curve names instead of just 'Curve'.</li>
   <li>Curves are now supported in Xdmf files. They are handled as 2DRectMesh objects with >1 points in X and 1 point in Y.</li>
   <li>The OnionPeel and IndexSelect operator Windows now allow typing into the 'Set' option as well as selecting from the dropwdown box. Typing will filter the available entries to match what has been typed so far, allowing easier selection than the pulldown if there is a large number of sets. If typing is completed with text that doesn't match an available entry a Warning message will pop up.<li>
+  <li>Support has been added for using the <code>jsrun</code> parallel job launcher.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -72,6 +72,10 @@ class JobSubmitter_mpirun_LLNL(JobSubmitter_mpirun):
 #   I tweeked the setting of the environment variables as part of the bsub
 #   command.
 #
+#   Eric Brugger, Mon Aug 26 10:54:18 PDT 2024
+#   I split out the jsrun portion of the job launcher into its own job
+#   launcher.
+#
 ###############################################################################
 
 class JobSubmitter_bsub_LLNL(JobSubmitter):
@@ -89,7 +93,7 @@ class JobSubmitter_bsub_LLNL(JobSubmitter):
         parcmd = parcmd + ["LSF_LIBDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/lib"]
         parcmd = parcmd + ["LSF_SERVERDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/etc"]
         parcmd = parcmd + ["XLSF_UIDDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/lib/uid"]
-        parcmd = parcmd + ["/usr/tcetmp/bin/bsub"]
+        parcmd = parcmd + self.Executable()
         parcmd = parcmd + ["-core_isolation", "2"]
         if self.parallel.launchargs != None:
             parcmd = parcmd + self.parallel.launchargs
@@ -101,14 +105,39 @@ class JobSubmitter_bsub_LLNL(JobSubmitter):
             parcmd = parcmd + ["-W", self.parallel.time]
         if self.parallel.bank != None:
             parcmd = parcmd + ["-G", self.parallel.bank]
+
+        subcmd = launcher.JobSubmitterFactory(sublauncher).CreateCommand(args, debugger)
+        parcmd = parcmd + subcmd
+        return parcmd
+
+###############################################################################
+# Class: JobSubmitter_jsrun_LLNL
+#
+# Purpose:    Custom "jsrun" job submitter for LLNL.
+#
+# Programmer: Eric Brugger
+# Date:       Mon Aug 26 10:54:18 PDT 2024
+#
+# Modifications:
+#
+###############################################################################
+
+class JobSubmitter_jsrun_LLNL(JobSubmitter):
+    def __init__(self, launcher):
+        super(JobSubmitter_jsrun_LLNL, self).__init__(launcher)
+
+    def Executable(self):
+        return ["/usr/tce/packages/jsrun/jsrun-2019.05.02/bin/jsrun"]
+
+    def CreateCommand(self, args, debugger):
         nodes = self.parallel.nn
         if nodes == None:
             nodes = self.parallel.np
         ppn = str(int(math.ceil(float(self.parallel.np) / float(nodes))))
-        parcmd = parcmd + ["env", "LD_LIBRARY_PATH=%s" % GETENV("LD_LIBRARY_PATH")]
-        parcmd = parcmd + ["/usr/tce/packages/jsrun/jsrun-2019.05.02/bin/jsrun"]
+        parcmd = ["env", "LD_LIBRARY_PATH=%s" % GETENV("LD_LIBRARY_PATH")]
+        parcmd = parcmd + self.Executable()
         parcmd = parcmd + ["--np", self.parallel.np]
-        parcmd = parcmd + ["--nrs", self.parallel.nn]
+        parcmd = parcmd + ["--nrs", nodes]
         parcmd = parcmd + ["-c", "ALL_CPUS", "-g", "ALL_GPUS"]
         parcmd = parcmd + ["-d", "plane:%s" % ppn]
         parcmd = parcmd + ["-b", "none", "-X", "1", "/usr/tce/packages/lrun/lrun-2019.05.07/bin/mpibind10"]
@@ -230,6 +259,9 @@ class JobSubmitter_bsub_LLNL(JobSubmitter):
 #   Cyrus Harrison, Wed Mar 27 09:45:27 PDT 2024
 #   Cleanup and added toss4 logic needed to run on CTS-2 with srun.
 #
+#   Eric Brugger, Mon Aug 26 10:54:18 PDT 2024
+#   Added an LLNL specific job launcher for jsrun.
+#
 ###############################################################################
 
 class LLNLLauncher(MainLauncher):
@@ -313,6 +345,11 @@ class LLNLLauncher(MainLauncher):
                 self.sectorname() == "rzansel" or \
                 self.sectorname() == "sierra":
                 return JobSubmitter_bsub_LLNL(self)
+        elif launch[:5] == "jsrun":
+            if self.sectorname() == "lassen" or \
+                self.sectorname() == "rzansel" or \
+                self.sectorname() == "sierra":
+                return JobSubmitter_jsrun_LLNL(self)
         return super(LLNLLauncher, self).JobSubmitterFactory(launch)
 
 # Launcher creation function

--- a/src/resources/hosts/llnl/host_llnl_lassen.xml
+++ b/src/resources/hosts/llnl/host_llnl_lassen.xml
@@ -71,7 +71,7 @@
         <Field name="timeLimitSet" type="bool">true</Field>
         <Field name="timeLimit" type="string">30</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">bsub/mpirun</Field>
+        <Field name="launchMethod" type="string">bsub/jsrun</Field>
         <Field name="forceStatic" type="bool">true</Field>
         <Field name="forceDynamic" type="bool">false</Field>
         <Field name="active" type="bool">false</Field>
@@ -111,7 +111,7 @@
         <Field name="timeLimitSet" type="bool">true</Field>
         <Field name="timeLimit" type="string">30</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">bsub/mpirun</Field>
+        <Field name="launchMethod" type="string">bsub/jsrun</Field>
         <Field name="forceStatic" type="bool">true</Field>
         <Field name="forceDynamic" type="bool">false</Field>
         <Field name="active" type="bool">false</Field>
@@ -138,6 +138,46 @@
         <Field name="allowableNodes" type="intVector"></Field>
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pbatch</Field>
+    </Object>
+    <Object name="LaunchProfile">
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">80</Field>
+        <Field name="numNodesSet" type="bool">true</Field>
+        <Field name="numNodes" type="int">2</Field>
+        <Field name="partitionSet" type="bool">false</Field>
+        <Field name="partition" type="string"></Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">false</Field>
+        <Field name="timeLimit" type="string"></Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+        <Field name="launchMethod" type="string">jsrun</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"></Field>
+        <Field name="parallel" type="bool">true</Field>
+        <Field name="launchArgsSet" type="bool">false</Field>
+        <Field name="launchArgs" type="string"></Field>
+        <Field name="sublaunchArgsSet" type="bool">false</Field>
+        <Field name="sublaunchArgs" type="string"></Field>
+        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
+        <Field name="sublaunchPreCmd" type="string"></Field>
+        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
+        <Field name="sublaunchPostCmd" type="string"></Field>
+        <Field name="machinefileSet" type="bool">false</Field>
+        <Field name="machinefile" type="string"></Field>
+        <Field name="visitSetsUpEnv" type="bool">false</Field>
+        <Field name="canDoHWAccel" type="bool">false</Field>
+        <Field name="GPUsPerNode" type="int">1</Field>
+        <Field name="XArguments" type="string"></Field>
+        <Field name="launchXServers" type="bool">false</Field>
+        <Field name="XDisplay" type="string">:%l</Field>
+        <Field name="numThreads" type="int">0</Field>
+        <Field name="constrainNodeProcs" type="bool">false</Field>
+        <Field name="allowableNodes" type="intVector"></Field>
+        <Field name="allowableProcs" type="intVector"></Field>
+        <Field name="profileName" type="string">parallel jsrun</Field>
     </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>

--- a/src/resources/hosts/llnl/host_llnl_rzansel.xml
+++ b/src/resources/hosts/llnl/host_llnl_rzansel.xml
@@ -71,7 +71,7 @@
         <Field name="timeLimitSet" type="bool">true</Field>
         <Field name="timeLimit" type="string">30</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">bsub/mpirun</Field>
+        <Field name="launchMethod" type="string">bsub/jsrun</Field>
         <Field name="forceStatic" type="bool">true</Field>
         <Field name="forceDynamic" type="bool">false</Field>
         <Field name="active" type="bool">false</Field>
@@ -98,6 +98,46 @@
         <Field name="allowableNodes" type="intVector"></Field>
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pdebug</Field>
+    </Object>
+    <Object name="LaunchProfile">
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">80</Field>
+        <Field name="numNodesSet" type="bool">true</Field>
+        <Field name="numNodes" type="int">2</Field>
+        <Field name="partitionSet" type="bool">false</Field>
+        <Field name="partition" type="string"></Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">false</Field>
+        <Field name="timeLimit" type="string"></Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+        <Field name="launchMethod" type="string">jsrun</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"></Field>
+        <Field name="parallel" type="bool">true</Field>
+        <Field name="launchArgsSet" type="bool">false</Field>
+        <Field name="launchArgs" type="string"></Field>
+        <Field name="sublaunchArgsSet" type="bool">false</Field>
+        <Field name="sublaunchArgs" type="string"></Field>
+        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
+        <Field name="sublaunchPreCmd" type="string"></Field>
+        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
+        <Field name="sublaunchPostCmd" type="string"></Field>
+        <Field name="machinefileSet" type="bool">false</Field>
+        <Field name="machinefile" type="string"></Field>
+        <Field name="visitSetsUpEnv" type="bool">false</Field>
+        <Field name="canDoHWAccel" type="bool">false</Field>
+        <Field name="GPUsPerNode" type="int">1</Field>
+        <Field name="XArguments" type="string"></Field>
+        <Field name="launchXServers" type="bool">false</Field>
+        <Field name="XDisplay" type="string">:%l</Field>
+        <Field name="numThreads" type="int">0</Field>
+        <Field name="constrainNodeProcs" type="bool">false</Field>
+        <Field name="allowableNodes" type="intVector"></Field>
+        <Field name="allowableProcs" type="intVector"></Field>
+        <Field name="profileName" type="string">parallel jsrun</Field>
     </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>

--- a/src/resources/hosts/llnl_closed/host_llnl_closed_sierra.xml
+++ b/src/resources/hosts/llnl_closed/host_llnl_closed_sierra.xml
@@ -71,7 +71,7 @@
         <Field name="timeLimitSet" type="bool">true</Field>
         <Field name="timeLimit" type="string">30</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">bsub/mpirun</Field>
+        <Field name="launchMethod" type="string">bsub/jsrun</Field>
         <Field name="forceStatic" type="bool">true</Field>
         <Field name="forceDynamic" type="bool">false</Field>
         <Field name="active" type="bool">false</Field>
@@ -111,7 +111,7 @@
         <Field name="timeLimitSet" type="bool">true</Field>
         <Field name="timeLimit" type="string">30</Field>
         <Field name="launchMethodSet" type="bool">true</Field>
-        <Field name="launchMethod" type="string">bsub/mpirun</Field>
+        <Field name="launchMethod" type="string">bsub/jsrun</Field>
         <Field name="forceStatic" type="bool">true</Field>
         <Field name="forceDynamic" type="bool">false</Field>
         <Field name="active" type="bool">false</Field>
@@ -138,6 +138,46 @@
         <Field name="allowableNodes" type="intVector"></Field>
         <Field name="allowableProcs" type="intVector"></Field>
         <Field name="profileName" type="string">parallel batch pbatch</Field>
+    </Object>
+    <Object name="LaunchProfile">
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">80</Field>
+        <Field name="numNodesSet" type="bool">true</Field>
+        <Field name="numNodes" type="int">2</Field>
+        <Field name="partitionSet" type="bool">false</Field>
+        <Field name="partition" type="string"></Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">false</Field>
+        <Field name="timeLimit" type="string"></Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+        <Field name="launchMethod" type="string">jsrun</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"></Field>
+        <Field name="parallel" type="bool">true</Field>
+        <Field name="launchArgsSet" type="bool">false</Field>
+        <Field name="launchArgs" type="string"></Field>
+        <Field name="sublaunchArgsSet" type="bool">false</Field>
+        <Field name="sublaunchArgs" type="string"></Field>
+        <Field name="sublaunchPreCmdSet" type="bool">false</Field>
+        <Field name="sublaunchPreCmd" type="string"></Field>
+        <Field name="sublaunchPostCmdSet" type="bool">false</Field>
+        <Field name="sublaunchPostCmd" type="string"></Field>
+        <Field name="machinefileSet" type="bool">false</Field>
+        <Field name="machinefile" type="string"></Field>
+        <Field name="visitSetsUpEnv" type="bool">false</Field>
+        <Field name="canDoHWAccel" type="bool">false</Field>
+        <Field name="GPUsPerNode" type="int">1</Field>
+        <Field name="XArguments" type="string"></Field>
+        <Field name="launchXServers" type="bool">false</Field>
+        <Field name="XDisplay" type="string">:%l</Field>
+        <Field name="numThreads" type="int">0</Field>
+        <Field name="constrainNodeProcs" type="bool">false</Field>
+        <Field name="allowableNodes" type="intVector"></Field>
+        <Field name="allowableProcs" type="intVector"></Field>
+        <Field name="profileName" type="string">parallel jsrun</Field>
     </Object>
     <Field name="activeProfile" type="int">0</Field>
 </Object>


### PR DESCRIPTION
Merge from the 3.4RC to develop.

### Description

Resolves #19099 

I added proper support for using `jsrun` and `bsub/jsrun` for launching parallel jobs on IBM systems. I added options in the GUI. I added support in the `internallauncher` and updated the LLNL `customlauncher` to leverage the new support. I updated the host profiles for `lassen`, `rzansel` and `sierra`.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I built and installed a private version on `rzansel`. I then updated the host profiles to point to my private installation and proceeded to test launching using `bsub/jsrun` and just `jsrun`.

I tested `bsub/jsrun` by creating a pseudocolor plot of `procid(mesh1)` from `multi_ucd3d.silo` to verify that it was running in parallel. Here is the terminal output.
```
rzansel61{brugger}235: visit/bin/visit
Running: gui3.4.2
Running: viewer3.4.2 -geometry 1558x1080+362+0 -borders 29,5,5,5 -shift 17,27 -preshift -12,2 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.4.2 -host 127.0.0.1 -port 5601
Running: env LSF_BINDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/bin LSF_CONFDIR=/opt/ibm/spectrumcomputing/lsf/conf LSF_ENVDIR=/opt/ibm/spectrumcomputing/lsf/conf LSF_LIBDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/lib LSF_SERVERDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/etc XLSF_UIDDIR=/opt/ibm/spectrumcomputing/lsf/10.1/linux3.10-glibc2.17-ppc64le-csm/lib/uid /usr/tcetmp/bin/bsub -core_isolation 2 -nnodes 2 -q pdebug -W 30 -G guests env LD_LIBRARY_PATH=/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/lib/osmesa:/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/lib/mesagl:/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/lib:/usr/local/tools/ifort-11.1.046/lib /usr/tce/packages/jsrun/jsrun-2019.05.02/bin/jsrun --np 80 --nrs 2 -c ALL_CPUS -g ALL_GPUS -d plane:40 -b none -X 1 /usr/tce/packages/lrun/lrun-2019.05.07/bin/mpibind10 /usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/bin/engine_par -plugindir /g/g17/brugger/.visit/3.4.2/linux-ppc64le/plugins:/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/plugins -visithome /usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2 -visitarchhome /usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le -dir /usr/workspace/brugger/visit_jsrun_dev/visit -forcestatic -idle-timeout 480 -noloopback -host rzansel61 -port 5600
Job <2504249> is submitted to queue <pdebug>.
```
I tested `jsrun` by first launching an `xterm` in a `bsub` job using:
```
rzansel61{brugger}236: /usr/tcetmp/bin/bsub -core_isolation 2 -nnodes 2 -q pdebug -W 30 -G guests xterm
Job <2504251> is submitted to queue <pdebug>.
```
Then I ran VisIt and created a `pseudcolor` plot of `procid(mesh1)` from `multi_ucd3d.silo`, which looked correct. Here is the terminal output in the `xterm` window.
```
[brugger@rzansel26 visit_jsrun_dev]$ visit/bin/visit
Running: gui3.4.2
Running: viewer3.4.2 -geometry 1558x1080+362+0 -borders 29,5,5,5 -shift 17,27 -preshift -12,2 -defer -host 127.0.0.1 -port 5600
Running: mdserver3.4.2 -host 127.0.0.1 -port 5601
Running: env LD_LIBRARY_PATH=/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/lib/osmesa:/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/lib/mesagl:/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/lib:/usr/local/tools/ifort-11.1.046/lib /usr/tce/packages/jsrun/jsrun-2019.05.02/bin/jsrun --np 80 --nrs 2 -c ALL_CPUS -g ALL_GPUS -d plane:40 -b none -X 1 /usr/tce/packages/lrun/lrun-2019.05.07/bin/mpibind10 /usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/bin/engine_par -plugindir /g/g17/brugger/.visit/3.4.2/linux-ppc64le/plugins:/usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le/plugins -visithome /usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2 -visitarchhome /usr/WS1/brugger/visit_jsrun_dev/visit/3.4.2/linux-ppc64le -dir /usr/workspace/brugger/visit_jsrun_dev/visit -forcestatic -idle-timeout 480 -noloopback -host rzansel26 -port 5600
```
To verify that I was using 40 cores on each of 2 nodes, I used `bjobs -l` to determine that it was running on nodes `rzansel26` and `rzansel5`. I then used `ssh` to login to each of the nodes and checked that there were 40 `engine_par` processes running on each.

On `rzansel26`:
```
rzansel26{brugger}22: ps -u brugger | grep engine_par | wc -l
40
```
On `rzansel5`:
```
rzansel5{brugger}21: ps -u brugger | grep engine_par | wc -l
40
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
