### PR TITLE
Improve handling of multiple inclusion facets in OBJ files

### DIFF
--- a/src/databases/WavefrontOBJ/avtWavefrontOBJFileFormat.h
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJFileFormat.h
@@ -64,7 +64,7 @@ class avtWavefrontOBJFileFormat : public avtSTSDFileFormat
 
     bool                  hasGroups;
     std::set<std::string> uniqueGroupNames;
-    bool                  multipleGroupInclusion;
+    std::set<std::string> aggregatedGroupNames;
 };
 
 


### PR DESCRIPTION
### Description

Resolves #19736 

This improves handling of Wavefront OBJ files with facets that have spaces in a `g` directive, indicating the facet is included in multiple groups. The old way would just silently fail to create any *material* metadata for the mesh. It  was not obvious to users what happened or why. However, it turns out that the old way did handle multiple inclusion for the *enumerated scalar* that was defined. So, that functionality remains.

What is new is that we now still go ahead and create material metadata too except that the material object will treat spaces in any `g` directive as underscores. So `g Mark Miller` would be treated as `g Mark_Miller` in the material object and as `g Mark Miller` (two different set names) in the enumerated scalar object.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I tested by adjusting one of the WaveFront OBJ test files, `cube1.obj` like so...

```
mtllib test.mtl

g face1
usemtl Red
v 0.000000 2.000000 2.000000
v 0.000000 0.000000 2.000000
v 2.000000 0.000000 2.000000
v 2.000000 2.000000 2.000000
f -4 -3 -2 -1

g face2 mark
usemtl Green
v 2.000000 2.000000 0.000000
v 2.000000 0.000000 0.000000
v 0.000000 0.000000 0.000000
v 0.000000 2.000000 0.000000
f -4 -3 -2 -1

g face3
usemtl Blue
v 2.000000 2.000000 2.000000
v 2.000000 0.000000 2.000000
.
.
.
```

And, then read into VisIt and manipulated and displayed it. You can see a **FilledBoundary** and **Mesh** plot below and the SIL for the enum scalar under the **Mesh** plot. Note the differences in configuration of the set names. I think this is a better state to be in than silently failing. In addition, it should be obvious to a user that set names have been combined via `_` char if they bother to look at the SIL controls.

![Screenshot 2024-10-24 at 12 40 40 PM](https://github.com/user-attachments/assets/cc721243-7acb-4b53-a670-3f10a02ebd64)


<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
