### PR TITLE
Fix macOS trackpad issue by ignoring Touch events on all platforms

### DIFF
--- a/src/common/utility/StringHelpers.C
+++ b/src/common/utility/StringHelpers.C
@@ -1166,9 +1166,10 @@ StringHelpers::CaseInsensitiveEqual(const char *str_a, const char *str_b, size_t
 }
 bool
 StringHelpers::CaseInsensitiveEqual(const std::string &str_a,
-                                   const std::string &str_b)
+                                   const std::string &str_b,
+                                   size_t n)
 {
-    return StringHelpers::CaseInsensitiveEqual(str_a.c_str(), str_b.c_str());
+    return StringHelpers::CaseInsensitiveEqual(str_a.c_str(), str_b.c_str(), n);
 }
 
 // ****************************************************************************

--- a/src/common/utility/StringHelpers.h
+++ b/src/common/utility/StringHelpers.h
@@ -92,7 +92,8 @@ namespace StringHelpers
                                          char const *str_b,
                                          size_t n = 0);
     bool UTILITY_API CaseInsensitiveEqual(const std::string &str_a,
-                                         const std::string &str_b);
+                                         const std::string &str_b,
+                                         size_t n = 0);
     std::string UTILITY_API UpperCase(const std::string &src);
 
     bool UTILITY_API StringToInt(const std::string &, int &);

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -54,6 +54,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where the operator attribute windows will show the default attributes when displaying the attributes for an operator applied to a plot after restoring a session. The plots displayed in the visualization windows will be correct, just the attributes displayed in the attribute window will be incorrect. This happens with session files saved with releases 3.4 and 3.4.1. To fix the issue you will need to save a new session file using a newer version of VisIt. If you restored a session with a bad session file, you will need to change the attributes of any affected operators before saving the new session file.</li>
   <li>Fixed a bug where the rubber band lines are either broken or missing when you click and move the mouse when zooming an image using zoom mode on Linux systems.</li>
   <li>Fixed a bug causing material edge lines to appear on problems produced by parallel runs.</li>
+  <li>Fixed a bug where trackpad on macOS laptops would get "sticky" never ending/releasing a rotation gesture.</li>
 </ul>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.4.2</font></b></p>

--- a/src/viewer/main/viewer.C
+++ b/src/viewer/main/viewer.C
@@ -11,6 +11,11 @@
 #include <cstdlib>
 
 #include <qapplication.h>
+#include <QDebug>
+#include <QEvent>
+#include <QMetaEnum>
+#include <QMouseEvent>
+#include <QObject>
 #include <QStringList>
 #include <QSurfaceFormat>
 
@@ -18,6 +23,7 @@
 #include <AppearanceAttributes.h>
 #include <DebugStream.h>
 #include <LostConnectionException.h>
+#include <StringHelpers.h>
 #include <ViewerMethods.h>
 #include <ViewerState.h>
 #include <VisItException.h>
@@ -69,6 +75,32 @@ Viewer_LogQtMessages(QtMsgType type, const QMessageLogContext &context, const QS
     }
 }
 
+// ****************************************************************************
+//  Method: getEventTypeName and EventFilter::eventFilter
+//
+//  Purpose: Functionality to filter all events whose stringified name begins
+//  with "touch". This ensures we do not attempt to process touch events.
+//  In general, VisIt's interface is designed around the concept of a 3-button
+//  mouse and in that context touch events can just wind up causing issues.
+//
+//  Programmer:  Mark C. Miller, Mon Oct 28 10:28:00 PDT 2024
+// ****************************************************************************
+static QString getEventTypeName(QEvent::Type type) {
+    const QMetaObject &mo = QEvent::staticMetaObject;
+    int index = mo.indexOfEnumerator("Type");
+    QMetaEnum metaEnum = mo.enumerator(index);
+    return metaEnum.valueToKey(type);
+}
+
+class EventFilter : public QObject {
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override {
+        if (StringHelpers::CaseInsensitiveEqual(
+                getEventTypeName(event->type()).toStdString(), "touch", 5))
+            return true;
+        return QObject::eventFilter(obj, event);
+    }
+};
 
 // ****************************************************************************
 //  Method: ViewerMain
@@ -133,7 +165,6 @@ Viewer_LogQtMessages(QtMsgType type, const QMessageLogContext &context, const QS
 //    Added delete of argv2 and mainApp to clean up memory before exiting.
 //
 // ****************************************************************************
-
 int
 ViewerMain(int argc, char *argv[])
 {
@@ -230,6 +261,8 @@ ViewerMain(int argc, char *argv[])
         {
             mainApp = new QApplication(argc2, argv2);
         }
+        EventFilter *filter = new EventFilter();
+        mainApp->installEventFilter(filter);
 
         //
         // Now that we've created the QApplication, let's call the viewer's

--- a/src/viewer/main/viewer.C
+++ b/src/viewer/main/viewer.C
@@ -162,6 +162,8 @@ protected:
 //    Eric Brugger, Wed Nov 27 14:35:58 PST 2019
 //    Added delete of argv2 and mainApp to clean up memory before exiting.
 //
+//    Mark C. Miller, Mon Oct 28 12:11:33 PDT 2024
+//    Install an event filter to ignore touch events.
 // ****************************************************************************
 int
 ViewerMain(int argc, char *argv[])

--- a/src/viewer/main/viewer.C
+++ b/src/viewer/main/viewer.C
@@ -11,10 +11,8 @@
 #include <cstdlib>
 
 #include <qapplication.h>
-#include <QDebug>
 #include <QEvent>
 #include <QMetaEnum>
-#include <QMouseEvent>
 #include <QObject>
 #include <QStringList>
 #include <QSurfaceFormat>


### PR DESCRIPTION
### Description

Resolves #19506 

* Improves interface to `StringHelpers::CaseInsensitiveEqual(std::string const &str1, std::strong const &str2, size_t n)` by adding the `size_t n` argument which defaults to 0. In the case of 0, it does a `strcasemp` and not a `strncasecmp`
* Fixes trackpad issues on macOS by ignoring all events whose stringified name begins with `Touch` on all platforms.

Note, this introduces some string processing logic to the main event loop in VisIt. Using this string-based approach has the effect, IMHO, of future proofing us a bit from the introduction of more `TouchXXX` events in the future. That said, if performance is a concern, I can easily adjust the logic to integer compares of the event's enum value. There are only 4 `TouchXXX` events currently supported in Qt; `TouchBegin`, `TouchEnd`, `TouchUpdate` and `TouchCancel`.

This fixes trackpad issue on macOS and AFAICT, does not introduce any issues with other interactions such as rubber-band zoom, wheel-zoom, pick, pan, depress and drag zoom, etc.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
