### PR TITLE
Change test suite notify script to convert email list to a single line.

### DIFF
--- a/src/tools/dev/scripts/visit-notify-test-failure
+++ b/src/tools/dev/scripts/visit-notify-test-failure
@@ -40,6 +40,7 @@ if test "$status" = "pass" ; then
    # Create the list to send the e-mail to.
    #
    emailList=`echo $logRecipients | tr ' ' '\n' | sort | uniq`
+   emailList=`echo $emailList | tr '\n' ' '`
 
    #
    # Create the email.
@@ -118,6 +119,7 @@ rm -f modifiers
 #
 emailList="`echo $logRecipients` `echo $modifiersEmails`"
 emailList=`echo $emailList | tr ' ' '\n' | sort | uniq`
+emailList=`echo $emailList | tr '\n' ' '`
 
 #
 # Create the email and send it.


### PR DESCRIPTION
### Description

I changed the logic in the `visit-notify-test-failure` to generate the email recipient list as a single line where the recipients are space separated. Previously, each email recipient was separated by a newline. Since the list gets passed to `sendmail` on the command line this seems like the right thing to do.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I tested the script on `poodle` using the results from last nights test suite run.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
