### PR TITLE
bv gcc by name check fix

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -394,13 +394,9 @@ function initialize_build_visit()
         if [[ "$(uname -m)" == "x86_64" ]] ; then
             CFLAGS="$CFLAGS -m64 -fPIC"
             FCFLAGS="$FCFLAGS -m64 -fPIC"
-            if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-            fi
+            C_OPT_FLAGS="$C_OPT_FLAGS -O2"
             CXXFLAGS="$CXXFLAGS -m64 -fPIC"
-            if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-            fi
+            CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
         elif [[ "$(uname -m)" == "ppc64" ]] ; then
             if [[ "$C_COMPILER" == "xlc" ]] ; then
                 CFLAGS="$CFLAGS -qpic"
@@ -412,13 +408,9 @@ function initialize_build_visit()
             else
                 CFLAGS="$CFLAGS -fPIC"
                 FCFLAGS="$FCFLAGS -fPIC"
-                if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                    C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-                fi
+                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
                 CXXFLAGS="$CXXFLAGS -fPIC"
-                if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                    CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-                fi
+                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
             fi
         elif [[ "$(uname -m)" == "ppc64le" ]] ; then
             if [[ "$C_COMPILER" == "xlc" ]] ; then
@@ -430,34 +422,25 @@ function initialize_build_visit()
             else
                 CFLAGS="$CFLAGS -fPIC"
                 FCFLAGS="$FCFLAGS -fPIC"
-                if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                    C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-                fi
+                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
                 CXXFLAGS="$CXXFLAGS -fPIC"
-                if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                    CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-                fi
+                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
                 QT_PLATFORM="linux-g++"
             fi
         elif [[ "$(uname -m)" == "ia64" ]] ; then
             CFLAGS="$CFLAGS -fPIC"
             FCFLAGS="$FCFLAGS -fPIC"
-            if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-            fi
+            C_OPT_FLAGS="$C_OPT_FLAGS -O2"
             CXXFLAGS="$CXXFLAGS -fPIC"
-            if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
+            CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
             fi
         elif [[ "$(uname -m)" == "aarch64" ]] ; then
             CFLAGS="$CFLAGS -fPIC"
             FCFLAGS="$FCFLAGS -fPIC"
-            if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
+            C_OPT_FLAGS="$C_OPT_FLAGS -O2"
             fi
             CXXFLAGS="$CXXFLAGS -fPIC"
-            if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
+            CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
             fi
             QT_PLATFORM="linux-aarch64-gnu-g++"
         fi
@@ -499,24 +482,16 @@ function initialize_build_visit()
         if [[ "$(uname -m)" == "x86_64" ]] ; then
             CFLAGS="$CFLAGS -m64 -fPIC"
             FCFLAGS="$FCFLAGS -m64 -fPIC"
-            if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-            fi
+            C_OPT_FLAGS="$C_OPT_FLAGS -O2"
             CXXFLAGS="$CXXFLAGS -m64 -fPIC"
-            if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-            fi
+            CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
         fi
         if [[ "$(uname -m)" == "ia64" ]] ; then
             CFLAGS="$CFLAGS -fPIC"
             FCFLAGS="$FCFLAGS -fPIC"
-            if [[ "$C_COMPILER" == "gcc" || "$C_COMPILER" == "" ]]; then
-                C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-            fi
+            C_OPT_FLAGS="$C_OPT_FLAGS -O2"
             CXXFLAGS="$CXXFLAGS -fPIC"
-            if [[ "$CXX_COMPILER" == "g++" || "$CXX_COMPILER" == "" ]]; then
-                CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-            fi
+            CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
         fi
         export C_COMPILER=${C_COMPILER:-"gcc"}
         export FC_COMPILER=${FC_COMPILER:-$GFORTRAN}


### PR DESCRIPTION
### Description

Resolves #19693

Remaining cases of direct check for `"gcc"` were only used to set OPT compiler flags to `-O2`.

Removes these checks in favor of just always included `-O2` as OPT where this was checked.


### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

build_visit change
### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

~~- [ ] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
