### PR TITLE
Fix xdmf baseline and fix rebase.py tool

### DIFF
--- a/test/baseline/databases/xdmf/xdmf_8_01.png
+++ b/test/baseline/databases/xdmf/xdmf_8_01.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:973500f3f52e412ecd7a60132309edff8649d8cc403e1c77d772e159a79042f6
-size 1563
+oid sha256:fa5962fbff295443f4b6cf2907e3835a99d4c44175b5fd6ef977a14544e9150e
+size 1356

--- a/test/baseline/rebase.py
+++ b/test/baseline/rebase.py
@@ -197,21 +197,21 @@ def copy_currents_from_html_pages(prefix, filelist, datetag, prompt, test_type):
         cursize = os.stat(target_file).st_size
         if (sys.version_info > (3, 0)):
             try:
-                g = urllib.request.urlopen("%s/%s/pascal_trunk_%s/c_%s"%(prefix,datetag,mode,f))
+                g = urllib.request.urlopen("%s/%s/poodle_trunk_%s/c_%s"%(prefix,datetag,mode,f))
             except:
                 print("*** Current \"%s\" not found or HTTP request failed in some way. Skipping."%f)
                 continue
         else:
-            g = urllib.urlopen("%s/%s/pascal_trunk_%s/c_%s"%(prefix,datetag,mode,f))
+            g = urllib.urlopen("%s/%s/poodle_trunk_%s/c_%s"%(prefix,datetag,mode,f))
             if 'Not Found' in g.read():
                 print("*** Current \"%s\" not found. Skipping."%f)
                 continue
         print("Copying file \"%s\""%f)
         if (sys.version_info > (3, 0)):
-            urllib.request.urlretrieve("%s/%s/pascal_trunk_%s/c_%s"%(prefix,datetag,mode,f),
+            urllib.request.urlretrieve("%s/%s/poodle_trunk_%s/c_%s"%(prefix,datetag,mode,f),
                                        filename=target_file)
         else:
-            urllib.urlretrieve("%s/%s/pascal_trunk_%s/c_%s"%(prefix,datetag,mode,f),
+            urllib.urlretrieve("%s/%s/poodle_trunk_%s/c_%s"%(prefix,datetag,mode,f),
                                filename=target_file)
         # Do some simple sanity checks on the resulting file
         isLFS = False


### PR DESCRIPTION
This fixes xdmf baseline file and also fixes `rebase.py` tool to use `poodle` in paths and not `pascal`
