### PR TITLE
Fix avtUnstructuredDomainBoundaries::ExchangeScalars and ExchangeVectors

### DIFF
--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -7988,6 +7988,10 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundariesFromFile(
 //    Justin Privitera, Tue Oct 22 10:32:27 PDT 2024
 //    Exchange extra ghost zone/node arrays.
 //
+//    Kathleen Biagas, Thu Oct 31, 2024
+//    Don't attempt to Exchange extra ghost zone/node arrays if no process
+//    has extra ghost information.
+//
 // ****************************************************************************
 
 bool
@@ -8630,16 +8634,25 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         }
     }
 
-    vector<vtkDataArray *> extraGhostZonesOut;
-    extraGhostZonesOut = dbi->ExchangeScalar(doms,false,extraGhostZones);
-    for (int j = 0 ; j < (int)doms.size() ; j++)
+    int canDoExchange = (extraGhostZones.size() > 0);
+#ifdef PARALLEL
+    int myCanDoExchange = canDoExchange;
+    MPI_Allreduce(&myCanDoExchange, &canDoExchange, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+#endif
+
+    if(canDoExchange)
     {
-        vtkDataSet *ds1 = ds.GetDataset(j, 0);
-        if (ds1 == NULL ||
-            ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
-            continue;
-        ds1->GetCellData()->AddArray(extraGhostZonesOut[j]);
-        extraGhostZonesOut[j]->Delete();
+        vector<vtkDataArray *> extraGhostZonesOut;
+        extraGhostZonesOut = dbi->ExchangeScalar(doms,false,extraGhostZones);
+        for (int j = 0 ; j < (int)doms.size() ; j++)
+        {
+            vtkDataSet *ds1 = ds.GetDataset(j, 0);
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
+                continue;
+            ds1->GetCellData()->AddArray(extraGhostZonesOut[j]);
+            extraGhostZonesOut[j]->Delete();
+        }
     }
 
     //
@@ -8664,16 +8677,24 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         }
     }
 
-    vector<vtkDataArray *> extraGhostNodesOut;
-    extraGhostNodesOut = dbi->ExchangeScalar(doms,true,extraGhostNodes);
-    for (int j = 0 ; j < (int)doms.size() ; j++)
+    canDoExchange = (extraGhostNodes.size() > 0);
+#ifdef PARALLEL
+    myCanDoExchange = canDoExchange;
+    MPI_Allreduce(&myCanDoExchange, &canDoExchange, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+#endif
+    if(canDoExchange)
     {
-        vtkDataSet *ds1 = ds.GetDataset(j, 0);
-        if (ds1 == NULL ||
-            ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
-            continue;
-        ds1->GetPointData()->AddArray(extraGhostNodesOut[j]);
-        extraGhostNodesOut[j]->Delete();
+        vector<vtkDataArray *> extraGhostNodesOut;
+        extraGhostNodesOut = dbi->ExchangeScalar(doms,true,extraGhostNodes);
+        for (int j = 0 ; j < (int)doms.size() ; j++)
+        {
+            vtkDataSet *ds1 = ds.GetDataset(j, 0);
+            if (ds1 == NULL ||
+                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
+                continue;
+            ds1->GetPointData()->AddArray(extraGhostNodesOut[j]);
+            extraGhostNodesOut[j]->Delete();
+        }
     }
 
     //

--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -302,7 +302,7 @@ DebugDumpDatasetCollection(avtDatasetCollection &dsc, int ndoms,
 //
 //  Purpose:
 //      Merge generated ghost zones/nodes with extra ghost zones/nodes provided
-//      by the database in the form of avtExtraGhostZones and 
+//      by the database in the form of avtExtraGhostZones and
 //      avtExtraGhostNodes.
 //
 //  Returns:    void
@@ -328,7 +328,7 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
         if (dataset != NULL)
         {
             // this lambda handles zone and node cases
-            auto combineGhosts = [this, spec, domain_id](vtkUnsignedCharArray* ghosts, 
+            auto combineGhosts = [this, spec, domain_id](vtkUnsignedCharArray* ghosts,
                                                          vtkUnsignedCharArray* extraGhosts,
                                                          vtkDataSet* dataset,
                                                          const std::string &arrayName,
@@ -352,12 +352,12 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
                         if (num_tuples != extraGhosts->GetNumberOfTuples())
                         {
                             // we don't know what to do in the case that the original
-                            // and extra ghost zone/node arrays do not have the same 
+                            // and extra ghost zone/node arrays do not have the same
                             // number of tuples.
                             EXCEPTION0(ImproperUseException);
                         }
 
-                        // create a new ghost zone/node array that will be the result 
+                        // create a new ghost zone/node array that will be the result
                         // of merging the existing and extra.
                         vtkUnsignedCharArray *newGhosts = vtkUnsignedCharArray::New();
                         newGhosts->SetName(arrayName.c_str());
@@ -419,8 +419,8 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
                             newGhosts->Delete();
                             dataset->GetCellData()->CopyFieldOn(arrayName.c_str());
 
-                            // if we are cell centered then we need to perform some 
-                            // extra steps to tell the metadata that we now have 
+                            // if we are cell centered then we need to perform some
+                            // extra steps to tell the metadata that we now have
                             // ghost zones.
                             const int ts = spec->GetTimestep();
                             avtDatabaseMetaData *md = GetMetaData(ts);
@@ -439,10 +439,10 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
             };
 
             // zones first
-            vtkUnsignedCharArray *ghostZones = 
+            vtkUnsignedCharArray *ghostZones =
                 static_cast<vtkUnsignedCharArray*>(
                     dataset->GetCellData()->GetArray("avtGhostZones"));
-            vtkUnsignedCharArray *extraGhostZones = 
+            vtkUnsignedCharArray *extraGhostZones =
                 static_cast<vtkUnsignedCharArray*>(
                     dataset->GetCellData()->GetArray("avtExtraGhostZones"));
 
@@ -453,10 +453,10 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
                           true /*cell centered is true*/);
 
             // nodes second
-            vtkUnsignedCharArray *ghostNodes = 
+            vtkUnsignedCharArray *ghostNodes =
                 static_cast<vtkUnsignedCharArray*>(
                     dataset->GetPointData()->GetArray("avtGhostNodes"));
-            vtkUnsignedCharArray *extraGhostNodes = 
+            vtkUnsignedCharArray *extraGhostNodes =
                 static_cast<vtkUnsignedCharArray*>(
                     dataset->GetPointData()->GetArray("avtExtraGhostNodes"));
 
@@ -667,7 +667,7 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
 //
 //    Alister Maguire, Tue Sep 24 10:04:42 MST 2019
 //    Added a call to GetQOTOutput when prompted.
-// 
+//
 //    Justin Privitera, Tue Oct 22 10:32:27 PDT 2024
 //    Call augment ghost data unconditionally.
 //
@@ -3299,7 +3299,7 @@ avtGenericDatabase::GetLabelVariable(const char *varname, int ts, int domain,
 //
 //    Kathleen Biagas, Thu Sep 11 09:10:42 PDT 2014
 //    Keep avtOriginalNodeNumbers if present.
-// 
+//
 //    Justin Privitera, Tue Oct 22 10:32:27 PDT 2024
 //    Keep extra ghost zone/node arrays if present.
 //
@@ -6023,7 +6023,7 @@ avtGenericDatabase::EnumScalarSelect(avtDatasetCollection &dsc,
 //
 //    Mark C. Miller, Wed Mar  4 18:00:38 PST 2009
 //    Adjusted for dbio-only build
-// 
+//
 //    Justin Privitera, Fri Sep 27 10:18:37 PDT 2024
 //    Relaxed restriction on input data only being floats.
 // ****************************************************************************
@@ -7984,12 +7984,9 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundariesFromFile(
 //    Modified to handle the case where a variable is defined on a subset
 //    of the materials and a domain has mixed materials without the material
 //    the variable was defined on.
-// 
+//
 //    Justin Privitera, Tue Oct 22 10:32:27 PDT 2024
 //    Exchange extra ghost zone/node arrays.
-// 
-//    Justin Privitera, Thu Oct 24 11:50:43 PDT 2024
-//    Avoid segfault when exchanging extra ghost zone/node arrays.
 //
 // ****************************************************************************
 
@@ -8614,7 +8611,7 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
     //
     // Exchange ExtraGhostZone Arrays.
     //
-    // this logic was added to support the functionality in the 
+    // this logic was added to support the functionality in the
     // AugmentGhostData() function.
     vector<vtkDataArray *> extraGhostZones;
     for (size_t j = 0 ; j < doms.size() ; j++)
@@ -8629,29 +8626,26 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         if (ds1->GetCellData()->GetArray("avtExtraGhostZones"))
         {
             extraGhostZones.push_back(ds1->GetCellData()->GetArray(
-                                                "avtExtraGhostZones"));            
+                                                "avtExtraGhostZones"));
         }
-
     }
-    if (extraGhostZones.size() > 0)
+
+    vector<vtkDataArray *> extraGhostZonesOut;
+    extraGhostZonesOut = dbi->ExchangeScalar(doms,false,extraGhostZones);
+    for (int j = 0 ; j < (int)doms.size() ; j++)
     {
-        vector<vtkDataArray *> extraGhostZonesOut;
-        extraGhostZonesOut = dbi->ExchangeScalar(doms,false,extraGhostZones);
-        for (int j = 0 ; j < (int)doms.size() ; j++)
-        {
-            vtkDataSet *ds1 = ds.GetDataset(j, 0);
-            if (ds1 == NULL ||
-                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
-                continue;
-            ds1->GetCellData()->AddArray(extraGhostZonesOut[j]);
-            extraGhostZonesOut[j]->Delete();
-        }
+        vtkDataSet *ds1 = ds.GetDataset(j, 0);
+        if (ds1 == NULL ||
+            ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
+            continue;
+        ds1->GetCellData()->AddArray(extraGhostZonesOut[j]);
+        extraGhostZonesOut[j]->Delete();
     }
 
     //
     // Exchange ExtraGhostNode Arrays.
     //
-    // this logic was added to support the functionality in the 
+    // this logic was added to support the functionality in the
     // AugmentGhostData() function.
     vector<vtkDataArray *> extraGhostNodes;
     for (size_t j = 0 ; j < doms.size() ; j++)
@@ -8666,23 +8660,20 @@ avtGenericDatabase::CommunicateGhostZonesFromDomainBoundaries(
         if (ds1->GetPointData()->GetArray("avtExtraGhostNodes"))
         {
             extraGhostNodes.push_back(ds1->GetPointData()->GetArray(
-                                                "avtExtraGhostNodes"));            
+                                                "avtExtraGhostNodes"));
         }
-
     }
-    if (extraGhostNodes.size() > 0)
+
+    vector<vtkDataArray *> extraGhostNodesOut;
+    extraGhostNodesOut = dbi->ExchangeScalar(doms,true,extraGhostNodes);
+    for (int j = 0 ; j < (int)doms.size() ; j++)
     {
-        vector<vtkDataArray *> extraGhostNodesOut;
-        extraGhostNodesOut = dbi->ExchangeScalar(doms,true,extraGhostNodes);
-        for (int j = 0 ; j < (int)doms.size() ; j++)
-        {
-            vtkDataSet *ds1 = ds.GetDataset(j, 0);
-            if (ds1 == NULL ||
-                ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
-                continue;
-            ds1->GetPointData()->AddArray(extraGhostNodesOut[j]);
-            extraGhostNodesOut[j]->Delete();
-        }
+        vtkDataSet *ds1 = ds.GetDataset(j, 0);
+        if (ds1 == NULL ||
+            ds1->GetNumberOfPoints() == 0 || ds1->GetNumberOfCells() == 0)
+            continue;
+        ds1->GetPointData()->AddArray(extraGhostNodesOut[j]);
+        extraGhostNodesOut[j]->Delete();
     }
 
     //

--- a/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
@@ -1823,11 +1823,10 @@ avtStructuredDomainBoundaries::ExchangeScalar(vector<int>           domainNum,
     // Let's get them all to agree on one data type.
     MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
 #endif
-
     if (maxDataType < 0)
         return scalars;
 
-    if(dataType != maxDataType)
+    if((dataType >= 0) && (dataType != maxDataType))
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,
@@ -2333,7 +2332,7 @@ avtStructuredDomainBoundaries::ExchangeVector(vector<int>           domainNum,
     if (maxDataType < 0)
         return vectors;
 
-    if(dataType != maxDataType)
+    if((dataType >= 0) && (dataType != maxDataType))
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,

--- a/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
@@ -1822,17 +1822,21 @@ avtStructuredDomainBoundaries::ExchangeScalar(vector<int>           domainNum,
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
     MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
-#endif
-    if (maxDataType < 0)
-        return scalars;
 
-    if((dataType >= 0) && (dataType != maxDataType))
+    int hasDataTypeMismatch = ((dataType >= 0) && (dataType != maxDataType));
+    int hasDataTypeMismatchMax = hasDataTypeMismatch;
+    MPI_Allreduce(&hasDataTypeMismatch, &hasDataTypeMismatchMax, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    if(hasDataTypeMismatchMax)
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,
                    "avtStructuredDomainBoundaries:ExchangeScalar "
-                   "vtkDatArray data types do not match.");
+                   "vtkDataArray data types do not match.");
     }
+#endif
+
+    if (maxDataType < 0)
+        return scalars;
 
     switch (maxDataType)
     {
@@ -2327,18 +2331,22 @@ avtStructuredDomainBoundaries::ExchangeVector(vector<int>           domainNum,
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
     MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
-#endif
 
-    if (maxDataType < 0)
-        return vectors;
-
-    if((dataType >= 0) && (dataType != maxDataType))
+    // Now verify if there is a dataType mismatch.
+    int hasDataTypeMismatch = ((dataType >= 0) && (dataType != maxDataType));
+    int hasDataTypeMismatchMax = hasDataTypeMismatch;
+    MPI_Allreduce(&hasDataTypeMismatch, &hasDataTypeMismatchMax, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    if(hasDataTypeMismatchMax)
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,
                    "avtStructuredDomainBoundaries:ExchangeVector "
-                   "vtkDatArray data types do not match.");
+                   "vtkDataArray data types do not match.");
     }
+#endif
+
+    if (maxDataType < 0)
+        return vectors;
 
     switch (maxDataType)
     {

--- a/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtStructuredDomainBoundaries.C
@@ -401,7 +401,7 @@ BoundaryHelperFunctions<T>::FillRectilinearBoundaryData(int      d1,
 //  Programmer:  Jeremy Meredith
 //  Creation:    November 21, 2001
 //
-//  Note:  bnddata, bndmixmat, and bndmixzone may each be NULL.  
+//  Note:  bnddata, bndmixmat, and bndmixzone may each be NULL.
 //         olddata may be NULL as well as long as the mixlen is zero.
 //
 //  Modifications:
@@ -874,7 +874,7 @@ BoundaryHelperFunctions<T>::CommunicateMixedBoundaryData(const vector<int> &doma
 
             if (domain2proc[d1] != domain2proc[d2])
             {
-            
+
                 if (domain2proc[d1] == rank)
                 {
                     if (bnddata)
@@ -996,12 +996,12 @@ BoundaryHelperFunctions<T>::CopyOldValues(int      d1,
 //    comp_num       0=X, 1=Y, 2=Z
 //
 //  Programmer:  Hank Childs
-//  Creation:    November 11, 2003 
+//  Creation:    November 11, 2003
 //
 // ****************************************************************************
 template <class T>
 void
-BoundaryHelperFunctions<T>::CopyOldRectilinearValues(int d1, const T *olddata, 
+BoundaryHelperFunctions<T>::CopyOldRectilinearValues(int d1, const T *olddata,
                                                      T *newdata, int comp_num)
 {
     Boundary *bi = &sdb->boundary[d1];
@@ -1013,7 +1013,7 @@ BoundaryHelperFunctions<T>::CopyOldRectilinearValues(int d1, const T *olddata,
     int nInew = newbiextents[1] - newbiextents[0] + 1;
     int nJnew = newbiextents[3] - newbiextents[2] + 1;
     int nKnew = newbiextents[5] - newbiextents[4] + 1;
-    
+
     if (comp_num == 0)
     {
         //
@@ -1030,7 +1030,7 @@ BoundaryHelperFunctions<T>::CopyOldRectilinearValues(int d1, const T *olddata,
             int newindex = bi->NewPointIndex(i_ind, j_ind, k_ind);
             int oldI = oldindex % nIold;
             int newI = newindex % nInew;
-            newdata[newI] = olddata[oldI]; 
+            newdata[newI] = olddata[oldI];
         }
     }
     else if (comp_num == 1)
@@ -1043,7 +1043,7 @@ BoundaryHelperFunctions<T>::CopyOldRectilinearValues(int d1, const T *olddata,
             int newindex = bi->NewPointIndex(i_ind, j_ind, k_ind);
             int oldJ = (oldindex/nIold) % nJold;
             int newJ = (newindex/nInew) % nJnew;
-            newdata[newJ] = olddata[oldJ]; 
+            newdata[newJ] = olddata[oldJ];
         }
     }
     else if (comp_num == 2)
@@ -1056,7 +1056,7 @@ BoundaryHelperFunctions<T>::CopyOldRectilinearValues(int d1, const T *olddata,
             int newindex = bi->NewPointIndex(i_ind, j_ind, k_ind);
             int oldK = (oldindex/(nIold*nJold)) % nKold;
             int newK = (newindex/(nInew*nJnew)) % nKnew;
-            newdata[newK] = olddata[oldK]; 
+            newdata[newK] = olddata[oldK];
         }
     }
 }
@@ -1154,7 +1154,7 @@ avtStructuredDomainBoundaries::SetExistence(int      d1,
             {
                 for (int i=n1extents[0]; i<=n1extents[1]; i++)
                 {
-                    int index = (isPointData ? 
+                    int index = (isPointData ?
                                  bi->NewPointIndexFromNeighbor(n1, i,j,k) :
                                  bi->NewCellIndexFromNeighbor(n1, i,j,k));
                     if (index >= 0)
@@ -1171,7 +1171,7 @@ avtStructuredDomainBoundaries::SetExistence(int      d1,
 //  Method:  BoundaryHelperFunctions::SetNewBoundaryData
 //
 //  Purpose:
-//    Set the ghost values of the given domain using the temporary 
+//    Set the ghost values of the given domain using the temporary
 //    boundary data.
 //
 //  Arguments:
@@ -1253,7 +1253,7 @@ BoundaryHelperFunctions<T>::SetNewBoundaryData(int       d1,
             {
                 for (int i=n1extents[0]; i<=n1extents[1]; i++)
                 {
-                    int newindex = (isPointData ? 
+                    int newindex = (isPointData ?
                                     bi->NewPointIndexFromNeighbor(n1, i,j,k) :
                                     bi->NewCellIndexFromNeighbor(n1, i,j,k));
                     if (newindex >= 0)
@@ -1272,7 +1272,7 @@ BoundaryHelperFunctions<T>::SetNewBoundaryData(int       d1,
 //  Method:  BoundaryHelperFunctions::SetNewRectilinearBoundaryData
 //
 //  Purpose:
-//    Set the ghost values of the given domain using the temporary 
+//    Set the ghost values of the given domain using the temporary
 //    boundary data.
 //
 //  Arguments:
@@ -1576,7 +1576,7 @@ BoundaryHelperFunctions<T>::FakeNonexistentBoundaryData(int  d1,
     }
     delete[] newexists;
 }
-    
+
 
 // ----------------------------------------------------------------------------
 //                               public methods
@@ -1609,7 +1609,7 @@ avtStructuredDomainBoundaries::avtStructuredDomainBoundaries(
     bhf_float = new BoundaryHelperFunctions<float>(this);
     bhf_double = new BoundaryHelperFunctions<double>(this);
     bhf_uchar = new BoundaryHelperFunctions<unsigned char>(this);
-    shouldComputeNeighborsFromExtents = canComputeNeighborsFromExtents; 
+    shouldComputeNeighborsFromExtents = canComputeNeighborsFromExtents;
     haveCalculatedBoundaries = false;
     maxAMRLevel = 1;
 }
@@ -1622,7 +1622,7 @@ avtStructuredDomainBoundaries::avtStructuredDomainBoundaries(
 //
 //  Modifications:
 //    Mark C. Miller, ed Mar 23 15:29:56 PST 2005
-//    Added code to delete stuff new'd in constructor 
+//    Added code to delete stuff new'd in constructor
 //
 // ****************************************************************************
 avtStructuredDomainBoundaries::~avtStructuredDomainBoundaries()
@@ -1741,8 +1741,8 @@ avtStructuredDomainBoundaries::SetExtents(int domain, int e[6])
 //
 // ****************************************************************************
 void
-avtStructuredDomainBoundaries::AddNeighbor(int domain, int d, int mi, int o[3], 
-                                           int e[6], RefinementRelationship rr, 
+avtStructuredDomainBoundaries::AddNeighbor(int domain, int d, int mi, int o[3],
+                                           int e[6], RefinementRelationship rr,
                                            const std::vector<int>& ref_ratio,
                                            NeighborRelationship nr)
 {
@@ -1807,6 +1807,9 @@ avtStructuredDomainBoundaries::Finish(int domain)
 //    Brad Whitlock, Sun Apr 22 08:52:14 PDT 2012
 //    Double support.
 //
+//    Kathleen Biagas, Fri Nov 1, 2024
+//    Added consistency check for dataTypes.
+//
 // ****************************************************************************
 vector<vtkDataArray*>
 avtStructuredDomainBoundaries::ExchangeScalar(vector<int>           domainNum,
@@ -1815,16 +1818,24 @@ avtStructuredDomainBoundaries::ExchangeScalar(vector<int>           domainNum,
 {
     int dataType = (scalars.empty() ? -1 : scalars[0]->GetDataType());
 
+    int maxDataType = dataType;
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
-    int myDataType = dataType;
-    MPI_Allreduce(&myDataType, &dataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
 #endif
 
-    if (dataType < 0)
+    if (maxDataType < 0)
         return scalars;
 
-    switch (dataType)
+    if(dataType != maxDataType)
+    {
+        // This should never happen, so throw the exception.
+        EXCEPTION1(VisItException,
+                   "avtStructuredDomainBoundaries:ExchangeScalar "
+                   "vtkDatArray data types do not match.");
+    }
+
+    switch (maxDataType)
     {
       case VTK_FLOAT:
         return ExchangeFloatScalar(domainNum, isPointData, scalars);
@@ -1870,7 +1881,7 @@ avtStructuredDomainBoundaries::ExchangeScalar(vector<int>           domainNum,
 //    Propagate variable names.
 //
 //    Kathleen Bonnell, Fri Feb  8 11:03:49 PST 2002
-//    vtkScalars has been deprecated in VTK 4.0, use vtkDataArray 
+//    vtkScalars has been deprecated in VTK 4.0, use vtkDataArray
 //    and vtkFloatArray instead.
 //
 //    Jeremy Meredith, Fri Nov  7 15:13:56 PST 2003
@@ -1940,7 +1951,7 @@ avtStructuredDomainBoundaries::ExchangeFloatScalar(vector<int>     domainNum,
         Boundary *bi = &boundary[domainNum[d]];
 
         // Create the new VTK objects
-        out[d] = vtkFloatArray::New(); 
+        out[d] = vtkFloatArray::New();
         out[d]->SetName(scalars[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(bi->newnpts);
@@ -2041,7 +2052,7 @@ avtStructuredDomainBoundaries::ExchangeDoubleScalar(vector<int>     domainNum,
         Boundary *bi = &boundary[domainNum[d]];
 
         // Create the new VTK objects
-        out[d] = vtkDoubleArray::New(); 
+        out[d] = vtkDoubleArray::New();
         out[d]->SetName(scalars[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(bi->newnpts);
@@ -2150,7 +2161,7 @@ avtStructuredDomainBoundaries::ExchangeIntScalar(vector<int>       domainNum,
         Boundary *bi = &boundary[domainNum[d]];
 
         // Create the new VTK objects
-        out[d] = vtkIntArray::New(); 
+        out[d] = vtkIntArray::New();
         out[d]->SetName(scalars[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(bi->newnpts);
@@ -2260,7 +2271,7 @@ avtStructuredDomainBoundaries::ExchangeUCharScalar(vector<int>     domainNum,
         Boundary *bi = &boundary[domainNum[d]];
 
         // Create the new VTK objects
-        out[d] = vtkUnsignedCharArray::New(); 
+        out[d] = vtkUnsignedCharArray::New();
         out[d]->SetName(scalars[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(bi->newnpts);
@@ -2302,6 +2313,8 @@ avtStructuredDomainBoundaries::ExchangeUCharScalar(vector<int>     domainNum,
 //  Creation:    April 21, 2015
 //
 //  Modifications:
+//    Kathleen Biagas, Fri Nov 1, 2024
+//    Added consistency check for dataTypes.
 //
 // ****************************************************************************
 vector<vtkDataArray*>
@@ -2310,17 +2323,25 @@ avtStructuredDomainBoundaries::ExchangeVector(vector<int>           domainNum,
                                               vector<vtkDataArray*> vectors)
 {
     int dataType = (vectors.empty() ? -1 : vectors[0]->GetDataType());
-    
+
+    int maxDataType = dataType;
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
-    int myDataType = dataType;    
-    MPI_Allreduce(&myDataType, &dataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
 #endif
-    
-    if (dataType < 0)
+
+    if (maxDataType < 0)
         return vectors;
-    
-    switch (dataType)
+
+    if(dataType != maxDataType)
+    {
+        // This should never happen, so throw the exception.
+        EXCEPTION1(VisItException,
+                   "avtStructuredDomainBoundaries:ExchangeVector "
+                   "vtkDatArray data types do not match.");
+    }
+
+    switch (maxDataType)
     {
         case VTK_FLOAT:
             return ExchangeFloatVector(domainNum, isPointData, vectors);
@@ -2363,13 +2384,13 @@ avtStructuredDomainBoundaries::ExchangeVector(vector<int>           domainNum,
 //    Propagate variable names.
 //
 //    Kathleen Bonnell, Fri Feb  8 11:03:49 PST 2002
-//    vtkVectors has been deprecated in VTK 4.0, use vtkDataArray 
+//    vtkVectors has been deprecated in VTK 4.0, use vtkDataArray
 //    and vtkFloatArray instead.
 //
-//    Kathleen Bonnell, Mon May 20 13:33:03 PDT 2002 
+//    Kathleen Bonnell, Mon May 20 13:33:03 PDT 2002
 //    Change name to reflect underlying data type.  Allow for arbitrary
-//    number of components in the array. 
-//    
+//    number of components in the array.
+//
 //    Hank Childs, Fri Dec  6 14:56:20 PST 2002
 //    Do not assume that the number of vectors is > 0.
 //
@@ -2438,7 +2459,7 @@ avtStructuredDomainBoundaries::ExchangeFloatVector(vector<int>      domainNum,
     {
         // Create the new VTK objects
         out[d] = vtkFloatArray::New();
-        out[d]->SetNumberOfComponents(nComp); 
+        out[d]->SetNumberOfComponents(nComp);
         out[d]->SetName(vectors[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(boundary[domainNum[d]].newnpts);
@@ -2538,8 +2559,8 @@ avtStructuredDomainBoundaries::ExchangeDoubleVector(vector<int>      domainNum,
     for (size_t d = 0; d < vectors.size(); d++)
     {
         // Create the new VTK objects
-        out[d] = vtkDoubleArray::New(); 
-        out[d]->SetNumberOfComponents(nComp); 
+        out[d] = vtkDoubleArray::New();
+        out[d]->SetNumberOfComponents(nComp);
         out[d]->SetName(vectors[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(boundary[domainNum[d]].newnpts);
@@ -2580,19 +2601,19 @@ avtStructuredDomainBoundaries::ExchangeDoubleVector(vector<int>      domainNum,
 //  Notes:
 //    Taken from ExchangeFloatVector and modified for integer data types.
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    May 20, 2002 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    May 20, 2002
 //
 //  Modifications:
 //
 //    Hank Childs, Fri Dec  6 14:56:20 PST 2002
 //    Do not assume that the number of vectors is > 0.
 //
-//    Kathleen Bonnell, Wed Dec 11 09:13:25 PST 2002 
-//    Preserver underlying data type:  use MakeObject instead of New. 
+//    Kathleen Bonnell, Wed Dec 11 09:13:25 PST 2002
+//    Preserver underlying data type:  use MakeObject instead of New.
 //
-//    Kathleen Bonnell, Fri Dec 13 14:07:15 PST 2002  
-//    Use NewInstance instead of MakeObject, new vtk api. 
+//    Kathleen Bonnell, Fri Dec 13 14:07:15 PST 2002
+//    Use NewInstance instead of MakeObject, new vtk api.
 //
 //    Hank Childs, Wed Jun 29 15:24:35 PDT 2005
 //    Cache domain2proc.
@@ -2658,8 +2679,8 @@ avtStructuredDomainBoundaries::ExchangeIntVector(vector<int>        domainNum,
     for (size_t d = 0; d < vectors.size(); d++)
     {
         // Create the new VTK objects
-        out[d] = vectors[d]->NewInstance(); 
-        out[d]->SetNumberOfComponents(nComp); 
+        out[d] = vectors[d]->NewInstance();
+        out[d]->SetNumberOfComponents(nComp);
         out[d]->SetName(vectors[d]->GetName());
         if (isPointData)
             out[d]->SetNumberOfTuples(boundary[domainNum[d]].newnpts);
@@ -2844,7 +2865,7 @@ avtStructuredDomainBoundaries::ExchangeMaterial(vector<int>          domainNum,
         // Set the remaining unset ones (reduced connectivity, etc.)
         bhf_int->FakeNonexistentBoundaryData(domainNum[d], newmatlist, false);
 
-        out[d] = new avtMaterial(oldmat->GetNMaterials(), 
+        out[d] = new avtMaterial(oldmat->GetNMaterials(),
                                  oldmat->GetMaterials(),
                                  boundary[domainNum[d]].newncells,
                                  newmatlist,
@@ -3160,8 +3181,8 @@ avtStructuredDomainBoundaries::ConfirmMesh(vector<int>         domainNum,
         {
             debug1 << "Rejecting domain boundaries because of inconsistency "
                    << "with domain " << domainNum[i] << endl;
-            debug1 << "File returned " << meshes[i]->GetNumberOfPoints() 
-                   << " points, but dbi object believed it should be " 
+            debug1 << "File returned " << meshes[i]->GetNumberOfPoints()
+                   << " points, but dbi object believed it should be "
                    << b.oldnpts << endl;
             return false;
         }
@@ -3169,8 +3190,8 @@ avtStructuredDomainBoundaries::ConfirmMesh(vector<int>         domainNum,
         {
             debug1 << "Rejecting domain boundaries because of inconsistency "
                    << "with domain " << domainNum[i] << endl;
-            debug1 << "File returned " << meshes[i]->GetNumberOfCells() 
-                   << "cells, but dbi object believed it should be " 
+            debug1 << "File returned " << meshes[i]->GetNumberOfCells()
+                   << "cells, but dbi object believed it should be "
                    << b.oldncells << endl;
             return false;
         }
@@ -3238,7 +3259,7 @@ avtStructuredDomainBoundaries::ResetCachedMembers(void)
 void
 avtStructuredDomainBoundaries::CreateGhostZones(vtkDataSet *outMesh,
                                               vtkDataSet *inMesh, Boundary *bi,
-                                              bool haveCommunicatedGhosts, 
+                                              bool haveCommunicatedGhosts,
                                               int domain, unsigned char ***ghosts)
 {
     vtkUnsignedCharArray *oldGhosts = (vtkUnsignedCharArray *)
@@ -3255,11 +3276,11 @@ avtStructuredDomainBoundaries::CreateGhostZones(vtkDataSet *outMesh,
     {
         if (oldGhosts == NULL)
             EXCEPTION0(ImproperUseException);  // we should never get to this point
-        bhf_uchar->CopyOldValues(domain, 
+        bhf_uchar->CopyOldValues(domain,
                                  (unsigned char *) oldGhosts->GetVoidPointer(0),
                                  (unsigned char *) ghostCells->GetVoidPointer(0),
                                  false, 1);
-        bhf_uchar->SetNewBoundaryData(domain, ghosts, 
+        bhf_uchar->SetNewBoundaryData(domain, ghosts,
                                  (unsigned char *) ghostCells->GetVoidPointer(0),
                                  false, 1);
     }
@@ -3291,7 +3312,7 @@ avtStructuredDomainBoundaries::CreateGhostZones(vtkDataSet *outMesh,
 
     outMesh->GetCellData()->AddArray(ghostCells);
     ghostCells->Delete();
-    outMesh->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0); 
+    outMesh->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0);
 
     //
     //  Create a field-data array indicating the extents of real zones.
@@ -3330,7 +3351,7 @@ avtStructuredDomainBoundaries::CreateGhostZones(vtkDataSet *outMesh,
 //    Made use of templatized functions.  Added call to fake boundary
 //    data when it is nonexistent.
 //
-//    Kathleen Bonnell, Wed Jul 10 16:02:56 PDT 2002 
+//    Kathleen Bonnell, Wed Jul 10 16:02:56 PDT 2002
 //    Create a field-data array indicating the extents of real zones.
 //    Used during ghostzone removal.
 //
@@ -3462,7 +3483,7 @@ avtCurvilinearDomainBoundaries::ExchangeMesh(Helper *bhf, int vtktype,
         Boundary *bi = &boundary[d1];
 
         // Create the VTK objects
-        vtkStructuredGrid    *outm  = vtkStructuredGrid::New(); 
+        vtkStructuredGrid    *outm  = vtkStructuredGrid::New();
         vtkPoints            *outp  = vtkPoints::New(vtktype);
         outm->SetPoints(outp);
         outp->Delete();
@@ -3486,7 +3507,7 @@ avtCurvilinearDomainBoundaries::ExchangeMesh(Helper *bhf, int vtktype,
         out[d] = outm;
     }
     visitTimer->StopTimer(timer_UnpackData, "Ghost Zone Generation phase 4: Unpack Data (in curvmesh version)");
- 
+
     bhf->FreeBoundaryData(coord);
 }
 
@@ -3621,7 +3642,7 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
         int d1 = domainNum[d];
         Boundary *bi = &boundary[d1];
 
-        vtkRectilinearGrid   *outm  = vtkRectilinearGrid::New(); 
+        vtkRectilinearGrid   *outm  = vtkRectilinearGrid::New();
         vtkDataArray         *newx, *newy, *newz;
         if(oldx->GetDataType() == VTK_DOUBLE)
         {
@@ -3645,7 +3666,7 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
         newx->SetNumberOfTuples(bi->newndims[0]);
         newy->SetNumberOfTuples(bi->newndims[1]);
         newz->SetNumberOfTuples(bi->newndims[2]);
-     
+
         int  i;
         for (i = 0 ; i < bi->newndims[0] ; i++)
         {
@@ -3658,7 +3679,7 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
             }
             else if (id > bi->oldnextents[1])
             {
-                double last_dist = (oldx->GetTuple1(bi->oldndims[0]-1) - 
+                double last_dist = (oldx->GetTuple1(bi->oldndims[0]-1) -
                                     oldx->GetTuple1(bi->oldndims[0]-2));
                 int   num_off = (id - bi->oldnextents[1]);
                 newx->SetTuple1(i, oldx->GetTuple1(bi->oldndims[0]-1) + last_dist*num_off);
@@ -3683,7 +3704,7 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
             }
             else if (id > bi->oldnextents[3])
             {
-                double last_dist = (oldy->GetTuple1(bi->oldndims[1]-1) - 
+                double last_dist = (oldy->GetTuple1(bi->oldndims[1]-1) -
                                     oldy->GetTuple1(bi->oldndims[1]-2));
                 int   num_off = (id - bi->oldnextents[3]);
                 newy->SetTuple1(i, oldy->GetTuple1(bi->oldndims[1]-1) + last_dist*num_off);
@@ -3708,7 +3729,7 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
             }
             else if (id > bi->oldnextents[5])
             {
-                double last_dist = (oldz->GetTuple1(bi->oldndims[2]-1) - 
+                double last_dist = (oldz->GetTuple1(bi->oldndims[2]-1) -
                                     oldz->GetTuple1(bi->oldndims[2]-2));
                 int   num_off = (id - bi->oldnextents[5]);
                 newz->SetTuple1(i, oldz->GetTuple1(bi->oldndims[2]-1) + last_dist*num_off);
@@ -3717,9 +3738,9 @@ avtRectilinearDomainBoundaries::ExchangeMesh(vector<int>         domainNum,
             {
                 int oldindex = bi->OldPointIndex(0, 0, id);
                 int newindex = bi->NewPointIndex(0, 0, id);
-                int oldK = (oldindex/(bi->oldndims[0]*bi->oldndims[1])) 
+                int oldK = (oldindex/(bi->oldndims[0]*bi->oldndims[1]))
                          % bi->oldndims[2];
-                int newK = (newindex/(bi->newndims[0]*bi->newndims[1])) 
+                int newK = (newindex/(bi->newndims[0]*bi->newndims[1]))
                          % bi->newndims[2];
                 newz->SetTuple1(newK, oldz->GetTuple1(oldK));
             }
@@ -3789,7 +3810,7 @@ avtStructuredDomainBoundaries::CreateGhostNodes(vector<int>         domainNum,
     // If we are doing DLB, we want to mark nodes as ghost, even if their
     // neighboring domains are not being used on this iteration.  Do this by
     // consulting the "allDomains" list.  Note that we can only play this
-    // trick because the rest of the routine does not care which domains 
+    // trick because the rest of the routine does not care which domains
     // are on which processors -- only that we are using them.
     //
     int ntotaldomains = (int)wholeBoundary.size();
@@ -3814,7 +3835,7 @@ avtStructuredDomainBoundaries::CreateGhostNodes(vector<int>         domainNum,
         gn->SetNumberOfTuples(npts);
         gn->SetName("avtGhostNodes");
         unsigned char *gnp = gn->GetPointer(0);
-   
+
         for (int j = 0 ; j < npts ; j++)
             gnp[j] = 0;
 
@@ -3963,14 +3984,14 @@ avtStructuredDomainBoundaries::SetRefinementRatios(const std::vector<int> &r)
 //
 //    Kathleen Bonnell, Tue Jan 20 17:26:40 PST 2004
 //    Reversed order of Exceptions, per Mark Miller's request.
-// 
+//
 //    Hank Childs, Fri Nov 14 10:50:06 PST 2008
 //    Set data member for tracking maximum AMR level.
 //
 // ****************************************************************************
 
 void
-avtStructuredDomainBoundaries::SetIndicesForAMRPatch(int domain, 
+avtStructuredDomainBoundaries::SetIndicesForAMRPatch(int domain,
                                                      int level, int e[6])
 {
     if (!shouldComputeNeighborsFromExtents)
@@ -4039,7 +4060,7 @@ avtStructuredDomainBoundaries::SetIndicesForAMRPatch(int domain,
 //    of levels.
 //
 //    Hank Childs, Tue Jan  4 13:35:56 PST 2011
-//    Add support for the types of ghost data needed to create crack-free 
+//    Add support for the types of ghost data needed to create crack-free
 //    isosurfaces with the AMR stitch operator.  They are:
 //      (1) values from the coarse patch when a fine patch is embedded in a
 //          coarse patch.
@@ -4053,7 +4074,7 @@ avtStructuredDomainBoundaries::SetIndicesForAMRPatch(int domain,
 //    Add support for T-intersections.
 //
 //    Gunther H. Weber, Thu Jan 19 14:35:59 PST 2012
-//    Select new support for T-intersections by defining 
+//    Select new support for T-intersections by defining
 //    CREATE_GHOSTS_FOR_T_INTERSECTIONS
 //
 //    Gunther H. Weber, Thu Jun 14 17:31:59 PDT 2012
@@ -4204,7 +4225,7 @@ avtStructuredDomainBoundaries::CalculateBoundaries(void)
                     "computation of neighbors from index extents");
         }
 
-        // 
+        //
         // The logic for setting up boundaries across AMR levels and within an
         // AMR level are similar.  So the code is combined into a single loop.
         // Also, the normal rectilinear case is the same as "within an AMR level".
@@ -4382,9 +4403,9 @@ avtStructuredDomainBoundaries::CalculateBoundaries(void)
 
                                     // if the current boundary doesn't apply, skip it
                                     if ((axisOffset[0]==-1 && !minFace[0]) ||
-                                            (axisOffset[0]==+1 && !maxFace[0]) || 
+                                            (axisOffset[0]==+1 && !maxFace[0]) ||
                                             (axisOffset[1]==-1 && !minFace[1]) ||
-                                            (axisOffset[1]==+1 && !maxFace[1]) || 
+                                            (axisOffset[1]==+1 && !maxFace[1]) ||
                                             (axisOffset[2]==-1 && !minFace[2]) ||
                                             (axisOffset[2]==+1 && !maxFace[2]))
                                     {
@@ -4486,8 +4507,8 @@ avtStructuredDomainBoundaries::CalculateBoundaries(void)
 //    domain     the domain to get the extents of
 //    e          the extents
 //
-//  Programmer:  Kathleen Bonnell 
-//  Creation:    February 8, 2005 
+//  Programmer:  Kathleen Bonnell
+//  Creation:    February 8, 2005
 //
 // ****************************************************************************
 
@@ -4495,7 +4516,7 @@ void
 avtStructuredDomainBoundaries::GetExtents(int domain, int e[6])
 {
     int ntotaldomains = (int)wholeBoundary.size();
-  
+
     if (domain < 0 || ntotaldomains <= domain)
     {
         EXCEPTION2(BadIndexException, domain, ntotaldomains);
@@ -4574,11 +4595,11 @@ avtStructuredDomainBoundaries::GetNeighborPresence(int domain, bool *b,
 //  Creation:   Dec 15, 2008
 //
 // ****************************************************************************
-vector<Neighbor> 
+vector<Neighbor>
 avtStructuredDomainBoundaries::GetNeighbors(int domain)
 {
     int ntotaldomains = (int)wholeBoundary.size();
-  
+
     if (domain < 0 || ntotaldomains <= domain)
     {
         EXCEPTION2(BadIndexException, domain, ntotaldomains);

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -626,18 +626,21 @@ avtUnstructuredDomainBoundaries::ExchangeScalar(vector<int>         domainNum,
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
     MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
-#endif
 
-    if (maxDataType < 0)
-        return scalars;
-
-    if((dataType >= 0) && (dataType != maxDataType))
+    int hasDataTypeMismatch = ((dataType >= 0) && (dataType != maxDataType));
+    int hasDataTypeMismatchMax = hasDataTypeMismatch;
+    MPI_Allreduce(&hasDataTypeMismatch, &hasDataTypeMismatchMax, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    if(hasDataTypeMismatchMax)
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,
                    "avtUnstructuredDomainBoundaries:ExchangeScalar "
-                   "vtkDatArray data types do not match.");
+                   "vtkDataArray data types do not match.");
     }
+#endif
+
+    if (maxDataType < 0)
+        return scalars;
 
     // This one's a little more complicated because there are different
     // types of scalars we might encounter. If more cases arise,
@@ -709,18 +712,21 @@ avtUnstructuredDomainBoundaries::ExchangeVector(vector<int> domainNum, bool isPo
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
     MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
-#endif
 
-    if (maxDataType < 0)
-        return vectors;
-
-    if((dataType >= 0) && (dataType != maxDataType))
+    int hasDataTypeMismatch = ((dataType >= 0) && (dataType != maxDataType));
+    int hasDataTypeMismatchMax = hasDataTypeMismatch;
+    MPI_Allreduce(&hasDataTypeMismatch, &hasDataTypeMismatchMax, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    if(hasDataTypeMismatchMax)
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,
                    "avtUnstructuredDomainBoundaries:ExchangeVector "
-                   "vtkDatArray data types do not match.");
+                   "vtkDataArray data types do not match.");
     }
+#endif
+
+    if (maxDataType < 0)
+        return vectors;
 
     // This one's a little more complicated because there are different
     // types of vectors we might encounter. If more cases arise,

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -225,9 +225,9 @@ avtUnstructuredDomainBoundaries::SetGivenCellsAndPoints(int fromDom, int toDom,
     else
     {
         int sIndex = GetGivenIndex(fromDom, toDom);
-        
+
         map<int, int> &smap = sharedPointsMap[sIndex];
-        
+
         // Go through and manually insert the points that are not shared.
 
         for (size_t i = 0; i < points.size(); ++i)
@@ -299,7 +299,7 @@ CopyPointer(T *src, T *dest, int components,
     for (i = 1; i < nIter; ++i)
         *(++dest) = *(++src);
 }
- 
+
 // ****************************************************************************
 //  Method:  avtUnstructuredDomainBoundaries::ExchangeMesh
 //
@@ -408,9 +408,9 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
         int i;
         for (i = 0; i < nTotalDomains; ++i)
             nGivenPoints += nGainedPoints[i][recvDom];
-        
+
         // Create the VTK objects
-        vtkUnstructuredGrid    *outm  = vtkUnstructuredGrid::New(); 
+        vtkUnstructuredGrid    *outm  = vtkUnstructuredGrid::New();
         vtkPoints *outp  = vtkPoints::New(mesh->GetPoints()->GetDataType());
 
         outm->DeepCopy(meshes[d]);
@@ -433,15 +433,15 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
         {
             if (sendDom == recvDom)
                 continue;
-            
+
             int nGivenPointsThisDomain = nGainedPoints[sendDom][recvDom];
             if (nGivenPointsThisDomain == 0)
                 continue;
-            
+
             // We need to remember what the point id for this exchange
             // of points is.
             startingPoint[pair<int,int>(sendDom, recvDom)] = newId;
-            
+
             T *pts = gainedPoints[sendDom][recvDom];
             int *origPointIdsThisDomain = origPointIds[sendDom][recvDom];
 
@@ -450,14 +450,14 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
                 *(newcoord++) = *(pts++);
                 *(newcoord++) = *(pts++);
                 *(newcoord++) = *(pts++);
-                translatedPointsMap[sendDom][origPointIdsThisDomain[i]] = 
+                translatedPointsMap[sendDom][origPointIdsThisDomain[i]] =
                                                                         newId++;
             }
         }
-        
+
         int nOldCells = outm->GetNumberOfCells();
 
-        
+
         vtkIdList *idList = vtkIdList::New();
         // Put in the new cells
         for (sendDom = 0; sendDom < nTotalDomains; ++sendDom)
@@ -469,19 +469,19 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
 
             if (nGainedCellsThisDomain == 0)
                 continue;
-            
+
             // We're going to be be giving cells from sendDom to recvDom.
             // The id that the cells will be inserted at is
             // important, and we need to remember.
             startingCell[pair<int,int>(sendDom, recvDom)] = outm->
                                                             GetNumberOfCells();
-            
+
             // We want the map that indexes the ptIds from sendDom into
             // the ptIds of recvDom.
             int index = GetGivenIndex(sendDom, recvDom);
             map<int, int> &smap = sharedPointsMap[index];
             map<int, int> &tmap = translatedPointsMap[sendDom];
-            
+
             for (i = 0; i < nGainedCellsThisDomain; ++i)
             {
                 int nPointsThisCell = nPointsPerCell[sendDom][recvDom][i];
@@ -493,7 +493,7 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
                     if (smap.find(id) != smap.end())
                         idList->SetId(k, smap[id]);
                     else
-                       idList->SetId(k, tmap[id]); 
+                       idList->SetId(k, tmap[id]);
                 }
                 outm->InsertNextCell(cellTypes[sendDom][recvDom][i], idList);
             }
@@ -518,7 +518,7 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
         }
         outm->GetCellData()->AddArray(ghostCells);
         ghostCells->Delete();
-        outm->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0); 
+        outm->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0);
 
         // Rebuild the links now that we've added ghost cells.
         outm->BuildLinks();
@@ -560,7 +560,7 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
         delete [] nGainedCells[a];
         delete [] nPointsPerCell[a];
     }
-    
+
     delete [] gainedPoints;
     delete [] cellTypes;
     delete [] cellPoints;
@@ -600,6 +600,9 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
 //    Eric Brugger, Fri Mar 13 15:20:08 PDT 2020
 //    Modify to handle NULL meshes.
 //
+//    Kathleen Biagas, Thu Oct 31, 2024
+//    Ensure all procs are calling the same Exchange function.
+//
 // ****************************************************************************
 
 vector<vtkDataArray*>
@@ -607,22 +610,28 @@ avtUnstructuredDomainBoundaries::ExchangeScalar(vector<int>         domainNum,
                                               bool                isPointData,
                                               vector<vtkDataArray*> scalars)
 {
-    // We're in a bit of a sticky situation if we don't have any actual data.
-    // Without a valid vtkDataArray, we don't know which ExchangeData to
-    // call. But if there's no data, nothing will actually be exchanged
-    // aside from basic communications (eg: domain2proc, MPI_Barrier),
-    // so we'll choose to call one. 
-    if (!scalars.size())
+    int nonNullDomain = 0;
+    int dataType = -1;
+    if(!scalars.empty())
     {
-        return ExchangeData_float(domainNum, isPointData, scalars);
+        while (nonNullDomain < domainNum.size() && scalars[nonNullDomain] == NULL)
+            nonNullDomain++;
+        dataType = scalars[nonNullDomain]->GetDataType();
     }
+
+#ifdef PARALLEL
+    // Let's get them all to agree on one data type.
+    int myDataType = dataType;
+    MPI_Allreduce(&myDataType, &dataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+#endif
+
+    if (dataType < 0)
+        return scalars;
+
     // This one's a little more complicated because there are different
     // types of scalars we might encounter. If more cases arise,
     // expand this function.
-    int nonNullDomain = 0;
-    while (nonNullDomain < domainNum.size() && scalars[nonNullDomain] == NULL)
-        nonNullDomain++;
-    switch (scalars[nonNullDomain]->GetDataType())
+    switch (dataType)
     {
         case VTK_INT:
             return ExchangeData_int(domainNum, isPointData, scalars);
@@ -665,27 +674,36 @@ avtUnstructuredDomainBoundaries::ExchangeScalar(vector<int>         domainNum,
 //    Eric Brugger, Fri Mar 13 15:20:08 PDT 2020
 //    Modify to handle NULL meshes.
 //
+//    Kathleen Biagas, Thu Oct 31, 2024
+//    Ensure all procs are calling the same Exchange function.
+//
 // ****************************************************************************
 
 vector<vtkDataArray*>
 avtUnstructuredDomainBoundaries::ExchangeVector(vector<int> domainNum, bool isPointData, vector<vtkDataArray*> vectors)
 {
-    // We're in a bit of a sticky situation if we don't have any actual data.
-    // Without a valid vtkDataArray, we don't know which ExchangeData to
-    // call. But if there's no data, nothing will actually be exchanged
-    // aside from basic communications (eg: domain2proc, MPI_Barrier),
-    // so we'll choose to call one. 
-    if (!vectors.size())
+    int nonNullDomain = 0;
+    int dataType = -1;
+    if(!vectors.empty())
     {
-        return ExchangeFloatVector(domainNum, isPointData, vectors);
+        while (nonNullDomain < domainNum.size() && vectors[nonNullDomain] == NULL)
+            nonNullDomain++;
+        dataType = vectors[nonNullDomain]->GetDataType();
     }
+
+#ifdef PARALLEL
+    // Let's get them all to agree on one data type.
+    int myDataType = dataType;
+    MPI_Allreduce(&myDataType, &dataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+#endif
+
+    if (dataType < 0)
+        return vectors;
+
     // This one's a little more complicated because there are different
     // types of vectors we might encounter. If more cases arise,
     // expand this function.
-    int nonNullDomain = 0;
-    while (nonNullDomain < domainNum.size() && vectors[nonNullDomain] == NULL)
-        nonNullDomain++;
-    switch (vectors[nonNullDomain]->GetDataType())
+    switch (dataType)
     {
         case VTK_FLOAT:
             return ExchangeFloatVector(domainNum, isPointData, vectors);
@@ -803,7 +821,7 @@ avtUnstructuredDomainBoundaries::ExchangeIntVector(vector<int>        domainNum,
 //
 //  Purpose:
 //    Exchange the ghost zone information for some materials,
-//    returning the new ones. 
+//    returning the new ones.
 //
 //  Arguments:
 //    domainNum    an array of domain numbers for each mesh
@@ -845,7 +863,7 @@ avtUnstructuredDomainBoundaries::ExchangeMaterial(vector<int>    domainNum,
 //
 //  Purpose:
 //    Exchange the ghost zone information for some materials,
-//    returning the new ones. 
+//    returning the new ones.
 //
 //  Arguments:
 //    domainNum    an array of domain numbers for each mesh
@@ -888,10 +906,10 @@ avtUnstructuredDomainBoundaries::ExchangeMixedMaterials(vector<int> domainNum,
         avtMaterial *oldMat = mats[i];
         if (oldMat == NULL)
             continue;
- 
+
         //
         // Estimate the sizes we will need for the new object.
-        // 
+        //
         int oldNCells = oldMat->GetNZones();
         int oldMixlen = oldMat->GetMixlen();
         int newNCells  = oldNCells;
@@ -962,9 +980,9 @@ avtUnstructuredDomainBoundaries::ExchangeMixedMaterials(vector<int> domainNum,
             }
         }
 
-        out[i] = new avtMaterial(oldMat->GetNMaterials(), 
-                                 oldMat->GetMaterials(), newNCells, 
-                                 new_matlist, newMixlen, new_mix_mat, 
+        out[i] = new avtMaterial(oldMat->GetNMaterials(),
+                                 oldMat->GetMaterials(), newNCells,
+                                 new_matlist, newMixlen, new_mix_mat,
                                  new_mix_next, new_mix_zone, new_mix_vf);
 
         delete [] new_matlist;
@@ -973,7 +991,7 @@ avtUnstructuredDomainBoundaries::ExchangeMixedMaterials(vector<int> domainNum,
         delete [] new_mix_zone;
         delete [] new_mix_vf;
     }
-    
+
     // Cleanup memory ... a bit of work.
     if (nGainedCells != NULL)
     {
@@ -1035,7 +1053,7 @@ avtUnstructuredDomainBoundaries::ExchangeMixedMaterials(vector<int> domainNum,
 //
 //  Purpose:
 //    Exchange the ghost zone information for some materials,
-//    returning the new ones. 
+//    returning the new ones.
 //
 //  Arguments:
 //    domainNum    an array of domain numbers for each mesh
@@ -1072,7 +1090,7 @@ avtUnstructuredDomainBoundaries::ExchangeCleanMaterials(vector<int> domainNum,
     {
         if (mats[i] == NULL)
             continue;
- 
+
         // This should never happen, but it doesn't hurt to check.
         if (mats[i]->GetMixlen() != 0)
         {
@@ -1102,11 +1120,11 @@ avtUnstructuredDomainBoundaries::ExchangeCleanMaterials(vector<int> domainNum,
     {
         if (mats[i] == NULL)
             continue;
- 
+
         int nMaterials = mats[i]->GetNMaterials();
         int nZones = result[i]->GetNumberOfTuples();
         int *matPtr = (int *)(result[i]->GetVoidPointer(0));
-        
+
         out[i] = new avtMaterial(nMaterials, mats[i]->GetMaterials(),
                                  nZones, matPtr, 0,
                                  NULL, NULL, NULL, NULL);
@@ -1114,7 +1132,7 @@ avtUnstructuredDomainBoundaries::ExchangeCleanMaterials(vector<int> domainNum,
         materialArrays[i]->Delete();
         result[i]->Delete();
     }
-    
+
     return out;
 }
 
@@ -1124,7 +1142,7 @@ avtUnstructuredDomainBoundaries::ExchangeCleanMaterials(vector<int> domainNum,
 //
 //  Purpose:
 //    Exchange the ghost zone information for some mixvars,
-//    returning the new ones. 
+//    returning the new ones.
 //
 //  Arguments:
 //    domainNum    an array of domain numbers for each mesh
@@ -1139,7 +1157,7 @@ avtUnstructuredDomainBoundaries::ExchangeCleanMaterials(vector<int> domainNum,
 //    Hank Childs, Tue Mar  4 13:29:48 PST 2008
 //    Account for domains that do not have mixed variables.
 //
-//    Kathleen Bonnell, Thu Apr 10 17:56:33 PDT 2008 
+//    Kathleen Bonnell, Thu Apr 10 17:56:33 PDT 2008
 //    Removed redefinition of 'i'.
 //
 // ****************************************************************************
@@ -1232,10 +1250,10 @@ avtUnstructuredDomainBoundaries::ExchangeMixVar(vector<int>         domainNum,
         //
         for (int j = 0 ; j < nTotalDomains ; j++)
         {
-            memcpy(new_buff+mixlen_cnt, vals[j][domainNum[i]], 
+            memcpy(new_buff+mixlen_cnt, vals[j][domainNum[i]],
                    sizeof(float)*nGainedMixlen[j][domainNum[i]]);
             mixlen_cnt += nGainedMixlen[j][domainNum[i]];
-        }          
+        }
 
         out[i] = new avtMixedVariable(new_buff, newMixlen,mixvarname);
         delete [] new_buff;
@@ -1349,19 +1367,19 @@ avtUnstructuredDomainBoundaries::ConfirmMesh(vector<int>       domainNum,
             meshes[j]->GetPoint(d2ptId, pt2);
 
             const double epsilon = 1e-12;
-            
+
             // If these points are too dis-similar, it has to be
             // referring another mesh.
             if (fabs(pt1[0] - pt2[0]) + fabs(pt1[1] - pt2[1])
                                       + fabs(pt1[2] - pt2[2]) > epsilon)
                 return false;
-            
+
             // If we reached this point, then we've tested this pair of
             // domains.
             break;
         }
     }
-    
+
     return true;
 }
 
@@ -1387,7 +1405,7 @@ avtUnstructuredDomainBoundaries::ConfirmMesh(vector<int>       domainNum,
 //    Brad Whitlock, Thu Sep 16 12:58:27 PDT 2004
 //    I added conditionally compiled code to work around an apparent template
 //    instantiation bug that in the MSVC6.0 compiler that prevented VisIt
-//    from building on Windows. I added an argument to contribute to the 
+//    from building on Windows. I added an argument to contribute to the
 //    method signature and the contents of CommunicateDataInformation,
 //    which had to be inlined to get it to compile on Windows.
 //
@@ -1434,7 +1452,7 @@ avtUnstructuredDomainBoundaries::ExchangeData(vector<int>         &domainNum,
 
         out[i]->DeepCopy(data[i]);
         out[i]->SetName(data[i]->GetName());
-        
+
         int sendDom;
 
         int nGivenTuples = 0;
@@ -1445,7 +1463,7 @@ avtUnstructuredDomainBoundaries::ExchangeData(vector<int>         &domainNum,
 
             nGivenTuples += nGainedTuples[sendDom][recvDom];
         }
-        
+
         if (nGivenTuples > 0)
         {
             out[i]->Resize(nGivenTuples + out[i]->GetNumberOfTuples());
@@ -1628,7 +1646,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
     nPointsPerCell = new int **[nTotalDomains];
 
     vtkIdList *idList = vtkIdList::New();
-    
+
     for (int sendDom = 0; sendDom < nTotalDomains; ++sendDom)
     {
         gainedPoints[sendDom] = new T*[nTotalDomains];
@@ -1650,7 +1668,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
 
             nGainedPoints[sendDom][recvDom] = 0;
             nGainedCells[sendDom][recvDom] = 0;
-            
+
             // Cases where no computation is required.
             if (sendDom == recvDom)
                 continue;
@@ -1665,9 +1683,9 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 for (i = 0; i < domainNum.size(); ++i)
                     if (domainNum[i] == sendDom)
                         break;
-                
+
                 vtkUnstructuredGrid *givingUg = (vtkUnstructuredGrid*)meshes[i];
-                
+
                 int index = GetGivenIndex(sendDom, recvDom);
 
                 // If no domain boundary, then there's no work to do.
@@ -1676,7 +1694,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
 
                 size_t nPts = givenPoints[index].size();
                 nGainedPoints[sendDom][recvDom] += (int) nPts;
-                
+
                 gainedPoints[sendDom][recvDom] = new T[nPts * 3];
                 origPointIds[sendDom][recvDom] = new int[nPts];
 
@@ -1687,7 +1705,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 for (i = 0; i < nPts; ++i)
                 {
                     *(origIdPtr++) = givenPoints[index][i];
-                    
+
                     T *ptPtr = fromPtr + 3 * givenPoints[index][i];
                     *(gainedPtr++) = *(ptPtr++);
                     *(gainedPtr++) = *(ptPtr++);
@@ -1702,8 +1720,8 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 nPointsPerCell[sendDom][recvDom] = new int[nCells];
 
                 int *cellPtr = cellTypes[sendDom][recvDom];
-                int **cellPtsPtr = cellPoints[sendDom][recvDom]; 
-                int *nPtsPerCellPtr = nPointsPerCell[sendDom][recvDom]; 
+                int **cellPtsPtr = cellPoints[sendDom][recvDom];
+                int *nPtsPerCellPtr = nPointsPerCell[sendDom][recvDom];
 
                 for (i = 0; i < nCells; ++i)
                 {
@@ -1734,7 +1752,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
 
                 if (nPts == 0)
                     continue;
-                
+
                 nGainedPoints[sendDom][recvDom] += nPts;
                 gainedPoints[sendDom][recvDom] = new T[nPts * 3];
                 origPointIds[sendDom][recvDom] = new int[nPts];
@@ -1751,9 +1769,9 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 int nCells;
                 MPI_Recv(&nCells, 1, MPI_INT, fRank,
                          mpiNumGivenCellsTag, VISIT_MPI_COMM, &stat);
-                
+
                 nGainedCells[sendDom][recvDom] += nCells;
-                
+
                 cellTypes[sendDom][recvDom] = new int[nCells];
                 cellPoints[sendDom][recvDom] = new int *[nCells];
                 nPointsPerCell[sendDom][recvDom] = new int[nCells];
@@ -1771,7 +1789,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 int pntArrSize = 0;
                 for (k = 0; k < nCells; ++k)
                 {
-                    cellPoints[sendDom][recvDom][k] = 
+                    cellPoints[sendDom][recvDom][k] =
                                 new int [nPointsPerCell[sendDom][recvDom][k]];
                     pntArrSize += nPointsPerCell[sendDom][recvDom][k];
                 }
@@ -1797,8 +1815,8 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 MPI_Datatype type = GetMPIDataType<T>();
                 int tRank = domain2proc[recvDom];
 
-                int index = GetGivenIndex(sendDom, recvDom); 
-                
+                int index = GetGivenIndex(sendDom, recvDom);
+
                 // If no domain boundary, send 0 for nPts, and continue
                 // Also continue if there are no given points.
                 if (index < 0 || givenPoints[index].size() == 0)
@@ -1830,7 +1848,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 for (k = 0; k < nPts; ++k)
                 {
                     *(origIdPtr++) = givenPoints[index][k];
-                    
+
                     T *ptPtr = fromPtr + 3 * givenPoints[index][k];
                     *(gainedPtr++) = *(ptPtr++);
                     *(gainedPtr++) = *(ptPtr++);
@@ -1838,21 +1856,21 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                 }
 
                 // Send the number of points given
-                MPI_Send(&nPts, 1, MPI_INT, tRank, mpiNPtsTag, VISIT_MPI_COMM); 
-                
+                MPI_Send(&nPts, 1, MPI_INT, tRank, mpiNPtsTag, VISIT_MPI_COMM);
+
                 // Send the gained points
-                MPI_Send(gainedPtrStart, nPts * 3, type, tRank, 
+                MPI_Send(gainedPtrStart, nPts * 3, type, tRank,
                          mpiGainedPointsTag, VISIT_MPI_COMM);
-                
+
                 // Send the original ids for the gained points
-                MPI_Send(origIdPtrStart, nPts, MPI_INT, tRank, 
+                MPI_Send(origIdPtrStart, nPts, MPI_INT, tRank,
                          mpiOriginalIdsTag, VISIT_MPI_COMM);
 
                 // Send the number of given cells
                 int nCells = (int)givenCells[index].size();
-                MPI_Send(&nCells, 1, MPI_INT, tRank, mpiNumGivenCellsTag, 
+                MPI_Send(&nCells, 1, MPI_INT, tRank, mpiNumGivenCellsTag,
                          VISIT_MPI_COMM);
-                
+
                 // Prepare for sending the cell info
                 int *cellPtr = new int[nCells];
                 vector<int> cellPtsVector;
@@ -1869,8 +1887,8 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
                     for (int k = 0; k < nPts; ++k)
                         cellPtsVector.push_back(idList->GetId(k));
                 }
-                
-                
+
+
                 // Send the cell types
                 MPI_Send(cellPtr, nCells, MPI_INT, tRank, mpiCellTypesTag,
                     VISIT_MPI_COMM);
@@ -1905,7 +1923,7 @@ avtUnstructuredDomainBoundaries::CommunicateMeshInformation(
 //  Method:  avtUnstructuredDomainBoundaries::CommunicateMixvarInformation
 //
 //  Purpose:
-//    Send and collect information needed to exchange mixed variables. 
+//    Send and collect information needed to exchange mixed variables.
 //
 //  Notes:
 //    Returned arguments should be passed in as uninitialized pointers.
@@ -1979,7 +1997,7 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
                 for (i = 0 ; i < domainNum.size() ; i++)
                     if (domainNum[i] == sendDom)
                         break;
-                
+
                 int index = GetGivenIndex(sendDom, recvDom);
 
                 // If no domain boundary, then there's no work to do.
@@ -1987,7 +2005,7 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
                     continue;
 
                 avtMixedVariable *givingVar = mixvars[i];
-                
+
                 size_t nCells = givenCells[index].size();
 
                 // Assess the amount of mix in cells along the boundary.
@@ -2017,7 +2035,7 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
                     if (nmats >= 1000)
                     {
                         char str[1024];
-                        snprintf(str, 1024, 
+                        snprintf(str, 1024,
                                 "The mixed material entry for cell %d "
                                 "of domain %d appears to be invalid.  Unable "
                                 "to proceed.", givenCells[index][i], sendDom);
@@ -2063,7 +2081,7 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
 
                 if (amt == 0)
                     continue;
-                
+
                 mixGained[sendDom][recvDom] = amt;
                 vals[sendDom][recvDom] = new float[amt];
                 // Get the gained materials
@@ -2073,11 +2091,11 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
             // If this process owns the sending domain, we send information.
             else if (domain2proc[sendDom] == rank)
             {
-                
+
                 int tRank = domain2proc[recvDom];
 
-                int index = GetGivenIndex(sendDom, recvDom); 
-                
+                int index = GetGivenIndex(sendDom, recvDom);
+
                 // If no domain boundary, send 0 for nPts, and continue
                 // Also continue if there are no given points.
                 int amt = 0;
@@ -2092,7 +2110,7 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
                         break;
 
                 avtMixedVariable *givingVar = mixvars[i];
-                
+
                 size_t nCells = givenCells[index].size();
 
                 // Assess the amount of mix in cells along the boundary.
@@ -2122,7 +2140,7 @@ avtUnstructuredDomainBoundaries::CommunicateMixvarInformation(
                     if (nmats >= 1000)
                     {
                         char str[1024];
-                        snprintf(str, 1024, 
+                        snprintf(str, 1024,
                                 "The mixed material entry for cell %d "
                                 "of domain %d appears to be invalid.  Unable "
                                 "to proceed.", givenCells[index][i], sendDom);
@@ -2212,7 +2230,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                                  const vector<int> &domainNum,
                                  const vector<avtMaterial *> &mats,
                                  int **&nGainedCells, int **&nGainedMixlen,
-                                 int ***&gainedMatlist, int ***&gainedMixmat, 
+                                 int ***&gainedMatlist, int ***&gainedMixmat,
                                  float ***&gainedMixvf)
 {
     // Get the processor rank
@@ -2247,7 +2265,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
             gainedMatlist[sendDom][recvDom] = NULL;
             gainedMixmat[sendDom][recvDom]  = NULL;
             gainedMixvf[sendDom][recvDom] = NULL;
-            
+
             nGainedCells[sendDom][recvDom]  = 0;
             nGainedMixlen[sendDom][recvDom] = 0;
 
@@ -2266,7 +2284,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                 for (i = 0 ; i < domainNum.size() ; i++)
                     if (domainNum[i] == sendDom)
                         break;
-                
+
                 int index = GetGivenIndex(sendDom, recvDom);
 
                 // If no domain boundary, then there's no work to do.
@@ -2274,7 +2292,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                     continue;
 
                 avtMaterial *givingMat = mats[i];
-                
+
                 size_t nCells = givenCells[index].size();
                 nGainedCells[sendDom][recvDom] = (int)nCells;
 
@@ -2299,7 +2317,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                     if (nmats >= 1000)
                     {
                         char str[1024];
-                        snprintf(str, 1024, 
+                        snprintf(str, 1024,
                                 "The mixed material entry for cell %d "
                                 "of domain %d appears to be invalid.  Unable "
                                 "to proceed.", givenCells[index][i], sendDom);
@@ -2307,7 +2325,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                     }
                 }
                 nGainedMixlen[sendDom][recvDom] = nMixlen;
-                
+
                 gainedMatlist[sendDom][recvDom] = new int[nCells];
                 gainedMixmat[sendDom][recvDom]  = new int[nMixlen];
                 gainedMixvf[sendDom][recvDom]   = new float[nMixlen];
@@ -2362,7 +2380,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
 
                 if (amt[0] == 0 && amt[1] == 0)
                     continue;
-                
+
                 nGainedCells[sendDom][recvDom]  += amt[0];
                 nGainedMixlen[sendDom][recvDom] += amt[1];
 
@@ -2388,8 +2406,8 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
 
                 int tRank = domain2proc[recvDom];
 
-                int index = GetGivenIndex(sendDom, recvDom); 
-                
+                int index = GetGivenIndex(sendDom, recvDom);
+
                 // If no domain boundary, send 0 for nPts, and continue
                 // Also continue if there are no given points.
                 int amt[2] = { 0, 0 };
@@ -2398,15 +2416,15 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                     MPI_Send(amt, 2, MPI_INT,tRank,mpiNDataTag,VISIT_MPI_COMM);
                     continue;
                 }
-                
+
                 int i = 0;
-                
+
                 for (i = 0; i < (int)domainNum.size(); ++i)
                     if (domainNum[i] == sendDom)
                         break;
 
                 avtMaterial *givingMat = mats[i];
-                
+
                 int nCells = (int)givenCells[index].size();
                 nGainedCells[sendDom][recvDom] = nCells;
 
@@ -2431,7 +2449,7 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                     if (nmats >= 1000)
                     {
                         char str[1024];
-                        snprintf(str, 1024, 
+                        snprintf(str, 1024,
                                 "The mixed material entry for cell %d "
                                 "of domain %d appears to be invalid.  Unable "
                                 "to proceed.", givenCells[index][i], sendDom);
@@ -2439,11 +2457,11 @@ avtUnstructuredDomainBoundaries::CommunicateMaterialInformation(
                     }
                 }
                 nGainedMixlen[sendDom][recvDom] = nMixlen;
-                
+
                 amt[0] = nCells;
                 amt[1] = nMixlen;
                 MPI_Send(amt, 2, MPI_INT,tRank,mpiNDataTag,VISIT_MPI_COMM);
-              
+
                 int   *givenMatlist = new int[nCells];
                 int   *givenMixmat  = new int[nMixlen];
                 float *givenMixvf   = new float[nMixlen];
@@ -2599,7 +2617,7 @@ avtUnstructuredDomainBoundaries::CommunicateDataInformation(
             // calculation: no communication needed
             if (domain2proc[sendDom] == rank && domain2proc[recvDom] == rank)
             {
-                size_t i = 0; 
+                size_t i = 0;
                 for (i = 0; i < domainNum.size(); ++i)
                     if (domainNum[i] == sendDom)
                         break;
@@ -2610,14 +2628,14 @@ avtUnstructuredDomainBoundaries::CommunicateDataInformation(
                 if (index < 0)
                     continue;
 
-                vector<int> &mapRef = isPointData ? givenPoints[index] 
+                vector<int> &mapRef = isPointData ? givenPoints[index]
                                                   : givenCells[index];
-                
+
                 int nTuples =(int) mapRef.size();
                 nGainedTuples[sendDom][recvDom] = nTuples;
 
                 gainedData[sendDom][recvDom] = new T[nTuples * nComponents];
-                
+
                 T * origPtr = (T*)(data[i]->GetVoidPointer(0));
                 T * dataPtr = gainedData[sendDom][recvDom];
 
@@ -2645,7 +2663,7 @@ avtUnstructuredDomainBoundaries::CommunicateDataInformation(
                 int nTup;
                 MPI_Recv(&nTup, 1, MPI_INT, fRank, mpiNumTuplesTag,
                          VISIT_MPI_COMM, &stat);
-                
+
                 if (nTup == 0)
                     continue;
 
@@ -2711,7 +2729,7 @@ avtUnstructuredDomainBoundaries::CommunicateDataInformation(
 
                 delete [] dataArr;
             }
-#endif 
+#endif
         }
     }
 

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -603,6 +603,9 @@ avtUnstructuredDomainBoundaries::ExchangeMeshT(vector<int>       domainNum,
 //    Kathleen Biagas, Thu Oct 31, 2024
 //    Ensure all procs are calling the same Exchange function.
 //
+//    Kathleen Biagas, Fri Nov 1, 2024
+//    Added consistency check for dataTypes.
+///
 // ****************************************************************************
 
 vector<vtkDataArray*>
@@ -619,19 +622,27 @@ avtUnstructuredDomainBoundaries::ExchangeScalar(vector<int>         domainNum,
         dataType = scalars[nonNullDomain]->GetDataType();
     }
 
+    int maxDataType = dataType;
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
-    int myDataType = dataType;
-    MPI_Allreduce(&myDataType, &dataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
 #endif
 
-    if (dataType < 0)
+    if (maxDataType < 0)
         return scalars;
+
+    if(dataType != maxDataType)
+    {
+        // This should never happen, so throw the exception.
+        EXCEPTION1(VisItException,
+                   "avtUnstructuredDomainBoundaries:ExchangeScalar "
+                   "vtkDatArray data types do not match.");
+    }
 
     // This one's a little more complicated because there are different
     // types of scalars we might encounter. If more cases arise,
     // expand this function.
-    switch (dataType)
+    switch (maxDataType)
     {
         case VTK_INT:
             return ExchangeData_int(domainNum, isPointData, scalars);
@@ -677,6 +688,9 @@ avtUnstructuredDomainBoundaries::ExchangeScalar(vector<int>         domainNum,
 //    Kathleen Biagas, Thu Oct 31, 2024
 //    Ensure all procs are calling the same Exchange function.
 //
+//    Kathleen Biagas, Fri Nov 1, 2024
+//    Added consistency check for dataTypes.
+///
 // ****************************************************************************
 
 vector<vtkDataArray*>
@@ -691,19 +705,27 @@ avtUnstructuredDomainBoundaries::ExchangeVector(vector<int> domainNum, bool isPo
         dataType = vectors[nonNullDomain]->GetDataType();
     }
 
+    int maxDataType = dataType;
 #ifdef PARALLEL
     // Let's get them all to agree on one data type.
-    int myDataType = dataType;
-    MPI_Allreduce(&myDataType, &dataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
+    MPI_Allreduce(&dataType, &maxDataType, 1, MPI_INT, MPI_MAX, VISIT_MPI_COMM);
 #endif
 
-    if (dataType < 0)
+    if (maxDataType < 0)
         return vectors;
+
+    if(dataType != maxDataType)
+    {
+        // This should never happen, so throw the exception.
+        EXCEPTION1(VisItException,
+                   "avtUnstructuredDomainBoundaries:ExchangeVector "
+                   "vtkDatArray data types do not match.");
+    }
 
     // This one's a little more complicated because there are different
     // types of vectors we might encounter. If more cases arise,
     // expand this function.
-    switch (dataType)
+    switch (maxDataType)
     {
         case VTK_FLOAT:
             return ExchangeFloatVector(domainNum, isPointData, vectors);

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -631,7 +631,7 @@ avtUnstructuredDomainBoundaries::ExchangeScalar(vector<int>         domainNum,
     if (maxDataType < 0)
         return scalars;
 
-    if(dataType != maxDataType)
+    if((dataType >= 0) && (dataType != maxDataType))
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,
@@ -714,7 +714,7 @@ avtUnstructuredDomainBoundaries::ExchangeVector(vector<int> domainNum, bool isPo
     if (maxDataType < 0)
         return vectors;
 
-    if(dataType != maxDataType)
+    if((dataType >= 0) && (dataType != maxDataType))
     {
         // This should never happen, so throw the exception.
         EXCEPTION1(VisItException,


### PR DESCRIPTION
### Description

Ensure all procs are calling the same Exchange function based on dataType that they get from an MPI_Allreduce. 
This fixes problems in parallel (segv/hang) when avtExtraGhostNodes/Zones are exchanged, because the proc with data was calling Exchange_uchar but the proc without data was calling Exchange_float.

Modified avtGenericDatabase to ensure all procs participate in the exchange of avtExtraGhostNodes/Zones as originally intended.


Resolves #19988

Also performed whitespace cleanup in the files touched.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I ran the simple example in the bug ticket without a hang, and I ran the mili.py regression test in parallel mode with success.

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
