### PR TITLE
Fix pick by zone label failure related to new mili db enhancements

### DIFF
--- a/src/avt/Queries/Pick/avtPickByNodeQuery.C
+++ b/src/avt/Queries/Pick/avtPickByNodeQuery.C
@@ -191,7 +191,7 @@ avtPickByNodeQuery::Execute(vtkDataSet *ds, const int dom)
     } 
 
     bool DBsuppliedNodeId = true;
-    if (!pickAtts.GetMatSelected() && ghostType != AVT_CREATED_GHOSTS)
+    if (!pickAtts.GetMatSelected() && (ghostType != AVT_CREATED_GHOSTS || pickByLabel))
     {
         if (pickAtts.GetElementIsGlobal() && !pickByLabel)
         {

--- a/src/avt/Queries/Pick/avtPickByNodeQuery.C
+++ b/src/avt/Queries/Pick/avtPickByNodeQuery.C
@@ -117,6 +117,11 @@ avtPickByNodeQuery::~avtPickByNodeQuery()
 //    Alister Maguire, Thu Jul 15 14:38:13 PDT 2021
 //    If we were unable to retrieve variable information from the database,
 //    query the current dataset.
+// 
+//    Justin Privitera, Thu Oct 31 17:26:42 PDT 2024
+//    Allow pickByLabel to be a get out of jail free card if you have created
+//    ghosts. Mili now creates ghosts so we need another way for pick to 
+//    pass through the same logic as before.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Pick/avtPickByZoneQuery.C
+++ b/src/avt/Queries/Pick/avtPickByZoneQuery.C
@@ -123,6 +123,11 @@ avtPickByZoneQuery::~avtPickByZoneQuery()
 //    Alister Maguire, Thu Jul 15 14:38:13 PDT 2021
 //    If we were unable to retrieve variable information from the database,
 //    query the current dataset.
+// 
+//    Justin Privitera, Thu Oct 31 17:26:42 PDT 2024
+//    Allow pickByLabel to be a get out of jail free card if you have created
+//    ghosts. Mili now creates ghosts so we need another way for pick to 
+//    pass through the same logic as before.
 //
 // ****************************************************************************
 

--- a/src/avt/Queries/Pick/avtPickByZoneQuery.C
+++ b/src/avt/Queries/Pick/avtPickByZoneQuery.C
@@ -204,7 +204,7 @@ avtPickByZoneQuery::Execute(vtkDataSet *ds, const int dom)
     }
 
     bool DBsuppliedZoneId = true;
-    if (!pickAtts.GetMatSelected() && ghostType != AVT_CREATED_GHOSTS)
+    if (!pickAtts.GetMatSelected() && (ghostType != AVT_CREATED_GHOSTS || pickByLabel))
     {
         if (pickAtts.GetElementIsGlobal() && !pickByLabel)
         {

--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -3302,7 +3302,6 @@ avtMiliFileFormat::GetAuxiliaryData(const char *varName,
     }
     else if (strcmp(auxType, AUXILIARY_DATA_GLOBAL_NODE_IDS) == 0)
     {
-        return NULL;
         const char *mesh = varName;
         //
         // The valid meshnames are meshX or sand_meshX, where X is an int > 0.

--- a/src/databases/Mili/avtMiliFileFormat.C
+++ b/src/databases/Mili/avtMiliFileFormat.C
@@ -3302,6 +3302,7 @@ avtMiliFileFormat::GetAuxiliaryData(const char *varName,
     }
     else if (strcmp(auxType, AUXILIARY_DATA_GLOBAL_NODE_IDS) == 0)
     {
+        return NULL;
         const char *mesh = varName;
         //
         // The valid meshnames are meshX or sand_meshX, where X is an int > 0.


### PR DESCRIPTION
### Description

Fix the test failure caused by pick by zone tests.
Pick by zone asks if you haven't created ghosts. The mili plugin now does end up creating ghosts, so we go down a different path and the tests fail. We relax the condition so that the mili case can move through as before.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Ran all tests that use pick by zone and pick by node
```
databases/samrai.py 
meshtype/emptydomains.py 
queries/consistencyChecks.py 
queries/pick.py 
queries/pickNamedArgs.py 
queries/queriesOverTime.py 
queries/queryMultiWindow.py 
quickrecipes/quantitative_operations.py 
expressions/tensor_expr.py 
hybrid/missingdata.py 
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
