### PR TITLE
Update some rendering/volume_rect_singleDomain mode specific baselines.

### DIFF
--- a/test/baseline/rendering/volume_rect_singleDomain/parallel/volume_16.png
+++ b/test/baseline/rendering/volume_rect_singleDomain/parallel/volume_16.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41210eba64838237b548c20f0fc98e974f25d83996bcdee328609eafb3bf0dce
-size 59863
+oid sha256:9faafa197715893522d9da58a181438f0d4fa2d0665c90fc26df8ab02213886e
+size 59865

--- a/test/baseline/rendering/volume_rect_singleDomain/scalable_parallel_icet/volume_16.png
+++ b/test/baseline/rendering/volume_rect_singleDomain/scalable_parallel_icet/volume_16.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41210eba64838237b548c20f0fc98e974f25d83996bcdee328609eafb3bf0dce
-size 59863
+oid sha256:9faafa197715893522d9da58a181438f0d4fa2d0665c90fc26df8ab02213886e
+size 59865


### PR DESCRIPTION
### Description

I updated a couple of mode specific baselines from `rendering/volume_rect_singleDomain.py` that had a few imperceptible pixel differences.

### Type of change

* [X] Other - Update test suite baseline images

### How Has This Been Tested?

I copied the test results directly from last nights test suite run. I verified that the new images looked as expected.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
