### PR TITLE
Modify the internallauncher so that it doesn't create core files on non-AMD systems. (#19996)

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -2725,12 +2725,23 @@ class MainLauncher(object):
                  "/opt/rocm-6.1.0/lib/llvm/bin/offload-arch"]
 
         gpu_arch = None
-        for file in files:
-            if os.path.exists(file):
-                p = subprocess.run(file, capture_output=True, text=True)
-                if p.stdout != "":
-                    gpu_arch = p.stdout.rstrip()
-                break
+
+        # Assume we are on an AMD system if lspci displays any AMD devices.
+        have_amd = False
+        if os.path.exists("/usr/sbin/lspci"):
+            p = subprocess.run("/usr/sbin/lspci", capture_output=True, text=True)
+            if "amd" in p.stdout.lower():
+                have_amd =  True
+
+        # If we are on an AMD system, use offload-arch to determine the
+        # GPU architecture.
+        if have_amd:
+            for file in files:
+                if os.path.exists(file):
+                    p = subprocess.run(file, capture_output=True, text=True)
+                    if p.stdout != "":
+                        gpu_arch = p.stdout.rstrip()
+                    break
 
         return gpu_arch
 


### PR DESCRIPTION
Merge from the 3.4RC to develop.

### Description

Resolves #19992

The `internallauncher` script uses `offload-arch` to determine the AMD GPU architecture. Unfortunately this utility can exist on non-AMD systems and cores when run on them. I added additional logic to prevent the script from running `offload-arch` on non-AMD systems.

I didn't update the release notes since this feature was just added and has not been in a release.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built and installed VisIt on `poodle`, which is a non-AMD system. I ran VisIt from the installation and verified that it properly identified the system type and didn't produce any core files. The system type in this case was `linux-x86_64`.

I built and installed VisIt on `rzvernal`, which is an AMD system with MI250X GPUs. I ran VisIt from the installation and verified that it properly identified the system type and didn't produce any core files. The system type in this case was `linux-x86_64-gfx90a`.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
