### PR TITLE
Fix some syntax error in build_visit.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -433,15 +433,12 @@ function initialize_build_visit()
             C_OPT_FLAGS="$C_OPT_FLAGS -O2"
             CXXFLAGS="$CXXFLAGS -fPIC"
             CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-            fi
         elif [[ "$(uname -m)" == "aarch64" ]] ; then
             CFLAGS="$CFLAGS -fPIC"
             FCFLAGS="$FCFLAGS -fPIC"
             C_OPT_FLAGS="$C_OPT_FLAGS -O2"
-            fi
             CXXFLAGS="$CXXFLAGS -fPIC"
             CXX_OPT_FLAGS="$CXX_OPT_FLAGS -O2"
-            fi
             QT_PLATFORM="linux-aarch64-gnu-g++"
         fi
         export C_COMPILER=${C_COMPILER:-"gcc"}


### PR DESCRIPTION
### Description

I ran `build_visit` and got some error regarding mismatched `fi` statements. This fixes them. Here is the output.
```
src/tools/dev/scripts/build_visit --write-unified-file build_visit3_4_2
src/tools/dev/scripts/bv_support//bv_main.sh: line 444: syntax error near unexpected token `fi'
src/tools/dev/scripts/bv_support//bv_main.sh: line 444: `            fi'
Processing bsd license.
Warning visit3.4.1.tar.gz doesn't exist, not adding checksums for VisIt.
Writing to File: build_visit3_4_2
```

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I used `build_visit` with the following output.
```
src/tools/dev/scripts/build_visit --write-unified-file build_visit3_4_2
Processing bsd license.
Warning visit3.4.1.tar.gz doesn't exist, not adding checksums for VisIt.
Writing to File: build_visit3_4_2
```

I then used the resulting `build_visit3_4_2` to build on `tuolumne`.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
