### PR TITLE
Add a timestamp of the start of the test run to the test suite script.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_poodle
+++ b/src/tools/dev/scripts/regressiontest_poodle
@@ -381,6 +381,8 @@ rm -f runit_${testHost}
 cat <<EOF > runit_${testHost}
 #!/bin/sh
 
+echo "Test run started at: \`date\`"
+
 # So the script uses the correct git.
 export PATH=/usr/tce/bin:$PATH
 


### PR DESCRIPTION
### Description

I enhanced the regression suite script to timestamp the start of the execution of the batch job so that issues with jobs not getting started in a timely fashion can be tracked.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I reviewed the one line change it looks good.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
