### PR TITLE
Add missing py src to trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ pr:
     - '**/*.h'
     - 'data/silo*'
     - 'data/blueprint*'
+    - 'src/test/py_src/*.py'
     - 'src/test/tests/databases/silo.py'
     - 'src/test/tests/databases/blueprint.py'
     - 'src/test/tests/databases/blueprint_export.py'


### PR DESCRIPTION
Looks like I neglected to include the `.py` src used to actually run tests in the CI trigger.
