### PR TITLE
Increase the save image width and height.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,9 @@
 #    Kathleen Biagas, Mon Sep 30, 2024
 #    Add build/install scripts from scripts directory to visit-dist target.
 #
+#    Eric Brugger, Wed Nov 13 13:39:08 PST 2024
+#    Increase the rendering size limit from 16384 to 32768.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
@@ -690,13 +693,13 @@ else()
     endif()
 endif()
 
-# Set the rendering size limit to 16384 so that we are not unnecessarily
+# Set the rendering size limit to 32768 so that we are not unnecessarily
 # constraining the user. There is no way to set this properly since this
 # is used in the viewer and the limit really comes from the engine, which
 # may have a different size if running client/server. This setting should
 # be removed and a runtime check should be added to the engine.
-message(STATUS "Setting VISIT_RENDERING_SIZE_LIMIT to 16384")
-set(VISIT_RENDERING_SIZE_LIMIT 16384 CACHE INTERNAL "rendering size limit")
+message(STATUS "Setting VISIT_RENDERING_SIZE_LIMIT to 32768")
+set(VISIT_RENDERING_SIZE_LIMIT 32768 CACHE INTERNAL "rendering size limit")
 
 configure_file(${VISIT_SOURCE_DIR}/include/visit-cmake.h.in
                ${VISIT_BINARY_DIR}/include/visit-config.h @ONLY IMMEDIATE)

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -82,7 +82,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added the ability to skip the remote host validity check when using a gateway. This allows VisIt to work with gateways that are transparently handled by <code>ssh</code>. The check can now be bypassed by checking "Use gateway" and leaving the gateway name blank in the host profile for the remote system.</li>
   <li>Added support for MFEM Wedge (aka Prism) Meshes.</li>
   <li>Added new global mesh expressions: global_avg(), global_max(), global_min(), global_rms(), global_std_dev(), global_sum(), and global_variance(). These are expressions that calculate statistics across the mesh and the result is a constant variable that contains the result. So, global_max(d) produces a new variable that is the maximum of d at every zone or node across the mesh.</li>
-  <li>The maximum image size that can be saved has been increased to a maximum of 32,768 for either the width or height with a total pixel count not to exceed 536,870,912 pixels. For a square image that corresponds to an image size of 23,170 by 23,170 or less. For a rectangular image that corresponds to an image size of 32,768 by 16,384 or less.</li>
+  <li>The maximum image size that can be saved has been increased to a maximum of 32,768 for either the width or height with a total pixel count not to exceed 536,756,224 pixels. For a square image that corresponds to an image size of 23,170 by 23,168 or less. For a rectangular image that corresponds to an image size of 32,768 by 16,380 or less.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -82,6 +82,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added the ability to skip the remote host validity check when using a gateway. This allows VisIt to work with gateways that are transparently handled by <code>ssh</code>. The check can now be bypassed by checking "Use gateway" and leaving the gateway name blank in the host profile for the remote system.</li>
   <li>Added support for MFEM Wedge (aka Prism) Meshes.</li>
   <li>Added new global mesh expressions: global_avg(), global_max(), global_min(), global_rms(), global_std_dev(), global_sum(), and global_variance(). These are expressions that calculate statistics across the mesh and the result is a constant variable that contains the result. So, global_max(d) produces a new variable that is the maximum of d at every zone or node across the mesh.</li>
+  <li>The maximum image size that can be saved has been increased to a maximum of 32,768 for either the width or height with a total pixel count not to exceed 536,870,912 pixels. For a square image that corresponds to an image size of 23,170 by 23,170 or less. For a rectangular image that corresponds to an image size of 32,768 by 16,384 or less.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -201,7 +201,7 @@ EOF
     #
     # Patch to increase the maximum image size in the llvmpipe
     # driver to 32K x 32K. There are 2 changes. The first is to
-    # the number of 2D levels to 16 (2^(16-1) = 32K. The second is
+    # the number of 2D levels to 16 (2^(16-1)) = 32K. The second is
     # to the maximum texture size - 32768 x 32768 is the maximum
     # number of pixels, the 4 is 4 bytes per pixel, and the 2 is from
     # the fact that a texture can actually store a multi-resolution

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -200,29 +200,30 @@ EOF
 
     #
     # Patch to increase the maximum image size in the llvmpipe
-    # driver to 16K x 16K.
+    # driver to 32K x 32K. There are 2 changes. The first is to
+    # the number of 2D to 16 (2^(16-1) = 32K. The second is to
+    # the maximum texture size - 32768 x 32768 is maximum number
+    # of pixels, the 4 is 4 bytes per pixel, and the 2 is from
+    # the fact that a texture can actually store a multi-resolution
+    # representation of the image. For example if the image size
+    # is 256x256, it has storage for textures of size 256x256,
+    # 128x128, 64x64, 32x32, 16x16, 8x8, 4x4, 2x2 and 1x1.
     #
     patch -p0 << \EOF
-diff -c src/gallium/drivers/llvmpipe/lp_limits.h.orig src/gallium/drivers/llvmpipe/lp_limits.h
-*** src/gallium/drivers/llvmpipe/lp_limits.h.orig       Fri Jul 30 10:03:06 2021
---- src/gallium/drivers/llvmpipe/lp_limits.h    Fri Jul 30 10:04:41 2021
-***************
-*** 44,50 ****
-   * Max texture sizes
-   */
-  #define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
-! #define LP_MAX_TEXTURE_2D_LEVELS 14  /* 8K x 8K for now */
-  #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
-  #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
-  #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
---- 44,50 ----
-   * Max texture sizes
-   */
-  #define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
-! #define LP_MAX_TEXTURE_2D_LEVELS 15  /* 16K x 16K for now */
-  #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
-  #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
-  #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
+diff -u src/gallium/drivers/llvmpipe/lp_limits.h.orig src/gallium/drivers/llvmpipe/lp_limits.h
+--- src/gallium/drivers/llvmpipe/lp_limits.h.orig	2018-04-18 01:44:00.000000000 -0700
++++ src/gallium/drivers/llvmpipe/lp_limits.h	2024-11-13 13:47:04.388202316 -0800
+@@ -43,8 +43,8 @@
+ /**
+  * Max texture sizes
+  */
+-#define LP_MAX_TEXTURE_SIZE (1 * 1024 * 1024 * 1024ULL)  /* 1GB for now */
+-#define LP_MAX_TEXTURE_2D_LEVELS 14  /* 8K x 8K for now */
++#define LP_MAX_TEXTURE_SIZE (2 * 4 * 32768 * 32768ULL)  /* 8GB for now */
++#define LP_MAX_TEXTURE_2D_LEVELS 16  /* 32K x 32K for now */
+ #define LP_MAX_TEXTURE_3D_LEVELS 12  /* 2K x 2K x 2K for now */
+ #define LP_MAX_TEXTURE_CUBE_LEVELS 14  /* 8K x 8K for now */
+ #define LP_MAX_TEXTURE_ARRAY_LAYERS 512 /* 8K x 512 / 8K x 8K x 512 */
 EOF
     if [[ $? != 0 ]] ; then
         warn "MesaGL patch 4 failed."
@@ -234,26 +235,24 @@ EOF
     # driver. This is required for large image sizes.
     #
     patch -p0 << \EOF
-diff -c src/gallium/drivers/llvmpipe/lp_scene.h.orig src/gallium/drivers/llvmpipe/lp_scene.h
-*** src/gallium/drivers/llvmpipe/lp_scene.h.orig        Fri Jul 30 12:11:39 2021
---- src/gallium/drivers/llvmpipe/lp_scene.h     Fri Jul 30 12:11:49 2021
-***************
-*** 60,66 ****
-  
-  /* Scene temporary storage is clamped to this size:
-   */
-! #define LP_SCENE_MAX_SIZE (9*1024*1024)
-  
-  /* The maximum amount of texture storage referenced by a scene is
-   * clamped to this size:
---- 60,66 ----
-  
-  /* Scene temporary storage is clamped to this size:
-   */
-! #define LP_SCENE_MAX_SIZE (64*1024*1024)
-  
-  /* The maximum amount of texture storage referenced by a scene is
-   * clamped to this size:
+diff -u src/gallium/drivers/llvmpipe/lp_scene.h.orig src/gallium/drivers/llvmpipe/lp_scene.h
+--- src/gallium/drivers/llvmpipe/lp_scene.h.orig	2018-04-18 01:44:00.000000000 -0700
++++ src/gallium/drivers/llvmpipe/lp_scene.h	2024-11-13 13:57:33.700075750 -0800
+@@ -60,12 +60,12 @@
+
+ /* Scene temporary storage is clamped to this size:
+  */
+-#define LP_SCENE_MAX_SIZE (9*1024*1024)
++#define LP_SCENE_MAX_SIZE (256*1024*1024)
+
+ /* The maximum amount of texture storage referenced by a scene is
+  * clamped to this size:
+  */
+-#define LP_SCENE_MAX_RESOURCE_SIZE (64*1024*1024)
++#define LP_SCENE_MAX_RESOURCE_SIZE (256*1024*1024)
+
+
+ /* switch to a non-pointer value for this:
 EOF
     if [[ $? != 0 ]] ; then
         warn "MesaGL patch 5 failed."
@@ -261,6 +260,66 @@ EOF
     fi
 
     #
+    # Patch to increase the maximum image size in mesa to 32K x 32K.
+    #
+    patch -p0 << \EOF
+diff -u src/mesa/main/config.h.orig src/mesa/main/config.h
+--- src/mesa/main/config.h.orig	2018-04-18 01:44:00.000000000 -0700
++++ src/mesa/main/config.h	2024-11-13 14:00:35.358860569 -0800
+@@ -91,19 +91,19 @@
+ #define LINE_WIDTH_GRANULARITY 0.1
+
+ /** Max memory to allow for a single texture image (in megabytes) */
+-#define MAX_TEXTURE_MBYTES 1024
++#define MAX_TEXTURE_MBYTES 8196
+
+ /** Number of 1D/2D texture mipmap levels */
+-#define MAX_TEXTURE_LEVELS 15
++#define MAX_TEXTURE_LEVELS 16
+
+ /** Number of 3D texture mipmap levels */
+-#define MAX_3D_TEXTURE_LEVELS 15
++#define MAX_3D_TEXTURE_LEVELS 16
+
+ /** Number of cube texture mipmap levels - GL_ARB_texture_cube_map */
+-#define MAX_CUBE_TEXTURE_LEVELS 15
++#define MAX_CUBE_TEXTURE_LEVELS 16
+
+ /** Maximum rectangular texture size - GL_NV_texture_rectangle */
+-#define MAX_TEXTURE_RECT_SIZE 16384
++#define MAX_TEXTURE_RECT_SIZE 32768
+
+ /**
+  * Maximum number of layers in a 1D or 2D array texture - GL_MESA_texture_array
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "MesaGL patch 6 failed."
+        return 1
+    fi
+
+    #
+    # Patch to fix an arithmetic overflow error calculating the size
+    # of a texture.
+    #
+    patch -p0 << \EOF
+diff -u src/gallium/drivers/llvmpipe/lp_texture.c.orig src/gallium/drivers/llvmpipe/lp_texture.c
+--- src/gallium/drivers/llvmpipe/lp_texture.c.orig	2018-04-18 01:44:00.000000000 -0700
++++ src/gallium/drivers/llvmpipe/lp_texture.c	2024-11-13 14:17:18.979693408 -0800
+@@ -155,7 +155,7 @@
+
+       lpr->mip_offsets[level] = total_size;
+
+-      total_size += align((unsigned)mipsize, mip_align);
++      total_size += align64(mipsize, mip_align);
+       if (total_size > LP_MAX_TEXTURE_SIZE) {
+          goto fail;
+       }
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "MesaGL patch 7 failed."
+        return 1
+    fi
+
     # Patch to address VTK texture buffer error.
     # Taken from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/9750
     #
@@ -287,7 +346,7 @@ diff -c src/gallium/drivers/llvmpipe/lp_screen.c.orig src/gallium/drivers/llvmpi
      case PIPE_CAP_PREFER_BLIT_BASED_TEXTURE_TRANSFER:
 EOF
     if [[ $? != 0 ]] ; then
-        warn "MesaGL patch 6 failed."
+        warn "MesaGL patch 8 failed."
         return 1
     fi
 

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -201,9 +201,9 @@ EOF
     #
     # Patch to increase the maximum image size in the llvmpipe
     # driver to 32K x 32K. There are 2 changes. The first is to
-    # the number of 2D to 16 (2^(16-1) = 32K. The second is to
-    # the maximum texture size - 32768 x 32768 is maximum number
-    # of pixels, the 4 is 4 bytes per pixel, and the 2 is from
+    # the number of 2D levels to 16 (2^(16-1) = 32K. The second is
+    # to the maximum texture size - 32768 x 32768 is the maximum
+    # number of pixels, the 4 is 4 bytes per pixel, and the 2 is from
     # the fact that a texture can actually store a multi-resolution
     # representation of the image. For example if the image size
     # is 256x256, it has storage for textures of size 256x256,

--- a/src/viewer/core/ViewerWindowManager.C
+++ b/src/viewer/core/ViewerWindowManager.C
@@ -1644,6 +1644,10 @@ ViewerWindowManager::ChooseCenterOfRotation(int windowIndex,
 //    Kathleen Biagas, Fri Aug 31 13:15:56 PDT 2018
 //    Send Options from SaveWindowAttributes to fileWriter if non-image.
 //
+//    Eric Brugger, Wed Nov 13 15:40:54 PST 2024
+//    I added logic so that the maximum image size is limited to 536,756,224
+//    pixels.
+//
 // ****************************************************************************
 
 void
@@ -1885,6 +1889,17 @@ ViewerWindowManager::SaveWindow(int windowIndex)
             {
                 w = (int)((double)w * (double)VISIT_RENDERING_SIZE_LIMIT / (double)h);
                 h = VISIT_RENDERING_SIZE_LIMIT;
+                GetViewerMessaging()->Message(
+                    TR("The window was too large to save at the requested resolution.  "
+                       "The resolution has been automatically reduced."));
+            }
+	    // if the total image size is too large, reduce them
+	    // proportionally.
+	    if (w * h > 536756224)
+            {
+                double image_size = (double)(w * h);
+                w = (int)((double)w * std::sqrt(536756224. / image_size));
+                h = (int)((double)h * std::sqrt(536756224. / image_size));
                 GetViewerMessaging()->Message(
                     TR("The window was too large to save at the requested resolution.  "
                        "The resolution has been automatically reduced."));


### PR DESCRIPTION
### Description

Resolves #19430

I increased the maximum image that could be saved to a total of 536,756,224 pixels with a maximum height or width of 32,768. This gives a maximum image size of 23,168 by 23,168 for a square image and 32768 by 16380 for a rectangular image.

This involved a number of patches to Mesa. I believe Mesa can go all the way up to 32768 by 32768, but VTK is having an issue with getting a buffer above 2GBytes from Mesa.

I added logic to the viewer to reduce the image size if the maximum was exceeded, maintaining the aspect ratio.

I also updated the release notes.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I saved images at 23,168 x 23,168 and 32,768 x 16,380. I also tested the error logic by specifying a size of 32,768 x 32,768 and getting an image of 23,168 x 23,168 as well as specifying a size of 32,768 x 24,000 and getting an image of 27,071 x 19,827.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
