### PR TITLE
Increase the save image width and height. (#20041)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,9 @@
 #    Kathleen Biagas, Mon Sep 30, 2024
 #    Add build/install scripts from scripts directory to visit-dist target.
 #
+#    Eric Brugger, Wed Nov 13 13:39:08 PST 2024
+#    Increase the rendering size limit from 16384 to 32768.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
@@ -690,13 +693,13 @@ else()
     endif()
 endif()
 
-# Set the rendering size limit to 16384 so that we are not unnecessarily
+# Set the rendering size limit to 32768 so that we are not unnecessarily
 # constraining the user. There is no way to set this properly since this
 # is used in the viewer and the limit really comes from the engine, which
 # may have a different size if running client/server. This setting should
 # be removed and a runtime check should be added to the engine.
-message(STATUS "Setting VISIT_RENDERING_SIZE_LIMIT to 16384")
-set(VISIT_RENDERING_SIZE_LIMIT 16384 CACHE INTERNAL "rendering size limit")
+message(STATUS "Setting VISIT_RENDERING_SIZE_LIMIT to 32768")
+set(VISIT_RENDERING_SIZE_LIMIT 32768 CACHE INTERNAL "rendering size limit")
 
 configure_file(${VISIT_SOURCE_DIR}/include/visit-cmake.h.in
                ${VISIT_BINARY_DIR}/include/visit-config.h @ONLY IMMEDIATE)

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -82,6 +82,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added the ability to skip the remote host validity check when using a gateway. This allows VisIt to work with gateways that are transparently handled by <code>ssh</code>. The check can now be bypassed by checking "Use gateway" and leaving the gateway name blank in the host profile for the remote system.</li>
   <li>Added support for MFEM Wedge (aka Prism) Meshes.</li>
   <li>Added new global mesh expressions: global_avg(), global_max(), global_min(), global_rms(), global_std_dev(), global_sum(), and global_variance(). These are expressions that calculate statistics across the mesh and the result is a constant variable that contains the result. So, global_max(d) produces a new variable that is the maximum of d at every zone or node across the mesh.</li>
+  <li>The maximum image size that can be saved has been increased to a maximum of 32,768 for either the width or height with a total pixel count not to exceed 536,756,224 pixels. For a square image that corresponds to an image size of 23,170 by 23,168 or less. For a rectangular image that corresponds to an image size of 32,768 by 16,380 or less.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/viewer/core/ViewerWindowManager.C
+++ b/src/viewer/core/ViewerWindowManager.C
@@ -1644,6 +1644,10 @@ ViewerWindowManager::ChooseCenterOfRotation(int windowIndex,
 //    Kathleen Biagas, Fri Aug 31 13:15:56 PDT 2018
 //    Send Options from SaveWindowAttributes to fileWriter if non-image.
 //
+//    Eric Brugger, Wed Nov 13 15:40:54 PST 2024
+//    I added logic so that the maximum image size is limited to 536,756,224
+//    pixels.
+//
 // ****************************************************************************
 
 void
@@ -1885,6 +1889,17 @@ ViewerWindowManager::SaveWindow(int windowIndex)
             {
                 w = (int)((double)w * (double)VISIT_RENDERING_SIZE_LIMIT / (double)h);
                 h = VISIT_RENDERING_SIZE_LIMIT;
+                GetViewerMessaging()->Message(
+                    TR("The window was too large to save at the requested resolution.  "
+                       "The resolution has been automatically reduced."));
+            }
+	    // if the total image size is too large, reduce them
+	    // proportionally.
+	    if (w * h > 536756224)
+            {
+                double image_size = (double)(w * h);
+                w = (int)((double)w * std::sqrt(536756224. / image_size));
+                h = (int)((double)h * std::sqrt(536756224. / image_size));
                 GetViewerMessaging()->Message(
                     TR("The window was too large to save at the requested resolution.  "
                        "The resolution has been automatically reduced."));


### PR DESCRIPTION
### Description

Resolves #19430

I increased the maximum image that could be saved to a total of 536,756,224 pixels with a maximum height or width of 32,768. This gives a maximum image size of 23,168 by 23,168 for a square image and 32768 by 16380 for a rectangular image.

This involved a number of patches to Mesa. I believe Mesa can go all the way up to 32768 by 32768, but VTK is having an issue with getting a buffer above 2GBytes from Mesa.

I added logic to the viewer to reduce the image size if the maximum was exceeded, maintaining the aspect ratio.

I also updated the release notes.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I saved images at 23,168 x 23,168 and 32,768 x 16,380. I also tested the error logic by specifying a size of 32,768 x 32,768 and getting an image of 23,168 x 23,168 as well as specifying a size of 32,768 x 24,000 and getting an image of 27,071 x 19,827.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
