### PR TITLE
Modify the test suite to copy failed text results to the dashboard.

### DIFF
--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -99,6 +99,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Documented the -norun option in visit --fullhelp.</li>
   <li>Added support for GPU architectures in <code>CMake</code> and the <code>internallauncher</code>. When a <code>make package</code> comnand is executed, the GPU architecture will be added to the operating system and CPU identifier in the tar file name. For example, on a Linux system with an x86_64 CPU and an AMD MI250X GPU the tar file name will be <code>visit3_4_2.linux-x86_64-gfx90a.tar.gz</code>. Likewise, the operating system and CPU identiefier identifier in a VisIt installation will include the GPU architecture in the same manner. As part of this change, the CPU identifier for a 64 bit, little endian, PowerPC processor will now be <code>ppc64le</code> instead of <code>intel</code>. The default CPU identifier for an unidentified CPU will now be <code>x86_64</code> instead of <code>intel</code>. Currently, only relatively new AMD GPUs are supported.</li>
   <li>When CMakeing VisIt, if <code>-C <cachefile></code> is used or a slew of <code>-DVISIT_CMAKE_VARIABLE=VALUE</code> options are specified in lieu of a config-site file, the option <code>-DVISIT_CONFIG_SITE=NONE</code> is also required.</li>
+  <li>The regression suite has been modified to copy current text results for failed tests to the dashboard repository. This allows the <code>test/baseline/rebase.py</code> script to rebaseline text results as well as image results.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/visit-copy-test-results.py
+++ b/src/tools/dev/scripts/visit-copy-test-results.py
@@ -314,6 +314,12 @@ def copy_results(cur_dir):
             # This is a current or difference image.
             #
             shutil.copy(os.path.join(mode_dir, file), out_mode_dir)
+        elif (file.startswith("c_") and file.endswith(".txt")):
+            #
+            # This is a current text file. This isn't needed for the
+            # web pages, but is there for use with the rebaseline script.
+            #
+            shutil.copy(os.path.join(mode_dir, file), out_mode_dir)
         elif (file.endswith(".html")):
             #
             # This is a generic html file. Unfortunately, we have to open it


### PR DESCRIPTION
### Description

Resolves #5353

Modify the test suite to copy current failed text results to the dashboard. This will allow the `test/baseline/rebase.py` script to re-baseline text results as well as image results.

The failed text results are not necessary for the website, they are just there for convenient re-baselining of results.

### Type of change

* [X] Enhancement~~

### How Has This Been Tested?

I ran the test `tests/unit/launcher.py` which always fails with environment variable differences when run by users generating text test failures. I then ran the script that copies the results to ensure that the additional files were copied.

Here is the dashboard clone used to update the repository.
```
ls /usr/WS1/visit/dashboard/dashboard
2021-08-18-22:00  2024-09-23-22:00  2024-10-17-22:00  2024-11-07-22:00
2022-09-05-22:00  2024-09-24-22:00  2024-10-18-22:00  2024-11-08-22:00
2022-12-05-22:00  2024-09-25-22:00  2024-10-19-22:00  2024-11-10-22:00
2024-01-06-22:00  2024-09-26-22:00  2024-10-20-22:00  2024-11-11-22:00
2024-09-09-22:00  2024-09-27-22:00  2024-10-21-22:00  2024-11-12-22:00
2024-09-10-22:00  2024-09-28-22:00  2024-10-22-22:00  2024-11-13-22:00
2024-09-11-22:00  2024-09-29-22:00  2024-10-23-22:00  2024-11-14-22:00
2024-09-12-22:00  2024-09-30-22:00  2024-10-24-22:00  2024-11-15-22:00
2024-09-13-22:00  2024-10-01-22:00  2024-10-25-22:00  2024-11-16-22:00
2024-09-14-22:00  2024-10-07-10:33  2024-10-26-22:00  2024-11-17-22:00
2024-09-15-22:00  2024-10-07-22:00  2024-10-27-22:00  2024-11-18-22:00
2024-09-16-22:00  2024-10-10-22:00  2024-10-28-22:00  baselines
2024-09-17-22:00  2024-10-11-22:00  2024-10-29-22:00  files
2024-09-18-22:00  2024-10-12-22:00  2024-10-30-22:00  index.html
2024-09-19-22:00  2024-10-13-22:00  2024-10-31-22:00  remove_old.sh
2024-09-20-22:00  2024-10-14-22:00  2024-11-01-22:00
2024-09-21-22:00  2024-10-15-22:00  2024-11-02-22:00
2024-09-22-22:00  2024-10-16-22:00  2024-11-03-22:00
```
Here is the test directory.
```
ls
2024-11-19-13:00  cmake_install.cmake  output	run_visit_test_suite.sh
CMakeFiles	  Makefile	       output2	tmp
```
This is the output of the script getting run. Note that it mentions that text test results are being copied. The script eventually crashes with an error since I only have serial results, but that isn't relevant to the testing.
```
python3 /usr/WS1/visit/test_trunk/visit/src/tools/dev/scripts/visit-copy-test-results.py
Processing 2024-11-19-13:00
    Doing mode 0
        The baseline directories are:
           2024-11-11-22:00
           2024-11-08-22:00
           2024-11-07-22:00
           2024-11-01-22:00
           2024-10-30-22:00
           2024-10-24-22:00
           2024-10-10-22:00
           2024-10-07-22:00
           2024-10-07-10:33
        Copying text diff msub_aprun.html
        Copying text diff msub_ibrun.html
        Copying text diff msub_mpiexec.html
        Copying text diff msub_mpirun.html
        Copying text diff msub_srun.html
        Copying text diff sbatch.html
        Copying text diff sbatch_aprun.html
    Doing mode 1
        The baseline directories are:
           2024-11-11-22:00
           2024-11-10-22:00
           2024-11-07-22:00
           2024-11-01-22:00
           2024-10-30-22:00
           2024-10-24-22:00
           2024-10-07-22:00
           2024-10-07-10:33
...
```
Here is the updated dashboard directory. Note the addition of `2024-11-19-13:00`.
```
ls /usr/WS1/visit/dashboard/dashboard                     2021-08-18-22:00  2024-09-23-22:00  2024-10-17-22:00  2024-11-07-22:00
2022-09-05-22:00  2024-09-24-22:00  2024-10-18-22:00  2024-11-08-22:00
2022-12-05-22:00  2024-09-25-22:00  2024-10-19-22:00  2024-11-10-22:00
2024-01-06-22:00  2024-09-26-22:00  2024-10-20-22:00  2024-11-11-22:00
2024-09-09-22:00  2024-09-27-22:00  2024-10-21-22:00  2024-11-12-22:00
2024-09-10-22:00  2024-09-28-22:00  2024-10-22-22:00  2024-11-13-22:00
2024-09-11-22:00  2024-09-29-22:00  2024-10-23-22:00  2024-11-14-22:00
2024-09-12-22:00  2024-09-30-22:00  2024-10-24-22:00  2024-11-15-22:00
2024-09-13-22:00  2024-10-01-22:00  2024-10-25-22:00  2024-11-16-22:00
2024-09-14-22:00  2024-10-07-10:33  2024-10-26-22:00  2024-11-17-22:00
2024-09-15-22:00  2024-10-07-22:00  2024-10-27-22:00  2024-11-18-22:00
2024-09-16-22:00  2024-10-10-22:00  2024-10-28-22:00  2024-11-19-13:00
2024-09-17-22:00  2024-10-11-22:00  2024-10-29-22:00  baselines
2024-09-18-22:00  2024-10-12-22:00  2024-10-30-22:00  files
2024-09-19-22:00  2024-10-13-22:00  2024-10-31-22:00  index.html
2024-09-20-22:00  2024-10-14-22:00  2024-11-01-22:00  remove_old.sh
2024-09-21-22:00  2024-10-15-22:00  2024-11-02-22:00
2024-09-22-22:00  2024-10-16-22:00  2024-11-03-22:00
```
Here is the contents of the newly added directory. Note that it has the current failing text files. They all start with `c_`.
```
ls /usr/WS1/visit/dashboard/dashboard/2024-11-19-13:00/poodle_trunk_serial/
c_msub_aprun.txt    css		       msub_srun.html
c_msub_ibrun.txt    index.html	       sbatch_aprun.html
c_msub_mpiexec.txt  js		       sbatch.html
c_msub_mpirun.txt   msub_aprun.html    unit_launcher.html
c_msub_srun.txt     msub_ibrun.html    unit_launcher_py.html
c_sbatch_aprun.txt  msub_mpiexec.html
c_sbatch.txt	    msub_mpirun.html
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
