### PR TITLE
Reorder some git operations in the regression suite to avoid unnecessary merges.

### DIFF
--- a/src/tools/dev/scripts/regressiontest_poodle
+++ b/src/tools/dev/scripts/regressiontest_poodle
@@ -170,6 +170,10 @@
 #   Eric Brugger, Mon Oct  7 11:15:18 PDT 2024
 #   Updated to run the test suite on poodle instead of pascal. Made
 #   the logic that detects new test results more general.
+#
+#   Eric Brugger, Thu Nov 21 12:15:11 PST 2024
+#   Reorder some git operations when committing changes to GitHub to
+#   avoid unnecessary merges.
 # 
 
 # Determine the users name and e-mail address.
@@ -577,12 +581,17 @@ if test "$post" = "true" ; then
     cd $repoDir
     if test "\$hasFailed" = ""; then
         gitHead=\`git log -1 | grep "^commit" | cut -d' ' -f2\`
+        # First do a "git checkout" on lastpass to restore it in case
+        # it was modified and not committed. Then do a "git pull" to
+        # update develop in case there have been an commits since the
+        # test suite run started. Then update lastpass and push to
+        # GitHub.
         git checkout src/tools/dev/scripts/lastpass_$testHost
         rm -f src/tools/dev/scripts/lastpass_$testHost
+        git pull
         echo "\$gitHead" > src/tools/dev/scripts/lastpass_$testHost
         git add src/tools/dev/scripts/lastpass_$testHost
         git commit -m "Update the last test suite pass on $testHost."
-        git pull
         git push
     fi
 
@@ -598,9 +607,13 @@ if test "$post" = "true" ; then
     newResults=\`ls -d ????-??-??-??:??\`
     # should the dashboard have group perms?
     cd /usr/WS1/visit/dashboard/dashboard
+    # First do a "git pull" to update main in case there have been
+    # any commits since the last update. This is most likely from
+    # removing an old test result. Then add the new results and push
+    # to GitHub.
+    git pull
     git add \$newResults baselines index.html
     git commit -m "Add new results to the dashboard."
-    git pull
     git push
     
     # Move the new results to old_results.


### PR DESCRIPTION
### Description

I reordered some git operations in the regression suite to do a `git pull` before doing any commits to avoid unnecessary merge operations. This was done for updating `lastpass` in the visit repository and for adding new results to the dashboard repository.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

This was a fairly simple change and isn't easy to test, so I'll just let the next regression suite run be the test.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
