### PR TITLE
Adjust handling of errno in ANSYS plugin

### DIFF
--- a/src/databases/ANSYS/avtANSYSFileFormat.C
+++ b/src/databases/ANSYS/avtANSYSFileFormat.C
@@ -160,6 +160,10 @@ avtANSYSFileFormat::ActivateTimestep()
 // 
 //    Justin Privitera, Tue Jul  5 14:40:55 PDT 2022
 //    Changed 'supressed' to 'suppressed'.
+//
+//    Mark C. Miller, Tue Dec  3 17:47:41 PST 2024
+//    Explicitly set errno to zero so that calls to check its value after
+//    calling strtod() don't wind up using an old value.
 // ****************************************************************************
 
 int
@@ -299,18 +303,21 @@ avtANSYSFileFormat::ReadFile(const char *name, int nLines)
             char *valstart = line + fieldStart;
             char *valend = valstart + fieldWidth;
             char *endptr = 0;
+            errno = 0;
             pt[2] = strtod(valstart, &endptr);
             CHECK_COORD_COMPONENT(pt[2]);
 
             valstart -= fieldWidth;
             valend -= fieldWidth;
             *valend = '\0';
+            errno = 0;
             pt[1] = strtod(valstart, &endptr);
             CHECK_COORD_COMPONENT(pt[1]);
 
             valstart -= fieldWidth;
             valend -= fieldWidth;
             *valend = '\0';
+            errno = 0;
             pt[0] = strtod(valstart, &endptr);
             CHECK_COORD_COMPONENT(pt[0]);
 #if 0


### PR DESCRIPTION
### Description

I checked `ANSYS.py` test running under the test harness with valgrind on poodle. It was a bit tricky so recording the command here...

```
./run_visit_test_suite.sh -v --no-cleanup --vargs "-debug 5 -np 2 -l srun -valgrind engine_par" tests/databases/ANSYS.py
```

The `--no-cleanup` arg to `run_visit_test_suite.sh` is important. Otherwise, valgrind logs will be deleted upon completion of the tests. The logs wind up in files of the form `output/_run/databases/ANSYS/engine_par_397656.log`, one for each MPI rank.

I did run into something odd on **ONLY** processor 1. It produced some weird output on stderr...

```
    BEGIN SECTION: pipe.inp
Running: mdserver -dv -debug 5 -exec-timeout 800 -idle-timeout 800 -timing --params=/g/g11/miller86/visit/visit/build/test/output/_run/_databases_ANSYS/params.json -host 127.0.0.1 -port 5600 -valgrind engine_par
) at or near line 8 value "No such file or directory" (-3.142539784E-02
Encountered invalid value "No such file or directory" (-2.428081632E-02) at or near line 8
Encountered invalid value "No such file or directory" (-3.095419407E-01) at or near line 8
) at or near line 9 value "No such file or directory" (-3.499274328E-02
Further warnings will be suppressed
) at or near line 8 value "No such file or directory" (-3.142539784E-02
Encountered invalid value "No such file or directory" (-2.428081632E-02) at or near line 8
Encountered invalid value "No such file or directory" (-3.095419407E-01) at or near line 8
) at or near line 9 value "No such file or directory" (-3.499274328E-02
```

When I looked at the debug logs for processor 1, I saw similar error messages. What was happening is that `errno` was left unset by the caller but was later being checked after successful calls to `strtod()`. Successful calls **DO NOT** set `errno` to zero. The caller must explicitly set `errno` to zero before making a call that potentially sets `errno` on failure. Otherwise, `errno` will be left to whatever value it was set to on the last failing system call...which may have been long ago. In this case, it was some call to open a non-existent file.

With this change, I confirmed the error messages no longer appear.

I don't know if this could be cause for glitchy behavior of `ANSYS.py` test but I think it is plausible. In any case, the coding was definitely wrong.

I am fixing only on `develop` because we're trying to release. If anyone wants it on `3.4RC`, lemme know.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
