### PR TITLE
Fix config.cmake name used when searching for VTK 9 using VISIT_VTK_DIR.

### DIFF
--- a/src/CMake/FindVTK9.cmake
+++ b/src/CMake/FindVTK9.cmake
@@ -25,9 +25,9 @@
 
 # Use the VTK_DIR hint from the config-site .cmake file
 
-if(EXISTS ${VISIT_VTK_DIR}/lib/cmake/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}/VTKConfig.cmake)
+if(EXISTS ${VISIT_VTK_DIR}/lib/cmake/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}/vtk-config.cmake)
     set(VTK_DIR ${VISIT_VTK_DIR}/lib/cmake/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION})
-elseif(EXISTS ${VISIT_VTK_DIR}/lib64/cmake/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}/VTKConfig.cmake)
+elseif(EXISTS ${VISIT_VTK_DIR}/lib64/cmake/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}/vtk-config.cmake)
     set(VTK_DIR ${VISIT_VTK_DIR}/lib64/cmake/vtk-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION})
 endif()
 


### PR DESCRIPTION
I discovered problems during a couple of my builds, where Visit was using the wrong path to VTK (not the one specified by VISIT_VTK_DIR). Finally narrowed it down to using the wrong name for VTK's installed 'config.cmake' file that helps us set VTK_DIR to point to the path containing that .cmake file.

If no-one else is experiencing this problem during their builds, this PR can wait until after the tag for 3.4.2

### Type of change

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Successfully compiled VisIt on the system where previously it picked up the wrong VTK.
I double-checked the filename on our TP-shared libs on LC, and in my windows build of VTK. The new name is the correct one.

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
