### PR TITLE
Fix ghost communication

### DIFF
--- a/src/avt/Database/Database/avtGenericDatabase.C
+++ b/src/avt/Database/Database/avtGenericDatabase.C
@@ -311,6 +311,8 @@ DebugDumpDatasetCollection(avtDatasetCollection &dsc, int ndoms,
 //  Creation:   10/17/24
 //
 //  Modifications:
+//    Justin Privitera, Thu Dec 12 16:49:08 PST 2024
+//    Added debugging information.
 //
 // ****************************************************************************
 
@@ -346,6 +348,11 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
                         {
                             // we don't know what to do in the case that the ghost
                             // zone/node array has more than one component
+                            debug1 << "AugmentGhostData: When attempting to combine "
+                                      "avtGhostNodes/Zones and avtExtraGhostNodes/Zones, "
+                                      "one of the arrays has more than one component. "
+                                      "This should not be possible. Please contact a "
+                                      "VisIt developer." << std::endl;
                             EXCEPTION0(ImproperUseException);
                         }
                         const int num_tuples = ghosts->GetNumberOfTuples();
@@ -354,6 +361,11 @@ avtGenericDatabase::AugmentGhostData(avtDatasetCollection &ds,
                             // we don't know what to do in the case that the original
                             // and extra ghost zone/node arrays do not have the same
                             // number of tuples.
+                            debug1 << "AugmentGhostData: When attempting to combine "
+                                      "avtGhostNodes/Zones and avtExtraGhostNodes/Zones, "
+                                      "the arrays do not have the same number of tuples. "
+                                      "This should not be possible. Please contact a "
+                                      "VisIt developer." << std::endl;
                             EXCEPTION0(ImproperUseException);
                         }
 

--- a/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
+++ b/src/avt/Database/Ghost/avtUnstructuredDomainBoundaries.C
@@ -198,6 +198,13 @@ avtUnstructuredDomainBoundaries::SetSharedPoints(int d1, int d2,
 //
 //  Programmer:  Akira Haddox
 //  Creation:    August 11, 2003
+// 
+//  Modifications:
+//    Justin Privitera, Thu Dec 12 16:30:22 PST 2024
+//    Prevent there from being given cells when there are no given points.
+//    Later logic unconditionally sends cells without checking if points
+//    exist or not. The correct thing to do is to send 0 for num cells if
+//    num points is 0.
 //
 // ****************************************************************************
 
@@ -237,6 +244,11 @@ avtUnstructuredDomainBoundaries::SetGivenCellsAndPoints(int fromDom, int toDom,
                 givenPoints[index].push_back(points[i]);
             }
         }
+    }
+
+    if (givenPoints[index].empty())
+    {
+        givenCells[index].clear();
     }
 }
 

--- a/src/resources/help/en_US/relnotes3.4.2.html
+++ b/src/resources/help/en_US/relnotes3.4.2.html
@@ -59,6 +59,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed time slider annotation handling of printf-style format string.</li>
   <li>Fixed an issue with the displace operator where it would not accept vector mesh variables defined as expressions if the expressions had not been used in a plot already.</li>
   <li>Fixed an issue where the GUI panel's timeslider would display incorrect numerical values for cycle.</li>
+  <li>Fixed a longstanding issue with Ghost Zone communication in parallel.</li>
 </ul>
 <a name="Enhancements"></a>
 <p><b><font size="4">Enhancements in version 3.4.2</font></b></p>


### PR DESCRIPTION
### Description

Resolves # <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

Prevents an issue where cells were sent even when there were no new points to send.
This fix saves the failing mili dataset. We will need to see how it affects the nightly tests.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

This solves the issue for the large mili database on the SCF. It remains to be seen how it will affect the test suite.
I ran the mili tests in parallel and they passed.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
