### PR TITLE
ppc64le front end launcher fix and el cap host profile (#20123)

### DIFF
--- a/src/bin/frontendlauncher
+++ b/src/bin/frontendlauncher
@@ -43,6 +43,9 @@
 #   Added logic to use system `python3` if `python` is not available.
 #   (Installed use finds and calls our python, this helps with developer use)
 #
+#   Cyrus Harrison, Thu Dec 12 11:33:24 PST 2024
+#   Added case for power9 architecture
+#
 ###############################################################################
 
 #
@@ -64,6 +67,8 @@ if test "$osname" = "Linux"; then
         platform="linux-ppc"
     elif test "$proc" = "ppc64"; then
         platform="linux-ppc64"
+    elif test "$proc" = "ppc64le"; then
+        platform="linux-ppc64le"
     else
         platform="linux-intel"
     fi

--- a/src/resources/hosts/llnl/host_llnl_elcap.xml
+++ b/src/resources/hosts/llnl/host_llnl_elcap.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<Object name="MachineProfile">
+    <Field name="hostNickname" type="string">LLNL El Capitan</Field>
+    <Field name="host" type="string">elcap.llnl.gov</Field>
+    <Field name="userName" type="string">notset</Field>
+    <Field name="hostAliases" type="string">elcap#.llnl.gov elcap##.llnl.gov elcap###.llnl.gov elcap####.llnl.gov elcap#####.llnl.gov elcap######.llnl.gov elcap# elcap## elcap### elcap#### elcap##### elcap######</Field>
+    <Field name="directory" type="string">/usr/gapps/visit</Field>
+    <Field name="shareOneBatchJob" type="bool">false</Field>
+    <Field name="sshPortSpecified" type="bool">false</Field>
+    <Field name="sshPort" type="int">22</Field>
+    <Field name="sshCommandSpecified" type="bool">false</Field>
+    <Field name="sshCommand" type="stringVector">"ssh" </Field>
+    <Field name="useGateway" type="bool">false</Field>
+    <Field name="gatewayHost" type="string"></Field>
+    <Field name="clientHostDetermination" type="string">MachineName</Field>
+    <Field name="manualClientHostName" type="string"></Field>
+    <Field name="tunnelSSH" type="bool">true</Field>
+    <Field name="maximumNodesValid" type="bool">false</Field>
+    <Field name="maximumNodes" type="int">1</Field>
+    <Field name="maximumProcessorsValid" type="bool">false</Field>
+    <Field name="maximumProcessors" type="int">1</Field>
+    <Object name="LaunchProfile">
+        <Field name="profileName" type="string">serial</Field>
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">1</Field>
+        <Field name="numNodesSet" type="bool">false</Field>
+        <Field name="numNodes" type="int">0</Field>
+        <Field name="partitionSet" type="bool">false</Field>
+        <Field name="partition" type="string"></Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">false</Field>
+        <Field name="timeLimit" type="string"></Field>
+        <Field name="launchMethodSet" type="bool">false</Field>
+        <Field name="launchMethod" type="string"></Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"></Field>
+        <Field name="parallel" type="bool">false</Field>
+    </Object>
+    <Object name="LaunchProfile">
+        <Field name="profileName" type="string">parallel interactive pdebug</Field>
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">96</Field>
+        <Field name="numNodesSet" type="bool">true</Field>
+        <Field name="numNodes" type="int">1</Field>
+        <Field name="partitionSet" type="bool">true</Field>
+        <Field name="partition" type="string">pdebug</Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">true</Field>
+        <Field name="timeLimit" type="string">3600s</Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+    <Field name="launchMethod" type="string">flux/run</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="parallel" type="bool">true</Field>
+    </Object>
+    <Object name="LaunchProfile">
+        <Field name="profileName" type="string">parallel batch</Field>
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">96</Field>
+        <Field name="numNodesSet" type="bool">true</Field>
+        <Field name="numNodes" type="int">1</Field>
+        <Field name="partitionSet" type="bool">true</Field>
+        <Field name="partition" type="string">pbatch</Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">true</Field>
+        <Field name="timeLimit" type="string">3600s</Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+    <Field name="launchMethod" type="string">flux/batch</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"></Field>
+        <Field name="parallel" type="bool">true</Field>
+    </Object>
+    <Object name="LaunchProfile">
+        <Field name="profileName" type="string">parallel xterm</Field>
+        <Field name="timeout" type="int">480</Field>
+        <Field name="numProcessors" type="int">96</Field>
+        <Field name="numNodesSet" type="bool">false</Field>
+        <Field name="numNodes" type="int">0</Field>
+        <Field name="partitionSet" type="bool">false</Field>
+        <Field name="partition" type="string"></Field>
+        <Field name="bankSet" type="bool">false</Field>
+        <Field name="bank" type="string"></Field>
+        <Field name="timeLimitSet" type="bool">false</Field>
+        <Field name="timeLimit" type="string"></Field>
+        <Field name="launchMethodSet" type="bool">true</Field>
+    <Field name="launchMethod" type="string">flux/run</Field>
+        <Field name="forceStatic" type="bool">true</Field>
+        <Field name="forceDynamic" type="bool">false</Field>
+        <Field name="active" type="bool">false</Field>
+        <Field name="arguments" type="stringVector"> </Field>
+        <Field name="parallel" type="bool">true</Field>
+    </Object>
+    <Field name="activeProfile" type="int">0</Field>
+</Object>

--- a/src/resources/hosts/networks.json
+++ b/src/resources/hosts/networks.json
@@ -150,6 +150,9 @@
           "name": "host_llnl_dane.xml"
         },
         {
+          "name": "host_llnl_elcap.xml"
+        },
+        {
           "name": "host_llnl_lassen.xml"
         },
         {


### PR DESCRIPTION
Develop PR for #20123

* ppc64le front end launcher fix and el cap host profile

* change el cap launch configs to use 96 cores (targets 5gb of ram per core)

