### PR TITLE
Fix Pillow install.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -696,7 +696,7 @@ function build_pillow
     CC=${C_COMPILER} CXX=${CXX_COMPILER} CFLAGS="${PYEXT_CFLAGS}" \
      CXXFLAGS="${PYEXT_CXXFLAGS}" \
      LDFLAGS="${PYEXT_LDFLAGS}" \
-     ${PYTHON_COMMAND} ./setup.py build_ext --disable-webp --disable-webpmux --disable-freetype --disable-lcms --disable-tiff --disable-xcb --disable-jpeg2000 --disable-jpeg install --prefix="${PYHOME} --single-version-externally-managed --record record.txt"
+     ${PYTHON_COMMAND} ./setup.py build_ext --disable-webp --disable-webpmux --disable-freetype --disable-lcms --disable-tiff --disable-xcb --disable-jpeg2000 --disable-jpeg install --prefix="${PYHOME}" --single-version-externally-managed --record record.txt
     set +x
 
     if test $? -ne 0 ; then


### PR DESCRIPTION
Change location of closing quote.

build_visit log file showed:
```
Copying Pillow-10.0.0-py3.9-linux-x86_64.egg to /kats_tp_install_loc/python/3.9.18/linux-x86_64_gcc-10.3 --single-version-externally-managed --record record.txt/lib/python3.9/site-packages
```
