### PR TITLE
Fix 2D Silo PBCs

### DIFF
--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -5695,6 +5695,9 @@ static void copy_mmadj_neighbor_entry(DBmultimeshadj *dst, int dstidx,
 //  pbcBndList and pbcDomList parallel array arguments).
 //
 //  Mark C. Miller, Thu Oct 24 19:12:18 PDT 2024
+//
+//  Mark C. Miller, Fri Jan 17 18:25:55 PST 2025
+//  Adjust to handle 2D as well as 3D meshes.
 // ****************************************************************************
 static bool 
 process_pbcs_for_one_domain(int dom, int const nBndEntries,
@@ -5746,11 +5749,16 @@ process_pbcs_for_one_domain(int dom, int const nBndEntries,
 
     new_mmadj->nneighbors[dom] = ncopied;
 
-    // These consistency checks assume a rectangular arrangement of domains.
-    // 7 is for domains on extreme corners; 11 for domains on edges, 17
-    // for domains on faces and 26 for wholly internal domains
-    return ncopied == 7 || ncopied == 11 ||
-          ncopied == 17 || ncopied == 26;
+    // The consistency checks here assume a rectangular arrangement of domains
+    // in 2D or 3D. A removal of PB domains will wind up copying only specific
+    // numbers of domains. For 2D, there are 3 cases for domains on the extreme
+    // corner, edge or wholly internal to the mesh. For 3D, there are 4 cases 
+    // for domains on the extreme corner, edge, face or wholly internal.
+    // The the 2D cases, ncopied can assume only the values 3, 5 and 8.
+    // For the 3D cases, ncopied can assume only the values 7, 11, 17 and 26.
+    return
+        ncopied == 3 || ncopied == 5  ||  ncopied == 8 || 
+        ncopied == 7 || ncopied == 11 || ncopied == 17 || ncopied == 26;
 }
 
 // ****************************************************************************


### PR DESCRIPTION
### Description

@cyrush I cannot find the issue associated with this. I thought you had created one?

Apologies for not catching this when original work was done. I would have been very easy to include logic to ensure 2D case was covered. But, I guess I had been assuming that in the 2D case, even if PBCs completely surrounded the mesh, all plotting would still work fine and so it isn't really relevant in 2D.

While that might be true, the code that processes PBC data in the file is still executed and when it got to a point where 3D was assumed, it failed some integrity checks. This just adds the 2D case to those very rudimentary checks.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
