### PR TITLE
Add support for building xkbcommon and xcb to build_visit.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,9 @@
 #    Eric Brugger, Wed Nov 13 13:39:08 PST 2024
 #    Increase the rendering size limit from 16384 to 32768.
 #
+#    Eric Brugger, Thu Jan 23 13:10:04 PST 2025
+#    Add the xcb and xkbcommon libraries to the distribution.
+#
 #****************************************************************************
 
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
@@ -520,6 +523,32 @@ endif()
 
 include(${VISIT_SOURCE_DIR}/CMake/SetUpThirdParty.cmake)
 
+if(VISIT_XCB_DIR)
+    message(STATUS "Installing xcb")
+    file(GLOB xcb_libs "${VISIT_XCB_DIR}/lib/libxcb*.so*")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy
+	            ${xcb_libs}
+		    ${VISIT_BINARY_DIR}/lib)
+    install(FILES ${xcb_libs}
+            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                        WORLD_READ             WORLD_EXECUTE)
+
+endif()
+
+if(VISIT_XKBCOMMON_DIR)
+    message(STATUS "Installing xkbcommon")
+    file(GLOB xkbcommon_libs "${VISIT_XKBCOMMON_DIR}/lib/libxkb*.so*")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy
+	            ${xkbcommon_libs}
+		    ${VISIT_BINARY_DIR}/lib)
+    install(FILES ${xkbcommon_libs}
+            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                        WORLD_READ             WORLD_EXECUTE)
+endif()
 
 # Enable thread build of VisIt
 if(VISIT_THREAD)

--- a/src/tools/dev/scripts/bv_support/bv_meson.sh
+++ b/src/tools/dev/scripts/bv_support/bv_meson.sh
@@ -114,10 +114,10 @@ function build_meson
     if [[ ! -d ${MESON_INSTALL_DIR}/bin ]] ; then
         mkdir -p ${MESON_INSTALL_DIR}/bin
     fi
+    MESON_CMD="${MESON_INSTALL_DIR}/bin/meson"
     if [[ -f ${MESON_INSTALL_DIR}/bin/meson ]] ; then
         rm $MESON_CMD
     fi
-    MESON_CMD="${MESON_INSTALL_DIR}/bin/meson"
     echo "#!${PYTHON_COMMAND}" > $MESON_CMD
     echo "# -*- coding: utf-8 -*-" >> $MESON_CMD
     echo "import re" >> $MESON_CMD

--- a/src/tools/dev/scripts/bv_support/bv_meson.sh
+++ b/src/tools/dev/scripts/bv_support/bv_meson.sh
@@ -1,0 +1,176 @@
+function bv_meson_initialize
+{
+    export DO_MESON="no"
+    export USE_SYSTEM_MESON="no"
+    add_extra_commandline_args "meson" "alt-meson-dir" 1 "Use alternative directory for meson"
+}
+
+function bv_meson_enable
+{
+    DO_MESON="yes"
+}
+
+function bv_meson_disable
+{
+    DO_MESON="no"
+}
+
+function bv_meson_alt_meson_dir
+{
+    bv_meson_enable
+    USE_SYSTEM_MESON="yes"
+    MESON_INSTALL_DIR="$1"
+    info "Using Alternate meson: $MESON_INSTALL_DIR"
+}
+
+function bv_meson_depends_on
+{
+    depends_on="python"
+
+    echo ${depends_on}
+}
+
+function bv_meson_initialize_vars
+{
+    if [[ "$USE_SYSTEM_MESON" == "no" ]]; then
+        MESON_INSTALL_DIR="${VISITDIR}/meson/${MESON_VERSION}/${VISITARCH}"
+    fi
+}
+
+function bv_meson_info
+{
+    export MESON_VERSION=${MESON_VERSION:-"1.6.1"}
+    export MESON_FILE=${MESON_FILE:-"meson-${MESON_VERSION}.tar.gz"}
+    export MESON_BUILD_DIR=${MESON_BUILD_DIR:-"meson-${MESON_VERSION}"}
+    export MESON_SHA256_CHECKSUM="1eca49eb6c26d58bbee67fd3337d8ef557c0804e30a6d16bfdf269db997464de"
+}
+
+function bv_meson_print
+{
+    printf "%s%s\n" "MESON_FILE=" "${MESON_FILE}"
+    printf "%s%s\n" "MESON_VERSION=" "${MESON_VERSION}"
+    printf "%s%s\n" "MESON_BUILD_DIR=" "${MESON_BUILD_DIR}"
+}
+
+function bv_meson_print_usage
+{
+    printf "%-20s %s [%s]\n" "--meson" "Build meson support" "$DO_MESON"
+    printf "%-20s %s [%s]\n" "--alt-meson-dir" "Use meson from an alternative directory"
+}
+
+function bv_meson_host_profile
+{
+    # Nothing added to the host profile since meson is only used for
+    # building third party libraries.
+    return 0
+}
+
+function bv_meson_ensure
+{
+    if [[ "$DO_MESON" == "yes" && "$USE_SYSTEM_MESON" == "no" ]] ; then
+        ensure_built_or_ready "meson" $MESON_VERSION $MESON_BUILD_DIR $MESON_FILE $MESON_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_MESON="no"
+            error "Unable to build meson. ${MESON_FILE} not found."
+        fi
+    fi
+}
+
+# *************************************************************************** #
+#                            Function 8, build_meson
+#
+#
+# *************************************************************************** #
+function build_meson
+{
+    #
+    # Build meson
+    #
+    info "Installing Meson . . . (~2 minutes)"
+
+    # Install the python meson package.
+    check_if_py_module_installed "meson"
+    if [[ $? != 0 ]] ; then
+        download_py_module ${MESON_FILE} ${MESON_URL}
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+
+        extract_py_module ${MESON_BUILD_DIR} ${MESON_FILE} "meson"
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+
+        install_py_module ${MESON_BUILD_DIR} "meson"
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+
+        fix_py_permissions
+    fi
+
+    # Create a python script that loads the meson package.
+    if [[ ! -d ${MESON_INSTALL_DIR}/bin ]] ; then
+        mkdir -p ${MESON_INSTALL_DIR}/bin
+    fi
+    if [[ -f ${MESON_INSTALL_DIR}/bin/meson ]] ; then
+        rm $MESON_CMD
+    fi
+    MESON_CMD="${MESON_INSTALL_DIR}/bin/meson"
+    echo "#!${PYTHON_COMMAND}" > $MESON_CMD
+    echo "# -*- coding: utf-8 -*-" >> $MESON_CMD
+    echo "import re" >> $MESON_CMD
+    echo "import sys" >> $MESON_CMD
+    echo "from mesonbuild.mesonmain import main" >> $MESON_CMD
+    echo "if __name__ == '__main__':" >> $MESON_CMD
+    echo "    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])" >> $MESON_CMD
+    echo "    sys.exit(main())" >> $MESON_CMD
+
+    if [[ "$DO_GROUP" == "yes" ]] ; then
+        chmod -R ug+w,a+rX "$VISITDIR/meson"
+        chgrp -R ${GROUP} "$VISITDIR/meson"
+    fi
+    cd "$START_DIR"
+    info "Done with meson"
+    return 0
+}
+
+function bv_meson_is_enabled
+{
+    if [[ $DO_MESON == "yes" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_meson_is_installed
+{
+    if [[ "$USE_SYSTEM_MESON" == "yes" ]]; then
+        return 1
+    fi
+
+    check_if_installed "meson" $MESON_VERSION
+    if [[ $? == 0 ]] ; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_meson_build
+{
+    cd "$START_DIR"
+    if [[ "$DO_MESON" == "yes" && "$USE_SYSTEM_MESON" == "no" ]] ; then
+        check_if_installed "meson" $MESON_VERSION
+        if [[ $? == 0 ]] ; then
+            info "Skipping meson build. Meson is already installed."
+        else
+            info "Building meson (~2 minutes)"
+            build_meson
+            if [[ $? != 0 ]] ; then
+                error "Unable to build or install meson.  Bailing out."
+            fi
+            info "Done building meson"
+        fi
+    fi
+}

--- a/src/tools/dev/scripts/bv_support/bv_meson.sh
+++ b/src/tools/dev/scripts/bv_support/bv_meson.sh
@@ -127,6 +127,8 @@ function build_meson
     echo "    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])" >> $MESON_CMD
     echo "    sys.exit(main())" >> $MESON_CMD
 
+    chmod 700 $MESON_CMD
+
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/meson"
         chgrp -R ${GROUP} "$VISITDIR/meson"

--- a/src/tools/dev/scripts/bv_support/bv_meson.sh
+++ b/src/tools/dev/scripts/bv_support/bv_meson.sh
@@ -115,7 +115,7 @@ function build_meson
         mkdir -p ${MESON_INSTALL_DIR}/bin
     fi
     MESON_CMD="${MESON_INSTALL_DIR}/bin/meson"
-    if [[ -f ${MESON_INSTALL_DIR}/bin/meson ]] ; then
+    if [[ -f $MESON_CMD ]] ; then
         rm $MESON_CMD
     fi
     echo "#!${PYTHON_COMMAND}" > $MESON_CMD

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -1,0 +1,195 @@
+function bv_ninja_initialize
+{
+    export DO_NINJA="no"
+    export USE_SYSTEM_NINJA="no"
+    add_extra_commandline_args "ninja" "alt-ninja-dir" 1 "Use alternative directory for ninja"
+}
+
+function bv_ninja_enable
+{
+    DO_NINJA="yes"
+}
+
+function bv_ninja_disable
+{
+    DO_NINJA="no"
+}
+
+function bv_ninja_alt_ninja_dir
+{
+    bv_ninja_enable
+    USE_SYSTEM_NINJA="yes"
+    NINJA_INSTALL_DIR="$1"
+    info "Using Alternate ninja: $NINJA_INSTALL_DIR"
+}
+
+function bv_ninja_depends_on
+{
+    depends_on="cmake"
+
+    echo ${depends_on}
+}
+
+function bv_ninja_initialize_vars
+{
+    if [[ "$USE_SYSTEM_NINJA" == "no" ]]; then
+        NINJA_INSTALL_DIR="\${VISITHOME}/ninja/$NINJA_VERSION/\${VISITARCH}"
+    fi
+}
+
+function bv_ninja_info
+{
+    export NINJA_VERSION=${NINJA_VERSION:-"1.12.1"}
+    export NINJA_FILE=${NINJA_FILE:-"ninja-${NINJA_VERSION}.tar.gz"}
+    export NINJA_BUILD_DIR=${NINJA_BUILD_DIR:-"ninja-${NINJA_VERSION}"}
+    export NINJA_SHA256_CHECKSUM="821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a"
+}
+
+function bv_ninja_print
+{
+    printf "%s%s\n" "NINJA_FILE=" "${NINJA_FILE}"
+    printf "%s%s\n" "NINJA_VERSION=" "${NINJA_VERSION}"
+    printf "%s%s\n" "NINJA_BUILD_DIR=" "${NINJA_BUILD_DIR}"
+}
+
+function bv_ninja_print_usage
+{
+    printf "%-20s %s [%s]\n" "--ninja" "Build ninja support" "$DO_NINJA"
+    printf "%-20s %s [%s]\n" "--alt-ninja-dir" "Use ninja from an alternative directory"
+}
+
+function bv_ninja_host_profile
+{
+    # Nothing added to the host profile since ninja is only used for
+    # building third pary libraries.
+    return 0
+}
+
+function bv_ninja_ensure
+{
+    if [[ "$DO_NINJA" == "yes" && "$USE_SYSTEM_NINJA" == "no" ]] ; then
+        ensure_built_or_ready "ninja" $NINJA_VERSION $NINJA_BUILD_DIR $NINJA_FILE $NINJA_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_NINJA="no"
+            error "Unable to build ninja. ${NINJA_FILE} not found."
+        fi
+    fi
+}
+
+# *************************************************************************** #
+#                            Function 8, build_ninja
+#
+#
+# *************************************************************************** #
+function build_ninja
+{
+    #
+    # Extract the sources
+    #
+    if [[ -d $NINJA_BUILD_DIR ]] ; then
+        if [[ ! -f $NINJA_FILE ]] ; then
+            warn "The directory NINJA exists, deleting before uncompressing"
+            rm -Rf $NINJA_BUILD_DIR
+            ensure_built_or_ready $NINJA_INSTALL_DIR $NINJA_VERSION $NINJA_BUILD_DIR $NINJA_FILE
+        fi
+    fi
+
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $NINJA_BUILD_DIR $NINJA_FILE
+    untarred_ninja=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_ninja == -1 ]] ; then
+        warn "Unable to prepare ninja build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure NINJA
+    #
+    info "Configuring ninja . . ."
+
+    CMAKE_BIN="${CMAKE_INSTALL}/cmake"
+
+    cd $NINJA_BUILD_DIR || error "Can't cd to ninja build dir."
+
+    vopts=""
+    vopts="${vopts} -DCMAKE_INSTALL_PREFIX:PATH=${VISITDIR}/ninja/${NINJA_VERSION}/${VISITARCH}"
+    vopts="${vopts} -DBUILD_TESTING:BOOL=OFF"
+    vopts="${vopts} -DCMAKE_BUILD_TYPE:STRING=${VISIT_BUILD_MODE}"
+
+    #
+    # Several platforms have had problems with the VTK cmake configure
+    # command issued simply via "issue_command".  This was first discovered
+    # on BGQ and then showed up in random cases for both OSX and Linux
+    # machines. Brad resolved this on BGQ  with a simple work around - we
+    # write a simple script that we invoke with bash which calls cmake with
+    # all of the properly arguments. We are now using this strategy for all
+    # platforms.
+    #
+    if test -e bv_run_cmake.sh ; then
+        rm -f bv_run_cmake.sh
+    fi
+    echo "\"${CMAKE_BIN}\"" ${vopts} . > bv_run_cmake.sh
+    cat bv_run_cmake.sh
+    issue_command bash bv_run_cmake.sh || error "ninja configuration failed."
+
+    #
+    # Build ninja
+    #
+    info "Building ninja . . . (~2 minutes)"
+    $MAKE $MAKE_OPT_FLAGS || error "Ninja did not build correctly. Giving up."
+
+    info "Installing Ninja . . . (~2 minutes)"
+    $MAKE install || error "Ninja did not install correctly."
+
+    if [[ "$DO_GROUP" == "yes" ]] ; then
+        chmod -R ug+w,a+rX "$VISITDIR/ninja"
+        chgrp -R ${GROUP} "$VISITDIR/ninja"
+    fi
+    cd "$START_DIR"
+    info "Done with ninja"
+    return 0
+}
+
+function bv_ninja_is_enabled
+{
+    if [[ $DO_NINJA == "yes" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_ninja_is_installed
+{
+    if [[ "$USE_SYSTEM_NINJA" == "yes" ]]; then
+        return 1
+    fi
+
+    check_if_installed "ninja" $NINJA_VERSION
+    if [[ $? == 0 ]] ; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_ninja_build
+{
+    cd "$START_DIR"
+    if [[ "$DO_NINJA" == "yes" && "$USE_SYSTEM_NINJA" == "no" ]] ; then
+        check_if_installed "ninja" $NINJA_VERSION
+        if [[ $? == 0 ]] ; then
+            info "Skipping ninja build. Ninja is already installed."
+        else
+            info "Building ninja (~2 minutes)"
+            build_ninja
+            if [[ $? != 0 ]] ; then
+                error "Unable to build or install ninja.  Bailing out."
+            fi
+            info "Done building ninja"
+        fi
+    fi
+}

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -33,7 +33,7 @@ function bv_ninja_depends_on
 function bv_ninja_initialize_vars
 {
     if [[ "$USE_SYSTEM_NINJA" == "no" ]]; then
-        NINJA_INSTALL_DIR="\${VISITDIR}/ninja/$NINJA_VERSION/\${VISITARCH}"
+        NINJA_INSTALL_DIR="${VISITDIR}/ninja/$NINJA_VERSION/${VISITARCH}"
     fi
 }
 

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -85,17 +85,6 @@ function bv_ninja_ensure
 function build_ninja
 {
     #
-    # Extract the sources
-    #
-    if [[ -d $NINJA_BUILD_DIR ]] ; then
-        if [[ ! -f $NINJA_FILE ]] ; then
-            warn "The directory NINJA exists, deleting before uncompressing"
-            rm -Rf $NINJA_BUILD_DIR
-            ensure_built_or_ready $NINJA_INSTALL_DIR $NINJA_VERSION $NINJA_BUILD_DIR $NINJA_FILE
-        fi
-    fi
-
-    #
     # Prepare build dir
     #
     prepare_build_dir $NINJA_BUILD_DIR $NINJA_FILE

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -33,7 +33,7 @@ function bv_ninja_depends_on
 function bv_ninja_initialize_vars
 {
     if [[ "$USE_SYSTEM_NINJA" == "no" ]]; then
-        NINJA_INSTALL_DIR="\${VISITHOME}/ninja/$NINJA_VERSION/\${VISITARCH}"
+        NINJA_INSTALL_DIR="\${VISITDIR}/ninja/$NINJA_VERSION/\${VISITARCH}"
     fi
 }
 

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -110,15 +110,6 @@ function build_ninja
     vopts="${vopts} -DBUILD_TESTING:BOOL=OFF"
     vopts="${vopts} -DCMAKE_BUILD_TYPE:STRING=${VISIT_BUILD_MODE}"
 
-    #
-    # Several platforms have had problems with the VTK cmake configure
-    # command issued simply via "issue_command".  This was first discovered
-    # on BGQ and then showed up in random cases for both OSX and Linux
-    # machines. Brad resolved this on BGQ  with a simple work around - we
-    # write a simple script that we invoke with bash which calls cmake with
-    # all of the properly arguments. We are now using this strategy for all
-    # platforms.
-    #
     if test -e bv_run_cmake.sh ; then
         rm -f bv_run_cmake.sh
     fi

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -61,7 +61,7 @@ function bv_ninja_print_usage
 function bv_ninja_host_profile
 {
     # Nothing added to the host profile since ninja is only used for
-    # building third pary libraries.
+    # building third party libraries.
     return 0
 }
 

--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -94,13 +94,11 @@ function bv_python_initialize
     export USE_SYSTEM_PYTHON="no"
     export PY_BUILD_MPI4PY="no"
     export PY_BUILD_SPHINX="yes"
-    export PY_BUILD_MESON="no"
     export VISIT_PYTHON_DIR=${VISIT_PYTHON_DIR:-""}
     add_extra_commandline_args "python" "system-python" 0 "Using system python"
     add_extra_commandline_args "python" "alt-python-dir" 1 "Using alternate python directory"
     add_extra_commandline_args "python" "mpi4py" 0 "Build mpi4py"
     add_extra_commandline_args "python" "no-sphinx" 0 "Disable building sphinx"
-    add_extra_commandline_args "python" "meson" 0 "Build meson"
 }
 
 function bv_python_enable
@@ -202,12 +200,6 @@ function bv_python_no_sphinx
 {
     echo "Disabling building sphinx"
     export PY_BUILD_SPHINX="no"
-}
-
-function bv_python_meson
-{
-    echo "configuring for building meson"
-    export PY_BUILD_MESON="yes"
 }
 
 function bv_python_alt_python_dir
@@ -421,10 +413,6 @@ function bv_python_info
     export PY_SPHINX_TABS_FILE="sphinx-tabs-3.4.1.tar.gz"
     export PY_SPHINX_TABS_BUILD_DIR="sphinx-tabs-3.4.1"
     export PY_SPHINX_TABS_SHA256_CHECKSUM=""
-
-    export PY_MESON_FILE="meson-1.6.1.tar.gz"
-    export PY_MESON_BUILD_DIR="meson-1.6.1"
-    export PY_MESON_SHA256_CHECKSUM=""
 }
 
 function bv_python_print
@@ -442,7 +430,6 @@ function bv_python_print_usage
     printf "%-20s %s [%s]\n" "--alt-python-dir" "Use Python from an alternative directory"
     printf "%-20s %s [%s]\n" "--mpi4py" "Build mpi4py with Python"
     printf "%-20s %s [%s]\n" "--no-sphinx" "Disable building sphinx"
-    printf "%-20s %s [%s]\n" "--meson" "Build meson with Python"
   }
 
 function bv_python_host_profile
@@ -1404,31 +1391,6 @@ function build_sphinx_tabs
     return 0
 }
 
-# *************************************************************************** #
-#                              build_meson                                    #
-# *************************************************************************** #
-function build_meson
-{
-    download_py_module ${PY_MESON_FILE} ${PY_MESON_URL}
-    if [[ $? != 0 ]] ; then
-        return 1
-    fi
-
-    extract_py_module ${PY_MESON_BUILD_DIR} ${PY_MESON_FILE} "meson"
-    if [[ $? != 0 ]] ; then
-        return 1
-    fi
-
-    install_py_module ${PY_MESON_BUILD_DIR} "meson"
-    if [[ $? != 0 ]] ; then
-        return 1
-    fi
-
-    fix_py_permissions
-
-    return 0
-}
-
 function bv_python_is_enabled
 {
     if [[ $DO_PYTHON == "yes" ]]; then
@@ -1510,17 +1472,6 @@ function bv_python_is_installed
         if [[ $? != 0 ]] ; then
             if [[ $PY_CHECK_ECHO != 0 ]] ; then
                 info "python module mpi4py is not installed"
-            fi
-            PY_OK=0
-        fi
-    fi
-
-    if [[ "$PY_BUILD_MESON" == "yes" ]]; then
-
-        check_if_py_module_installed "meson"
-        if [[ $? != 0 ]] ; then
-            if [[ $PY_CHECK_ECHO != 0 ]] ; then
-                info "python module meson is not installed"
             fi
             PY_OK=0
         fi
@@ -1634,19 +1585,6 @@ function bv_python_build
                         error "sphinx tabs python module build failed. Bailing out."
                     fi
                     info "Done building the sphinx tabs."
-                fi
-            fi
-
-            if [[ "$PY_BUILD_MESON" == "yes" ]]; then
-
-                check_if_py_module_installed "meson"
-                if [[ $? != 0 ]] ; then
-                    info "Building the meson module"
-                    build_meson
-                    if [[ $? != 0 ]] ; then
-                        error "meson build failed. Bailing out."
-                    fi
-                    info "Done building the meson module"
                 fi
             fi
         fi

--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -94,11 +94,13 @@ function bv_python_initialize
     export USE_SYSTEM_PYTHON="no"
     export PY_BUILD_MPI4PY="no"
     export PY_BUILD_SPHINX="yes"
+    export PY_BUILD_MESON="no"
     export VISIT_PYTHON_DIR=${VISIT_PYTHON_DIR:-""}
     add_extra_commandline_args "python" "system-python" 0 "Using system python"
     add_extra_commandline_args "python" "alt-python-dir" 1 "Using alternate python directory"
     add_extra_commandline_args "python" "mpi4py" 0 "Build mpi4py"
     add_extra_commandline_args "python" "no-sphinx" 0 "Disable building sphinx"
+    add_extra_commandline_args "python" "meson" 0 "Build meson"
 }
 
 function bv_python_enable
@@ -196,11 +198,16 @@ function bv_python_mpi4py
     export PY_BUILD_MPI4PY="yes"
 }
 
-
 function bv_python_no_sphinx
 {
     echo "Disabling building sphinx"
     export PY_BUILD_SPHINX="no"
+}
+
+function bv_python_meson
+{
+    echo "configuring for building meson"
+    export PY_BUILD_MESON="yes"
 }
 
 function bv_python_alt_python_dir
@@ -415,6 +422,9 @@ function bv_python_info
     export PY_SPHINX_TABS_BUILD_DIR="sphinx-tabs-3.4.1"
     export PY_SPHINX_TABS_SHA256_CHECKSUM=""
 
+    export PY_MESON_FILE="meson-1.6.1.tar.gz"
+    export PY_MESON_BUILD_DIR="meson-1.6.1"
+    export PY_MESON_SHA256_CHECKSUM=""
 }
 
 function bv_python_print
@@ -432,6 +442,7 @@ function bv_python_print_usage
     printf "%-20s %s [%s]\n" "--alt-python-dir" "Use Python from an alternative directory"
     printf "%-20s %s [%s]\n" "--mpi4py" "Build mpi4py with Python"
     printf "%-20s %s [%s]\n" "--no-sphinx" "Disable building sphinx"
+    printf "%-20s %s [%s]\n" "--meson" "Build meson with Python"
   }
 
 function bv_python_host_profile
@@ -1393,6 +1404,31 @@ function build_sphinx_tabs
     return 0
 }
 
+# *************************************************************************** #
+#                              build_meson                                    #
+# *************************************************************************** #
+function build_meson
+{
+    download_py_module ${PY_MESON_FILE} ${PY_MESON_URL}
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+
+    extract_py_module ${PY_MESON_BUILD_DIR} ${PY_MESON_FILE} "meson"
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+
+    install_py_module ${PY_MESON_BUILD_DIR} "meson"
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+
+    fix_py_permissions
+
+    return 0
+}
+
 function bv_python_is_enabled
 {
     if [[ $DO_PYTHON == "yes" ]]; then
@@ -1474,6 +1510,17 @@ function bv_python_is_installed
         if [[ $? != 0 ]] ; then
             if [[ $PY_CHECK_ECHO != 0 ]] ; then
                 info "python module mpi4py is not installed"
+            fi
+            PY_OK=0
+        fi
+    fi
+
+    if [[ "$PY_BUILD_MESON" == "yes" ]]; then
+
+        check_if_py_module_installed "meson"
+        if [[ $? != 0 ]] ; then
+            if [[ $PY_CHECK_ECHO != 0 ]] ; then
+                info "python module meson is not installed"
             fi
             PY_OK=0
         fi
@@ -1587,6 +1634,19 @@ function bv_python_build
                         error "sphinx tabs python module build failed. Bailing out."
                     fi
                     info "Done building the sphinx tabs."
+                fi
+            fi
+
+            if [[ "$PY_BUILD_MESON" == "yes" ]]; then
+
+                check_if_py_module_installed "meson"
+                if [[ $? != 0 ]] ; then
+                    info "Building the meson module"
+                    build_meson
+                    if [[ $? != 0 ]] ; then
+                        error "meson build failed. Bailing out."
+                    fi
+                    info "Done building the meson module"
                 fi
             fi
         fi

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -385,7 +385,9 @@ function build_qt6_base
     if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
         export PKG_CONFIG_PATH=$XKBCOMMON_INSTALL_DIR/pkgconfig:$PKG_CONFIG_PATH
     fi
-
+    if [[ "$DO_XCB" == "yes" ]] ; then
+        export PKG_CONFIG_PATH=$XCB_INSTALL_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+    fi
 
     QT6_CFLAGS="${CFLAGS} ${C_OPT_FLAGS}"
     QT6_CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}"

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -20,11 +20,15 @@ function bv_qt6_disable
 
 function bv_qt6_depends_on
 {
+    QT6_DEPENDS=""
     if [[ "$DO_MESAGL" == "yes" ]] ; then
-        echo "mesagl glu"
-    else
-        echo ""
+        QT6_DEPENDS="mesagl glu"
     fi
+    if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
+        QT6_DEPENDS="$QT6_DEPENDS xkbcommon"
+    fi
+
+    echo $QT6_DEPENDS
 }
 
 function bv_qt6_info
@@ -374,6 +378,11 @@ function build_qt6_base
     #
     # Call configure
     #
+
+    if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
+        export PKG_CONFIG_PATH=$XKBCOMMON_INSTALL_DIR/pkgconfig:$PKG_CONFIG_PATH
+    fi
+
 
     QT6_CFLAGS="${CFLAGS} ${C_OPT_FLAGS}"
     QT6_CXXFLAGS="${CXXFLAGS} ${CXX_OPT_FLAGS}"

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -383,7 +383,7 @@ function build_qt6_base
     #
 
     if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
-        export PKG_CONFIG_PATH=$XKBCOMMON_INSTALL_DIR/pkgconfig:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=$XKBCOMMON_INSTALL_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
     fi
     if [[ "$DO_XCB" == "yes" ]] ; then
         export PKG_CONFIG_PATH=$XCB_INSTALL_DIR/lib/pkgconfig:$PKG_CONFIG_PATH

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -27,6 +27,9 @@ function bv_qt6_depends_on
     if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
         QT6_DEPENDS="$QT6_DEPENDS xkbcommon"
     fi
+    if [[ "$DO_XCB" == "yes" ]] ; then
+        QT6_DEPENDS="$QT6_DEPENDS xcb"
+    fi
 
     echo $QT6_DEPENDS
 }

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -56,6 +56,7 @@ function bv_xcb_info
 
 function bv_xcb_print
 {
+    printf "%s%s\n" "XCB_VERSION=" "${XCB_VERSION}"
     printf "%s%s\n" "XCB_IMAGE_FILE=" "${XCB_IMAGE_FILE}"
     printf "%s%s\n" "XCB_IMAGE_VERSION=" "${XCB_IMAGE_VERSION}"
     printf "%s%s\n" "XCB_IMAGE_BUILD_DIR=" "${XCB_IMAGE_BUILD_DIR}"

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -84,9 +84,14 @@ function bv_xcb_print_usage
 
 function bv_xcb_host_profile
 {
-    # Nothing added to the host profile since xcb is only used for
-    # building third party libraries.
-    return 0
+    if [[ "$DO_XCB" == "yes" ]] ; then
+        echo >> $HOSTCONF
+        echo "##" >> $HOSTCONF
+        echo "## Xcb" >> $HOSTCONF
+        echo "##" >> $HOSTCONF
+        echo "VISIT_OPTION_DEFAULT(VISIT_XCB_DIR \${VISITHOME}/xcb/$XCB_VERSION/\${VISITARCH})" \
+            >> $HOSTCONF
+    fi
 }
 
 function bv_xcb_ensure

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -1,0 +1,372 @@
+function bv_xcb_initialize
+{
+    export DO_XCB="no"
+}
+
+function bv_xcb_enable
+{
+    DO_XCB="yes"
+}
+
+function bv_xcb_disable
+{
+    DO_XCB="no"
+}
+
+function bv_xcb_depends_on
+{
+    depends_on="meson ninja"
+
+    echo ${depends_on}
+}
+
+function bv_xcb_initialize_vars
+{
+    XCB_INSTALL_DIR="${VISITDIR}/xcb/$XCB_VERSION/${VISITARCH}"
+}
+
+function bv_xcb_info
+{
+    export XCB_IMAGE_VERSION=${XCB_IMAGE_VERSION:-"0.4.1"}
+    export XCB_IMAGE_FILE=${XCB_IMAGE_FILE:-"libxcb-image-xcb-util-image-${XCB_IMAGE_VERSION}.tar.gz"}
+    export XCB_IMAGE_BUILD_DIR=${XCB_IMAGE_BUILD_DIR:-"libxcb-image-xcb-util-image-${XCB_IMAGE_VERSION}"}
+    export XCB_IMAGE_SHA256_CHECKSUM="f8aea5230dcf736aa86a005ba486f58b689f183006c26ecc44b91ed6b11598d4"
+    export XCB_KEYSYMS_VERSION=${XCB_KEYSYMS_VERSION:-"0.4.1"}
+    export XCB_KEYSYMS_FILE=${XCB_KEYSYMS_FILE:-"libxcb-keysyms-xcb-util-keysyms-${XCB_KEYSYMS_VERSION}.tar.gz"}
+    export XCB_KEYSYMS_BUILD_DIR=${XCB_KEYSYMS_BUILD_DIR:-"libxcb-keysyms-xcb-util-keysyms-${XCB_KEYSYMS_VERSION}"}
+    export XCB_KEYSYMS_SHA256_CHECKSUM="2780db069685a95f132a48d637e7f66ffd0a2483e960157536f58f4671d93f5c"
+    export XCB_M4_VERSION=${XCB_M4_VERSION:-"0.4.1"}
+    export XCB_M4_FILE=${XCB_M4_FILE:-"libxcb-m4-xcb-util-m4-${XCB_M4_VERSION}.tar.gz"}
+    export XCB_M4_BUILD_DIR=${XCB_M4_BUILD_DIR:-"libxcb-m4-xcb-util-m4-${XCB_M4_VERSION}"}
+    export XCB_M4_SHA256_CHECKSUM="f60369c3bad234798867b768fc01183395a20f74c521a48e5e996f938df2d45a"
+    export XCB_RENDERUTIL_VERSION=${XCB_RENDERUTIL_VERSION:-"0.3.10"}
+    export XCB_RENDERUTIL_FILE=${XCB_RENDERUTIL_FILE:-"libxcb-render-util-xcb-util-renderutil-${XCB_RENDERUTIL_VERSION}.tar.gz"}
+    export XCB_RENDERUTIL_BUILD_DIR=${XCB_RENDERUTIL_BUILD_DIR:-"libxcb-render-util-xcb-util-renderutil-${XCB_RENDERUTIL_VERSION}"}
+    export XCB_RENDERUTIL_SHA256_CHECKSUM="160017e3e8e61acb8ddfbce885f294623a46f92f20c5f5066ee6d1b720971548"
+    export XCB_UTIL_VERSION=${XCB_UTIL_VERSION:-"0.4.1"}
+    export XCB_UTIL_FILE=${XCB_UTIL_FILE:-"libxcb-util-xcb-util-${XCB_UTIL_VERSION}.tar.gz"}
+    export XCB_UTIL_BUILD_DIR=${XCB_UTIL_BUILD_DIR:-"libxcb-util-xcb-util-${XCB_UTIL_VERSION}"}
+    export XCB_UTIL_SHA256_CHECKSUM="7b56592b339d47809cbefb9f46721705c662de1a001bc773d335975cd2eba34f"
+    export XCB_WM_VERSION=${XCB_WM_VERSION:-"0.4.2"}
+    export XCB_WM_FILE=${XCB_WM_FILE:-"libxcb-wm-xcb-util-wm-${XCB_WM_VERSION}.tar.gz"}
+    export XCB_WM_BUILD_DIR=${XCB_WM_BUILD_DIR:-"libxcb-wm-xcb-util-wm-${XCB_WM_VERSION}"}
+    export XCB_WM_SHA256_CHECKSUM="c1b792306874c36b535413a33edc71a0ac46e78adcf6ddb1a34090a07393d717"
+}
+
+function bv_xcb_print
+{
+    printf "%s%s\n" "XCB_IMAGE_FILE=" "${XCB_IMAGE_FILE}"
+    printf "%s%s\n" "XCB_IMAGE_VERSION=" "${XCB_IMAGE_VERSION}"
+    printf "%s%s\n" "XCB_IMAGE_BUILD_DIR=" "${XCB_IMAGE_BUILD_DIR}"
+    printf "%s%s\n" "XCB_KEYSYMS_FILE=" "${XCB_KEYSYMS_FILE}"
+    printf "%s%s\n" "XCB_KEYSYMS_VERSION=" "${XCB_KEYSYMS_VERSION}"
+    printf "%s%s\n" "XCB_KEYSYMS_BUILD_DIR=" "${XCB_KEYSYMS_BUILD_DIR}"
+    printf "%s%s\n" "XCB_M4_FILE=" "${XCB_M4_FILE}"
+    printf "%s%s\n" "XCB_M4_VERSION=" "${XCB_M4_VERSION}"
+    printf "%s%s\n" "XCB_M4_BUILD_DIR=" "${XCB_M4_BUILD_DIR}"
+    printf "%s%s\n" "XCB_RENDERUTIL_FILE=" "${XCB_RENDERUTIL_FILE}"
+    printf "%s%s\n" "XCB_RENDERUTIL_VERSION=" "${XCB_RENDERUTIL_VERSION}"
+    printf "%s%s\n" "XCB_RENDERUTIL_BUILD_DIR=" "${XCB_RENDERUTIL_BUILD_DIR}"
+    printf "%s%s\n" "XCB_UTIL_FILE=" "${XCB_UTIL_FILE}"
+    printf "%s%s\n" "XCB_UTIL_VERSION=" "${XCB_UTIL_VERSION}"
+    printf "%s%s\n" "XCB_UTIL_BUILD_DIR=" "${XCB_UTIL_BUILD_DIR}"
+    printf "%s%s\n" "XCB_WM_FILE=" "${XCB_WM_FILE}"
+    printf "%s%s\n" "XCB_WM_VERSION=" "${XCB_WM_VERSION}"
+    printf "%s%s\n" "XCB_WM_BUILD_DIR=" "${XCB_WM_BUILD_DIR}"
+}
+
+function bv_xcb_print_usage
+{
+    printf "%-20s %s [%s]\n" "--xcb" "Build xcb support" "$DO_XCB"
+}
+
+function bv_xcb_host_profile
+{
+    # Nothing added to the host profile since xcb is only used for
+    # building third party libraries.
+    return 0
+}
+
+function bv_xcb_ensure
+{
+    if [[ "$DO_XCB" == "yes" ]] ; then
+        ensure_built_or_ready "xcb-image" $XCB_IMAGE_VERSION $XCB_IMAGE_BUILD_DIR $XCB_IMAGE_FILE $XCB_IMAGE_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XCB="no"
+            error "Unable to build xcb image. ${XCB_IMAGE_FILE} not found."
+        fi
+
+        ensure_built_or_ready "xcb-keysyms" $XCB_KEYSYMS_VERSION $XCB_KEYSYMS_BUILD_DIR $XCB_KEYSYMS_FILE $XCB_KEYSYMS_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XCB="no"
+            error "Unable to build xcb keysyms. ${XCB_KEYSYMS_FILE} not found."
+        fi
+
+        ensure_built_or_ready "xcb-m4" $XCB_M4_VERSION $XCB_M4_BUILD_DIR $XCB_M4_FILE $XCB_M4_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XCB="no"
+            error "Unable to build xcb m4. ${XCB_M4_FILE} not found."
+        fi
+
+        ensure_built_or_ready "xcb-renderutil" $XCB_RENDERUTIL_VERSION $XCB_RENDERUTIL_BUILD_DIR $XCB_RENDERUTIL_FILE $XCB_RENDERUTIL_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XCB="no"
+            error "Unable to build xcb renderutil. ${XCB_RENDERUTIL_FILE} not found."
+        fi
+
+        ensure_built_or_ready "xcb-util" $XCB_UTIL_VERSION $XCB_UTIL_BUILD_DIR $XCB_UTIL_FILE $XCB_UTIL_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XCB="no"
+            error "Unable to build xcb util. ${XCB_UTIL_FILE} not found."
+        fi
+
+        ensure_built_or_ready "xcb-wm" $XCB_WM_VERSION $XCB_WM_BUILD_DIR $XCB_WM_FILE $XCB_WM_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XCB="no"
+            error "Unable to build xcb wm. ${XCB_WM_FILE} not found."
+        fi
+    fi
+}
+
+# *************************************************************************** #
+#                            Function 8, build_xcb
+#
+# Modifications:
+#
+# *************************************************************************** #
+function build_xcb
+{
+    # QT6 requires the following XCB modules
+    # The modules marked with an asterisk are being built by build_visit.
+    # The remaining ones come from XCB proper and are usually installed on
+    # the system. If we run across a system that doesn't have any XCB
+    # stuff installed we can add building XCB. It can be found at
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb.
+    #
+    # XCB
+    # ICCCM       *
+    # SHM
+    # IMAGE       *
+    # KEYSYMS     *
+    # RENDER
+    # RENDERUTIL  *
+    # RANDR
+    # SHAPE
+    # SYNC
+    # XFIXES
+    # XKB
+    # GLX
+    # XINPUT
+
+    # XCB M4
+    # https://gitlab.freedesktop.org/xorg/util/xcb-util-m4
+    # Provides m4 macros needed as part of configure process by other packages.
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XCB_IMAGE_BUILD_DIR $XCB_IMAGE_FILE
+    untarred_xcb=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xcb == -1 ]] ; then
+        warn "Unable to prepare xcb image build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Nothing else to do since all we do is untar the file.
+    #
+
+    # XCB UTIL
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb-util
+    # Provides aux, atom, event
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XCB_UTIL_BUILD_DIR $XCB_UTIL_FILE
+    untarred_xcb=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xcb == -1 ]] ; then
+        warn "Unable to prepare xcb util build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure and install
+    #
+    info "Configuring and installing xcb util . . . (~1 minute)"
+    cd $XCB_UTIL_BUILD_DIR || error "Can't cd to xcb util build dir."
+    cd m4
+    cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
+    cd ..
+
+    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    make install
+    cd ..
+
+    # Add the pkgconfig directory to the PKG_CONFIG_PATH so that pkg-config
+    # can find xcb util needed by the rest of the xcb packages and qt6.
+    export PKG_CONFIG_PATH=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/lib/pkgconfig:$PKG_CONFIG_PATH
+
+    # XCB IMAGE
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb-image
+    # Provides image
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XCB_IMAGE_BUILD_DIR $XCB_IMAGE_FILE
+    untarred_xcb=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xcb == -1 ]] ; then
+        warn "Unable to prepare xcb image build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure and install
+    #
+    info "Configuring and installing xcb image . . . (~1 minute)"
+    cd $XCB_IMAGE_BUILD_DIR || error "Can't cd to xcb image build dir."
+    cd m4
+    cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
+    cd ..
+
+    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    make install
+    cd ..
+
+    # XCB KEYSYMS
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb-keysyms
+    # Provides keysyms
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XCB_KEYSYMS_BUILD_DIR $XCB_KEYSYMS_FILE
+    untarred_xcb=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xcb == -1 ]] ; then
+        warn "Unable to prepare xcb keysyms build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure and install
+    #
+    info "Configuring and installing xcb keysyms . . . (~1 minute)"
+    cd $XCB_KEYSYMS_BUILD_DIR || error "Can't cd to xcb keysyms build dir."
+    cd m4
+    cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
+    cd ..
+
+    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    make install
+    cd ..
+
+    # XCB WM
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb-wm
+    # Provides ewmh, icccm
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XCB_WM_BUILD_DIR $XCB_WM_FILE
+    untarred_xcb=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xcb == -1 ]] ; then
+        warn "Unable to prepare xcb wm build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure and install
+    #
+    info "Configuring and installing xcb wm . . . (~1 minute)"
+    cd $XCB_WM_BUILD_DIR || error "Can't cd to xcb wm build dir."
+    cd m4
+    cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
+    cd ..
+
+    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    make install
+    cd ..
+
+    # XCB RENDERUTIL
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb-render-util
+    # Provides renderutil
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XCB_RENDERUTIL_BUILD_DIR $XCB_RENDERUTIL_FILE
+    untarred_xcb=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xcb == -1 ]] ; then
+        warn "Unable to prepare xcb renderutil build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure and install
+    #
+    info "Configuring and installing xcb renderutil . . . (~1 minute)"
+    cd $XCB_RENDERUTIL_BUILD_DIR || error "Can't cd to xcb renderutil build dir."
+    cd m4
+    cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
+    cd ..
+
+    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    make install
+    cd ..
+
+    if [[ "$DO_GROUP" == "yes" ]] ; then
+        chmod -R ug+w,a+rX "$VISITDIR/xcb"
+        chgrp -R ${GROUP} "$VISITDIR/xcb"
+    fi
+    cd "$START_DIR"
+    info "Done with xcb"
+    return 0
+}
+
+function bv_xcb_is_enabled
+{
+    if [[ $DO_XCB == "yes" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_xcb_is_installed
+{
+    check_if_installed "xcb" $XCB_VERSION
+    if [[ $? == 0 ]] ; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_xcb_build
+{
+    cd "$START_DIR"
+    if [[ "$DO_XCB" == "yes" ]] ; then
+        check_if_installed "xcb" $XCB_VERSION
+        if [[ $? == 0 ]] ; then
+            info "Skipping xcb build. Xcb is already installed."
+        else
+            info "Building xcb (~5 minutes)"
+            build_xcb
+            if [[ $? != 0 ]] ; then
+                error "Unable to build or install xcb.  Bailing out."
+            fi
+            info "Done building xcb"
+        fi
+    fi
+}

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -27,6 +27,7 @@ function bv_xcb_initialize_vars
 
 function bv_xcb_info
 {
+    export XCB_VERSION=${XCB_VERSION:-"0.4.1"}
     export XCB_IMAGE_VERSION=${XCB_IMAGE_VERSION:-"0.4.1"}
     export XCB_IMAGE_FILE=${XCB_IMAGE_FILE:-"libxcb-image-xcb-util-image-${XCB_IMAGE_VERSION}.tar.gz"}
     export XCB_IMAGE_BUILD_DIR=${XCB_IMAGE_BUILD_DIR:-"libxcb-image-xcb-util-image-${XCB_IMAGE_VERSION}"}
@@ -170,12 +171,12 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_IMAGE_BUILD_DIR $XCB_IMAGE_FILE
+    prepare_build_dir $XCB_M4_BUILD_DIR $XCB_M4_FILE
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
     if [[ $untarred_xcb == -1 ]] ; then
-        warn "Unable to prepare xcb image build directory. Giving Up!"
+        warn "Unable to prepare xcb m4 build directory. Giving Up!"
         return 1
     fi
 

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -207,7 +207,8 @@ function build_xcb
     cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
     cd ..
 
-    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    ./autogen.sh --prefix=${XCB_INSTALL_DIR}
+
     make install
     cd ..
 
@@ -239,7 +240,7 @@ function build_xcb
     cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
     cd ..
 
-    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    ./autogen.sh --prefix=${XCB_INSTALL_DIR}
     make install
     cd ..
 
@@ -267,7 +268,7 @@ function build_xcb
     cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
     cd ..
 
-    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    ./autogen.sh --prefix=${XCB_INSTALL_DIR}
     make install
     cd ..
 
@@ -295,7 +296,7 @@ function build_xcb
     cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
     cd ..
 
-    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    ./autogen.sh --prefix=${XCB_INSTALL_DIR}
     make install
     cd ..
 
@@ -323,7 +324,7 @@ function build_xcb
     cp ../../libxcb-m4-xcb-util-m4-0.4.1/* .
     cd ..
 
-    ./autogen.sh --prefix=/usr/WS1/brugger/visit_spack_xcb_build/bv_test/third_party/xcb/0.4.1/linux-ppc64le_gcc-8.3/
+    ./autogen.sh --prefix=${XCB_INSTALL_DIR}
     make install
     cd ..
 

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -117,6 +117,8 @@ function build_xkbcommon
     meson compile -C build || error "Xkbcommon did not build correctly. Giving up."
 
     info "Installing Xkbcommon . . . (~1 minutes)"
+
+    # The libraries
     if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/lib ]] ; then
         mkdir -p ${XKBCOMMON_INSTALL_DIR}/lib
     fi
@@ -129,10 +131,47 @@ function build_xkbcommon
     cp build/libxkbregistry.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib
     ln -s libxkbregistry.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbregistry.so
     ln -s libxkbregistry.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbregistry.so.0
+
+    # The header files
     if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon ]] ; then
         mkdir -p ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon
     fi
     cp include/xkbcommon/* ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon
+
+    # The pkg-config files
+    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/pkgconfig ]] ; then
+        mkdir -p ${XKBCOMMON_INSTALL_DIR}/pkgconfig
+    fi
+
+    PC_FILE=${XKBCOMMON_INSTALL_DIR}/pkgconfig/xkbcommon.pc
+    if [[ -f $PC_FILE ]] ; then
+        rm $PC_FILE
+    fi
+    echo "prefix=${XKBCOMMON_INSTALL_DIR}" > $PC_FILE
+    echo "libdir=\${prefix}/lib" >> $PC_FILE
+    echo "includedir=\${prefix}/inlude" >> $PC_FILE
+    echo "" >> $PC_FILE
+    echo "Name: xkbcommon" >> $PC_FILE
+    echo "Description: XKB API common to servers and clients" >> $PC_FILE
+    echo "Version: 1.7.0" >> $PC_FILE
+    echo "Libs: -L\${libdir} -lxkbcommon" >> $PC_FILE
+    echo "Cflags: -I\${includedir}" >> $PC_FILE
+
+    PC_FILE=${XKBCOMMON_INSTALL_DIR}/pkgconfig/xkbcommon-x11.pc
+    if [[ -f $PC_FILE ]] ; then
+        rm $PC_FILE
+    fi
+    echo "prefix=${XKBCOMMON_INSTALL_DIR}" > $PC_FILE
+    echo "libdir=\${prefix}/lib" >> $PC_FILE
+    echo "includedir=\${prefix}/inlude" >> $PC_FILE
+    echo "" >> $PC_FILE
+    echo "Name: xkbcommon-x11" >> $PC_FILE
+    echo "Description: XKB API common to servers and clients - X11 support" >> $PC_FILE
+    echo "Version: 1.7.0" >> $PC_FILE
+    echo "Requires: xkbcommon" >> $PC_FILE
+    echo "Requires.private: xcb >= 1.10, xcb-xkb >= 1.10" >> $PC_FILE
+    echo "Libs: -L\${libdir} -lxkbcommon" >> $PC_FILE
+    echo "Cflags: -I\${includedir}" >> $PC_FILE
 
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/xkbcommon"

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -1,0 +1,179 @@
+function bv_xkbcommon_initialize
+{
+    export DO_XKBCOMMON="no"
+}
+
+function bv_xkbcommon_enable
+{
+    DO_XKBCOMMON="yes"
+}
+
+function bv_xkbcommon_disable
+{
+    DO_XKBCOMMON="no"
+}
+
+function bv_xkbcommon_depends_on
+{
+    depends_on="meson ninja"
+
+    echo ${depends_on}
+}
+
+function bv_xkbcommon_initialize_vars
+{
+    XKBCOMMON_INSTALL_DIR="${VISITDIR}/xkbcommon/$XKBCOMMON_VERSION/${VISITARCH}"
+}
+
+function bv_xkbcommon_info
+{
+    export XKBCOMMON_VERSION=${XKBCOMMON_VERSION:-"1.7.0"}
+    export XKBCOMMON_FILE=${XKBCOMMON_FILE:-"libxkbcommon-${XKBCOMMON_VERSION}.tar.xz"}
+    export XKBCOMMON_BUILD_DIR=${XKBCOMMON_BUILD_DIR:-"libxkbcommon-${XKBCOMMON_VERSION}"}
+    export XKBCOMMON_SHA256_CHECKSUM=""65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247
+}
+
+function bv_xkbcommon_print
+{
+    printf "%s%s\n" "XKBCOMMON_FILE=" "${XKBCOMMON_FILE}"
+    printf "%s%s\n" "XKBCOMMON_VERSION=" "${XKBCOMMON_VERSION}"
+    printf "%s%s\n" "XKBCOMMON_BUILD_DIR=" "${XKBCOMMON_BUILD_DIR}"
+}
+
+function bv_xkbcommon_print_usage
+{
+    printf "%-20s %s [%s]\n" "--xkbcommon" "Build xkbcommon support" "$DO_XKBCOMMON"
+}
+
+function bv_xkbcommon_host_profile
+{
+    # Nothing added to the host profile since xkbcommon is only used for
+    # building third party libraries.
+    return 0
+}
+
+function bv_xkbcommon_ensure
+{
+    if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
+        ensure_built_or_ready "xkbcommon" $XKBCOMMON_VERSION $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE $XKBCOMMON_URL
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_XKBCOMMON="no"
+            error "Unable to build xkbcommon. ${XKBCOMMON_FILE} not found."
+        fi
+    fi
+}
+
+# *************************************************************************** #
+#                            Function 8, build_xkbcommon
+#
+#
+# *************************************************************************** #
+function build_xkbcommon
+{
+    #
+    # Extract the sources
+    #
+    if [[ -d $XKBCOMMON_BUILD_DIR ]] ; then
+        if [[ ! -f $XKBCOMMON_FILE ]] ; then
+            warn "The directory XKBCOMMON exists, deleting before uncompressing"
+            rm -Rf $XKBCOMMON_BUILD_DIR
+            ensure_built_or_ready $XKBCOMMON_INSTALL_DIR $XKBCOMMON_VERSION $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE
+        fi
+    fi
+
+    #
+    # Prepare build dir
+    #
+    prepare_build_dir $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE
+    untarred_xkbcommon=$?
+    # 0, already exists, 1 untarred src, 2 error
+
+    if [[ $untarred_xkbcommon == -1 ]] ; then
+        warn "Unable to prepare xkbcommon build directory. Giving Up!"
+        return 1
+    fi
+
+    #
+    # Configure XKBCOMMON
+    #
+    info "Configuring xkbcommon . . ."
+
+    MESON_BIN="${MESON_INSTALL}/meson"
+
+    cd $XKBCOMMON_BUILD_DIR || error "Can't cd to xkbcommon build dir."
+
+    export PATH=$MESON_INSTALL_DIR/bin:$NINJA_INSTALL_DIR/bin:$PATH
+    echo "PATH=${PATH}"
+    echo "MESON_INSTALL_DIR=${MESON_INSTALL_DIR}"
+    echo "NINJA_INSTALL_DIR=${NINJA_INSTALL_DIR}"
+
+    meson setup build || error "Xkbcommon did not configure correctly. Giving up."
+
+    #
+    # Build xkbcommon
+    #
+    info "Building xkbcommon . . . (~1 minutes)"
+    meson compile -C build || error "Xkbcommon did not build correctly. Giving up."
+
+    info "Installing Xkbcommon . . . (~1 minutes)"
+    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/lib ]] ; then
+        mkdir -p ${XKBCOMMON_INSTALL_DIR}/lib
+    fi
+    cp build/libxkbcommon.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib
+    ln -s libxkbcommon.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbcommon.so
+    ln -s libxkbcommon.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbcommon.so.0
+    cp build/libxkbcommon-x11.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib
+    ln -s libxkbcommon-x11.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbcommon-x11.so
+    ln -s libxkbcommon-x11.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbcommon-x11.so.0
+    cp build/libxkbregistry.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib
+    ln -s libxkbregistry.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbregistry.so
+    ln -s libxkbregistry.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbregistry.so.0
+    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon ]] ; then
+        mkdir -p ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon
+    fi
+    cp include/xkbcommon/* ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon
+
+    if [[ "$DO_GROUP" == "yes" ]] ; then
+        chmod -R ug+w,a+rX "$VISITDIR/xkbcommon"
+        chgrp -R ${GROUP} "$VISITDIR/xkbcommon"
+    fi
+    cd "$START_DIR"
+    info "Done with xkbcommon"
+    return 0
+}
+
+function bv_xkbcommon_is_enabled
+{
+    if [[ $DO_XKBCOMMON == "yes" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_xkbcommon_is_installed
+{
+    check_if_installed "xkbcommon" $XKBCOMMON_VERSION
+    if [[ $? == 0 ]] ; then
+        return 1
+    fi
+    return 0
+}
+
+function bv_xkbcommon_build
+{
+    cd "$START_DIR"
+    if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
+        check_if_installed "xkbcommon" $XKBCOMMON_VERSION
+        if [[ $? == 0 ]] ; then
+            info "Skipping xkbcommon build. Xkbcommon is already installed."
+        else
+            info "Building xkbcommon (~2 minutes)"
+            build_xkbcommon
+            if [[ $? != 0 ]] ; then
+                error "Unable to build or install xkbcommon.  Bailing out."
+            fi
+            info "Done building xkbcommon"
+        fi
+    fi
+}

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -47,9 +47,14 @@ function bv_xkbcommon_print_usage
 
 function bv_xkbcommon_host_profile
 {
-    # Nothing added to the host profile since xkbcommon is only used for
-    # building third party libraries.
-    return 0
+    if [[ "$DO_XKBCOMMON" == "yes" ]] ; then
+        echo >> $HOSTCONF
+        echo "##" >> $HOSTCONF
+        echo "## Xkbcommon" >> $HOSTCONF
+        echo "##" >> $HOSTCONF
+        echo "VISIT_OPTION_DEFAULT(VISIT_XKBCOMMON_DIR \${VISITHOME}/xkbcommon/$XKBCOMMON_VERSION/\${VISITARCH})" \
+            >> $HOSTCONF
+    fi
 }
 
 function bv_xkbcommon_ensure

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -144,7 +144,7 @@ function build_xkbcommon
     fi
     echo "prefix=${XKBCOMMON_INSTALL_DIR}" > $PC_FILE
     echo "libdir=\${prefix}/lib" >> $PC_FILE
-    echo "includedir=\${prefix}/inlude" >> $PC_FILE
+    echo "includedir=\${prefix}/include" >> $PC_FILE
     echo "" >> $PC_FILE
     echo "Name: xkbcommon" >> $PC_FILE
     echo "Description: XKB API common to servers and clients" >> $PC_FILE
@@ -158,7 +158,7 @@ function build_xkbcommon
     fi
     echo "prefix=${XKBCOMMON_INSTALL_DIR}" > $PC_FILE
     echo "libdir=\${prefix}/lib" >> $PC_FILE
-    echo "includedir=\${prefix}/inlude" >> $PC_FILE
+    echo "includedir=\${prefix}/include" >> $PC_FILE
     echo "" >> $PC_FILE
     echo "Name: xkbcommon-x11" >> $PC_FILE
     echo "Description: XKB API common to servers and clients - X11 support" >> $PC_FILE

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -165,7 +165,7 @@ function build_xkbcommon
     echo "Version: 1.7.0" >> $PC_FILE
     echo "Requires: xkbcommon" >> $PC_FILE
     echo "Requires.private: xcb >= 1.10, xcb-xkb >= 1.10" >> $PC_FILE
-    echo "Libs: -L\${libdir} -lxkbcommon" >> $PC_FILE
+    echo "Libs: -L\${libdir} -lxkbcommon-x11" >> $PC_FILE
     echo "Cflags: -I\${includedir}" >> $PC_FILE
 
     if [[ "$DO_GROUP" == "yes" ]] ; then

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -30,7 +30,7 @@ function bv_xkbcommon_info
     export XKBCOMMON_VERSION=${XKBCOMMON_VERSION:-"1.7.0"}
     export XKBCOMMON_FILE=${XKBCOMMON_FILE:-"libxkbcommon-${XKBCOMMON_VERSION}.tar.xz"}
     export XKBCOMMON_BUILD_DIR=${XKBCOMMON_BUILD_DIR:-"libxkbcommon-${XKBCOMMON_VERSION}"}
-    export XKBCOMMON_SHA256_CHECKSUM=""65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247
+    export XKBCOMMON_SHA256_CHECKSUM="65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247"
 }
 
 function bv_xkbcommon_print

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -103,7 +103,7 @@ function build_xkbcommon
 
     export PATH=$MESON_INSTALL_DIR/bin:$NINJA_INSTALL_DIR/bin:$PATH
 
-    meson setup build || error "Xkbcommon did not configure correctly. Giving up."
+    meson setup build --prefix $XKBCOMMON_INSTALL_DIR || error "Xkbcommon did not configure correctly. Giving up."
 
     #
     # Build xkbcommon
@@ -111,11 +111,14 @@ function build_xkbcommon
     info "Building xkbcommon . . . (~1 minutes)"
     meson compile -C build || error "Xkbcommon did not build correctly. Giving up."
 
-    info "Installing Xkbcommon . . . (~1 minutes)"
+    info "Installing xkbcommon . . . (~1 minutes)"
+    # Manually installing xkbcommon since "meson install -C build" gave
+    # an error with an unhandled python OSError.
 
     # The libraries
-    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/lib ]] ; then
-        mkdir -p ${XKBCOMMON_INSTALL_DIR}/lib
+    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/lib64 ]] ; then
+        mkdir -p ${XKBCOMMON_INSTALL_DIR}/lib64
+	ln -s lib64 ${XKBCOMMON_INSTALL_DIR}/lib
     fi
     cp build/libxkbcommon.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib
     ln -s libxkbcommon.so.0.0.0 ${XKBCOMMON_INSTALL_DIR}/lib/libxkbcommon.so
@@ -134,39 +137,12 @@ function build_xkbcommon
     cp include/xkbcommon/* ${XKBCOMMON_INSTALL_DIR}/include/xkbcommon
 
     # The pkg-config files
-    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/pkgconfig ]] ; then
-        mkdir -p ${XKBCOMMON_INSTALL_DIR}/pkgconfig
+    if [[ ! -d ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig ]] ; then
+        mkdir -p ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig
     fi
-
-    PC_FILE=${XKBCOMMON_INSTALL_DIR}/pkgconfig/xkbcommon.pc
-    if [[ -f $PC_FILE ]] ; then
-        rm $PC_FILE
-    fi
-    echo "prefix=${XKBCOMMON_INSTALL_DIR}" > $PC_FILE
-    echo "libdir=\${prefix}/lib" >> $PC_FILE
-    echo "includedir=\${prefix}/include" >> $PC_FILE
-    echo "" >> $PC_FILE
-    echo "Name: xkbcommon" >> $PC_FILE
-    echo "Description: XKB API common to servers and clients" >> $PC_FILE
-    echo "Version: 1.7.0" >> $PC_FILE
-    echo "Libs: -L\${libdir} -lxkbcommon" >> $PC_FILE
-    echo "Cflags: -I\${includedir}" >> $PC_FILE
-
-    PC_FILE=${XKBCOMMON_INSTALL_DIR}/pkgconfig/xkbcommon-x11.pc
-    if [[ -f $PC_FILE ]] ; then
-        rm $PC_FILE
-    fi
-    echo "prefix=${XKBCOMMON_INSTALL_DIR}" > $PC_FILE
-    echo "libdir=\${prefix}/lib" >> $PC_FILE
-    echo "includedir=\${prefix}/include" >> $PC_FILE
-    echo "" >> $PC_FILE
-    echo "Name: xkbcommon-x11" >> $PC_FILE
-    echo "Description: XKB API common to servers and clients - X11 support" >> $PC_FILE
-    echo "Version: 1.7.0" >> $PC_FILE
-    echo "Requires: xkbcommon" >> $PC_FILE
-    echo "Requires.private: xcb >= 1.10, xcb-xkb >= 1.10" >> $PC_FILE
-    echo "Libs: -L\${libdir} -lxkbcommon-x11" >> $PC_FILE
-    echo "Cflags: -I\${includedir}" >> $PC_FILE
+    cp build/meson-private/xkbcommon.pc ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig
+    cp build/meson-private/xkbcommon-x11.pc ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig
+    cp build/meson-private/xkbregistry.pc ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig
 
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/xkbcommon"

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -72,17 +72,6 @@ function bv_xkbcommon_ensure
 function build_xkbcommon
 {
     #
-    # Extract the sources
-    #
-    if [[ -d $XKBCOMMON_BUILD_DIR ]] ; then
-        if [[ ! -f $XKBCOMMON_FILE ]] ; then
-            warn "The directory XKBCOMMON exists, deleting before uncompressing"
-            rm -Rf $XKBCOMMON_BUILD_DIR
-            ensure_built_or_ready $XKBCOMMON_INSTALL_DIR $XKBCOMMON_VERSION $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE
-        fi
-    fi
-
-    #
     # Prepare build dir
     #
     prepare_build_dir $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -99,14 +99,9 @@ function build_xkbcommon
     #
     info "Configuring xkbcommon . . ."
 
-    MESON_BIN="${MESON_INSTALL}/meson"
-
     cd $XKBCOMMON_BUILD_DIR || error "Can't cd to xkbcommon build dir."
 
     export PATH=$MESON_INSTALL_DIR/bin:$NINJA_INSTALL_DIR/bin:$PATH
-    echo "PATH=${PATH}"
-    echo "MESON_INSTALL_DIR=${MESON_INSTALL_DIR}"
-    echo "NINJA_INSTALL_DIR=${NINJA_INSTALL_DIR}"
 
     meson setup build || error "Xkbcommon did not configure correctly. Giving up."
 

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -53,6 +53,7 @@
             <lib name="uintah"/>
             <lib name="vtkm"/>
             <lib name="xdmf"/>
+            <lib name="xkbcommon"/>
         </optional>
 
         <!-- thirdparty flag -->
@@ -100,6 +101,7 @@
             <lib name="tbb"/>
             <lib name="vtkm"/>
             <lib name="xdmf"/>
+            <lib name="xkbcommon"/>
         </group>
 
         <group name="no-thirdparty" comment="Do not build required 3rd party libraries" enabled="no">

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -38,6 +38,7 @@
             <lib name="mpich"/>
             <lib name="nektarpp"/>
             <lib name="netcdf"/>
+            <lib name="ninja"/>
             <lib name="openexr"/>
             <lib name="osmesa"/>
             <lib name="ospray"/>
@@ -86,6 +87,7 @@
             <lib name="mili"/>
             <lib name="moab"/>
             <lib name="netcdf"/>
+            <lib name="ninja"/>
             <lib name="openexr"/>
             <lib name="ospray"/>
             <lib name="pidx"/>

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -53,6 +53,7 @@
             <lib name="uintah"/>
             <lib name="vtkm"/>
             <lib name="xdmf"/>
+            <lib name="xcb"/>
             <lib name="xkbcommon"/>
         </optional>
 
@@ -101,6 +102,7 @@
             <lib name="tbb"/>
             <lib name="vtkm"/>
             <lib name="xdmf"/>
+            <lib name="xcb"/>
             <lib name="xkbcommon"/>
         </group>
 

--- a/src/tools/dev/scripts/bv_support/modules.xml
+++ b/src/tools/dev/scripts/bv_support/modules.xml
@@ -32,6 +32,7 @@
             <lib name="llvm"/>
             <lib name="mdsplus"/>
             <lib name="mesagl"/>
+            <lib name="meson"/>
             <lib name="mfem"/>
             <lib name="mili"/>
             <lib name="moab"/>
@@ -83,6 +84,7 @@
             <lib name="icet"/>
             <lib name="ispc"/>
             <lib name="llvm"/>
+            <lib name="meson"/>
             <lib name="mfem"/>
             <lib name="mili"/>
             <lib name="moab"/>


### PR DESCRIPTION
### Description

I added support for building `ninja`, `meson`, `xkbcommon` and `xcb` to `build_visit`. This will allow building VisIt with Qt6 on systems without the `xkbcommon` and `xcb` development packages installed, which appears to be most supercomputer systems these days.

The goal was to add support for building `xkbcommon` and `xcb`, but `xkbcommon` uses `meson`, which uses `ninja`, so all four were added to `build_visit`. They are enabled with:
```
build_visit --ninja --meson --xkbcommon --xcb`
```

I am putting this on the 3.4RC so that we can use `build_visit` to build 3.4.2 on some additional systems. When I merge the changes to develop I will add release notes. I will also update the build scripts and config site files for building on `sierra` and its associated systems on another pull request.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I tested `build_visit` on `rzansel`, which doesn't have the `xkbcommon` and `xcb` development packages installed. I invoked `build_visit` with:
```
./build_visit3_4_2 --required --parallel --no-visit --qwt --cmake --ninja --zlib --python --meson --xkbcommon --xcb --llvm --mesagl --qt6 --silo --hdf5 --makeflags -j8
```

I installed the resulting distribution and ran the VisIt GUI. The Qt6 GUI came up and I created pseudocolor and mesh plots from `curv2d.silo` and saved the resulting image.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
