### PR TITLE
Use const& for exception objects in CATCH macros

### DIFF
--- a/src/common/misc/VisItException.h
+++ b/src/common/misc/VisItException.h
@@ -73,6 +73,8 @@
 //    Tom Fogal, Sat Jun 14 18:44:35 EDT 2008
 //    Added const qualifications to avoid warnings (and bugs too I guess :)
 //
+//    Mark C. Miller, Tue Jan 28 11:00:01 PST 2025
+//    Make caught exception objects const ref.
 // ****************************************************************************
 
 class MISC_API2 VisItException
@@ -154,8 +156,8 @@ class MISC_API2 VisItException
 }
 
 #define TRY                 try {
-#define CATCH(T)            } catch(T)   { VisItException::LogCatch(#T, __FILE__,  __LINE__);
-#define CATCH2(T, A)        } catch(T &A) { VisItException::LogCatch(#T, __FILE__,  __LINE__);
+#define CATCH(T)            } catch(const T& __visit__exception__)   { VisItException::LogCatch(#T, __FILE__,  __LINE__);
+#define CATCH2(T, A)        } catch(const T& A) { VisItException::LogCatch(#T, __FILE__,  __LINE__);
 #define CATCHALL            } catch(...) { VisItException::LogCatch("VisItException", __FILE__,  __LINE__);
 #define ENDTRY              }
 #define RETHROW             throw

--- a/src/common/parser/ParseException.h
+++ b/src/common/parser/ParseException.h
@@ -33,13 +33,15 @@ class Rule;
 //    Hank Childs, Fri Jan 28 14:57:14 PST 2005
 //    Inherit from VisItException.
 //
+//    Mark C. Miller, Tue Jan 28 11:00:39 PST 2025
+//    Const qualify read-only api methods.
 // ****************************************************************************
 class ParseException : public VisItException
 {
   public:
     ParseException(Pos p) : pos(p) { }
-    virtual const char *Message() = 0;
-    Pos GetPos() { return pos; }
+    virtual const char *Message() const = 0;
+    Pos GetPos() const { return pos; }
   private:
     Pos pos;
 };
@@ -48,7 +50,7 @@ class LexicalException : public ParseException
 {
   public:
     LexicalException(Pos p) : ParseException(p) { }
-    virtual const char *Message() { return "The text scanner encountered an unexpected character:"; }
+    virtual const char *Message() const { return "The text scanner encountered an unexpected character:"; }
 };
 
 class SyntacticException : public ParseException
@@ -62,7 +64,7 @@ class SyntacticException : public ParseException
     {
         snprintf(msg, 1024, "The expression parser encountered an unexpected token (%s):", s.c_str());
     }
-    virtual const char *Message() { return msg; }
+    virtual const char *Message() const { return msg; }
   private:
     char msg[1024];
 };
@@ -71,22 +73,22 @@ class UnexpectedEndException : public ParseException
 {
   public:
     UnexpectedEndException(Pos p) : ParseException(p) { }
-    virtual const char *Message() { return "The parser expected more stuff after the end of the expression:"; }
+    virtual const char *Message() const { return "The parser expected more stuff after the end of the expression:"; }
 };
 
 class SemanticException : public ParseException
 {
   public:
     SemanticException(Pos p) : ParseException(p) { }
-    virtual const char *Message() { return "Semantic error:"; }
+    virtual const char *Message() const { return "Semantic error:"; }
 };
 
 class UnhandledReductionException : public ParseException
 {
   public:
     UnhandledReductionException(Pos p, const Rule *r) : ParseException(p), rule(r) { }
-    virtual const char *Message() { return "Parse error -- unhandled reduction:"; }
-    virtual const Rule *GetRule() { return rule; }
+    virtual const char *Message() const { return "Parse error -- unhandled reduction:"; }
+    virtual const Rule *GetRule() const { return rule; }
   private:
     const Rule *rule;
 };

--- a/src/viewer/main/ViewerEngineManagerImplementation_macros.h
+++ b/src/viewer/main/ViewerEngineManagerImplementation_macros.h
@@ -24,6 +24,9 @@
 //    Brad Whitlock, Wed Feb 23 16:47:36 PST 2005
 //    Added ENGINE_PROXY_RPC_BEGIN_NOSTART that does not try to launch
 //    a compute engine before checking for its existence.
+//
+//    Mark C. Miller, Tue Jan 28 11:01:15 PST 2025
+//    Fix CATCH macro usage.
 
 #define ENGINE_PROXY_RPC_BEGIN_NOSTART(rpcname) \
     bool retval = false; \
@@ -99,7 +102,7 @@
                    retval = false; \
                 } \
             } \
-            CATCH(VisItException e) \
+            CATCH2(VisItException,e) \
             { \
                 retry = false; \
                 retval = false; \

--- a/src/visitpy/cli/cli.C
+++ b/src/visitpy/cli/cli.C
@@ -182,6 +182,8 @@ extern "C" void cli_runscript(const char *);
 //    as '-s' is a viable option that could be passed to srun via -sla or -la
 //    and we don't that option to be proccessed as a cli '-s' option.
 //
+//    Mark C. Miller, Tue Jan 28 11:01:53 PST 2025
+//    Fix CATCH macro usage. 
 // ****************************************************************************
 
 int
@@ -772,7 +774,7 @@ main(int argc, char *argv[])
 
     }
 
-    CATCH(VisItException &e)
+    CATCH2(VisItException,e)
     {
         cerr << "A fatal exception occurred when trying to launch the CLI." << endl;
         cerr << "The following information may help a VisIt developer debug the problem: " << endl;

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -19404,6 +19404,8 @@ NeedToLoadPlugins(Subject *, void *)
 //   directory, and user may not have write permissions there, making command
 //   logging fail silently.
 //
+//   Mark C. Miller, Tue Jan 28 11:02:20 PST 2025
+//   Fix CATCH macro usage.
 // ****************************************************************************
 
 static int
@@ -19459,7 +19461,7 @@ InitializeModule()
 
         VisItInit::Initialize(argc, argv, 0, 1, false);
     }
-    CATCH(VisItException &)
+    CATCH(VisItException)
     {
         // TODO: This case isn't handled.
         // Return that we could not initialize VisIt.
@@ -19718,7 +19720,7 @@ LaunchViewer(const char *visitProgram)
         GetViewerProxy()->InitializePlugins(PlotPluginManager::Scripting,
                                             visit_plugin_dir.c_str());
     }
-    CATCH(VisItException &)
+    CATCH(VisItException)
     {
         // Return since we could not initialize VisIt.
         CATCH_RETURN(1);
@@ -19743,7 +19745,7 @@ LaunchViewer(const char *visitProgram)
         //
         noViewer = false;
     }
-    CATCH(VisItException &)
+    CATCH(VisItException)
     {
         noViewer = true;
     }
@@ -20533,7 +20535,7 @@ visit_eventloop(void *)
                     GetViewerProxy()->ProcessInput();
                 MUTEX_UNLOCK();
             }
-            CATCH(LostConnectionException &)
+            CATCH(LostConnectionException)
             {
                 // We lost the viewer, terminate the event loop.
                 keepGoing = false;


### PR DESCRIPTION
### Description

Ensures `CATCH(...)` and `CATCH2(...)` macros use `const &` for the exception objects. This fixes a pervasive warning from gcc-12, `warning: catching polymorphic type ‘class XXX’ by value`
<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
