### PR TITLE
Fix warnings compiling Silo plugin

### DIFF
--- a/src/common/utility/BJHash.h
+++ b/src/common/utility/BJHash.h
@@ -111,7 +111,7 @@ inline unsigned int BJHash::Hash(const unsigned char *k, unsigned int length, un
    };
 
    for (i = len; i > 0; i--)
-      cases[i];
+      cases[11-i]();
 
    bjhash_mix(a,b,c);
 

--- a/src/common/utility/BJHash.h
+++ b/src/common/utility/BJHash.h
@@ -11,6 +11,8 @@
 
 #include <cstring>
 #include <string>
+#include <vector>
+#include <functional>
 
 namespace BJHash
 {
@@ -75,14 +77,13 @@ inline unsigned int BJHash::Mask(int n)
   c -= a; c -= b; c ^= (b>>15); \
 }
 
-
 inline unsigned int BJHash::Hash(const unsigned char *k, unsigned int length, unsigned int initval)
 {
-   unsigned int a,b,c,len;
-
-   len = length;
-   a = b = 0x9e3779b9;
-   c = initval;
+   unsigned int len = length;
+   unsigned int a = 0x9e3779b9;
+   unsigned int b = a;
+   unsigned int c = initval;
+   unsigned int i;
 
    while (len >= 12)
    {
@@ -95,28 +96,22 @@ inline unsigned int BJHash::Hash(const unsigned char *k, unsigned int length, un
 
    c += length;
 
-   if (len>=11)
-       c+=((unsigned int)k[10]<<24);
-   if (len>=10)
-      c+=((unsigned int)k[9]<<16);
-   if (len>=9)
-      c+=((unsigned int)k[8]<<8);
-   if (len>=8)
-      b+=((unsigned int)k[7]<<24);
-   if (len>=7)
-      b+=((unsigned int)k[6]<<16);
-   if (len>=6)
-      b+=((unsigned int)k[5]<<8);
-   if (len>=5)
-      b+=k[4];
-   if (len>=4)
-      a+=((unsigned int)k[3]<<24);
-   if (len>=3)
-      a+=((unsigned int)k[2]<<16);
-   if (len>=2)
-      a+=((unsigned int)k[1]<<8);
-   if (len>=1)
-      a+=k[0];
+   std::vector<std::function<void()>> cases = {
+      [&] { c+=((unsigned int)k[10]<<24); },
+      [&] { c+=((unsigned int)k[9]<<16);  },
+      [&] { c+=((unsigned int)k[8]<<8);   },
+      [&] { b+=((unsigned int)k[7]<<24);  },
+      [&] { b+=((unsigned int)k[6]<<16);  },
+      [&] { b+=((unsigned int)k[5]<<8);   },
+      [&] { b+=k[4];                      },
+      [&] { a+=((unsigned int)k[3]<<24);  },
+      [&] { a+=((unsigned int)k[2]<<16);  },
+      [&] { a+=((unsigned int)k[1]<<8);   },
+      [&] { a+=k[0];                      },
+   };
+
+   for (i = len; i > 0; i--)
+      cases[i];
 
    bjhash_mix(a,b,c);
 

--- a/src/common/utility/BJHash.h
+++ b/src/common/utility/BJHash.h
@@ -97,17 +97,19 @@ inline unsigned int BJHash::Hash(const unsigned char *k, unsigned int length, un
 
    switch(len)
    {
-      case 11: c+=((unsigned int)k[10]<<24);
-      case 10: c+=((unsigned int)k[9]<<16);
-      case 9 : c+=((unsigned int)k[8]<<8);
-      case 8 : b+=((unsigned int)k[7]<<24);
-      case 7 : b+=((unsigned int)k[6]<<16);
-      case 6 : b+=((unsigned int)k[5]<<8);
-      case 5 : b+=k[4];
-      case 4 : a+=((unsigned int)k[3]<<24);
-      case 3 : a+=((unsigned int)k[2]<<16);
-      case 2 : a+=((unsigned int)k[1]<<8);
-      case 1 : a+=k[0];
+      // The unusual coding style here is to explicitly indicate
+      // intentional fall through so compiler won't complain.
+               case 11: c+=((unsigned int)k[10]<<24);  goto case_10;
+      case_10: case 10: c+=((unsigned int)k[9]<<16);   goto case_9;
+      case_9:  case 9:  c+=((unsigned int)k[8]<<8);    goto case_8;
+      case_8:  case 8:  b+=((unsigned int)k[7]<<24);   goto case_7;
+      case_7:  case 7:  b+=((unsigned int)k[6]<<16);   goto case_6;
+      case_6:  case 6:  b+=((unsigned int)k[5]<<8);    goto case_5;
+      case_5:  case 5:  b+=k[4];                       goto case_4;
+      case_4:  case 4:  a+=((unsigned int)k[3]<<24);   goto case_3;
+      case_3:  case 3:  a+=((unsigned int)k[2]<<16);   goto case_2;
+      case_2:  case 2:  a+=((unsigned int)k[1]<<8);    goto case_1;
+      case_1:  case 1:  a+=k[0];
    }
 
    bjhash_mix(a,b,c);

--- a/src/common/utility/BJHash.h
+++ b/src/common/utility/BJHash.h
@@ -95,22 +95,28 @@ inline unsigned int BJHash::Hash(const unsigned char *k, unsigned int length, un
 
    c += length;
 
-   switch(len)
-   {
-      // The unusual coding style here is to explicitly indicate
-      // intentional fall through so compiler won't complain.
-               case 11: c+=((unsigned int)k[10]<<24);  goto case_10;
-      case_10: case 10: c+=((unsigned int)k[9]<<16);   goto case_9;
-      case_9:  case 9:  c+=((unsigned int)k[8]<<8);    goto case_8;
-      case_8:  case 8:  b+=((unsigned int)k[7]<<24);   goto case_7;
-      case_7:  case 7:  b+=((unsigned int)k[6]<<16);   goto case_6;
-      case_6:  case 6:  b+=((unsigned int)k[5]<<8);    goto case_5;
-      case_5:  case 5:  b+=k[4];                       goto case_4;
-      case_4:  case 4:  a+=((unsigned int)k[3]<<24);   goto case_3;
-      case_3:  case 3:  a+=((unsigned int)k[2]<<16);   goto case_2;
-      case_2:  case 2:  a+=((unsigned int)k[1]<<8);    goto case_1;
-      case_1:  case 1:  a+=k[0];
-   }
+   if (len>=11)
+       c+=((unsigned int)k[10]<<24);
+   if (len>=10)
+      c+=((unsigned int)k[9]<<16);
+   if (len>=9)
+      c+=((unsigned int)k[8]<<8);
+   if (len>=8)
+      b+=((unsigned int)k[7]<<24);
+   if (len>=7)
+      b+=((unsigned int)k[6]<<16);
+   if (len>=6)
+      b+=((unsigned int)k[5]<<8);
+   if (len>=5)
+      b+=k[4];
+   if (len>=4)
+      a+=((unsigned int)k[3]<<24);
+   if (len>=3)
+      a+=((unsigned int)k[2]<<16);
+   if (len>=2)
+      a+=((unsigned int)k[1]<<8);
+   if (len>=1)
+      a+=k[0];
 
    bjhash_mix(a,b,c);
 

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -2,14 +2,6 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wall"
-#pragma GCC diagnostic warning "-Wextra"
-#pragma GCC diagnostic warning "-Wpedantic"
-
-// Code with strict warnings here
-
-
 // ************************************************************************* //
 //                           avtSiloFileFormat.C                             //
 // ************************************************************************* //
@@ -18235,4 +18227,3 @@ db_get_index(DBnamescheme const *ns, int natnum)
 
     return (int) strtol(&name_str[i], 0, 10);
 }
-#pragma GCC diagnostic pop

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -15052,7 +15052,7 @@ avtSiloFileFormat::GetLocalDomainBoundaryInfo(int domain, const char *var)
     // extract the packed info into a avtLocalStructuredDomainBoundaryList
     //
 
-    int *dc_ptr = decomp;
+    int *dc_ptr = decomp+1;
     int nbnd    = *dc_ptr++;
     avtLocalStructuredDomainBoundaryList *res =
                     new avtLocalStructuredDomainBoundaryList(domain,dc_ptr);

--- a/src/databases/Silo/avtSiloFileFormat.C
+++ b/src/databases/Silo/avtSiloFileFormat.C
@@ -2,6 +2,14 @@
 // Project developers.  See the top-level LICENSE file for dates and other
 // details.  No copyright assignment is required to contribute to VisIt.
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wall"
+#pragma GCC diagnostic warning "-Wextra"
+#pragma GCC diagnostic warning "-Wpedantic"
+
+// Code with strict warnings here
+
+
 // ************************************************************************* //
 //                           avtSiloFileFormat.C                             //
 // ************************************************************************* //
@@ -125,7 +133,7 @@ static bool TetIsInverted(const int *siloTetrahedron,
                             vtkUnstructuredGrid *ugrid);
 
 static void ArbInsertArbitrary(vtkUnstructuredGrid *ugrid,
-    int nsdims, DBphzonelist *phzl, int gz, const vector<int> &nloffs,
+    DBphzonelist *phzl, int gz, const vector<int> &nloffs,
     const vector<int> &floffs, unsigned int ocdata[2],
     vector<int> *cellReMap, vector<int> *nodeReMap);
 
@@ -1153,7 +1161,9 @@ avtSiloFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
     // Do a recursive search through the subdirectories.
     //
     ReadDir(dbfile, topDir.c_str(), md);
+#ifdef PARALLEL
     BroadcastGlobalInfo(md);
+#endif
     DoRootDirectoryWork(md);
 
     //
@@ -4299,8 +4309,7 @@ avtSiloFileFormat::ReadMultispecies(DBfile *dbfile,
 // ****************************************************************************
 void
 avtSiloFileFormat::ReadDefvars(DBfile *dbfile,
-    int ndefvars, char **defvars_names,
-    const char *dirname, avtDatabaseMetaData *md)
+    int ndefvars, char **defvars_names, avtDatabaseMetaData *md)
 {
     for (int i = 0; i < ndefvars; i++)
     {
@@ -4478,7 +4487,7 @@ avtSiloFileFormat::ReadDir(DBfile *dbfile, const char *dirname,
     ReadCSGvars(dbfile, ncsgvar, csgvar_names, dirname, md);
 
     // Defined variables
-    ReadDefvars(dbfile, ndefvars, defvars_names, dirname, md);
+    ReadDefvars(dbfile, ndefvars, defvars_names, md);
 
     //
     // If the meshtv searchpath is defined then replace the list of
@@ -4646,10 +4655,10 @@ avtSiloFileFormat::ReadDir(DBfile *dbfile, const char *dirname,
 //    Mark C. Miller, Wed Jun 15 09:22:14 PDT 2016
 //    Added logic to support adding of block decomposition as a variable.
 // ****************************************************************************
+#ifdef PARALLEL
 void
 avtSiloFileFormat::BroadcastGlobalInfo(avtDatabaseMetaData *metadata)
 {
-#ifdef PARALLEL
     int rank = PAR_Rank();
 
     //
@@ -4750,8 +4759,8 @@ avtSiloFileFormat::BroadcastGlobalInfo(avtDatabaseMetaData *metadata)
     BroadcastInt(have_amr_group_info);
     haveAmrGroupInfo = have_amr_group_info;
 
-#endif
 }
+#endif
 
 // ****************************************************************************
 //  Method:  avtSiloFileFormat::StoreMultimeshInfo
@@ -6895,6 +6904,7 @@ PaintNodesForAnnotIntFacelist(vtkBitArray *nlvar,
                         edge[2][0] = zl->nodelist[nlIdx+2];
                         edge[2][1] = zl->nodelist[nlIdx+0];
                         nedges = 3;
+                        break;
                     }
                     case DB_ZONETYPE_QUAD_QUAD:
                     case DB_ZONETYPE_QUAD:
@@ -6908,6 +6918,7 @@ PaintNodesForAnnotIntFacelist(vtkBitArray *nlvar,
                         edge[3][0] = zl->nodelist[nlIdx+3];
                         edge[3][1] = zl->nodelist[nlIdx+0];
                         nedges = 4;
+                        break;
                     }
                 }
                 nlIdx += zl->shapesize[seg];
@@ -7024,6 +7035,7 @@ PaintNodesForAnnotIntFacelist(vtkBitArray *nlvar,
                         face[3][2] = zl->nodelist[nlIdx+2];
                         face[3][3] = -1;
                         nfaces = 4;
+                        break;
                     }
                     case DB_ZONETYPE_QUAD_PYRAMID:
                     case DB_ZONETYPE_PYRAMID:
@@ -7049,6 +7061,7 @@ PaintNodesForAnnotIntFacelist(vtkBitArray *nlvar,
                         face[4][2] = zl->nodelist[nlIdx+3];
                         face[4][3] = -1;
                         nfaces = 5;
+                        break;
                     }
                     case DB_ZONETYPE_QUAD_PRISM:
                     case DB_ZONETYPE_PRISM:
@@ -7074,6 +7087,7 @@ PaintNodesForAnnotIntFacelist(vtkBitArray *nlvar,
                         face[4][2] = zl->nodelist[nlIdx+4];
                         face[4][3] = zl->nodelist[nlIdx+3];
                         nfaces = 5;
+                        break;
                     }
                     case DB_ZONETYPE_QUAD_HEX:
                     case DB_ZONETYPE_HEX:
@@ -7103,6 +7117,7 @@ PaintNodesForAnnotIntFacelist(vtkBitArray *nlvar,
                         face[5][2] = zl->nodelist[nlIdx+6];
                         face[5][3] = zl->nodelist[nlIdx+7];
                         nfaces = 6;
+                        break;
                     }
                 }
                 nlIdx += zl->shapesize[seg];
@@ -8446,6 +8461,8 @@ vtkDataArray *
 avtSiloFileFormat::GetQuadVectorVar(DBfile *dbfile, const char *vname,
                                     const char *tvn, int domain)
 {
+    (void) domain; // if we ever cache mixed components, we'll need this here
+
     //
     // It's ridiculous, but Silo does not have all of the `const's in their
     // library, so let's cast it away.
@@ -8568,6 +8585,7 @@ avtSiloFileFormat::GetPointVectorVar(DBfile *dbfile, const char *vname)
 vtkDataArray *
 avtSiloFileFormat::GetCsgVectorVar(DBfile *dbfile, const char *vname)
 {
+    (void) dbfile; // not implemented but issue message if ever encounter it
     EXCEPTION1(InvalidVariableException, vname);
     return 0;
 }
@@ -10371,8 +10389,7 @@ avtSiloFileFormat::GetUnstructuredMesh(DBfile *dbfile, const char *mn,
 //
 // ****************************************************************************
 static int
-LookupPHZonelistFaceIdInFaceHash(const vector<int>& faceNodes,
-    const vector<int>& canonicalFaceNodes,
+LookupPHZonelistFaceIdInFaceHash(const vector<int>& canonicalFaceNodes,
     const map<unsigned int, vector<std::pair<int, vector<int> > > >& faceHash)
 {
     unsigned int hv = BJHash::Hash((const unsigned char*) &canonicalFaceNodes[0],
@@ -10432,7 +10449,7 @@ GetPHZonelistFaceId(int nnodes, const int *const nl,
         if (pass == 0) faceNodesF = canonicalFaceNodes;
 
         // Lookup the face
-        int phzlFaceId = LookupPHZonelistFaceIdInFaceHash(faceNodes, canonicalFaceNodes, faceHash);
+        int phzlFaceId = LookupPHZonelistFaceIdInFaceHash(canonicalFaceNodes, faceHash);
         if (phzlFaceId != -INT_MAX)
         {
             // This is where normal orientation (e.g. inward vs. outward) gets handled.
@@ -10728,7 +10745,7 @@ avtSiloFileFormat::ReadInConnectivity(vtkUnstructuredGrid *ugrid,
                     vtk_zonetype != -1)
                 {
                     *nl++ = shapesize;
-                    int nblinnod = 0 ;
+                    size_t nblinnod = 0 ;
 #ifdef DB_ZONETYPE_QUAD_BEAM
                     // Handle quadratic elements assuming the first nodes are in Silo convention.
                     // This is to be more easily compatible with an external face extractor that would consider only
@@ -11409,7 +11426,7 @@ ArbInsertHex(vtkUnstructuredGrid *ugrid, int *nids, unsigned int ocdata[2],
 //    DBucdmesh*.
 // ****************************************************************************
 static void
-ArbInsertArbitrary(vtkUnstructuredGrid *ugrid, int nsdims, DBphzonelist *phzl, int gz,
+ArbInsertArbitrary(vtkUnstructuredGrid *ugrid, DBphzonelist *phzl, int gz,
     const vector<int> &nloffs, const vector<int> &floffs, unsigned int ocdata[2],
     vector<int> *cellReMap, vector<int> *nodeReMap)
 {
@@ -11862,11 +11879,11 @@ avtSiloFileFormat::ReadInArbConnectivity(const char *meshname,
             // Now, based on information we gathered iterating over all the
             // faces of this zone, decide what case it is and handle it.
             //
-            int nids[8];
+            int nids[8] = {0,0,0,0,0,0,0,0};
             set<int>::iterator it;
             if (isNotZooElement)                // Arbitrary
             {
-                ArbInsertArbitrary(ugrid, nsdims, phzl, gz, nloffs, floffs, ocdata,
+                ArbInsertArbitrary(ugrid, phzl, gz, nloffs, floffs, ocdata,
                     cellReMap, nodeReMap);
                 encounteredFullyArbitraryCase = true;
             }
@@ -11886,7 +11903,7 @@ avtSiloFileFormat::ReadInArbConnectivity(const char *meshname,
                 }
                 else
                 {
-                    ArbInsertArbitrary(ugrid, nsdims, phzl, gz, nloffs, floffs, ocdata,
+                    ArbInsertArbitrary(ugrid, phzl, gz, nloffs, floffs, ocdata,
                         cellReMap, nodeReMap);
                     encounteredFullyArbitraryCase = true;
                 }
@@ -12171,14 +12188,14 @@ avtSiloFileFormat::ReadInArbConnectivity(const char *meshname,
             }
             else                        // Arbitrary
             {
-                ArbInsertArbitrary(ugrid, nsdims, phzl, gz, nloffs, floffs, ocdata,
+                ArbInsertArbitrary(ugrid, phzl, gz, nloffs, floffs, ocdata,
                     cellReMap, nodeReMap);
                 encounteredFullyArbitraryCase = true;
             }
         }
         else                            // Arbitrary
         {
-            ArbInsertArbitrary(ugrid, nsdims, phzl, gz, nloffs, floffs, ocdata,
+            ArbInsertArbitrary(ugrid, phzl, gz, nloffs, floffs, ocdata,
                 cellReMap, nodeReMap);
             encounteredFullyArbitraryCase = true;
         }
@@ -13709,6 +13726,7 @@ vtkDataSet *
 avtSiloFileFormat::GetCSGMesh(DBfile *dbfile, const char *mn, int dom)
 {
 #ifdef MDSERVER
+    (void) dbfile; (void) mn; (void) dom;
     return 0;
 #else
     //
@@ -14254,7 +14272,7 @@ avtSiloFileFormat::DetermineMultiMeshForSubVariable(DBfile *dbfile,
     // We weren't able to find a match -- throw an exception and let the
     // levels above us determine what the right thing to do is.
     //
-    char str[1024];
+    char str[2048];
     snprintf(str, sizeof(str), "Was not able to match multivar \"%s\" and its first \n"
                  "non-empty submesh \"%s\" in file %s to a multi-mesh.\n"
                  "This typically leads to the variable being invalidated\n"
@@ -14948,7 +14966,7 @@ avtSiloFileFormat::GetGlobalIds(int dom, char const *mesh, char const *idtype)
     // Save whatever current data read mask is
     unsigned long long saved_mask = DBGetDataReadMask2();
 
-    int ngids, gidtype;
+    int ngids = 0, gidtype = DB_INT;
     void *gids = 0;
     if (mtype == DB_UCDMESH)
     {
@@ -15043,7 +15061,6 @@ avtSiloFileFormat::GetLocalDomainBoundaryInfo(int domain, const char *var)
     //
 
     int *dc_ptr = decomp;
-    int lid     = *dc_ptr++;
     int nbnd    = *dc_ptr++;
     avtLocalStructuredDomainBoundaryList *res =
                     new avtLocalStructuredDomainBoundaryList(domain,dc_ptr);
@@ -15648,9 +15665,10 @@ avtSiloFileFormat::CalcExternalFacelist(DBfile *dbfile, const char *mesh)
 bool
 avtSiloFileFormat::PopulateIOInformation(const std::string &meshname, avtIOInformation &io)
 {
+    (void) meshname;
     if(!ioInfoValid)
     {
-        ioInfoValid = PopulateIOInformationEx(meshname, ioInfo);
+        ioInfoValid = PopulateIOInformationEx(ioInfo);
     }
 
     io = ioInfo;
@@ -15704,12 +15722,12 @@ avtSiloFileFormat::PopulateIOInformation(const std::string &meshname, avtIOInfor
 // ****************************************************************************
 
 bool
-avtSiloFileFormat::PopulateIOInformationEx(const std::string &meshname, avtIOInformation &ioInfo)
+avtSiloFileFormat::PopulateIOInformationEx(avtIOInformation &ioInfo)
 {
     bool retval = false;
     TRY
     {
-        int   i, j;
+        int   i;
         int nMeshes = metadata->GetNumMeshes();
 
         if (nMeshes < 1)
@@ -17677,9 +17695,9 @@ BuildDomainAuxiliaryInfoForAMRMeshes(DBfile *dbfile, DBmultimesh *mm,
     avtVariableCache *cache, int forceSingle)
 {
 #ifdef MDSERVER
-
+    (void) dbfile; (void) mm; (void) meshName; (void) timestate;
+    (void) db_mesh_type; (void) cache; (void) forceSingle;
     return;
-
 #else
 
     int i, j;
@@ -18217,3 +18235,4 @@ db_get_index(DBnamescheme const *ns, int natnum)
 
     return (int) strtol(&name_str[i], 0, 10);
 }
+#pragma GCC diagnostic pop

--- a/src/databases/Silo/avtSiloFileFormat.h
+++ b/src/databases/Silo/avtSiloFileFormat.h
@@ -385,10 +385,12 @@ class avtSiloFileFormat : public avtSTMDFileFormat
     void                  ReadMultimats(DBfile*,int,char**,const char*,avtDatabaseMetaData*);
     void                  ReadSpecies(DBfile*,int,char**,const char*,avtDatabaseMetaData*);
     void                  ReadMultispecies(DBfile*,int,char**,const char*,avtDatabaseMetaData*);
-    void                  ReadDefvars(DBfile*,int,char**,const char*,avtDatabaseMetaData*);
+    void                  ReadDefvars(DBfile*,int,char**,avtDatabaseMetaData*);
 
     void                  DoRootDirectoryWork(avtDatabaseMetaData*);
+#ifdef PARALLEL
     void                  BroadcastGlobalInfo(avtDatabaseMetaData*);
+#endif
     void                  StoreMultimeshInfo(const char *const dirname,
                                              const char *const name_w_dir,
                                              int meshnum,
@@ -535,8 +537,7 @@ class avtSiloFileFormat : public avtSTMDFileFormat
 
     void                        CheckForTimeVaryingMetadata(DBfile *toc);
 
-    bool                  PopulateIOInformationEx(const std::string &meshname,
-                                                  avtIOInformation &ioInfo);
+    bool                  PopulateIOInformationEx(avtIOInformation &ioInfo);
 };
 
 

--- a/src/sim/V2/ddtsim/ddtsim.cpp
+++ b/src/sim/V2/ddtsim/ddtsim.cpp
@@ -383,7 +383,7 @@ DDTSim::DDTSim(const char *libsimPath,int par_rank, int par_size) :
         snprintf(mAbsSimFileName,MAX_SIMFILE_NAME_LENGTH-1,
                  "%s/.ddt/visualizations/%012d.%s-ddt.sim2",
                  mDDTSharedPath,
-                 (int)visitSim.time(),
+                 static_cast<int>(visitSim.time()),
                  mProgramName);
 
         sprintf(desc,"DDT provided visualisation of %s", mProgramName);

--- a/src/sim/V2/ddtsim/ddtsim.cpp
+++ b/src/sim/V2/ddtsim/ddtsim.cpp
@@ -383,7 +383,7 @@ DDTSim::DDTSim(const char *libsimPath,int par_rank, int par_size) :
         snprintf(mAbsSimFileName,MAX_SIMFILE_NAME_LENGTH-1,
                  "%s/.ddt/visualizations/%012d.%s-ddt.sim2",
                  mDDTSharedPath,
-                 (int)time(NULL),
+                 (int)visitSim.time(),
                  mProgramName);
 
         sprintf(desc,"DDT provided visualisation of %s", mProgramName);

--- a/src/visit_vtk/full/vtkCSGGrid.C
+++ b/src/visit_vtk/full/vtkCSGGrid.C
@@ -3016,7 +3016,8 @@ vtkCSGGrid::DiscretizeSpaceMultiPass(int specificZone,
     // Threshold out the cells for this region
     vtkThreshold *threshold = vtkThreshold::New();
     threshold->SetInputData(rv);
-    threshold->ThresholdByUpper(0.5);
+    threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
+    threshold->SetUpperThreshold(0.5);
     threshold->Update();
     rv = threshold->GetOutput();
     rv->Register(0);

--- a/src/visit_vtk/full/vtkCSGGrid.h
+++ b/src/visit_vtk/full/vtkCSGGrid.h
@@ -113,7 +113,7 @@ class VISIT_VTK_API vtkCSGGrid : public vtkDataSet
 public:
   static vtkCSGGrid *New();
 
-  vtkTypeMacro(vtkCSGGrid,vtkDataSet);
+  vtkTypeMacro(vtkCSGGrid,vtkDataSet)
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:


### PR DESCRIPTION
Fixes warnings in Silo database plugin. The only warnings still generated after this are related to the CATCH macro fixed in another update to `develop`