### PR TITLE
Set AllBoundaries to editable.

### DIFF
--- a/src/databases/OpenFOAM/visit_vtkOpenFOAMReader.cxx
+++ b/src/databases/OpenFOAM/visit_vtkOpenFOAMReader.cxx
@@ -6001,6 +6001,8 @@ vtkMultiBlockDataSet *visit_vtkOpenFOAMReaderPrivate::MakeBoundaryMesh(
     const int boundaryStartFace =
         (this->BoundaryDict.size() > 0 ? this->BoundaryDict[0].StartFace : 0);
     this->AllBoundaries = vtkPolyData::New();
+    // needed for RemoveReferenceToCell, fixes crash with VTK 9.4.1.
+    this->AllBoundaries->EditableOn();
     this->AllBoundaries->Allocate(facesPoints->GetNumberOfElements()
         - boundaryStartFace);
     }


### PR DESCRIPTION
Fixes crash when used with vtk 9.4.1.
Resolves #20233.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

Ran the OpenFOAM regression test for a vtk-9.4.1 build of VisIt successfully in both serial and parallel.
Also ran the same test for a vtk-9.2.6 build of VisIt sucessfully.

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
