### PR TITLE
Fix vtk 9.4 vtkDataWriter patch.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -250,6 +250,7 @@ EOF
 function apply_vtk94_vtkdatawriter_patch
 {
   # patch vtkDataWriter to fix a bug when writing a vtkBitArray
+  # Make it use the same calculation as the reader.
    patch -p0 << \EOF
 --- IO/Legacy/vtkDataWriter.cxx.orig	2024-09-23 21:01:47.000000000 -0700
 +++ IO/Legacy/vtkDataWriter.cxx	2024-09-26 08:44:39.000000000 -0700
@@ -261,7 +262,7 @@ function apply_vtk94_vtkdatawriter_patch
        {
          unsigned char* cptr = static_cast<vtkBitArray*>(data)->GetPointer(0);
 -        fp->write(reinterpret_cast<char*>(cptr), (sizeof(unsigned char)) * ((num - 1) / 8 + 1));
-+        fp->write(reinterpret_cast<char*>(cptr), (sizeof(unsigned char)) * ((num*numComp*numComp - 1) / 8 + 1));
++        fp->write(reinterpret_cast<char*>(cptr), (sizeof(unsigned char)) * ((num*numComp + 7) / 8));
        }
        *fp << "\n";
      }


### PR DESCRIPTION
When writing binary bit data, use same calculation as used in vtkDataReader.
Resolves #20251.


### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other
Patch to 3rd party library.

### How Has This Been Tested?

I recompiled VTK 9.4.1 using the build_visit script, compiled VisIt against the new version and ran the overlink test.
No more vtk ERR messages being printed to terminal.


### Checklist:

- [X ] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
