### PR TITLE
Set 'outputToCurrentDirectory' to 1 for SaveWindow atts.

### DIFF
--- a/src/test/tests/quickrecipes/saving_images.py
+++ b/src/test/tests/quickrecipes/saving_images.py
@@ -19,6 +19,7 @@ def setting_output_image_characteristics():
     s.fileName = 'mybmpfile' 
     s.width, s.height = 1024,768 
     s.screenCapture = 0 
+    s.outputToCurrentDirectory = 1
     SetSaveWindowAttributes(s) 
     # Subsequent calls to SaveWindow() will use these settings
     # setting output image characteristics }

--- a/src/test/tests/quickrecipes/vqr_utils.py.inc
+++ b/src/test/tests/quickrecipes/vqr_utils.py.inc
@@ -5,7 +5,17 @@
 # to look natural where it is literalincluded in the docs but still access
 # files in their "normal" places in our test logic.
 #
+# Modifications:
+#   Kathleen Biagas, Fri Feb 21, 2025
+#   Added setting of outputToCurrentDirectory for SaveWindowAttributes.
 # ----------------------------------------------------------------------------
+
+# change where SaveWindow saves files, prevents filling up users home
+# dir on Windows when regression suite is run.
+
+swa = SaveWindowAttributes()
+swa.outputToCurrentDirectory = 1
+SetSaveWindowAttributes(swa)
 
 #
 # Map ordinary string paths used here which appear in rendered docs
@@ -129,3 +139,4 @@ def vqr_GetMachineProfile(name):
 # Override GetMachineProfile
 real_GetMachineProfile = GetMachineProfile
 GetMachineProfile = vqr_GetMachineProfile
+


### PR DESCRIPTION
For tests calling SaveWindow directly.
This prevents writing to user's home dir on Windows (those files won't be deleted when regression test cleans  up).

I discovered over 40,000 image files saved to my homedir on Windows, on the machine where I run the test suite.
With the change, those images are saved within  the test suite's output dir, and are thus deleted along with the rest during cleanup.
