### PR TITLE
Fixes for Vs database reader plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ visit.build_visit.docker.src.tar
 build-mb-*
 _logs
 *.vscode
+*.DS_Store

--- a/src/databases/Vs/HighOrderUnstructuredData.C
+++ b/src/databases/Vs/HighOrderUnstructuredData.C
@@ -22,7 +22,8 @@
 
 #define CLASSFUNCLINE __CLASS__ << "  " << __FUNCTION__ << "  " << __LINE__
 
-HighOrderUnstructuredData::HighOrderUnstructuredData() {
+HighOrderUnstructuredData::HighOrderUnstructuredData(VsReader* tReader,
+    VsRegistry* tRegistry) {
 
   VsLog::initialize(DebugStream::Stream3(), DebugStream::Stream4(),
       DebugStream::Stream5());
@@ -32,10 +33,9 @@ HighOrderUnstructuredData::HighOrderUnstructuredData() {
   delny2d = NULL;
   delny3d = NULL;
 
-  registry = NULL;
-  reader = NULL;
+  registry = tRegistry;
+  reader = tReader;
   cellArray = NULL;
-
 }
 
 HighOrderUnstructuredData::~HighOrderUnstructuredData() {

--- a/src/databases/Vs/HighOrderUnstructuredData.h
+++ b/src/databases/Vs/HighOrderUnstructuredData.h
@@ -56,7 +56,7 @@ class HighOrderUnstructuredData {
   public:
 
 // The constructor!!
-    HighOrderUnstructuredData();
+    HighOrderUnstructuredData(VsReader* tReader, VsRegistry* tRegistry);
 
     ~HighOrderUnstructuredData();
 
@@ -65,22 +65,6 @@ class HighOrderUnstructuredData {
  * @param mesh is the mesh of interest
  */
     void getData(VsUnstructuredMesh* mesh);
-
-/**
- * Set the reader that will be used
- * @param tReader is the reader used
- */
-    void setReader(VsReader* tReader) {
-      reader = tReader;
-    }
-
-/**
- * Set the registry to use
- * @param tRegistry is the registry to use
- */
-    void setRegistry(VsRegistry* tRegistry) {
-      registry = tRegistry;
-    }
 
 /**
  * Return the unstructured mesh data

--- a/src/databases/Vs/VsAttribute.C
+++ b/src/databases/Vs/VsAttribute.C
@@ -7,7 +7,7 @@
 
 #include "VsAttribute.h"
 #include "VsLog.h"
-#include <hdf5.h>
+#include <vshdf5.h>
   
 VsAttribute::VsAttribute(VsObject* parentObject, std::string attName, hid_t id):
   VsObject(parentObject->registry, parentObject, attName, id) {

--- a/src/databases/Vs/VsDataset.h
+++ b/src/databases/Vs/VsDataset.h
@@ -16,7 +16,7 @@
 
 #include <string>
 #include "VsObject.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <vector>
 #include <map>
 

--- a/src/databases/Vs/VsFile.C
+++ b/src/databases/Vs/VsFile.C
@@ -77,6 +77,7 @@ VsFile::~VsFile() {
   }
 
 // Close this file
+  VsLog::debugLog() <<"VsFile::~VsFile() - Closing " <<fileName.c_str() <<std::endl;
   H5Fclose(getId());
 }
 

--- a/src/databases/Vs/VsFile.C
+++ b/src/databases/Vs/VsFile.C
@@ -5,7 +5,7 @@
  *      Author: mdurant
  */
 
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <visit-hdf5.h>
 
 #include "VsFile.h"

--- a/src/databases/Vs/VsFile.h
+++ b/src/databases/Vs/VsFile.h
@@ -14,7 +14,7 @@
 #include <string>
 #include "VsGroup.h"
 #include "VsObject.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 
 class VsFile : public VsObject {
 public:

--- a/src/databases/Vs/VsFilter.C
+++ b/src/databases/Vs/VsFilter.C
@@ -1,4 +1,4 @@
-#include <hdf5.h>
+#include <vshdf5.h>
 /**
  *
  * @file        VsFilter.cpp
@@ -13,7 +13,7 @@
  */
 
 // vsh5
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <visit-hdf5.h>
 
 #include <VsFilter.h>

--- a/src/databases/Vs/VsFilter.C
+++ b/src/databases/Vs/VsFilter.C
@@ -38,6 +38,7 @@ struct RECURSION_DATA {
 VsFile* VsFilter::readFile(VsRegistry* registry, std::string fileName) {  
   hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+  VsLog::debugLog() <<"VsFilter::readFile() - Opening " <<fileName.c_str() <<std::endl;
   hid_t fileId = H5Fopen(fileName.c_str(), H5F_ACC_RDONLY, fapl);
   H5Pclose(fapl);
   if (fileId < 0) {

--- a/src/databases/Vs/VsFilter.h
+++ b/src/databases/Vs/VsFilter.h
@@ -12,7 +12,7 @@
  *
  * Copyright &copy; 2008 by Tech-X Corporation
  */
-#include <hdf5.h>
+#include <vshdf5.h>
 
 #ifndef VS_FILTER
 #define VS_FILTER
@@ -23,7 +23,7 @@
 
 // metadata
 #include "VsFile.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 
 class VsRegistry;
 

--- a/src/databases/Vs/VsGroup.C
+++ b/src/databases/Vs/VsGroup.C
@@ -9,7 +9,7 @@
 #include "VsSchema.h"
 #include "VsMesh.h"
 #include "VsUtils.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <map>
 #include "VsAttribute.h"
 

--- a/src/databases/Vs/VsGroup.h
+++ b/src/databases/Vs/VsGroup.h
@@ -16,7 +16,7 @@
 #include <map>
 
 #include "VsObject.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 
 class VsAttribute;
 class VsDataset;

--- a/src/databases/Vs/VsMDVariable.h
+++ b/src/databases/Vs/VsMDVariable.h
@@ -17,7 +17,7 @@
 #include "VsRegistryObject.h"
 
 #include <string>
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <vector>
 #include <map>
 

--- a/src/databases/Vs/VsObject.h
+++ b/src/databases/Vs/VsObject.h
@@ -16,7 +16,7 @@
 #define VS_OBJECT_H_
 
 #include <string>
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <vector>
 #include <map>
 #include "VsRegistryObject.h"

--- a/src/databases/Vs/VsReader.C
+++ b/src/databases/Vs/VsReader.C
@@ -1,4 +1,4 @@
-#include <hdf5.h>
+#include <vshdf5.h>
 
 /**
  *

--- a/src/databases/Vs/VsReader.C
+++ b/src/databases/Vs/VsReader.C
@@ -39,7 +39,7 @@
 
 int VsReader::numInstances = 0;
 
-VsReader::VsReader(const std::string& nm, VsRegistry* r) {
+VsReader::VsReader(const std::string& nm) {
 
   numInstances++;
   VsLog::debugLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "
@@ -58,7 +58,7 @@ VsReader::VsReader(const std::string& nm, VsRegistry* r) {
       << "Warning!  Debug messages may be interleaved." << std::endl;
   }
 
-  registry = r;
+  registry = new VsRegistry();
   
   // Read raw hdf5 metadata
   fileData = VsFilter::readFile(registry, nm);
@@ -122,6 +122,11 @@ VsReader::~VsReader() {
   if (fileData) {
     delete (fileData);
     fileData = NULL;
+  }
+
+  if (registry) {
+    delete (registry);
+    registry = NULL;
   }
   
   VsLog::debugLog() << __CLASS__ << __FUNCTION__ << "  " << __LINE__ << "  "

--- a/src/databases/Vs/VsReader.h
+++ b/src/databases/Vs/VsReader.h
@@ -12,12 +12,12 @@
  * Copyright &copy; 2008 by Tech-X Corporation
  */
 
-#include <hdf5.h>
+#include <vshdf5.h>
 
 #ifndef VS_READER_H_
 #define VS_READER_H_
 
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <string>
 
 class VsVariable;

--- a/src/databases/Vs/VsReader.h
+++ b/src/databases/Vs/VsReader.h
@@ -33,6 +33,7 @@ class VsUniformMesh;
 class VsRectilinearMesh;
 class VsDataset;
 
+
 /**
  * VsReader is a class for getting the vizschema metadata of objects
  * in and HDF5 file and also being able to return such objects.
@@ -45,7 +46,7 @@ public:
    * @param filename the name of the HDF5 file
    * @param r Empty VsRegistry object
    */
-  VsReader(const std::string& filename, VsRegistry* r);
+  VsReader(const std::string& filename);
 
   /**
    * Destructor.
@@ -88,12 +89,29 @@ public:
                int* destCounts = 0,
                int* destStrides = 0 ) const;    
 
+  VsRegistry* getRegistry() {
+      return registry;
+  }
+
 private:
   VsFile* fileData;
   
   static int numInstances;
   
   VsRegistry* registry;
+};
+
+class VsReaderHolder {
+  public:
+    VsReaderHolder(VsReader* r) {
+      reader = r;
+    }
+
+    ~VsReaderHolder() {
+      delete(reader);
+    }
+  private:
+    VsReader* reader;
 };
 
 #endif // VS_READER_H_

--- a/src/databases/Vs/VsRectilinearMesh.h
+++ b/src/databases/Vs/VsRectilinearMesh.h
@@ -12,7 +12,7 @@
 #define VSRECTILINEARMESH_H_
 
 #include "VsMesh.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 
 class VsDataset;
 class VsGroup;

--- a/src/databases/Vs/VsSchema.C
+++ b/src/databases/Vs/VsSchema.C
@@ -1,4 +1,4 @@
-#include <hdf5.h>
+#include <vshdf5.h>
 /**
  * @file  VsSchema.cpp
  *

--- a/src/databases/Vs/VsSchema.h
+++ b/src/databases/Vs/VsSchema.h
@@ -6,7 +6,7 @@
  *
  * Copyright &copy; 2008 by Tech-X Corporation
  */
-#include <hdf5.h>
+#include <vshdf5.h>
 #ifndef VS_SCHEMA
 #define VS_SCHEMA
 

--- a/src/databases/Vs/VsStructuredMesh.h
+++ b/src/databases/Vs/VsStructuredMesh.h
@@ -12,7 +12,7 @@
 #define VSSTRUCTUREDMESH_H_
 
 #include "VsMesh.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 
 class VsDataset;
 

--- a/src/databases/Vs/VsUniformMesh.h
+++ b/src/databases/Vs/VsUniformMesh.h
@@ -12,7 +12,7 @@
 #define VSUNIFORMMESH_H_
 
 #include "VsMesh.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 
 class VsGroup;
 

--- a/src/databases/Vs/VsUnstructuredMesh.h
+++ b/src/databases/Vs/VsUnstructuredMesh.h
@@ -12,7 +12,7 @@
 #define VSUNSTRUCTUREDMESH_H_
 
 #include "VsMesh.h"
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <string>
 
 class VsGroup;

--- a/src/databases/Vs/VsUtils.C
+++ b/src/databases/Vs/VsUtils.C
@@ -1,4 +1,4 @@
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <VsUtils.h>
 #include <VsLog.h>
 

--- a/src/databases/Vs/VsUtils.h
+++ b/src/databases/Vs/VsUtils.h
@@ -7,7 +7,7 @@
  * Copyright &copy; 2008 by Tech-X Corporation
  */
 
-#include <hdf5.h>
+#include <vshdf5.h>
 
 #ifndef VS_UTILS_H
 #define VS_UTILS_H

--- a/src/databases/Vs/VsVariable.h
+++ b/src/databases/Vs/VsVariable.h
@@ -11,7 +11,7 @@
 #ifndef VSVARIABLE_H_
 #define VSVARIABLE_H_
 
-#include <hdf5.h>
+#include <vshdf5.h>
 #include "VsRegistryObject.h"
 #include "VsGroup.h"
 

--- a/src/databases/Vs/VsVariableWithMesh.h
+++ b/src/databases/Vs/VsVariableWithMesh.h
@@ -16,7 +16,7 @@
 
 #include <vector>
 #include <string>
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <map>
 
 class VsAttribute;

--- a/src/databases/Vs/avtVsFileFormat.C
+++ b/src/databases/Vs/avtVsFileFormat.C
@@ -828,14 +828,23 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
         }
 
         hid_t axisDataType = axisData->getType();
+        size_t axisDataSize = axisData->getLength();
 
         // Read points and add in zero for any lacking dimension
         if( isDoubleType( axisDataType ) ) {
-            dblDataPtr = new double[gdims[i]];
+            VsLog::debugLog() << CLASSFUNCLINE
+                              << "Initializing dblDataPtr with space for "
+                              << axisDataSize
+                              << " double values.\n";
+            dblDataPtr = new double[axisDataSize];
             dataPtr = dblDataPtr;
         }
         else if( isFloatType( axisDataType ) ) {
-            fltDataPtr = new float[gdims[i]];
+            VsLog::debugLog() << CLASSFUNCLINE
+                              << "Initializing fltDataPtr with space for "
+                              << axisDataSize
+                              << " float values.\n";
+            fltDataPtr = new float[axisDataSize];
             dataPtr = fltDataPtr;
         } else {
             VsLog::debugLog() << CLASSFUNCLINE
@@ -844,7 +853,10 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
             return NULL;
         }
 
-        if (!dataPtr) {
+        if (dataPtr) {
+            VsLog::debugLog() << CLASSFUNCLINE
+                              << "Allocation succeeded.\n";
+        } else {
             VsLog::debugLog() << CLASSFUNCLINE
                               << "Allocation failed, pointer is NULL."
                               << "Returning NULL." << std::endl;
@@ -859,7 +871,7 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
 
         if (err < 0) {
             VsLog::debugLog() << CLASSFUNCLINE
-                              << "GetDataSet returned error: " << err << "  "
+                              << "GetData returned error: " << err << "  "
                               << "Returning NULL." << std::endl;
 
             if( isDoubleType( axisDataType ) )
@@ -868,6 +880,9 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
               delete [] fltDataPtr;
 
             return NULL;
+        } else {
+            VsLog::debugLog() << CLASSFUNCLINE
+                              << "GetData returned success.\n";
         }
 
         // Storage for mesh points in VisIt are spatially 3D. So create 3
@@ -937,6 +952,9 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
                           << std::endl;
     }
 
+    VsLog::debugLog() << CLASSFUNCLINE
+                      << "Completed reading axis data.\n";
+
     for (size_t i=numSpatialDims; i<vsdim; ++i) {
         if( isDouble )
           coords[i] = vtkDoubleArray::New();
@@ -952,7 +970,7 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
     if (!transform) {
         // Create vtkRectilinearGrid
         VsLog::debugLog() << CLASSFUNCLINE
-                          << "Creating rectilinear grid." << std::endl;
+                          << "Creating rectilinear grid.\n";
         vtkRectilinearGrid* rgrid = vtkRectilinearGrid::New();
         rgrid->SetDimensions(&(gdims[0]));
 
@@ -974,6 +992,8 @@ avtVsFileFormat::getRectilinearMesh(VsReader* reader,
         // true. Calculate the points and return a Structured mesh instead
         // of a Rectilinear mesh
         //
+        VsLog::debugLog() << CLASSFUNCLINE
+                          << "Creating transformed rectilinear grid.\n";
         float /*temp,*/ tempk, tempj, tempi;
         vtkPoints* vpoints = vtkPoints::New();
         if (isDouble) {
@@ -1072,7 +1092,7 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsReader* reader,
         return NULL;
     }
 
-    // ARS - Becasue of the way the data structures are used to hold
+    // ARS - Because of the way the data structures are used to hold
     // structured data in VTK and VisIt the topological dimension has
     // to equal the spatial dimension. That is ONLY the last dim(s) of
     // the nodes can be 1.

--- a/src/databases/Vs/avtVsFileFormat.C
+++ b/src/databases/Vs/avtVsFileFormat.C
@@ -1,4 +1,4 @@
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <visit-hdf5.h>
 #include <avtGhostData.h>
 #if HDF5_VERSION_GE(1,8,1)

--- a/src/databases/Vs/avtVsFileFormat.C
+++ b/src/databases/Vs/avtVsFileFormat.C
@@ -1117,8 +1117,8 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsReader* reader,
     haveDataSelections = 1;
 #endif
 
-    int numPoints = 1;
-    for (size_t i=0; i<numSpatialDims; ++i)
+    ssize_t numPoints = 1;
+    for (ssize_t i=0; i<numSpatialDims; ++i)
       numPoints *= gdims[i];
 
     VsLog::debugLog() << CLASSFUNCLINE
@@ -1183,7 +1183,7 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsReader* reader,
                           << numSpatialDims << " is less than 3.  "
                           << "Moving data into correct location." << std::endl;
 
-        for (int i=numPoints-1; i>=0; --i)
+        for (ssize_t i=numPoints-1; i>=0; --i)
         {
             unsigned char* destPtr
               = (unsigned char*) dataPtr + i*3*dsize;
@@ -1235,22 +1235,6 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsReader* reader,
         delete [] fltDataPtr;
     }
 
-    /*
-     // debug: output points
-     fltDataPtr = (float*)ptsPtr;
-     dblDataPtr = (double*)ptsPtr;
-     for (size_t i = 0; i < numPoints; ++i) {
-     VsLog::debugLog() << i << ":";
-     for (size_t j = 0; j < 3; ++j) {
-     if (H5Tequal(type, H5T_NATIVE_DOUBLE)) {
-     VsLog::debugLog() << " " << dblDataPtr[(3*i)+j];
-     }
-     else VsLog::debugLog() << " " << fltDataPtr[(3*i)+j];
-     }
-     VsLog::debugLog() << std::endl;
-     }
-     // end debug
-     */
     vtkStructuredGrid* sgrid = vtkStructuredGrid::New();
     sgrid->SetDimensions(&(gdims[0]));
     sgrid->SetPoints(vpoints);
@@ -3986,6 +3970,16 @@ void avtVsFileFormat::RegisterMeshes(VsRegistry* registry, avtDatabaseMetaData* 
                                       (int) numTopologicalDims, meshType);
 
                 vmd->SetBounds( bounds );
+                VsLog::debugLog() << CLASSFUNCLINE
+                                  << "Setting avtMeshMetaData.numberCells to "
+                                  << numCells
+                                  << " or " <<(int)numCells
+                                  << "." << std::endl;
+                if ((int)numCells < 0) {
+                    VsLog::errorLog() << CLASSFUNCLINE
+                                      << "Number of cells has overflowed the integer field."
+                                      <<std::endl;
+                }
                 vmd->SetNumberCells( (int)numCells );
                 setAxisLabels(registry, vmd, rectMesh->hasTransform());
                 setGlobalExtents(registry, vmd);
@@ -4078,6 +4072,16 @@ void avtVsFileFormat::RegisterMeshes(VsRegistry* registry, avtDatabaseMetaData* 
                                   (int) numTopologicalDims, meshType);
 
             vmd->SetBounds( bounds );
+            VsLog::debugLog() << CLASSFUNCLINE
+                  << "Setting avtMeshMetaData.numberCells to "
+                  << numCells
+                  << " or " <<(int)numCells
+                  << "." << std::endl;
+            if ((int)numCells < 0) {
+                VsLog::errorLog() << CLASSFUNCLINE
+                                  << "Number of cells has overflowed the integer field."
+                                  <<std::endl;
+            }
             vmd->SetNumberCells( (int) numCells );
             setAxisLabels(registry, vmd);
             setGlobalExtents(registry, vmd);
@@ -4379,6 +4383,16 @@ void avtVsFileFormat::RegisterVarsWithMesh(VsRegistry* registry, avtDatabaseMeta
                               AVT_POINT_MESH);
 
         vmd->SetBounds(bounds);
+        VsLog::debugLog() << CLASSFUNCLINE
+                          << "Setting avtMeshMetaData.numberCells to "
+                          << numCells
+                          << " or " <<(int)numCells
+                          << "." << std::endl;
+        if ((int)numCells < 0) {
+            VsLog::errorLog() << CLASSFUNCLINE
+                              << "Number of cells has overflowed the integer field."
+                              <<std::endl;
+        }
         vmd->SetNumberCells(numCells);
         setAxisLabels(registry, vmd);
         setGlobalExtents(registry, vmd);

--- a/src/databases/Vs/avtVsFileFormat.C
+++ b/src/databases/Vs/avtVsFileFormat.C
@@ -128,15 +128,7 @@ avtVsFileFormat::avtVsFileFormat(const char* filename,
                       << "VizSchema reader will "
                       << (processDataSelections? "" : "not ")
                       << "process data selections" << std::endl;
-
-    //reader starts off empty
-    reader = NULL;
-
-    //Initialize the registry for objects
-    registry = new VsRegistry();
-    curveNames.clear();
-
-//  LoadData();
+   curveNames.clear();
 
 //check types
     if (isFloatType(H5T_NATIVE_FLOAT)) {
@@ -174,9 +166,10 @@ avtVsFileFormat::avtVsFileFormat(const char* filename,
         EXCEPTION1(InvalidDBTypeException, msg.str().c_str());
     }
 
-    //NOTE: We used to initialize the VsReader object here
-    //But now do it on demand in 'populateDatabaseMetaData'
-    //To minimize I/O
+    // We used to initialize the VsReader object here.
+    // The VsReader object will hold a pointer to the underlying file.
+    // In order to avoid blocking access to this file, we only create
+    // the reader object as needed.
 
     VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
 }
@@ -382,13 +375,21 @@ avtVsFileFormat::ProcessDataSelections(int *mins, int *maxs, int *strides)
 
 vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
 {
-    VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsReaderHolder holder(reader);
+    return GetMesh(reader, domain, name);
+}
 
-    LoadData();
+vtkDataSet* avtVsFileFormat::GetMesh(VsReader* reader, int domain, const char* name)
+{
+    VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
     // Save the original name in a temporary variable
     // so that we can do some string manipulations on it
     std::string meshName = name;
+
+    VsRegistry* registry = reader->getRegistry();
 
     // Roopa: Check if this mesh name is a transformed mesh name. If
     // so, use the original mesh name to get data associated
@@ -465,7 +466,7 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
             VsLog::debugLog() << CLASSFUNCLINE
                               << "Trying to load & return uniform mesh" << std::endl;
 
-            return getUniformMesh(static_cast<VsUniformMesh*>(meta),
+            return getUniformMesh(reader, static_cast<VsUniformMesh*>(meta),
                                   haveDataSelections, mins, maxs, strides);
         }
 
@@ -474,7 +475,7 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
             VsLog::debugLog() << CLASSFUNCLINE
                               << "Trying to load & return rectilinear mesh."
                               << std::endl;
-            return getRectilinearMesh(static_cast<VsRectilinearMesh*>(meta),
+            return getRectilinearMesh(reader, static_cast<VsRectilinearMesh*>(meta),
                                       haveDataSelections, mins, maxs, strides, transform);
         }
 
@@ -482,7 +483,7 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
         else if (meta->isStructuredMesh()) {
             VsLog::debugLog() << CLASSFUNCLINE
                               << "Trying to load & return structured mesh" << std::endl;
-            return getStructuredMesh(static_cast<VsStructuredMesh*>(meta),
+            return getStructuredMesh(reader, static_cast<VsStructuredMesh*>(meta),
                                      haveDataSelections, mins, maxs, strides);
         }
 
@@ -505,14 +506,14 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
             if(meta->isHighOrder()) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Trying to load & return high order unstructured mesh" << std::endl;
-                return getHighOrderUnstructuredMesh(static_cast<VsUnstructuredMesh*>(meta),
+                return getHighOrderUnstructuredMesh(reader, static_cast<VsUnstructuredMesh*>(meta),
                                                     haveDataSelections, mins, maxs, strides);
             }
 
             else {
               VsLog::debugLog() << CLASSFUNCLINE
                                 << "Trying to load & return unstructured mesh" << std::endl;
-              return getUnstructuredMesh(static_cast<VsUnstructuredMesh*>(meta),
+              return getUnstructuredMesh(reader, static_cast<VsUnstructuredMesh*>(meta),
                                          haveDataSelections, mins, maxs, strides);
             }
         }
@@ -537,14 +538,14 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
         VsLog::debugLog() << CLASSFUNCLINE
 
                           << "Found Variable With Mesh. Loading data and returning." << std::endl;
-        return getPointMesh(vmMeta, haveDataSelections, mins, maxs, strides, transform);
+        return getPointMesh(reader, vmMeta, haveDataSelections, mins, maxs, strides, transform);
     }
 
     // Curve
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Looking for Curve with this name." << std::endl;
 
-    vtkDataArray* foundCurve = this->GetVar(domain, name);
+    vtkDataArray* foundCurve = this->GetVar(reader, domain, name);
 
     if (foundCurve != NULL)
     {
@@ -553,7 +554,7 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
 
         foundCurve->Delete();
 
-        return getCurve(domain, name);
+        return getCurve(reader, domain, name);
     }
 
     VsLog::debugLog() << CLASSFUNCLINE
@@ -577,7 +578,8 @@ vtkDataSet* avtVsFileFormat::GetMesh(int domain, const char* name)
 //    Fixed computation of grid spacing
 //
 
-vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
+vtkDataSet* avtVsFileFormat::getUniformMesh(VsReader* reader,
+                                            VsUniformMesh* uniformMesh,
                                             bool haveDataSelections,
                                             int* mins, int* maxs, int* strides)
 {
@@ -585,8 +587,7 @@ vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
+    VsRegistry* registry = reader->getRegistry();
 
     // ARS - Becasue of the way the data structures are used to hold
     // structured data in VTK and VisIt the topological dimension has
@@ -662,8 +663,9 @@ vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
                         mins, maxs, strides, haveDataSelections );
 
 #if (defined PARALLEL && defined VIZSCHEMA_DECOMPOSE_DOMAINS)
-    if( !GetParallelDecomp( numSpatialDims, gdims, mins, maxs, strides ) )
+    if( !GetParallelDecomp( numSpatialDims, gdims, mins, maxs, strides ) ) {
       return NULL; // No work for this processor.
+    }
 
     haveDataSelections = 1;
 #endif
@@ -744,7 +746,8 @@ vtkDataSet* avtVsFileFormat::getUniformMesh(VsUniformMesh* uniformMesh,
 //
 
 vtkDataSet*
-avtVsFileFormat::getRectilinearMesh(VsRectilinearMesh* rectilinearMesh,
+avtVsFileFormat::getRectilinearMesh(VsReader* reader,
+                                    VsRectilinearMesh* rectilinearMesh,
                                     bool haveDataSelections,
                                     int* mins, int* maxs, int* strides,
                                     bool transform)
@@ -754,7 +757,7 @@ avtVsFileFormat::getRectilinearMesh(VsRectilinearMesh* rectilinearMesh,
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
-    LoadData();
+    VsRegistry* registry = reader->getRegistry();
 
     // ARS - Becasue of the way the data structures are used to hold
     // structured data in VTK and VisIt the topological dimension has
@@ -1043,7 +1046,8 @@ avtVsFileFormat::getRectilinearMesh(VsRectilinearMesh* rectilinearMesh,
 //  Modifications:
 //
 
-vtkDataSet* avtVsFileFormat::getStructuredMesh(VsStructuredMesh* structuredMesh,
+vtkDataSet* avtVsFileFormat::getStructuredMesh(VsReader* reader,
+                                               VsStructuredMesh* structuredMesh,
                                                bool haveDataSelections,
                                                int* mins, int* maxs,
                                                int* strides)
@@ -1052,8 +1056,7 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsStructuredMesh* structuredMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
+    VsRegistry* registry = reader->getRegistry();
 
     // Find points: Structured meshes are datasets, and the data is
     // the points So, look for the dataset with the same name as the
@@ -1284,42 +1287,42 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsStructuredMesh* structuredMesh,
             if (isDoubleType(maskType)) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Mask is of type double." << std::endl;
-                this->fillInMaskNodeArray<double>(gdims, mask,
+                this->fillInMaskNodeArray<double>(reader, gdims, mask,
                         maskIsFortranOrder,
                         maskedNodes);
             }
             else if (isFloatType(maskType)) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Mask is of type float." << std::endl;
-                this->fillInMaskNodeArray<float>(gdims, mask,
+                this->fillInMaskNodeArray<float>(reader, gdims, mask,
                         maskIsFortranOrder,
                         maskedNodes);
             }
             else if (isIntType(maskType)) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Mask is of type int." << std::endl;
-                this->fillInMaskNodeArray<int>(gdims, mask,
+                this->fillInMaskNodeArray<int>(reader, gdims, mask,
                         maskIsFortranOrder,
                         maskedNodes);
             }
             else if (isShortType(maskType)) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Mask is of type short." << std::endl;
-                this->fillInMaskNodeArray<short>(gdims, mask,
+                this->fillInMaskNodeArray<short>(reader, gdims, mask,
                         maskIsFortranOrder,
                         maskedNodes);
             }
             else if (isCharType(maskType)) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Mask is of type char." << std::endl;
-                this->fillInMaskNodeArray<char>(gdims, mask,
+                this->fillInMaskNodeArray<char>(reader, gdims, mask,
                         maskIsFortranOrder,
                         maskedNodes);
             }
             else if (isUnsignedCharType(maskType)) {
                 VsLog::debugLog() << CLASSFUNCLINE
                                   << "Mask is of type unsigned char." << std::endl;
-                this->fillInMaskNodeArray<unsigned char>(gdims, mask,
+                this->fillInMaskNodeArray<unsigned char>(reader, gdims, mask,
                         maskIsFortranOrder,
                         maskedNodes);
             }
@@ -1357,19 +1360,17 @@ vtkDataSet* avtVsFileFormat::getStructuredMesh(VsStructuredMesh* structuredMesh,
 
 //Most of this really should be moved into the HighOrderUnstrucured class.
 vtkDataSet*
-avtVsFileFormat::getHighOrderUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
+avtVsFileFormat::getHighOrderUnstructuredMesh(VsReader* reader,
+                                              VsUnstructuredMesh* unstructuredMesh,
                                               bool haveDataSelections,
                                               int* mins, int* maxs, int* strides) {
     VsLog::debugLog() << CLASSFUNCLINE << "Entering." << std::endl;
+    VsRegistry* registry = reader->getRegistry();
 
-    LoadData();
-
-    thisData.setReader(reader);
-    thisData.setRegistry(registry);
-
+    HighOrderUnstructuredData thisData(reader, registry);
+    vtkDataSet* answer = thisData.getMesh(unstructuredMesh);
     VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
-
-    return thisData.getMesh(unstructuredMesh);
+    return answer;
 }
 
 // *****************************************************************************
@@ -1385,7 +1386,8 @@ avtVsFileFormat::getHighOrderUnstructuredMesh(VsUnstructuredMesh* unstructuredMe
 //
 
 vtkDataSet*
-avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
+avtVsFileFormat::getUnstructuredMesh(VsReader* reader,
+                                     VsUnstructuredMesh* unstructuredMesh,
                                      bool haveDataSelections,
                                      int* mins, int* maxs, int* strides)
 {
@@ -1393,8 +1395,7 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
+    VsRegistry* registry = reader->getRegistry();
 
     // Check for points type
     hid_t meshDataType = unstructuredMesh->getDataType();
@@ -2152,7 +2153,8 @@ avtVsFileFormat::getUnstructuredMesh(VsUnstructuredMesh* unstructuredMesh,
 //  Modifications:
 //
 
-vtkDataSet* avtVsFileFormat::getPointMesh(VsVariableWithMesh* variableWithMesh,
+vtkDataSet* avtVsFileFormat::getPointMesh(VsReader* reader,
+                                          VsVariableWithMesh* variableWithMesh,
                                           bool haveDataSelections,
                                           int* mins, int* maxs, int* strides,
                                           bool transform)
@@ -2161,8 +2163,7 @@ vtkDataSet* avtVsFileFormat::getPointMesh(VsVariableWithMesh* variableWithMesh,
     // instead of just returning NULL all the time.
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
+    VsRegistry* registry = reader->getRegistry();
 
     hid_t meshDataType = variableWithMesh->getType();
 
@@ -2417,15 +2418,15 @@ vtkDataSet* avtVsFileFormat::getPointMesh(VsVariableWithMesh* variableWithMesh,
 //
 //  Modifications:
 //
-vtkDataSet* avtVsFileFormat::getCurve(int domain,
+vtkDataSet* avtVsFileFormat::getCurve(VsReader* reader,
+                                      int domain,
                                       const std::string& requestedName)
 {
     // TODO - make "cleanupAndReturnNull" label, and do a "go to"
     // instead of just returning NULL all the time.
+    VsRegistry* registry = reader->getRegistry();
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
 
     // Save the original name in a temporary variable
     // so that we can do some string manipulation on it
@@ -2501,7 +2502,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
 
     vtkDataArray* varData = NULL;
     try {
-        varData = GetVar(domain, requestedName.c_str());
+        varData = GetVar(reader, domain, requestedName.c_str());
     } catch (...) {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Caught exception from GetVar().  "
@@ -2529,7 +2530,7 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
 
     vtkDataSet* meshData = NULL;
     try {
-        meshData = GetMesh(domain, meshName.c_str());
+        meshData = GetMesh(reader, domain, meshName.c_str());
     } catch (...) {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Caught exception from GetMesh().  "
@@ -2666,7 +2667,8 @@ vtkDataSet* avtVsFileFormat::getCurve(int domain,
 //
 //  Modifications:
 //
-bool avtVsFileFormat::nameIsComponent(std::string& name, int& componentIndex) {
+bool avtVsFileFormat::nameIsComponent(VsReader* reader, std::string& name, int& componentIndex) {
+    VsRegistry* registry = reader->getRegistry();
 
     bool isAComponent = false;
     // int componentIndex = -2; // No components
@@ -2699,8 +2701,8 @@ bool avtVsFileFormat::nameIsComponent(std::string& name, int& componentIndex) {
 //
 //  Modifications:
 //
-bool avtVsFileFormat::isTransformedName(std::string& name) {
-
+bool avtVsFileFormat::isTransformedName(VsReader* reader, std::string& name) {
+    VsRegistry* registry = reader->getRegistry();
     bool transform = false;
     std::string origVarName = registry->getOriginalVarName(name);
 
@@ -2731,12 +2733,22 @@ bool avtVsFileFormat::isTransformedName(std::string& name) {
 //
 //  Modifications:
 //
+
 vtkDataArray* avtVsFileFormat::StandardVar(int domain,
                                            const char* requestedName)
 {
-    VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsReaderHolder holder(reader);
+    return StandardVar(reader, domain, requestedName);
+}
 
-    LoadData();
+vtkDataArray* avtVsFileFormat::StandardVar(VsReader* reader,
+                                           int domain,
+                                           const char* requestedName)
+{
+    VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
+    VsRegistry* registry = reader->getRegistry();
 
     // Save the original name in a temporary variable so that we can
     // do some string manipulation on it
@@ -2760,8 +2772,8 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
     }
 
     int componentIndex = -2; // No components
-    bool isAComponent = nameIsComponent(name, componentIndex);
-    bool transform = isTransformedName(name); (void) transform;
+    bool isAComponent = nameIsComponent(reader, name, componentIndex);
+    bool transform = isTransformedName(reader, name); (void) transform;
 
     // The goal in all of the metadata loading is to fill one of
     // these two variables:
@@ -3333,17 +3345,19 @@ vtkDataArray* avtVsFileFormat::StandardVar(int domain,
 //
 //  Modifications:
 //
-VsVariable* avtVsFileFormat::getVariableMeta(int domain,
+VsVariable* avtVsFileFormat::getVariableMeta(VsReader* reader,
+                                             int domain,
                                              std::string requestedName,
                                              int &componentIndex) {
+    VsRegistry* registry = reader->getRegistry();
 
     // Save the original name in a temporary variable
     // so that we can do some string manipulation on it
     std::string name = requestedName;
 
     componentIndex = -2;  // No components
-    bool isAComponent = nameIsComponent(name, componentIndex);
-    bool transform = isTransformedName(name); (void) transform;
+    bool isAComponent = nameIsComponent(reader, name, componentIndex);
+    bool transform = isTransformedName(reader, name); (void) transform;
 
     // The goal in all of the metadata loading is to fill one of
     // these two variables:
@@ -3423,16 +3437,24 @@ VsVariable* avtVsFileFormat::getVariableMeta(int domain,
 vtkDataArray* avtVsFileFormat::NodalVar(VsVariable* meta,
                                         std::string name, int component)
 {
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsReaderHolder holder(reader);
+    return NodalVar(reader, meta, name, component);
+}
+
+vtkDataArray* avtVsFileFormat::NodalVar(VsReader* reader,
+                                        VsVariable* meta,
+                                        std::string name, int component)
+{
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
-    LoadData();
+    VsRegistry* registry = reader->getRegistry();
 
-    thisData.setReader(reader);
-    thisData.setRegistry(registry);
-
+    HighOrderUnstructuredData thisData(reader, registry);
+    vtkDataArray* answer = thisData.getData(meta, name, component);
     VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
-
-    return thisData.getData(meta, name, component);
+    return answer;
 }
 
 // *****************************************************************************
@@ -3446,27 +3468,33 @@ vtkDataArray* avtVsFileFormat::NodalVar(VsVariable* meta,
 //
 //  Modifications:
 //
+vtkDataArray* avtVsFileFormat::GetVar(int domain, const char* requestedName) {
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsReaderHolder holder(reader);
+    return GetVar(reader, domain, requestedName);
+}
 
-vtkDataArray* avtVsFileFormat::GetVar(int domain, const char* requestedName)
+vtkDataArray* avtVsFileFormat::GetVar(VsReader* reader, int domain, const char* requestedName)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
     int component;
-    VsVariable* meta = getVariableMeta(domain, requestedName, component);
+    VsVariable* meta = getVariableMeta(reader, domain, requestedName, component);
 
     if( meta != NULL) {
         if(meta->getMesh()->isHighOrder()) {
             VsLog::debugLog() << CLASSFUNCLINE
                               << "Exiting nodal case." << std::endl;
 
-            return NodalVar(meta, requestedName, component);
+            return NodalVar(reader, meta, requestedName, component);
         }
     }
 
     VsLog::debugLog() << CLASSFUNCLINE
                       << "Exiting standard case." << std::endl;
 
-    return StandardVar(domain, requestedName);
+    return StandardVar(reader, domain, requestedName);
 }
 
 // *****************************************************************************
@@ -3484,17 +3512,6 @@ vtkDataArray* avtVsFileFormat::GetVar(int domain, const char* requestedName)
 void avtVsFileFormat::FreeUpResources(void)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    if (reader != NULL) {
-        delete reader;
-        reader = NULL;
-    }
-
-    if (registry) {
-        delete registry;
-        registry = NULL;
-    }
-
     VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
 }
 
@@ -3510,11 +3527,9 @@ void avtVsFileFormat::FreeUpResources(void)
 //  Modifications:
 //
 
-void avtVsFileFormat::RegisterExpressions(avtDatabaseMetaData* md)
+void avtVsFileFormat::RegisterExpressions(VsRegistry* registry, avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
 
     //get list of expressions from reader
     std::map<std::string, std::string>* expressions =
@@ -3615,12 +3630,9 @@ void avtVsFileFormat::RegisterExpressions(avtDatabaseMetaData* md)
 //  Modifications:
 //
 
-void avtVsFileFormat::RegisterVars(avtDatabaseMetaData* md)
+void avtVsFileFormat::RegisterVars(VsRegistry* registry, avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
-
     // Get var names
     std::vector<std::string> names;
     registry->getAllVariableNames(names);
@@ -3832,11 +3844,9 @@ void avtVsFileFormat::RegisterVars(avtDatabaseMetaData* md)
 //  Modifications:
 //
 
-void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
+void avtVsFileFormat::RegisterMeshes(VsRegistry* registry, avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
 
     // All meshes names
     std::vector<std::string> names;
@@ -3977,8 +3987,8 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
 
                 vmd->SetBounds( bounds );
                 vmd->SetNumberCells( (int)numCells );
-                setAxisLabels(vmd, rectMesh->hasTransform());
-                setGlobalExtents(vmd);
+                setAxisLabels(registry, vmd, rectMesh->hasTransform());
+                setGlobalExtents(registry, vmd);
                 md->Add(vmd);
             }
         }
@@ -4069,8 +4079,8 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
 
             vmd->SetBounds( bounds );
             vmd->SetNumberCells( (int) numCells );
-            setAxisLabels(vmd);
-            setGlobalExtents(vmd);
+            setAxisLabels(registry, vmd);
+            setGlobalExtents(registry, vmd);
             md->Add(vmd);
         }
     }
@@ -4090,11 +4100,9 @@ void avtVsFileFormat::RegisterMeshes(avtDatabaseMetaData* md)
 //  Modifications:
 //
 
-void avtVsFileFormat::RegisterMdVars(avtDatabaseMetaData* md)
+void avtVsFileFormat::RegisterMdVars(VsRegistry* registry, avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
 
     // Get vars names
     std::vector<std::string> names;
@@ -4196,11 +4204,9 @@ void avtVsFileFormat::RegisterMdVars(avtDatabaseMetaData* md)
 //  Modifications:
 //
 
-void avtVsFileFormat::RegisterMdMeshes(avtDatabaseMetaData* md)
+void avtVsFileFormat::RegisterMdMeshes(VsRegistry* registry, avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
 
     std::vector<std::string> names;
     registry->getAllMDMeshNames(names);
@@ -4251,8 +4257,8 @@ void avtVsFileFormat::RegisterMdMeshes(avtDatabaseMetaData* md)
           new avtMeshMetaData(it->c_str(), (int)meta->getNumBlocks(), 1, 1, 0,
                               (int)meta->getNumSpatialDims(),
                               (int)meta->getNumSpatialDims(), meshType);
-        setAxisLabels(vmd);
-        setGlobalExtents(vmd);
+        setAxisLabels(registry, vmd);
+        setGlobalExtents(registry, vmd);
         md->Add(vmd);
     }
 
@@ -4270,11 +4276,9 @@ void avtVsFileFormat::RegisterMdMeshes(avtDatabaseMetaData* md)
 //
 //  Modifications:
 //
-void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
+void avtVsFileFormat::RegisterVarsWithMesh(VsRegistry* registry, avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
-    LoadData();
 
     std::vector<std::string> names;
     registry->getAllVariableWithMeshNames(names);
@@ -4376,8 +4380,8 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
 
         vmd->SetBounds(bounds);
         vmd->SetNumberCells(numCells);
-        setAxisLabels(vmd);
-        setGlobalExtents(vmd);
+        setAxisLabels(registry, vmd);
+        setGlobalExtents(registry, vmd);
         md->Add(vmd);
 
         // Register the transformed mesh (if this variable has a transform)
@@ -4397,8 +4401,8 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
             // This is the change for ticket 3340: the transformed
             // vars with mesh use r,z, phi.
             // To revert, use false in the next call.
-            setAxisLabels(vmd_transform, true);
-            setGlobalExtents(vmd_transform);
+            setAxisLabels(registry, vmd_transform, true);
+            setGlobalExtents(registry, vmd_transform);
             md->Add(vmd_transform);
         }
     }
@@ -4422,7 +4426,7 @@ void avtVsFileFormat::RegisterVarsWithMesh(avtDatabaseMetaData* md)
 
 void avtVsFileFormat::ActivateTimestep()
 {
-    LoadData();
+
 }
 
 // *****************************************************************************
@@ -4441,7 +4445,10 @@ void avtVsFileFormat::UpdateCyclesAndTimes(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
-    LoadData();
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsRegistry* registry = reader->getRegistry();
+    VsReaderHolder holder(reader);
 
     if (!md) {
       VsLog::debugLog() << CLASSFUNCLINE
@@ -4569,10 +4576,9 @@ void avtVsFileFormat::UpdateCyclesAndTimes(avtDatabaseMetaData* md)
 //  Modifications:
 //
 
-void avtVsFileFormat::LoadData()
+VsReader* avtVsFileFormat::LoadData()
 {
-    if (reader)
-      return;
+    VsReader* reader = NULL;
 
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
@@ -4581,10 +4587,7 @@ void avtVsFileFormat::LoadData()
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Initializing VsReader()" << std::endl;
 
-        if (!registry)
-          registry = new VsRegistry();
-
-        reader = new VsReader(dataFileName, registry);
+        reader = new VsReader(dataFileName);
     }
     catch (std::invalid_argument& ex) {
         std::ostringstream msg;
@@ -4597,6 +4600,8 @@ void avtVsFileFormat::LoadData()
     }
 
     VsLog::debugLog() << CLASSFUNCLINE << "exiting." << std::endl;
+
+    return reader;
 }
 
 // *****************************************************************************
@@ -4615,7 +4620,24 @@ void avtVsFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
 
-    LoadData();
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsRegistry* registry = reader->getRegistry();
+    VsReaderHolder holder(reader);
+
+    // Cache some simple information about the cycle.
+    int cycle = -1;
+    if (registry->hasCycle()) {
+      cycle = registry->getCycle();
+    }
+    cycleData[dataFileName] = cycle;
+
+    // Cache some simple information about the time.
+    double time = -1;
+    if (registry->hasTime()) {
+      time = registry->getTime();
+    }
+    timeData[dataFileName] = time;
 
     // Tell visit that we can split meshes into subparts when running
     // in parallel
@@ -4643,15 +4665,15 @@ void avtVsFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md)
                       << std::endl;
 #endif
 
-    RegisterMeshes(md);
-    RegisterMdMeshes(md);
+    RegisterMeshes(registry, md);
+    RegisterMdMeshes(registry, md);
 
-    RegisterVarsWithMesh(md);
+    RegisterVarsWithMesh(registry, md);
 
-    RegisterVars(md);
-    RegisterMdVars(md);
+    RegisterVars(registry, md);
+    RegisterMdVars(registry, md);
 
-    RegisterExpressions(md);
+    RegisterExpressions(registry, md);
 
     //add desperation last-ditch mesh if none exist in metadata
     if (md->GetNumMeshes() == 0 && md->GetNumCurves() == 0) {
@@ -4662,8 +4684,8 @@ void avtVsFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md)
         avtMeshMetaData* mmd =
         new avtMeshMetaData("ERROR_READING_FILE", 1, 1, 1, 0, 3, 3,
                             AVT_RECTILINEAR_MESH);
-        setAxisLabels(mmd);
-        setGlobalExtents(mmd);
+        setAxisLabels(registry, mmd);
+        setGlobalExtents(registry, mmd);
         md->Add(mmd);
     }
 
@@ -4682,10 +4704,10 @@ void avtVsFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md)
 //  Modifications:
 //
 
-void avtVsFileFormat::setAxisLabels(avtMeshMetaData* mmd, bool transform)
+void avtVsFileFormat::setAxisLabels(VsRegistry* registry, avtMeshMetaData* mmd,
+    bool transform)
 {
     VsLog::debugLog() << CLASSFUNCLINE << "entering." << std::endl;
-
     if (mmd == NULL) {
         VsLog::debugLog() << CLASSFUNCLINE
                           << "Input pointer was NULL?" << std::endl;
@@ -4735,7 +4757,7 @@ void avtVsFileFormat::setAxisLabels(avtMeshMetaData* mmd, bool transform)
 //
 //  Modifications:
 //
-void avtVsFileFormat::setGlobalExtents(avtMeshMetaData* mmd)
+void avtVsFileFormat::setGlobalExtents(VsRegistry* registry, avtMeshMetaData* mmd)
 {
   // If there are global bounds use them.
   if (registry->hasLowerBounds() && registry->hasUpperBounds()) {
@@ -4772,7 +4794,17 @@ void avtVsFileFormat::setGlobalExtents(avtMeshMetaData* mmd)
 int avtVsFileFormat::GetCycle() {
     VsLog::debugLog() << CLASSFUNCLINE << "entering" << std::endl;
 
-    LoadData();
+    // Look in the cache first.
+    auto it = cycleData.find(dataFileName);
+    if (it != cycleData.end()) {
+      return it->second;
+    }
+
+    // Fall back to loading from the file.
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsRegistry* registry = reader->getRegistry();
+    VsReaderHolder holder(reader);
 
     if (registry->hasCycle()) {
         VsLog::debugLog() << CLASSFUNCLINE
@@ -4805,7 +4837,17 @@ int avtVsFileFormat::GetCycle() {
 double avtVsFileFormat::GetTime() {
     VsLog::debugLog() << CLASSFUNCLINE << "entering" << std::endl;
 
-    LoadData();
+    // Look in the cache first.
+    auto it = timeData.find(dataFileName);
+    if (it != timeData.end()) {
+      return it->second;
+    }
+
+    // Fall back to loading from the file.
+    VsLog::debugLog() << CLASSFUNCLINE << "Calling LoadData" << std::endl;
+    VsReader* reader = LoadData();
+    VsRegistry* registry = reader->getRegistry();
+    VsReaderHolder holder(reader);
 
     if (registry->hasTime()) {
         VsLog::debugLog() << CLASSFUNCLINE
@@ -5114,11 +5156,13 @@ bool avtVsFileFormat::GetParallelDecomp( int numLogicalDims,
 //  Modifications:
 //
 template<typename TYPE>
-void avtVsFileFormat::fillInMaskNodeArray(const std::vector<int>& gdims,
+void avtVsFileFormat::fillInMaskNodeArray(VsReader* reader,
+                                          const std::vector<int>& gdims,
                                           VsDataset *mask,
                                           bool maskIsFortranOrder,
                                           vtkUnsignedCharArray *maskedNodes) {
 
+    VsRegistry* registry = reader->getRegistry();
     int numPoints = gdims[0] * gdims[1] * gdims[2];
     std::vector<TYPE> maskArray(numPoints);
 

--- a/src/databases/Vs/avtVsFileFormat.h
+++ b/src/databases/Vs/avtVsFileFormat.h
@@ -21,7 +21,7 @@
 #include <avtSTMDFileFormat.h>
 #include "HighOrderUnstructuredData.h"
 
-#include <hdf5.h>
+#include <vshdf5.h>
 #include <visit-hdf5.h>
 
 #include <string>

--- a/src/databases/Vs/avtVsFileFormat.h
+++ b/src/databases/Vs/avtVsFileFormat.h
@@ -102,6 +102,7 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  *         (must delete when done)
  */
     virtual vtkDataSet* GetMesh(int domain, const char* meshname);
+    vtkDataSet* GetMesh(VsReader* reader, int domain, const char* meshname);
 
 /**
  * get a scalar variable by name
@@ -113,6 +114,7 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  *         (must delete when done)
  */
     virtual vtkDataArray* GetVar(int domain, const char* varname);
+    vtkDataArray* GetVar(VsReader* reader, int domain, const char* varname);
 
 /**
  * Get variable in the case when it is stored on a node by node basis per cell.
@@ -122,6 +124,8 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  */
     virtual vtkDataArray* NodalVar(VsVariable* meta,
         std::string requestedName, int component);
+    vtkDataArray* NodalVar(VsReader* reader, VsVariable* meta,
+        std::string requestedName, int component);
 
 /**
  * Get a variable that is "standard".  A standard variable is a variable that
@@ -129,20 +133,21 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  * discontinuous Galerkin type data (or likely other high order data).
  */
     virtual vtkDataArray* StandardVar(int domain, const char* requestedName);
+    vtkDataArray* StandardVar(VsReader* reader, int domain, const char* requestedName);
 
 /**
  * Determine if the name is a component of a larger vector
  * @param name is the name of the variable
  * @param componentIndex is the index of that variable (returned).
  */
-    virtual bool nameIsComponent(std::string& name, int& componentIndex);
+    virtual bool nameIsComponent(VsReader* reader, std::string& name, int& componentIndex);
 
 /**
  * Check to see if the name has been transformed to a different name for
  * display
  * @param name is the name of the variable
  */
-    virtual bool isTransformedName(std::string& name);
+    virtual bool isTransformedName(VsReader* reader, std::string& name);
 
 /**
  * Free up any resources created by this object.
@@ -176,18 +181,8 @@ class avtVsFileFormat: public avtSTMDFileFormat {
 /** The file containing the data */
     std::string dataFileName;
 
-/** Pointer to the reader */
-    VsReader* reader;
-
 /** Ensure data has been read */
-    void LoadData();
-
-/**
- * This is not the best way to do this.  In fact every type of mesh should
- * have a separate class and then there would be a pointer to the type selected.
- * Since I only have one class that uses this approach I'm doing it this way.
- */
-    HighOrderUnstructuredData thisData;
+    VsReader* LoadData();
 
 /**
  * Change the default behavior so that the plugin does not populate
@@ -205,7 +200,7 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  * @requestedName is the full name of the variable
  * @componentIndex is the component we are requesting
  */
-    VsVariable* getVariableMeta(int domain, std::string requestedName,
+    VsVariable* getVariableMeta(VsReader* reader, int domain, std::string requestedName,
         int &componentIndex);
 
 /**
@@ -213,10 +208,6 @@ class avtVsFileFormat: public avtSTMDFileFormat {
  */
     static int instanceCounter;
 
-/**
- * A registry of all objects found in the data file
- */
-    VsRegistry* registry;
 
 /** Some stuff to keep track of data selections */
     std::vector<avtDataSelection_p> selList;
@@ -230,44 +221,51 @@ class avtVsFileFormat: public avtSTMDFileFormat {
     std::vector<std::string> curveNames;
 
 /**
+ * To minimize how often we need to open & read the file, cache some simple information.
+ * These are in the form of a map from the file name to the data required.
+ */
+    std::map<std::string, int> cycleData;
+    std::map<std::string, double> timeData;
+
+/**
  * Set the axis labels for a mesh.
  *
  * @param mmd a pointer to the object that needs the axis labels.
  */
-    void setAxisLabels(avtMeshMetaData* mmd, bool transform = false);
+    void setAxisLabels(VsRegistry* registry, avtMeshMetaData* mmd, bool transform = false);
 
 /**
  * Set the global extents for a mesh.
  *
  * @param mmd a pointer to the object that needs the axis labels.
  */
-    void setGlobalExtents(avtMeshMetaData* mmd);
+    void setGlobalExtents(VsRegistry* registry, avtMeshMetaData* mmd);
 
 /**
  * Create various meshes.
  */
-    vtkDataSet* getUniformMesh(VsUniformMesh*, bool, int*, int*, int*);
-    vtkDataSet* getRectilinearMesh(VsRectilinearMesh*, bool, int*, int*, int*,
+    vtkDataSet* getUniformMesh(VsReader*, VsUniformMesh*, bool, int*, int*, int*);
+    vtkDataSet* getRectilinearMesh(VsReader*, VsRectilinearMesh*, bool, int*, int*, int*,
         bool);
-    vtkDataSet* getStructuredMesh(VsStructuredMesh*, bool, int*, int*, int*);
-    vtkDataSet* getUnstructuredMesh(VsUnstructuredMesh*, bool, int*, int*,
+    vtkDataSet* getStructuredMesh(VsReader*, VsStructuredMesh*, bool, int*, int*, int*);
+    vtkDataSet* getUnstructuredMesh(VsReader*, VsUnstructuredMesh*, bool, int*, int*,
         int*);
-    vtkDataSet* getPointMesh(VsVariableWithMesh*, bool, int*, int*, int*, bool);
-    vtkDataSet* getHighOrderUnstructuredMesh(VsUnstructuredMesh*, bool, int*,
+    vtkDataSet* getPointMesh(VsReader*, VsVariableWithMesh*, bool, int*, int*, int*, bool);
+    vtkDataSet* getHighOrderUnstructuredMesh(VsReader*, VsUnstructuredMesh*, bool, int*,
         int*, int*);
-    vtkDataSet* getCurve(int domain, const std::string& name);
+    vtkDataSet* getCurve(VsReader*, int domain, const std::string& name);
 
 
 /**
  * Each type of object is added to the database with a separate method
  * for neatness.
  */
-    void RegisterMeshes(avtDatabaseMetaData* md);
-    void RegisterMdMeshes(avtDatabaseMetaData* md);
-    void RegisterVarsWithMesh(avtDatabaseMetaData* md);
-    void RegisterVars(avtDatabaseMetaData* md);
-    void RegisterMdVars(avtDatabaseMetaData* md);
-    void RegisterExpressions(avtDatabaseMetaData* md);
+    void RegisterMeshes(VsRegistry*, avtDatabaseMetaData* md);
+    void RegisterMdMeshes(VsRegistry*, avtDatabaseMetaData* md);
+    void RegisterVarsWithMesh(VsRegistry*, avtDatabaseMetaData* md);
+    void RegisterVars(VsRegistry*, avtDatabaseMetaData* md);
+    void RegisterMdVars(VsRegistry*, avtDatabaseMetaData* md);
+    void RegisterExpressions(VsRegistry*, avtDatabaseMetaData* md);
 
     void GetSelectionBounds(size_t numTopologicalDims,
         std::vector<int> &numCells,
@@ -286,7 +284,9 @@ class avtVsFileFormat: public avtSTMDFileFormat {
         bool isNodal = true);
 
     template <typename TYPE>
-    void fillInMaskNodeArray(const std::vector<int>& gdims,
+    void fillInMaskNodeArray(
+        VsReader* reader,
+        const std::vector<int>& gdims,
         VsDataset *mask, bool maskIsFortranOrder,
         vtkUnsignedCharArray *maskedNodes);
 

--- a/src/databases/Vs/vshdf5.h
+++ b/src/databases/Vs/vshdf5.h
@@ -1,0 +1,7 @@
+/*
+ * include hdf5.h with a certain api
+ *
+ */
+
+#define H5_USE_18_API
+#include <hdf5.h>


### PR DESCRIPTION
### Description

A collection of fixes for the Vs database reader plugin.
1. Fix a crash caused by an integer overflow when loading rectilinear meshes with more than 2,147,483,647 cells
2. Fix a file-handle conflict on Windows - the plugin no longer holds a file handle open when not actively reading the data files.
3. Fix a memory-overflow crash when loading a rectilinear mesh with domain decomposition enabled.
4. Fix a compile issue with hdf5-1.12 by creating a local wrapper (vshdf5.h) for the actual hdf5 header that sets the API version before including the actual hdf5.h

And one fix for general workability:
1. Change the .gitignore file to also ignore .DS_Store files (Mac-specific indexing) and src/test/py_src which appears to be a generated folder.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

All fixes tested by hand on linux, MacOS, and Windows. All changes are exercised in our internal nightly builds & automated UI tests.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [?] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
- [X] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
