### PR TITLE
Fix infinite loop in `has_nonspace_chars`

### DIFF
--- a/src/common/utility/StringHelpers.C
+++ b/src/common/utility/StringHelpers.C
@@ -868,6 +868,8 @@ StringHelpers::cdr(const std::string s, const char separator)
 //  Creation:   August 20, 2008
 //
 //  Modifications:
+//     Justin Privitera, Wed Mar 12 09:31:48 PDT 2025
+//     Increment iter to avoid infinite loop.
 //
 //****************************************************************************
 bool
@@ -881,6 +883,7 @@ has_nonspace_chars(const std::string &s)
         {
             return true;
         }
+        iter++;
     }
     return false;
 }

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -92,7 +92,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed command recording for a Pick query with global element.</li>
   <li>Fixed a crash in structured domain boundaries when exchanging materials that lack a <i>mix_zone</i> array.</li>
   <li>Fixed a crash in structured domain boundaries when exchanging mixed material data using local boundary data.</li>
-  <li>Bug Fix 2</li>
+  <li>Fixed a potential infinite loop in our internal string helper utilities.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
### Description

Resolves #20193 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Fix the infinite loop.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Built and ran on rzhound toss4. Stringhelpers unit tests pass.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
