### PR TITLE
Enable osmesa diagnostic tests when building with VTK 9.4.1.

### DIFF
--- a/src/tools/dev/diagnostics/CMakeLists.txt
+++ b/src/tools/dev/diagnostics/CMakeLists.txt
@@ -15,7 +15,8 @@ add_subdirectory(networktest)
 add_subdirectory(exceptiontest)
 
 
-if(HAVE_OSMESA AND VTK_VERSION VERSION_LESS "9.4.0")
+# OSMesa should always be available with VTK 9.4.1
+if(HAVE_OSMESA OR VTK_VERSION VERSION_GREATER_EQUAL "9.4.1")
     add_subdirectory(osmesatest)
 endif()
 

--- a/src/tools/dev/diagnostics/osmesatest/CMakeLists.txt
+++ b/src/tools/dev/diagnostics/osmesatest/CMakeLists.txt
@@ -51,14 +51,20 @@ ADD_EXECUTABLE(osmesatest_ser osmesatest.cpp)
 TARGET_LINK_LIBRARIES(osmesatest_ser ${VISIT_EXE_LINKER_FLAGS} ${OSMESA_LIBRARIES} ${LIBDL} Threads::Threads)
 
 ADD_EXECUTABLE(osmesavtktest_ser osmesavtktest.cpp)
-TARGET_LINK_LIBRARIES(osmesavtktest_ser ${VISIT_EXE_LINKER_FLAGS} visit_vtk_offscreen visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} Threads::Threads)
+TARGET_LINK_LIBRARIES(osmesavtktest_ser ${VISIT_EXE_LINKER_FLAGS} visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} Threads::Threads)
+if(VTK_VERSION VERSION_LESS "9.4.1")
+    TARGET_LINK_LIBRARIES(osmesavtktest_ser visit_vtk_offscreen)
+endif()
 
 IF(VISIT_PARALLEL)
     ADD_PARALLEL_EXECUTABLE(osmesatest_par osmesatest.cpp)
     PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesatest_par ${OSMESA_LIBRARIES} ${LIBDL} Threads::Threads)
 
     ADD_PARALLEL_EXECUTABLE(osmesavtktest_par osmesavtktest.cpp)
-    PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesavtktest_par visit_vtk_offscreen visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} Threads::Threads)
+    PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesavtktest_par visitcommon ${REQUIRED_VTK_LIBS} ${LIBDL} Threads::Threads)
+    if(VTK_VERSION VERSION_LESS "9.4.1")
+        PARALLEL_EXECUTABLE_LINK_LIBRARIES(osmesavtktest_par visit_vtk_offscreen )
+    endif()
 
     SET(TARGETS ${TARGETS} osmesatest_par osmesavtktest_par)
 ENDIF(VISIT_PARALLEL)


### PR DESCRIPTION
### Description

Resolves #20314

### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other
VTK 9.4 port cleanup

### How Has This Been Tested?

the osmesa tests run successfully when visit built with vtk 9.4.1.

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
