### PR TITLE
Add and adjust notes regarding aspects of python extension module objects.

### DIFF
--- a/src/doc/dev_manual/UpdatingPlugins.rst
+++ b/src/doc/dev_manual/UpdatingPlugins.rst
@@ -226,7 +226,7 @@ Now for the python getattr and setattr methods::
 
 .. danger::
 
-**Important**: Changes to fields in the Attributes are not allowed in patch releases, as it may cause incompatibility between client and server running different patches of the same major.minor release.
+   Changes to fields in the Attributes are not allowed in patch releases, as it may cause incompatibility between client and server running different patches of the same major.minor release.
 
 Non-static Python Functions in State Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/doc/dev_manual/UpdatingPlugins.rst
+++ b/src/doc/dev_manual/UpdatingPlugins.rst
@@ -224,4 +224,21 @@ Now for the python getattr and setattr methods::
     #endif
 
 
+.. danger::
+
 **Important**: Changes to fields in the Attributes are not allowed in patch releases, as it may cause incompatibility between client and server running different patches of the same major.minor release.
+
+Non-static Python Functions in State Objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Creating the C/C++ extension module version of VisIt_ state objects (e.g. attributes) involves defining two sets of functions.
+One set is the set of type object *slot* functions involving the ``.tp_xxx`` function pointers of the ``PythonTypeObject`` type. 
+The other is the set of *methods* defined in the ``PyMethodDef`` methods table.
+Ordinarily, all these functions would be be qualified with the ``static`` keyword for internal-only linkage.
+This is useful in minimizing pollution of the global namespace.
+
+However, VisIt_'s state objects support a simplified form of inheritance.
+An example is the state objects associated with database metadata.
+There is an ``avtBaseVarMetaData`` state object that most of the other metadata state objects are built on top of.
+Because of this *one case*, all of VisIt_'s python objects expose their ``setattro``, ``getattro`` functions and their ``_methods[]`` table for external linkage.
+It would be better to limit this exposure to just the cases that need it.
+That is, it would be better if *just* those state objects serving as a *parent* (e.g. ``avtBaseVarMetaData``) exposed their associated python functions and symbols.

--- a/src/doc/dev_manual/xmltools.rst
+++ b/src/doc/dev_manual/xmltools.rst
@@ -50,8 +50,11 @@ We rely on xml code generation to keep our State object, Attribute, and Plugin A
 To automate the process we provide CMake targets that call our xml code generation tools for each object or plugin registered. 
 Individual code gen targets are all wired into top level targets that allow you to apply the code gen tools to categories of code gen tasks.  
 These targets replace older tools such as regen-ajp and various regenerateatts.py scripts. 
-Keep in mind however, that these targets are only created for plugins that are enabled for building. 
-Any use of the plugin-reducing CMake vars (*VISIT_BUILD_MINIMAL_PLUGINS* and any of the *VISIT_SELECTED_XXX_PLUGINS*) will limit the created code gen targets to those plugins being built.
+
+.. danger::
+
+   Keep in mind however, that these targets are only created for plugins that are enabled for building. 
+   Any use of the plugin-reducing CMake vars (``VISIT_BUILD_MINIMAL_PLUGINS`` and any of the ``VISIT_SELECTED_XXX_PLUGINS``) will limit the created code gen targets to those plugins being built.
 
 
 Top Level CMake Code Gen Targets


### PR DESCRIPTION
### Description

I added some `.. danger::` directives to docs regarding some important caveats and I added some information about our python C extension module objects.

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* [x] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [x] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
