### PR TITLE
Fix multiple input math expressions crashing the compute engine on single input

### DIFF
--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -70,6 +70,10 @@ avtMinMaxExpression::~avtMinMaxExpression()
 //
 //  Programmer: Eddie Rusu
 //  Creation:   Mon Sep 30 14:09:49 PDT 2019
+// 
+//  Modifications:
+//    Justin Privitera, Wed Apr  2 15:03:35 PDT 2025
+//    Handle the single input case.
 //
 // ****************************************************************************
 

--- a/src/avt/Expressions/General/avtMinMaxExpression.C
+++ b/src/avt/Expressions/General/avtMinMaxExpression.C
@@ -79,11 +79,29 @@ avtMinMaxExpression::DoOperation()
     debug4 << "Entering avtMinMaxExpression::DoOperation()" << std::endl;
     vtkDataArray* output = CreateOutputVariable();
 
-    // Loop over all inputs and determine the min/max
-    DoOperationHelper(output, dataArrays[0], dataArrays[1]);
-    for (int i = 2; i < nProcessedArgs; ++i)
+    if (dataArrays.size() == 1)
     {
-        DoOperationHelper(output, output, dataArrays[i]);
+        const bool varIsSingleton = (dataArrays[0]->GetNumberOfTuples() == 1);
+        const int ntuples = output->GetNumberOfTuples();
+        const int ncomps = dataArrays[0]->GetNumberOfComponents();
+        for (int tuple_id = 0; tuple_id < ntuples; tuple_id ++)
+        {
+            for (int comp_id = 0; comp_id < ncomps; comp_id++)
+            {
+                vtkIdType tup = (varIsSingleton ? 0 : tuple_id);
+                const double outval = dataArrays[0]->GetComponent(tup, comp_id);
+                output->SetComponent(tuple_id, comp_id, outval);
+            }
+        }
+    }
+    else
+    {
+        // Loop over all inputs and determine the min/max
+        DoOperationHelper(output, dataArrays[0], dataArrays[1]);
+        for (int i = 2; i < nProcessedArgs; ++i)
+        {
+            DoOperationHelper(output, output, dataArrays[i]);
+        }
     }
 
     debug4 << "Exiting  avtMinMaxExpression::DoOperation()" << std::endl;

--- a/src/avt/Expressions/Math/avtSmartDivideExpression.C
+++ b/src/avt/Expressions/Math/avtSmartDivideExpression.C
@@ -78,23 +78,30 @@ avtSmartDivideExpression::RecenterData(vtkDataSet* in_ds)
 {
     debug5 << "Entering avtSmartDivideExpression::RecenterData(vtkDataSet*)"
             << std::endl;
-    if (centerings[0] != centerings[1])
+    if (centerings.size() == 1)
     {
-        centering = AVT_ZONECENT;
-        if (centerings[0] == AVT_NODECENT)
-        {
-            dataArrays[0] = Recenter(in_ds, dataArrays[0], centerings[0],
-                outputVariableName);
-        }
-        else
-        {
-            dataArrays[1] = Recenter(in_ds, dataArrays[1], centerings[1],
-                outputVariableName);
-        }
+        centering = centerings[0];
     }
     else
     {
-        centering = centerings[0];
+        if (centerings[0] != centerings[1])
+        {
+            centering = AVT_ZONECENT;
+            if (centerings[0] == AVT_NODECENT)
+            {
+                dataArrays[0] = Recenter(in_ds, dataArrays[0], centerings[0],
+                    outputVariableName);
+            }
+            else
+            {
+                dataArrays[1] = Recenter(in_ds, dataArrays[1], centerings[1],
+                    outputVariableName);
+            }
+        }
+        else
+        {
+            centering = centerings[0];
+        }
     }
     debug5 << "Exiting  avtSmartDivideExpression::RecenterData(vtkDataSet*)"
             << std::endl;
@@ -128,6 +135,12 @@ avtSmartDivideExpression::DoOperation()
     // multi-variable divide by zero case. For example, suppose the user
     // wants to specify varying tolernaces over the mesh as represented by
     // some variable or varying div_zero_value. This can be easily done here.
+
+    if (dataArrays.size() < 2)
+    {
+        EXCEPTION2(ExpressionException, outputVariableName, 
+                   "avtSmartDivideExpression cannot divide a single variable.");
+    }
 
     vtkDataArray* data1 = dataArrays[0];
     vtkDataArray* data2 = dataArrays[1];

--- a/src/avt/Expressions/Math/avtSmartDivideExpression.C
+++ b/src/avt/Expressions/Math/avtSmartDivideExpression.C
@@ -70,6 +70,10 @@ avtSmartDivideExpression::~avtSmartDivideExpression()
 //
 //  Programmer: Eddie Rusu
 //  Creation:   Tue Sep 24 09:07:44 PDT 2019
+// 
+//  Modifications:
+//    Justin Privitera, Wed Apr  2 15:03:35 PDT 2025
+//    Handle the single input case.
 //
 // ****************************************************************************
 
@@ -124,6 +128,9 @@ avtSmartDivideExpression::RecenterData(vtkDataSet* in_ds)
 //      Eddie Rusu, Mon Sep 30 14:49:38 PDT 2019
 //      Replaced output variable setup with
 //      avtMultiInputMathExpression::CreateOutputVariable.
+// 
+//      Justin Privitera, Wed Apr  2 15:03:35 PDT 2025
+//      Handle the single input case.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -85,7 +85,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Expression_changes"></a>
 <p><b><font size="4">Changes to VisIt's expression language in version 3.5</font></b></p>
 <ul>
-  <li>Expression Change 1</li>
+  <li>Fixed a bug causing the min, max, and divide expressions to crash the compute engine when given a single variable as input. Min and max now return the result of that single variable, and divide throws an error instead of crashing.</li>
   <li>Expression Change 2</li>
 </ul>
 


### PR DESCRIPTION
### Description

Resolves #19963 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
I prevented all multiple input math expressions from crashing when presented with a single input. There are two expressions in this category:
 - MinMax: I changed it so that the min or max of a single input is that input instead of crashing.
 - SmartDivide: this now throws an error instead of crashing.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
Built and ran on rzhound toss4. I verified that none of these expressions cause crashes anymore. There are no tests for these expressions so I did not add any new ones.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
