### PR TITLE
Ensure HAVE_LIBX11 gets defined

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,6 +308,7 @@ if(WIN32)
     include_visit_config_site()
 endif()
 
+include(${VISIT_SOURCE_DIR}/CMake/VisItOptions.cmake)
 include(${VISIT_SOURCE_DIR}/CMake/CheckMinimumCompilerVersion.cmake)
 include(${VISIT_SOURCE_DIR}/CMake/SystemChecks.cmake)
 include(${VISIT_SOURCE_DIR}/CMake/SetUpPlatformDefs.cmake)
@@ -346,7 +347,6 @@ set(CXX_TEST_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 #-----------------------------------------------------------------------------
 # configure options
 #-----------------------------------------------------------------------------
-include("${VISIT_SOURCE_DIR}/CMake/VisItOptions.cmake")
 
 # Set up placeholders for package vars: XXX_DIR
 foreach(pkg ADIOS ADIOS2 ADIOS2_PAR ADVIO BLOSC2 BOOST BOXLIB CFITSIO CGNS
@@ -1015,3 +1015,4 @@ add_custom_target(visit-dist
   COMMAND ${CMAKE_COMMAND} -E rm ${VISIT_SOURCE_DIR}/GIT_VERSION
   COMMAND ${CMAKE_COMMAND} -E rm -rf ${dist_name}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DR})
+

--- a/src/avt/QtVisWindow/vtk/CMakeLists.txt
+++ b/src/avt/QtVisWindow/vtk/CMakeLists.txt
@@ -4,18 +4,14 @@
 
 #****************************************************************************
 # Modifications:
+#   Kathleen Biagas, Tue April 15, 2025
+#   Removed setting of HAVE_XLIB definition. No longer needed.
 #
 #****************************************************************************
 
 target_sources(avtqtviswindow PRIVATE
     vtkDashedXorGridMapper2D.C
     vtkRubberBandMapper2D.C)
-
-if(NOT APPLE AND X11_FOUND)
-    set_source_files_properties(
-        vtkDashedXorGridMapper2D.C  vtkRubberBandMapper2D.C
-        PROPERTIES COMPILE_FLAGS "-DHAVE_XLIB")
-endif()
 
 target_include_directories(avtqtviswindow PUBLIC .)
 

--- a/src/avt/QtVisWindow/vtk/vtkDashedXorGridMapper2D.C
+++ b/src/avt/QtVisWindow/vtk/vtkDashedXorGridMapper2D.C
@@ -29,28 +29,21 @@
 #include <QPixmap>
 #include <QPainter>
 #include <QLine>
-#if defined(HAVE_XLIB)
-#  include <QtX11Extras/QX11Info>
-#  include <X11/Intrinsic.h>
-#endif
 
 struct vtkDashedXorGridMapper2DPrivate
 {
     QWidget *widget;
-    int      bestRenderer;
     QLabel  *overlay;
 
     vtkDashedXorGridMapper2DPrivate()
     {
         widget = 0;
-        bestRenderer = -1;
         overlay = 0;
     }
 
     vtkDashedXorGridMapper2DPrivate(const vtkDashedXorGridMapper2DPrivate &obj)
     {
         widget = obj.widget;
-        bestRenderer = obj.bestRenderer;
         overlay = 0;
     }
 
@@ -62,7 +55,6 @@ struct vtkDashedXorGridMapper2DPrivate
     void operator = (const vtkDashedXorGridMapper2DPrivate &obj)
     {
         widget = obj.widget;
-        bestRenderer = obj.bestRenderer;
         overlay = 0;
     }
 
@@ -73,39 +65,6 @@ struct vtkDashedXorGridMapper2DPrivate
         if(overlay != 0)
             overlay->deleteLater();
         overlay = 0;
-    }
-
-    int SelectBestRenderer()
-    {
-        if(bestRenderer != -1)
-            return bestRenderer;
-
-#if defined(__APPLE__) || defined (_WIN32)
-        bestRenderer = 2;
-#elif defined(HAVE_XLIB)
-        bestRenderer = 1;
-#if 0
-// X is not creating the Qt overlay as transparent. Disable for now.
-        // See if we're displaying to Apple X11. If so we want Qt renderer.
-        int nExt = 0, appleDisplay = 0;
-        char **ext = XListExtensions(QX11Info::display(), &nExt);
-        for(int e = 0; e < nExt; ++e)
-        {
-            if(strcmp(ext[e], "Apple-DRI") == 0 ||
-               strcmp(ext[e], "Apple-WM") == 0)
-            {
-                appleDisplay++;
-            }
-        }
-        XFreeExtensionList(ext);
-        if(appleDisplay == 2)
-            bestRenderer = 2;
-#endif
-#else
-        bestRenderer = 2;
-#endif
-
-        return bestRenderer;
     }
 };
 
@@ -232,15 +191,7 @@ vtkDashedXorGridMapper2D::RenderOverlay(vtkViewport* viewport, vtkActor2D* actor
 {
     if(privateInstance->widget != 0)
     {
-        switch(privateInstance->SelectBestRenderer())
-        {
-        case 1:
-            RenderOverlay_X11(viewport, actor);
-            break;
-        case 2:
-            RenderOverlay_Qt(viewport, actor);
-            break;
-        }
+        RenderOverlay_Qt(viewport, actor);
     }
 }
 
@@ -254,63 +205,6 @@ vtkDashedXorGridMapper2D::RenderOverlay(vtkViewport* viewport, vtkActor2D* actor
 void
 vtkDashedXorGridMapper2D::RenderOverlay_X11(vtkViewport* viewport, vtkActor2D* actor)
 {
-#if defined(HAVE_XLIB)
-#define SET_FOREGROUND_D(rgba) \
-      aColor.red = (unsigned short) (rgba[0] * 65535.0); \
-      aColor.green = (unsigned short) (rgba[1] * 65535.0); \
-      aColor.blue = (unsigned short) (rgba[2] * 65535.0); \
-      XAllocColor(displayId, attr.colormap, &aColor); \
-      XSetForeground(displayId, gc, aColor.pixel); \
-      XSetFillStyle(displayId, gc, FillSolid);
-
-#define SET_FOREGROUND(rgba) \
-      aColor.red = (unsigned short) (rgba[0] * 256); \
-      aColor.green = (unsigned short) (rgba[1] * 256); \
-      aColor.blue = (unsigned short) (rgba[2] * 256); \
-      XAllocColor(displayId, attr.colormap, &aColor); \
-      XSetForeground(displayId, gc, aColor.pixel);
-
-#define DRAW_XOR_LINE(x1, y1, x2, y2) \
-      XDrawLine(displayId, drawable, xorGC, x1, y1, x2, y2);
-
-#define FLUSH_AND_SYNC() XFlush(displayId); XSync(displayId, False); \
-      XFreeGC(displayId, gc);
-
-#define CLEAN_UP() delete [] points;
-
-    XColor aColor;
-    XPoint *points = new XPoint [1024];
-
-    Display* displayId = (Display*) QX11Info::display();
-    Window windowId = (Window) privateInstance->widget->winId();
-
-    Screen *screen = XDefaultScreenOfDisplay(displayId);
-    int screenN = XScreenNumberOfScreen(screen);
-    unsigned long black = BlackPixel(displayId, screenN);
-    unsigned long white = WhitePixel(displayId, screenN);
-    XGCValues xgcvalues;
-    xgcvalues.foreground = black ^ white;
-    xgcvalues.background = 0;
-    xgcvalues.function = GXxor;
-    GC gc = XCreateGC(displayId, windowId, GCForeground | GCBackground | GCFunction,
-        &xgcvalues);
-    GC xorGC = XCreateGC(displayId, windowId, GCForeground | GCBackground | GCFunction,
-        &xgcvalues);
-
-    // Get the drawable to draw into
-    Drawable drawable = (Drawable) windowId;
-    if (!drawable) vtkErrorMacro(<<"Window returned NULL drawable!");
-  
-    // Set up the forground color
-    XWindowAttributes attr;
-    XGetWindowAttributes(displayId,windowId,&attr);
-
-    // Set the line color
-    double* actorColor = actor->GetProperty()->GetColor();
-    SET_FOREGROUND_D(actorColor);
-
-#include <vtkDashedXorGridMapper2D_body.C>
-#endif
 }
 
 // ****************************************************************************

--- a/src/avt/QtVisWindow/vtk/vtkRubberBandMapper2D.C
+++ b/src/avt/QtVisWindow/vtk/vtkRubberBandMapper2D.C
@@ -26,28 +26,21 @@
 #include <QPixmap>
 #include <QPainter>
 #include <QLine>
-#if defined(HAVE_XLIB)
-#  include <QtX11Extras/QX11Info>
-#  include <X11/Intrinsic.h>
-#endif
 
 struct vtkRubberBandMapper2DPrivate
 {
     QWidget *widget;
-    int      bestRenderer;
     QLabel  *overlay;
 
     vtkRubberBandMapper2DPrivate()
     {
         widget = 0;
-        bestRenderer = -1;
         overlay = 0;
     }
 
     vtkRubberBandMapper2DPrivate(const vtkRubberBandMapper2DPrivate &obj)
     {
         widget = obj.widget;
-        bestRenderer = obj.bestRenderer;
         overlay = 0;
     }
 
@@ -59,7 +52,6 @@ struct vtkRubberBandMapper2DPrivate
     void operator = (const vtkRubberBandMapper2DPrivate &obj)
     {
         widget = obj.widget;
-        bestRenderer = obj.bestRenderer;
         overlay = 0;
     }
 
@@ -70,39 +62,6 @@ struct vtkRubberBandMapper2DPrivate
         if(overlay != 0)
             overlay->deleteLater();
         overlay = 0;
-    }
-
-    int SelectBestRenderer()
-    {
-        if(bestRenderer != -1)
-            return bestRenderer;
-
-#if defined(__APPLE__) || defined(_WIN32)
-        bestRenderer = 2;
-#elif defined(HAVE_XLIB)
-        bestRenderer = 1;
-#if 0
-// X is not creating the Qt overlay as transparent. Disable for now.
-        // See if we're displaying to Apple X11. If so we want Qt renderer.
-        int nExt = 0, appleDisplay = 0;
-        char **ext = XListExtensions(QX11Info::display(), &nExt);
-        for(int e = 0; e < nExt; ++e)
-        {
-            if(strcmp(ext[e], "Apple-DRI") == 0 ||
-               strcmp(ext[e], "Apple-WM") == 0)
-            {
-                appleDisplay++;
-            }
-        }
-        XFreeExtensionList(ext);
-        if(appleDisplay == 2)
-            bestRenderer = 2;
-#endif
-#else
-        bestRenderer = 2;
-#endif
-
-        return bestRenderer;
     }
 };
 
@@ -226,101 +185,8 @@ vtkRubberBandMapper2D::RenderOverlay(vtkViewport* viewport, vtkActor2D* actor)
 {
     if(privateInstance->widget != 0)
     {
-        switch(privateInstance->SelectBestRenderer())
-        {
-        case 1:
-            RenderOverlay_X11(viewport, actor);
-            break;
-        case 2:
-            RenderOverlay_Qt(viewport, actor);
-            break;
-        }
+        RenderOverlay_Qt(viewport, actor);
     }
-}
-
-// ***************************************************************************
-//
-// X11 coding and macros
-//
-// ***************************************************************************
-
-void
-vtkRubberBandMapper2D::RenderOverlay_X11(vtkViewport* viewport, vtkActor2D* actor)
-{
-#if defined(HAVE_XLIB)
-#define STORE_POINT(P, X, Y) P.x = short(X); P.y = short(Y);
-
-#define SET_FOREGROUND_D(rgba) \
-      aColor.red = (unsigned short) (rgba[0] * 65535.0); \
-      aColor.green = (unsigned short) (rgba[1] * 65535.0); \
-      aColor.blue = (unsigned short) (rgba[2] * 65535.0); \
-      XAllocColor(displayId, attr.colormap, &aColor); \
-      XSetForeground(displayId, gc, aColor.pixel); \
-      XSetFillStyle(displayId, gc, FillSolid);
-
-#define SET_FOREGROUND(rgba) \
-      aColor.red = (unsigned short) (rgba[0] * 256); \
-      aColor.green = (unsigned short) (rgba[1] * 256); \
-      aColor.blue = (unsigned short) (rgba[2] * 256); \
-      XAllocColor(displayId, attr.colormap, &aColor); \
-      XSetForeground(displayId, gc, aColor.pixel);
-
-#define DRAW_POLYGON(points, npts) XFillPolygon(displayId, drawable, \
-      gc, points, npts, Complex, CoordModeOrigin);
-
-#define RESIZE_POINT_ARRAY(points, npts, currSize) \
-      if (npts > currSize) \
-      { \
-      delete [] points; \
-      points = new XPoint [npts]; \
-      currSize = npts; \
-      }
-
-#define DRAW_XOR_LINE(x1, y1, x2, y2) \
-      XDrawLine(displayId, drawable, xorGC, x1, y1, x2, y2);
-
-#define FLUSH_AND_SYNC() XFlush(displayId); XSync(displayId, False); \
-      XFreeGC(displayId, gc);
-
-#define BEGIN_POLYLINE(X,Y)
-
-#define END_POLYLINE()
-
-#define CLEAN_UP() delete [] points;
-
-    XColor aColor;
-    XPoint *points = new XPoint [1024];
-
-    Display* displayId = (Display*) QX11Info::display();
-    Window windowId = (Window) privateInstance->widget->winId();
-
-    Screen *screen = XDefaultScreenOfDisplay(displayId);
-    int screenN = XScreenNumberOfScreen(screen);
-    unsigned long black = BlackPixel(displayId, screenN);
-    unsigned long white = WhitePixel(displayId, screenN);
-    XGCValues xgcvalues;
-    xgcvalues.foreground = black ^ white;
-    xgcvalues.background = 0;
-    xgcvalues.function = GXxor;
-    GC gc = XCreateGC(displayId, windowId, GCForeground | GCBackground | GCFunction,
-                      &xgcvalues);
-    GC xorGC = XCreateGC(displayId, windowId, GCForeground | GCBackground | GCFunction,
-                      &xgcvalues);
-
-    // Get the drawable to draw into
-    Drawable drawable = (Drawable) windowId;
-    if (!drawable) vtkErrorMacro(<<"Window returned NULL drawable!");
-
-    // Set up the forground color
-    XWindowAttributes attr;
-    XGetWindowAttributes(displayId,windowId,&attr);
-
-    // Set the line color
-    double* actorColor = actor->GetProperty()->GetColor();
-    SET_FOREGROUND_D(actorColor);
-
-#include <vtkRubberBandMapper2D_body.C>
-#endif
 }
 
 // ***************************************************************************


### PR DESCRIPTION
### Description

While working on my CMake project, testing values in visit-config.h,  I noticed that HAVE_LIBX11 wasn't getting defined.

I found the source of the problem and fixed that (change to src/CMakeLists.txt).

But then I discovered the vtkDashedXorGridMapper2D and vtkRubberBandMapper2D wouldn't compile due to dependence on QtX11 features not available in Qt 6.
Since that logic has basically been dormant since 3.3.3, I figured it would be okay to remove it. That's the second part of this.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Successful compile and run of parallel regression suite on poodle.
Played with zoom interaction, and the rubber band interaction seemed fine.


### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[