### PR TITLE
Fix mismatched slots/signals in XmlEdit code.

### DIFF
--- a/src/tools/dev/xmledit/XMLEditCode.C
+++ b/src/tools/dev/xmledit/XMLEditCode.C
@@ -302,7 +302,17 @@ XMLEditCode::BlockAllSignals(bool block)
 //    Also modified setText for codelist to use newname as I believe that
 //    was the original intent.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg nameTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
+void
+XMLEditCode::nameTextChanged()
+{
+    nameTextChanged(name->text());
+}
+
 void
 XMLEditCode::nameTextChanged(const QString &text)
 {
@@ -312,7 +322,7 @@ XMLEditCode::nameTextChanged(const QString &text)
         return;
     Code *c = a->codes[index];
 
-    QString newname = text.isEmpty() ? name->text().trimmed() : text.trimmed();
+    QString newname = text.trimmed();
 
     c->name = newname;
     if(CountCodes(newname) > 1)

--- a/src/tools/dev/xmledit/XMLEditCode.h
+++ b/src/tools/dev/xmledit/XMLEditCode.h
@@ -37,6 +37,9 @@ class QPushButton;
 //    to 'editingFinished' signal. nameTextChanged retains its arg as it
 //    can be called with the arg from another function.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg nameTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
 class XMLEditCode : public QFrame
 {
@@ -50,6 +53,7 @@ class XMLEditCode : public QFrame
     void UpdateWindowSensitivity();
     void UpdateWindowSingleItem();
     void targetTextChanged();
+    void nameTextChanged();
     void nameTextChanged(const QString&);
     void prefixChanged();
     void postfixChanged();

--- a/src/tools/dev/xmledit/XMLEditConstants.C
+++ b/src/tools/dev/xmledit/XMLEditConstants.C
@@ -313,7 +313,17 @@ XMLEditConstants::BlockAllSignals(bool block)
 //    Also changed the text set in constantlist from 'text' to 'newname' which
 //    I believe is the intent.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg nameTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
+void
+XMLEditConstants::nameTextChanged()
+{
+    nameTextChanged(name->text());
+}
+
 void
 XMLEditConstants::nameTextChanged(const QString &text)
 {
@@ -323,7 +333,7 @@ XMLEditConstants::nameTextChanged(const QString &text)
         return;
     Constant *c = a->constants[index];
 
-    QString newname = text.isEmpty() ? name->text().trimmed() : text.trimmed();
+    QString newname = text.trimmed();
     c->name = newname;
     if(CountConstants(newname) > 1)
     {

--- a/src/tools/dev/xmledit/XMLEditConstants.h
+++ b/src/tools/dev/xmledit/XMLEditConstants.h
@@ -37,7 +37,11 @@ class QPushButton;
 //    to 'editingFinished' signal. nameTextChanged retains its arg as it
 //    can be called with the arg from another function.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg nameTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
 class XMLEditConstants : public QFrame
 {
     Q_OBJECT
@@ -49,6 +53,7 @@ class XMLEditConstants : public QFrame
     void UpdateWindowContents();
     void UpdateWindowSensitivity();
     void UpdateWindowSingleItem();
+    void nameTextChanged();
     void nameTextChanged(const QString&);
     void targetTextChanged();
     void memberChanged();

--- a/src/tools/dev/xmledit/XMLEditFunctions.C
+++ b/src/tools/dev/xmledit/XMLEditFunctions.C
@@ -376,7 +376,17 @@ XMLEditFunctions::BlockAllSignals(bool block)
 //    'editingFinished' signal, grab contents of file widget.
 //    Arg is only non-empty when this function called from targetTextChanged.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg nameTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
+void
+XMLEditFunctions::nameTextChanged()
+{
+    nameTextChanged(name->text());
+}
+
 void
 XMLEditFunctions::nameTextChanged(const QString &text)
 {
@@ -386,7 +396,7 @@ XMLEditFunctions::nameTextChanged(const QString &text)
         return;
     Function *f = a->functions[index];
 
-    QString newname = text.isEmpty() ? name->text().trimmed() : text.trimmed();
+    QString newname = text.trimmed();
     f->name = newname;
     if(CountFunctions(newname) > 1)
     {

--- a/src/tools/dev/xmledit/XMLEditFunctions.h
+++ b/src/tools/dev/xmledit/XMLEditFunctions.h
@@ -42,7 +42,11 @@ class QPushButton;
 //    to 'editingFinished' signal. nameTextChanged retains its arg as it
 //    can be called with the arg from another function.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg nameTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
 class XMLEditFunctions : public QFrame
 {
     Q_OBJECT
@@ -54,6 +58,7 @@ class XMLEditFunctions : public QFrame
     void UpdateWindowContents();
     void UpdateWindowSensitivity();
     void UpdateWindowSingleItem();
+    void nameTextChanged();
     void nameTextChanged(const QString&);
     void typeGroupChanged(int);
     void accessChanged(int);

--- a/src/tools/dev/xmledit/XMLEditIncludes.C
+++ b/src/tools/dev/xmledit/XMLEditIncludes.C
@@ -325,7 +325,17 @@ XMLEditIncludes::BlockAllSignals(bool block)
 //    'editingFinished' signal, grab contents of file widget.
 //    Arg is only non-empty when this function called from targetTextChanged.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg includeTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
+void
+XMLEditIncludes::includeTextChanged()
+{
+    includeTextChanged(file->text());
+}
+
 void
 XMLEditIncludes::includeTextChanged(const QString &text)
 {
@@ -335,7 +345,7 @@ XMLEditIncludes::includeTextChanged(const QString &text)
         return;
     Include *n = a->includes[index];
 
-    QString newinclude = text.isEmpty() ? file->text().trimmed() : text.trimmed();
+    QString newinclude = text.trimmed();
     n->include = newinclude;
     if(CountIncludes(newinclude) > 1)
     {

--- a/src/tools/dev/xmledit/XMLEditIncludes.h
+++ b/src/tools/dev/xmledit/XMLEditIncludes.h
@@ -37,7 +37,11 @@ class QPushButton;
 //    Removed QString arg from targetTextChanged slot as it now connected
 //    to 'editingFinished' signal, and isn't called by another function.
 //
+//    Kathleen Biagas, Wed April 16, 2025
+//    Add no-arg includeTextChanged to match editingFinished signal.
+//
 // ****************************************************************************
+
 class XMLEditIncludes : public QFrame
 {
     Q_OBJECT
@@ -50,6 +54,7 @@ class XMLEditIncludes : public QFrame
     void UpdateWindowSensitivity();
     void UpdateWindowSingleItem();
     void targetTextChanged();
+    void includeTextChanged();
     void includeTextChanged(const QString&);
     void fileGroupChanged(int);
     void quotedGroupChanged(int);


### PR DESCRIPTION
### Description
I was playing with xmledit and noticed problems with a few of the widgets not getting processed correctly, and saw that Qt spit out message regarding missing slots.

This was due to my recent changes for using 'editingFinished' signal with QLineEdit widgets.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ 

### How Has This Been Tested?

xmledit no longer issues Qt messages related to missing slots.


### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
