### PR TITLE
Add viewport coords clamping

### DIFF
--- a/src/common/state/View2DAttributes.C
+++ b/src/common/state/View2DAttributes.C
@@ -586,13 +586,75 @@ View2DAttributes::SetWindowCoords(const double *windowCoords_)
     Select(ID_windowCoords, (void *)windowCoords, 4);
 }
 
+#include <DebugStream.h>
 void
 View2DAttributes::SetViewportCoords(const double *viewportCoords_)
 {
-    viewportCoords[0] = viewportCoords_[0];
-    viewportCoords[1] = viewportCoords_[1];
-    viewportCoords[2] = viewportCoords_[2];
-    viewportCoords[3] = viewportCoords_[3];
+//
+// THIS METHOD IS CUSTOM CODED!!!
+// see .code file
+//
+    bool clamping = false;
+    if(viewportCoords_[0] < 0.)
+    {
+        clamping = true;
+        viewportCoords[0] = 0.;
+    }
+    else if(viewportCoords_[0] > 1.)
+    {
+        clamping = true;
+        viewportCoords[0] = 1.;
+    }
+    else
+    {
+        viewportCoords[0] = viewportCoords_[0];
+    }
+    if(viewportCoords_[1] > 1.)
+    {
+        clamping = true;
+        viewportCoords[1] = 1.;
+    }
+    else if(viewportCoords_[1] < 0.)
+    {
+        clamping = true;
+        viewportCoords[1] = 0.;
+    }
+    else
+    {
+        viewportCoords[1] = viewportCoords_[1];
+    }
+    if(viewportCoords_[2] < 0.)
+    {
+        clamping = true;
+        viewportCoords[2] = 0.;
+    }
+    else if(viewportCoords_[2] > 1.)
+    {
+        clamping = true;
+        viewportCoords[2] = 1.;
+    }
+    else
+    {
+        viewportCoords[2] = viewportCoords_[2];
+    }
+    if(viewportCoords_[3] > 1.)
+    {
+        clamping = true;
+        viewportCoords[3] = 1.;
+    }
+    else if(viewportCoords_[3] < 0.)
+    {
+        clamping = true;
+        viewportCoords[3] = 0.;
+    }
+    else
+    {
+        viewportCoords[3] = viewportCoords_[3];
+    }
+    if(clamping)
+    {
+        debug3 << "View2DAttributes::viewportCoords have been clamped to values between [0,1]." << endl;
+    }
     Select(ID_viewportCoords, (void *)viewportCoords, 4);
 }
 

--- a/src/common/state/View2DAttributes.code
+++ b/src/common/state/View2DAttributes.code
@@ -10,6 +10,82 @@ Declaration: DEFAULT_FULL_FRAME_AUTO_THRESHOLD
 Definition:
     public final static double DEFAULT_FULL_FRAME_AUTO_THRESHOLD = 100.0;
 
+Target: xml2atts
+Function: SetViewportCoords
+Declaration: void SetViewportCoords(const double *);
+Definition:
+#include <DebugStream.h>
+void
+View2DAttributes::SetViewportCoords(const double *viewportCoords_)
+{
+//
+// THIS METHOD IS CUSTOM CODED!!!
+// see .code file
+//
+    bool clamping = false;
+    if(viewportCoords_[0] < 0.)
+    {
+        clamping = true;
+        viewportCoords[0] = 0.;
+    }
+    else if(viewportCoords_[0] > 1.)
+    {
+        clamping = true;
+        viewportCoords[0] = 1.;
+    }
+    else
+    {
+        viewportCoords[0] = viewportCoords_[0];
+    }
+    if(viewportCoords_[1] > 1.)
+    {
+        clamping = true;
+        viewportCoords[1] = 1.;
+    }
+    else if(viewportCoords_[1] < 0.)
+    {
+        clamping = true;
+        viewportCoords[1] = 0.;
+    }
+    else
+    {
+        viewportCoords[1] = viewportCoords_[1];
+    }
+    if(viewportCoords_[2] < 0.)
+    {
+        clamping = true;
+        viewportCoords[2] = 0.;
+    }
+    else if(viewportCoords_[2] > 1.)
+    {
+        clamping = true;
+        viewportCoords[2] = 1.;
+    }
+    else
+    {
+        viewportCoords[2] = viewportCoords_[2];
+    }
+    if(viewportCoords_[3] > 1.)
+    {
+        clamping = true;
+        viewportCoords[3] = 1.;
+    }
+    else if(viewportCoords_[3] < 0.)
+    {
+        clamping = true;
+        viewportCoords[3] = 0.;
+    }
+    else
+    {
+        viewportCoords[3] = viewportCoords_[3];
+    }
+    if(clamping)
+    {
+        debug3 << "View2DAttributes::viewportCoords have been clamped to values between [0,1]." << endl;
+    }
+    Select(ID_viewportCoords, (void *)viewportCoords, 4);
+}
+
 
 Target: xml2atts
 Function: GetUseFullFrame

--- a/src/common/state/View2DAttributes.xml
+++ b/src/common/state/View2DAttributes.xml
@@ -32,6 +32,8 @@
     <Field name="windowValid" label="windowValid" type="bool">
       false
     </Field>
+    <Function name="SetViewportCoords" user="false" member="true">
+    </Function>
     <Function name="GetUseFullFrame" user="true" member="true">
     </Function>
     <Function name="SetUseFullFrame" user="true" member="true">

--- a/src/common/state/ViewAxisArrayAttributes.C
+++ b/src/common/state/ViewAxisArrayAttributes.C
@@ -496,13 +496,75 @@ ViewAxisArrayAttributes::SetRangeCoords(const double *rangeCoords_)
     Select(ID_rangeCoords, (void *)rangeCoords, 2);
 }
 
+#include <DebugStream.h>
 void
 ViewAxisArrayAttributes::SetViewportCoords(const double *viewportCoords_)
 {
-    viewportCoords[0] = viewportCoords_[0];
-    viewportCoords[1] = viewportCoords_[1];
-    viewportCoords[2] = viewportCoords_[2];
-    viewportCoords[3] = viewportCoords_[3];
+//
+// THIS METHOD IS CUSTOM CODED!!!
+// see .code file
+//
+    bool clamping = false;
+    if(viewportCoords_[0] < 0.)
+    {
+        clamping = true;
+        viewportCoords[0] = 0.;
+    }
+    else if(viewportCoords_[0] > 1.)
+    {
+        clamping = true;
+        viewportCoords[0] = 1.;
+    }
+    else
+    {
+        viewportCoords[0] = viewportCoords_[0];
+    }
+    if(viewportCoords_[1] > 1.)
+    {
+        clamping = true;
+        viewportCoords[1] = 1.;
+    }
+    else if(viewportCoords_[1] < 0.)
+    {
+        clamping = true;
+        viewportCoords[1] = 0.;
+    }
+    else
+    {
+        viewportCoords[1] = viewportCoords_[1];
+    }
+    if(viewportCoords_[2] < 0.)
+    {
+        clamping = true;
+        viewportCoords[2] = 0.;
+    }
+    else if(viewportCoords_[2] > 1.)
+    {
+        clamping = true;
+        viewportCoords[2] = 1.;
+    }
+    else
+    {
+        viewportCoords[2] = viewportCoords_[2];
+    }
+    if(viewportCoords_[3] > 1.)
+    {
+        clamping = true;
+        viewportCoords[3] = 1.;
+    }
+    else if(viewportCoords_[3] < 0.)
+    {
+        clamping = true;
+        viewportCoords[3] = 0.;
+    }
+    else
+    {
+        viewportCoords[3] = viewportCoords_[3];
+    }
+    if(clamping)
+    {
+        debug3 << "ViewAxisArrayAttributes::viewportCoords have been clamped to values between [0,1]." << endl;
+    }
     Select(ID_viewportCoords, (void *)viewportCoords, 4);
 }
 

--- a/src/common/state/ViewAxisArrayAttributes.code
+++ b/src/common/state/ViewAxisArrayAttributes.code
@@ -1,0 +1,75 @@
+Target: xml2atts
+Function: SetViewportCoords
+Declaration: void SetViewportCoords(const double *);
+Definition:
+#include <DebugStream.h>
+void
+ViewAxisArrayAttributes::SetViewportCoords(const double *viewportCoords_)
+{
+//
+// THIS METHOD IS CUSTOM CODED!!!
+// see .code file
+//
+    bool clamping = false;
+    if(viewportCoords_[0] < 0.)
+    {
+        clamping = true;
+        viewportCoords[0] = 0.;
+    }
+    else if(viewportCoords_[0] > 1.)
+    {
+        clamping = true;
+        viewportCoords[0] = 1.;
+    }
+    else
+    {
+        viewportCoords[0] = viewportCoords_[0];
+    }
+    if(viewportCoords_[1] > 1.)
+    {
+        clamping = true;
+        viewportCoords[1] = 1.;
+    }
+    else if(viewportCoords_[1] < 0.)
+    {
+        clamping = true;
+        viewportCoords[1] = 0.;
+    }
+    else
+    {
+        viewportCoords[1] = viewportCoords_[1];
+    }
+    if(viewportCoords_[2] < 0.)
+    {
+        clamping = true;
+        viewportCoords[2] = 0.;
+    }
+    else if(viewportCoords_[2] > 1.)
+    {
+        clamping = true;
+        viewportCoords[2] = 1.;
+    }
+    else
+    {
+        viewportCoords[2] = viewportCoords_[2];
+    }
+    if(viewportCoords_[3] > 1.)
+    {
+        clamping = true;
+        viewportCoords[3] = 1.;
+    }
+    else if(viewportCoords_[3] < 0.)
+    {
+        clamping = true;
+        viewportCoords[3] = 0.;
+    }
+    else
+    {
+        viewportCoords[3] = viewportCoords_[3];
+    }
+    if(clamping)
+    {
+        debug3 << "ViewAxisArrayAttributes::viewportCoords have been clamped to values between [0,1]." << endl;
+    }
+    Select(ID_viewportCoords, (void *)viewportCoords, 4);
+}

--- a/src/common/state/ViewAxisArrayAttributes.xml
+++ b/src/common/state/ViewAxisArrayAttributes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-  <Attribute name="ViewAxisArrayAttributes" purpose="This class contains the axis array view attributes." persistent="true" exportAPI="STATE_API" exportInclude="state_exports.h">
+  <Attribute name="ViewAxisArrayAttributes" purpose="This class contains the axis array view attributes." persistent="true" exportAPI="STATE_API" exportInclude="state_exports.h" codefile="ViewAxisArrayAttributes.code">
     <Field name="domainCoords" label="domainCoords" type="doubleArray" length="2">
       0.000000
       1.000000
@@ -14,4 +14,6 @@
       0.100000
       0.850000
     </Field>
+    <Function name="SetViewportCoords" user="false" member="true">
+    </Function>
   </Attribute>

--- a/src/common/state/ViewCurveAttributes.C
+++ b/src/common/state/ViewCurveAttributes.C
@@ -520,13 +520,75 @@ ViewCurveAttributes::SetRangeCoords(const double *rangeCoords_)
     Select(ID_rangeCoords, (void *)rangeCoords, 2);
 }
 
+#include <DebugStream.h>
 void
 ViewCurveAttributes::SetViewportCoords(const double *viewportCoords_)
 {
-    viewportCoords[0] = viewportCoords_[0];
-    viewportCoords[1] = viewportCoords_[1];
-    viewportCoords[2] = viewportCoords_[2];
-    viewportCoords[3] = viewportCoords_[3];
+//
+// THIS METHOD IS CUSTOM CODED!!!
+// see .code file
+//
+    bool clamping = false;
+    if(viewportCoords_[0] < 0.)
+    {
+        clamping = true;
+        viewportCoords[0] = 0.;
+    }
+    else if(viewportCoords_[0] > 1.)
+    {
+        clamping = true;
+        viewportCoords[0] = 1.;
+    }
+    else
+    {
+        viewportCoords[0] = viewportCoords_[0];
+    }
+    if(viewportCoords_[1] > 1.)
+    {
+        clamping = true;
+        viewportCoords[1] = 1.;
+    }
+    else if(viewportCoords_[1] < 0.)
+    {
+        clamping = true;
+        viewportCoords[1] = 0.;
+    }
+    else
+    {
+        viewportCoords[1] = viewportCoords_[1];
+    }
+    if(viewportCoords_[2] < 0.)
+    {
+        clamping = true;
+        viewportCoords[2] = 0.;
+    }
+    else if(viewportCoords_[2] > 1.)
+    {
+        clamping = true;
+        viewportCoords[2] = 1.;
+    }
+    else
+    {
+        viewportCoords[2] = viewportCoords_[2];
+    }
+    if(viewportCoords_[3] > 1.)
+    {
+        clamping = true;
+        viewportCoords[3] = 1.;
+    }
+    else if(viewportCoords_[3] < 0.)
+    {
+        clamping = true;
+        viewportCoords[3] = 0.;
+    }
+    else
+    {
+        viewportCoords[3] = viewportCoords_[3];
+    }
+    if(clamping)
+    {
+        debug3 << "ViewCurveAttributes::viewportCoords have been clamped to values between [0,1]." << endl;
+    }
     Select(ID_viewportCoords, (void *)viewportCoords, 4);
 }
 

--- a/src/common/state/ViewCurveAttributes.code
+++ b/src/common/state/ViewCurveAttributes.code
@@ -1,0 +1,75 @@
+Target: xml2atts
+Function: SetViewportCoords
+Declaration: void SetViewportCoords(const double *);
+Definition:
+#include <DebugStream.h>
+void
+ViewCurveAttributes::SetViewportCoords(const double *viewportCoords_)
+{
+//
+// THIS METHOD IS CUSTOM CODED!!!
+// see .code file
+//
+    bool clamping = false;
+    if(viewportCoords_[0] < 0.)
+    {
+        clamping = true;
+        viewportCoords[0] = 0.;
+    }
+    else if(viewportCoords_[0] > 1.)
+    {
+        clamping = true;
+        viewportCoords[0] = 1.;
+    }
+    else
+    {
+        viewportCoords[0] = viewportCoords_[0];
+    }
+    if(viewportCoords_[1] > 1.)
+    {
+        clamping = true;
+        viewportCoords[1] = 1.;
+    }
+    else if(viewportCoords_[1] < 0.)
+    {
+        clamping = true;
+        viewportCoords[1] = 0.;
+    }
+    else
+    {
+        viewportCoords[1] = viewportCoords_[1];
+    }
+    if(viewportCoords_[2] < 0.)
+    {
+        clamping = true;
+        viewportCoords[2] = 0.;
+    }
+    else if(viewportCoords_[2] > 1.)
+    {
+        clamping = true;
+        viewportCoords[2] = 1.;
+    }
+    else
+    {
+        viewportCoords[2] = viewportCoords_[2];
+    }
+    if(viewportCoords_[3] > 1.)
+    {
+        clamping = true;
+        viewportCoords[3] = 1.;
+    }
+    else if(viewportCoords_[3] < 0.)
+    {
+        clamping = true;
+        viewportCoords[3] = 0.;
+    }
+    else
+    {
+        viewportCoords[3] = viewportCoords_[3];
+    }
+    if(clamping)
+    {
+        debug3 << "ViewCurveAttributes::viewportCoords have been clamped to values between [0,1]." << endl;
+    }
+    Select(ID_viewportCoords, (void *)viewportCoords, 4);
+}

--- a/src/common/state/ViewCurveAttributes.xml
+++ b/src/common/state/ViewCurveAttributes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-  <Attribute name="ViewCurveAttributes" purpose="This class contains the curve view attributes." persistent="true" exportAPI="STATE_API" exportInclude="state_exports.h">
+  <Attribute name="ViewCurveAttributes" purpose="This class contains the curve view attributes." persistent="true" exportAPI="STATE_API" exportInclude="state_exports.h" codefile="ViewCurveAttributes.code">
     <Field name="domainCoords" label="domainCoords" type="doubleArray" length="2">
       0.000000
       1.000000
@@ -20,4 +20,6 @@
     <Field name="rangeScale" label="rangeScale" type="scalemode">
       0
     </Field>
+    <Function name="SetViewportCoords" user="false" member="true">
+    </Function>
   </Attribute>

--- a/src/gui/QvisViewWindow.C
+++ b/src/gui/QvisViewWindow.C
@@ -32,6 +32,30 @@
 #define MIN_LINEEDIT_WIDTH 200
 #define VIEW_WINDOW_SPACING 10
 
+
+void QVW_ClampViewport(double vp[4])
+{
+    if(vp[0] < 0.)
+       vp[0] = 0.;
+    else if(vp[0] > 1.)
+       vp[0] = 1.;
+
+    if(vp[1] > 1.)
+       vp[1] = 1.;
+    else if(vp[1] < 0.)
+       vp[1] = 0.;
+
+    if(vp[2] < 0.)
+       vp[2] = 0.;
+    else if(vp[2] > 1.)
+       vp[2] = 1.;
+
+    if(vp[3] > 1.)
+       vp[3] = 1.;
+    else if(vp[3] < 0.)
+       vp[3] = 0.;
+}
+
 // ****************************************************************************
 // Method: QvisViewWindow::QvisViewWindow
 //
@@ -296,7 +320,7 @@ QvisViewWindow::CreateWindowContents()
     layout2D->setSpacing(VIEW_WINDOW_SPACING);
 
     viewportLineEdit = new QLineEdit(page2D);
-    connect(viewportLineEdit, SIGNAL(returnPressed()),
+    connect(viewportLineEdit, SIGNAL(editingFinished()),
             this, SLOT(processViewportText()));
     layout2D->addWidget(viewportLineEdit, 0, 1, 1, 4);
     QLabel *viewportLabel = new QLabel(tr("Viewport"), page2D);
@@ -793,7 +817,7 @@ QvisViewWindow::UpdateCurve(bool doAll)
             rangeCurveLineEdit->setText(temp);
             break;
         case ViewCurveAttributes::ID_viewportCoords:
-           temp = DoublesToQString(viewCurve->GetViewportCoords(), 4);
+            temp = DoublesToQString(viewCurve->GetViewportCoords(), 4);
             viewportCurveLineEdit->setText(temp);
             break;
         case ViewCurveAttributes::ID_domainScale:
@@ -1451,6 +1475,9 @@ QvisViewWindow::SetFromNode(DataNode *parentNode, const int *borders)
 //   Brad Whitlock, Wed Jun 18 15:25:26 PDT 2008
 //   Rewrote with utility methods.
 //
+//   Kathleen Biagas, Fri Apr 18, 2025
+//   Clamp ViewportCoords before setting.
+//
 // ****************************************************************************
 
 void
@@ -1463,7 +1490,10 @@ QvisViewWindow::GetCurrentValuesAxisArray(int which_widget)
     {
         double v[4];
         if(LineEditGetDoubles(viewportAxisArrayLineEdit, v, 4))
+        {
+            QVW_ClampViewport(v);
             viewAxisArray->SetViewportCoords(v);
+        }
         else
         {
             ResettingError(tr("viewport"),
@@ -1520,6 +1550,9 @@ QvisViewWindow::GetCurrentValuesAxisArray(int which_widget)
 //   Brad Whitlock, Wed Jun 18 15:28:28 PDT 2008
 //   Rewrote using utility methods.
 //
+//   Kathleen Biagas, Fri Apr 18, 2025
+//   Clamp ViewportCoords before setting.
+//
 // ****************************************************************************
 
 void
@@ -1532,7 +1565,10 @@ QvisViewWindow::GetCurrentValuesCurve(int which_widget)
     {
         double v[4];
         if(LineEditGetDoubles(viewportCurveLineEdit, v, 4))
+        {
+            QVW_ClampViewport(v);
             viewCurve->SetViewportCoords(v);
+        }
         else
         {
             ResettingError(tr("viewport"),
@@ -1595,6 +1631,9 @@ QvisViewWindow::GetCurrentValuesCurve(int which_widget)
 //   Brad Whitlock, Wed Jun 18 15:28:28 PDT 2008
 //   Rewrote using utility methods.
 //
+//   Kathleen Biagas, Fri Apr 18, 2025
+//   Clamp ViewportCoords before setting.
+//
 // ****************************************************************************
 
 void
@@ -1607,7 +1646,10 @@ QvisViewWindow::GetCurrentValues2d(int which_widget)
     {
         double v[4];
         if(LineEditGetDoubles(viewportLineEdit, v, 4))
+        {
+            QVW_ClampViewport(v);
             view2d->SetViewportCoords(v);
+        }
         else
         {
             ResettingError(tr("viewport"),
@@ -1917,6 +1959,9 @@ QvisViewWindow::GetCurrentValues(int which_widget)
 //   Kathleen Biagas, Thu Jan 21, 2021
 //   Replace QString.asprintf with QString.arg.
 //
+//   Kathleen Biagas, Fri Apr 18, 2025
+//   Clamp ViewportCoords before setting.
+//
 // ****************************************************************************
 
 void
@@ -2124,6 +2169,7 @@ QvisViewWindow::ParseViewCommands(const char *str)
             if (sscanf(&command[3], "%lg %lg %lg %lg", &viewport[0],
                        &viewport[1], &viewport[2], &viewport[3]) == 4)
             {
+                QVW_ClampViewport(viewport);
                 Viewport(viewport);
                 doApply = true;
             }
@@ -3039,3 +3085,4 @@ QvisViewWindow::processAxis3DScalesText()
     GetCurrentValues3d(View3DAttributes::ID_axis3DScales);
     Apply();
 }
+

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -105,6 +105,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a potential infinite loop in our internal string helper utilities.</li>
   <li>Fixed error in Command Recording of a Query, where python tuples weren't represented correctly.</li>
   <li>3D Text Annotation's relative height widget has been fixed so that whether the value is changed via the spin box up/down arrows or a new value is typed, the widget will update and so will the height of the text.</li>
+  <li>View computations become garbled when Viewport Coordinate values are set outside the range of [0,1]. The docs specify the values should be in this range, and they are now automatically clamped to this range when being set via the GUI or CLI.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
### Description
View computations get garbled when the view coordinates get set outside the [0,1] range.
Our docs specify this restriction but it has never been enforced.
It is now enforced in the GUI directly by the widget, and from CLI by changes to the Set method in the Attributes.

Resolves #20261

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
*~~ [ ] Other~~

### How Has This Been Tested?

Tried setting viewport coords outside the range via gui and cli, and they were sucessfully clamped.


### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
