### PR TITLE
Skip CI for PRs in draft mode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ stages:
 - stage: Consistency
   jobs:
   - job: BLT_Time_Travel_Check
+    condition: ne(variables['System.PullRequest.IsDraft'], 'True')
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -93,6 +94,7 @@ stages:
 - stage: Main
   jobs:
   - job: Main_Build
+    condition: ne(variables['System.PullRequest.IsDraft'], 'True')
     pool:
       vmImage: 'ubuntu-latest'
     timeoutInMinutes: 0


### PR DESCRIPTION
Its probably best that we don't run CI for PRs in draft mode. This update adjusts our logic a bit for that.