### PR TITLE
add -python-log-file option to override visitlog.py

### DIFF
--- a/src/doc/getting_started/Startup_Options.rst
+++ b/src/doc/getting_started/Startup_Options.rst
@@ -40,7 +40,7 @@ USAGE: visit [options]::
         -launchengine <host> Launch an engine at startup. The <host> parameter
                              is optional. If it is not specified, the engine
                              will be launched on the local host. If you wish
-                             to launch an engine on a remote host, specify 
+                             to launch an engine on a remote host, specify
                              the host's name as the <host> parameter.
         -nosplash            Do not display the splash screen at startup.
 
@@ -73,7 +73,7 @@ USAGE: visit [options]::
                              page-flipping, or 'CrystalEyes' mode.
         -nowindowmetrics     Prevents X11 from grabbing and moving a test
                              widget used in calculating window borders. This
-                             option can be useful if VisIt hangs when 
+                             option can be useful if VisIt hangs when
                              displaying to an Apple X-server.
 
     Version options
@@ -100,7 +100,7 @@ USAGE: visit [options]::
     Parallel launch options
     ---------------------------------------------------------------------------
         Notes: All of these options are ordinarily obtained from host profiles.
-        However, the command line options override anything in the profiles. 
+        However, the command line options override anything in the profiles.
 
         When parallel arguments are added but the engine is not the
         component being launched, -launchengine is implied.  Explicitly
@@ -131,7 +131,7 @@ USAGE: visit [options]::
     ---------------------------------------------------------------------------
         Notes: These options should only be used with parallel clusters that
         have graphics cards.  If you are using a serial version of VisIt, you
-        are already getting hardware acceleration and these options are not 
+        are already getting hardware acceleration and these options are not
         needed.  Furthermore, you must be in scalable rendering mode for VisIt
         to utilize a cluster's GPUs.  By default, VisIt is configured to
         switch into scalable rendering mode when rendering complexity exceeds
@@ -168,9 +168,9 @@ USAGE: visit [options]::
                              by the same processor but can also lead to poor
                              balance when only a subset of domains is selected.
         -lb-random           Randomly assign domains to processors.
-        -allowdynamic        Dedicate one processor to spreading the work 
+        -allowdynamic        Dedicate one processor to spreading the work
                              dynamically among the other processors.  This mode
-                             has limitations in the types of queries it can 
+                             has limitations in the types of queries it can
                              perform.  Under development.
         -lb-stream           Similar to -lb-block, but have the domains travel
                              down the pipeline one at a time, instead of all
@@ -203,7 +203,7 @@ USAGE: visit [options]::
 
         Note that the differences VisIt will compute in this mode are single
         precision. This is true regardless of whether the input data is itself
-        double precision. VisIt will convert double precision to single 
+        double precision. VisIt will convert double precision to single
         precision before processing it. Although this is a result of earlier
         visualization-specific design requirements and constraints, the intention
         is that eventually double precision will be supported.
@@ -240,15 +240,15 @@ USAGE: visit [options]::
         -noint               Disable interruption capability.
         -nopty               Run without PTYs.
         -norun <compname>    Don't run the specified component, but instead
-                             print the environment variables to set and the 
-                             command to run when launching a specific 
+                             print the environment variables to set and the
+                             command to run when launching a specific
                              component. For example, '-norun engine_par' will
-                             show the full launch command for the parallel 
+                             show the full launch command for the parallel
                              engine without executing it.
         -verbose             Prints status information during pipeline
                              execution.
         -dir <directory>     Run a version of VisIt in the specified directory.
-                             The directory argument should specify the 
+                             The directory argument should specify the
                              path to a VisIt installation directory.
                              /bin is automatically appended to this path.
         -forceversion <ver>  Force the given version.  Overrides all
@@ -280,7 +280,7 @@ USAGE: visit [options]::
                              is used as the cycle number. Do a 'man 7 regex'
                              to get more information on regular expression
                              syntax.
-        -ui-bcast-thresholds <int1> <int2> 
+        -ui-bcast-thresholds <int1> <int2>
                              Two integers controlling behavior of parallel
                              engine waiting in a broadcast for the next RPC
                              from the viewer. VisIt used to rely solely upon
@@ -326,7 +326,9 @@ USAGE: visit [options]::
                              hang around, tying up parallel compute resources,
                              following an exit-triggering error condition on
                              any one process.
-                     
+        -python-log-file     A string for the name of the log file in which visit
+                             records python cli methods (default=visitlog.py)
+
     Developer options (most for xml2... tools)
     ---------------------------------------------------------------------------
         -public              xml2cmake: force install plugins publicly
@@ -339,7 +341,7 @@ USAGE: visit [options]::
 
     Debugging options
     ---------------------------------------------------------------------------
-        Note: Debugging options may degrade performance 
+        Note: Debugging options may degrade performance
     ---------------------------------------------------------------------------
         -debug <level>       Run with <level> levels of output logging.
                              <level> must be between 1 and 5. This will generate
@@ -388,11 +390,11 @@ USAGE: visit [options]::
         -env                 Print env. variables VisIt will use when run.
         -dump (dump_dir)     Dump intermediate results from AVT filters,
                              scalably rendered images, and html pages.
-                             Takes an optional argument that specifies the 
+                             Takes an optional argument that specifies the
                              directory for -dump output files.
-        -info-dump (dump_dir) 
-                             Dump html pages only. 
-                             Takes an optional argument that specifies the 
+        -info-dump (dump_dir)
+                             Dump html pages only.
+                             Takes an optional argument that specifies the
                              directory for -info-dump output files.
         -gdb <args> <comp>   Run gdb with <args> on component <comp>.
                              Default <args> is whitespace.
@@ -444,7 +446,7 @@ USAGE: visit [options]::
                              Run with MallocDebug:
                              Perl does not seem to be happy with libMallocDebug
                              so you can run the GUI like this:
-                             % visit -cli 
+                             % visit -cli
                              >>> OpenGUI('-debug-malloc', 'MallocDebug', 'gui')
                              Connect to the gui with MallocDebug and do your
                              sampling.

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -36,6 +36,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Added command recording for Annotation Objects.</li>
   <li>Added new surface rendering option using <a href="https://github.com/KhronosGroup/ANARI-SDK">ANARI</a>.</li>
+  <li>Added '-python-log-file' command line option to control the name of the file used to log python methods (default='visitlog.py').</li>
 </ul>
 
 <a name="Advanced_features"></a>

--- a/src/resources/usage/visitusageplus.txt
+++ b/src/resources/usage/visitusageplus.txt
@@ -234,7 +234,7 @@
                              hang around, tying up parallel compute resources,
                              following an exit-triggering error condition on
                              any one process.
-        -python-log-file     A string for the name of the log file that visit
+        -python-log-file     A string for the name of the log file in which visit
                              records python cli methods (default=visitlog.py)
 
     Developer options (most for xml2... tools)

--- a/src/resources/usage/visitusageplus.txt
+++ b/src/resources/usage/visitusageplus.txt
@@ -234,7 +234,9 @@
                              hang around, tying up parallel compute resources,
                              following an exit-triggering error condition on
                              any one process.
-                     
+        -python-log-file     A string for the name of the log file that visit
+                             records python cli methods (default=visitlog.py)
+
     Developer options (most for xml2... tools)
     ---------------------------------------------------------------------------
         -public              xml2cmake: force install plugins publicly

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -10716,7 +10716,7 @@ visit_GetDefaultDiscreteColorTable(PyObject *self, PyObject *args)
 // Modifications:
 //    Justin Privitera, Wed Aug  3 14:12:07 PDT 2022
 //    Error is thrown for editing built-in color tables.
-// 
+//
 //    Justin Privitera, Wed Aug  3 19:46:13 PDT 2022
 //    New CT's are correctly marked as NOT built-in.
 //
@@ -12058,11 +12058,11 @@ visit_GetQueryParameters(PyObject *self, PyObject *args)
 //   Now you can pass the output type directly to the xray image query as a
 //   string and it will handle which output type it should be internally.
 //   You can also send the output directory to the xray image query.
-// 
+//
 //   Justin Privitera, Tue Nov 22 14:56:04 PST 2022
 //   Added another tuple (tuple2) to store double vector info.
 //   This one is used for the x ray image query to store energy group bins.
-// 
+//
 //    Justin Privitera, Mon Nov 28 15:38:25 PST 2022
 //    Renamed energy group bins to energy group bounds.
 //
@@ -18148,7 +18148,7 @@ AddMethod(const char *methodName,
 //   Eric Brugger, Tue Sep 24 11:44:41 PDT 2024
 //   Added documentation for GetExportOptions.
 //
-//   Kathleen Biagas, Tue Mar 18, 2025 
+//   Kathleen Biagas, Tue Mar 18, 2025
 //   Removed Ultrawrapper methods.
 //
 // ****************************************************************************
@@ -19299,6 +19299,11 @@ NeedToLoadPlugins(Subject *, void *)
 //
 //   Mark C. Miller, Tue Jan 28 11:02:20 PST 2025
 //   Fix CATCH macro usage.
+//
+//   Cyrus Harrison, Wed May 21 15:22:26 PDT 2025
+//   Added support for -python-log-file option, which allows users to
+//   change the name of visitlog.py
+//
 // ****************************************************************************
 
 static int
@@ -19433,16 +19438,28 @@ InitializeViewerProxy(ViewerProxy* proxy)
     //
     // Open the log file
     //
-#ifndef _WIN32
-    const char *logName = "visitlog.py";
-#else
-    std::string vud = GetUserVisItDirectory() + "\\visitlog.py";
-    const char *logName = vud.c_str();
+
+    std::string log_filename = "visitlog.py";
+    //
+    // check if the user provided a custom log name
+    //
+    for(int i = 1; i < cli_argc; ++i)
+    {
+        if(strcmp(cli_argv[i],"-python-log-file") == 0 &&
+           (i+1) < cli_argc) // make sure the following arg is in bounds
+        {
+            // use specified file name
+            log_filename = std::string(cli_argv[i+1]);
+        }
+    }
+#ifdef _WIN32
+    std::string log_filename = GetUserVisItDirectory() + "\\" + log_filename;
 #endif
+
     if(!viewerEmbedded)
     {
-        if(!LogFile_Open(logName))
-            fprintf(stderr, "Could not open %s log file.\n", logName);
+        if(!LogFile_Open(log_filename.c_str()))
+            fprintf(stderr, "Could not open %s log file.\n", log_filename.c_str());
     }
 
     //remove NULL command


### PR DESCRIPTION
### Description

Resolves #20401

Adds command line option `-python-log-file` that allows a user to change the name of the `visitlog.py`


### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [x] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
