### PR TITLE
Fix Tecplot reader engine crash.

### DIFF
--- a/src/databases/Tecplot/TecplotFile.C
+++ b/src/databases/Tecplot/TecplotFile.C
@@ -1828,6 +1828,13 @@ TecplotFEConnectivity::NewInstance() const
     return new TecplotFEConnectivity(*this);
 }
 
+// ****************************************************************************
+// Modifications:
+//   Kathleen Biagas, Wed June 4, 2025.
+//   Reduce likelihood of arithmetic overflow by casting to long long.
+//
+// ****************************************************************************
+
 bool
 TecplotFEConnectivity::Read(FILE *f, const TecplotZone &zone, 
     const TecplotDataRecord *data)
@@ -1836,8 +1843,8 @@ TecplotFEConnectivity::Read(FILE *f, const TecplotZone &zone,
     if(data->zoneNumberForConnectivity == -1)
     {
         zoneConnectivityOffset = FTELL(f);
-        zoneConnectivitySize = zone.GetNumElements() * 
-                               TecplotNumNodesForZoneType(zone.zoneType) * 4;
+        zoneConnectivitySize = static_cast<long long>(zone.GetNumElements()) * 
+                               static_cast<long long>(TecplotNumNodesForZoneType(zone.zoneType)) * 4;
         FSEEK(f, zoneConnectivitySize, SEEK_CUR);
     }
 
@@ -1845,8 +1852,8 @@ TecplotFEConnectivity::Read(FILE *f, const TecplotZone &zone,
        zone.rawLocalFaceNeighbors > 0)
     {
         raw1to1FaceNeighborOffset = FTELL(f);
-        raw1to1FaceNeighborSize = zone.GetNumElements() *
-                                  TecplotNumFacesForZoneType(zone.zoneType) * 4;
+        raw1to1FaceNeighborSize = static_cast<long long>(zone.GetNumElements()) *
+                                  static_cast<long long>(TecplotNumFacesForZoneType(zone.zoneType)) * 4;
         FSEEK(f, raw1to1FaceNeighborSize, SEEK_CUR);
     }
 
@@ -1854,8 +1861,8 @@ TecplotFEConnectivity::Read(FILE *f, const TecplotZone &zone,
        zone.numUserDefinedNeighborConnections != 0)
     {
         faceNeighborConnectionOffset = FTELL(f);
-        faceNeighborConnectionSize = zone.numUserDefinedNeighborConnections *
-                                     TecplotNumNodesForZoneType(zone.zoneType) * 4;
+        faceNeighborConnectionSize = static_cast<long long>(zone.numUserDefinedNeighborConnections) *
+                                     static_cast<long long>(TecplotNumNodesForZoneType(zone.zoneType)) * 4;
         FSEEK(f, faceNeighborConnectionSize, SEEK_CUR);
     }
 

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -112,6 +112,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>3D Text Annotation's relative height widget has been fixed so that whether the value is changed via the spin box up/down arrows or a new value is typed, the widget will update and so will the height of the text.</li>
   <li>View computations become garbled when Viewport Coordinate values are set outside the range of [0,1]. The docs specify the values should be in this range, and they are now automatically clamped to this range when being set via the GUI or CLI.</li>
   <li>Fixed a bug crashing viewer if label tick spacing was too cramped exceeding a builtin threshold of 200 labels.</li>
+  <li>Fixed a Tecplot reader bug that crashed the engine.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
Mitigate arithmetic overflow by casting to long long.

Resolves #19983

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ 

### How Has This Been Tested?

I generated the dataset provided by the user, observed the crash with the bad408.plt file. After the fix no crash.
tecplot.py regression test still runs successfully.

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
