### PR TITLE
Replace use of `unsigned long` with `uint64_t`.

### DIFF
--- a/src/databases/AMR/AMRreaderAgg.C
+++ b/src/databases/AMR/AMRreaderAgg.C
@@ -11,7 +11,7 @@ const int kid2i[8] = {0,1,0,1,0,1,0,1};
 const int kid2j[8] = {0,0,1,1,0,0,1,1};
 const int kid2k[8] = {0,0,0,0,1,1,1,1};
 
-const unsigned long LeafTemp=0x7;
+const uint64_t LeafTemp=0x7;
 
 
 #define WP(x,y,z)  << x << "  " << y << "  " << z << "\n"
@@ -180,7 +180,7 @@ genAggInfo()
         return -1;
     }
 
-    unsigned long pk,ck;
+    uint64_t pk,ck;
     int pos=0;
     int cnt=0;
     while(pos+7<nblks_)

--- a/src/databases/AMR/AMRreaderAgg.h
+++ b/src/databases/AMR/AMRreaderAgg.h
@@ -10,7 +10,7 @@
 
 typedef union {
     unsigned int fb[2];
-    unsigned long eb;
+    uint64_t eb;
 } OctKey;
 
 

--- a/src/databases/AMR/AMRreaderWithLevels.C
+++ b/src/databases/AMR/AMRreaderWithLevels.C
@@ -181,7 +181,7 @@ AMRreaderWithLevels::MakeOctTree()
                         p.xe[0] = xMax;
                         p.xe[1] = yMax;
                         p.xe[2] = zMax;
-                        p.key = OctKey_Root((unsigned long int)rootid);
+                        p.key = OctKey_Root((uint64_t)rootid);
                         p.fileBID = FindBlock(p.key);
                         patches.push_back(p);
 
@@ -911,7 +911,7 @@ AMRreaderWithLevels::GetBlockVariable(int bid, int vid, float *dat)
                 debug1 << "AMRreaderWithLevels::GetBlockVariable(): bid=" << bid << ", sz=" << sz << "\n";
 
                 // The level 0 mesh is made from all of the level 2 blocks.
-                OctKey root = OctKey_Root((unsigned long int)root_index);
+                OctKey root = OctKey_Root((uint64_t)root_index);
                 int rbid = BlockKeyToBID(root);
                 for(int l0 = 0; l0 < 8; ++l0)
                 {

--- a/src/databases/AMR/OctKey.C
+++ b/src/databases/AMR/OctKey.C
@@ -43,7 +43,7 @@ OctKey_new()
 }
 
 OctKey
-OctKey_new(unsigned long val)
+OctKey_new(uint64_t val)
 {
     OctKey key;
     key.eb = val;
@@ -53,7 +53,7 @@ OctKey_new(unsigned long val)
 int
 OctKey_NumLevels(const OctKey &key)
 {
-    unsigned long k = key.eb;
+    uint64_t k = key.eb;
     int nlevels = 0;
     for(int it = 0; it < OctKey_GlobalMaxLevels(); ++it)
     {
@@ -71,25 +71,25 @@ OctKey_OctCellForLevel(const OctKey &key, int level)
     if(level >= 0 && level < OctKey_GlobalMaxLevels())
     {
         int shift = ((OctKey_NumLevels(key)-1) - level) * 3;
-        unsigned long mask = 7 << shift;
+        uint64_t mask = 7 << shift;
         retval = (key.eb & mask) >> shift;
     }
     return retval;
 }
 
-static const unsigned long ROOT_KEY   = 0x4000000000000000;
-static const unsigned long ROOT_MASK  = 0x7fffffffffffffff;
-static const unsigned long ROOT_MASK2 = 0x3fffffffffffffff;
+static const uint64_t ROOT_KEY   = 0x4000000000000000;
+static const uint64_t ROOT_MASK  = 0x7fffffffffffffff;
+static const uint64_t ROOT_MASK2 = 0x3fffffffffffffff;
 
 OctKey
 OctKey_Root()
 {
-    return OctKey_Root((unsigned long int)1);
+    return OctKey_Root((uint64_t)1);
     //return OctKey_new(ROOT_KEY | 1);
 }
 
 OctKey
-OctKey_Root(unsigned long int iroot)
+OctKey_Root(uint64_t iroot)
 {
     return OctKey_new((iroot << (OctKey_Len-OctKey_RootLen)) | 1);
 }
@@ -105,8 +105,8 @@ OctKey
 OctKey_AddLevel(const OctKey &key, int cell)
 {
     int shift = OctKey_Len - OctKey_RootLen;
-    unsigned long int rk = ((key.eb >> shift) << shift);
-    unsigned long int rm = (ROOT_MASK << (OctKey_RootLen)) >> (OctKey_RootLen);
+    uint64_t rk = ((key.eb >> shift) << shift);
+    uint64_t rm = (ROOT_MASK << (OctKey_RootLen)) >> (OctKey_RootLen);
     return OctKey_new( (((key.eb << 3) | (cell & 7)) & rm) | rk);
     //return OctKey_new( (((key.eb << 3) | (cell & 7)) & ROOT_MASK) | ROOT_KEY);
 }
@@ -121,8 +121,8 @@ OctKey
 OctKey_RemoveLevel(const OctKey &key)
 {
     int shift = OctKey_Len - OctKey_RootLen;
-    unsigned long int rk = ((key.eb >> shift) << shift);
-    unsigned long int rm = (ROOT_MASK << (OctKey_RootLen)) >> (OctKey_RootLen);
+    uint64_t rk = ((key.eb >> shift) << shift);
+    uint64_t rm = (ROOT_MASK << (OctKey_RootLen)) >> (OctKey_RootLen);
 
     return OctKey_new(((key.eb & rm) >> 3) | rk);
     // Mask off the top 2 bits and shift 3 to remove a level. Then add back the 2nd top bit.

--- a/src/databases/AMR/OctKey.h
+++ b/src/databases/AMR/OctKey.h
@@ -2,15 +2,19 @@
 #define OCTKEY_H
 #include <iostream>
 
+// Modifications:
+//   Kathleen Biagas, Wed Jun 11, 2025
+//   Use uint64_t for eb since unsigned long is 32 bit on windows.
+
 typedef union {
     unsigned int fv[2]; // force 64-bit?
-    unsigned long eb;
+    uint64_t eb;
 } OctKey;
 
 OctKey OctKey_new();
-OctKey OctKey_new(unsigned long val);
+OctKey OctKey_new(uint64_t val);
 OctKey OctKey_Root();
-OctKey OctKey_Root(unsigned long iroot);
+OctKey OctKey_Root(uint64_t iroot);
 OctKey OctKey_AddLevel(const OctKey &key, int cell);
 OctKey OctKey_RemoveLevel(const OctKey &key);
 bool   OctKey_HasImmediateParent(const OctKey &key, const OctKey &parent);


### PR DESCRIPTION
Resolves #20430 engine crash on Windows with new AMR regression tests.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Compiled and successfully ran regressions on Windows and Linux

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
