### PR TITLE
Fixed a bug with the XRayImage query running in parallel.

### DIFF
--- a/src/avt/Filters/avtXRayFilter.C
+++ b/src/avt/Filters/avtXRayFilter.C
@@ -670,6 +670,10 @@ avtXRayFilter::SetOutputRayBounds(bool flag)
 //    Eric Brugger, Wed May 27 10:10:28 PDT 2015
 //    I modified the filter to also output the path length field.
 //
+//    Eric Brugger, Thu Jun 12 11:37:36 PDT 2025
+//    I corrected the setting of pixelsForFirstPassLastProc and
+//    pixelsForLastPassLastProc.
+//
 // ****************************************************************************
 
 void
@@ -689,15 +693,11 @@ avtXRayFilter::Execute(void)
     while (PAR_Size() > 1 && (pixelsForFirstPassFirstProc + 1) * (PAR_Size() - 1) < pixelsForFirstPass)
         pixelsForFirstPassFirstProc++;
     pixelsForFirstPassLastProc =
-        ((pixelsForFirstPass % pixelsForFirstPassFirstProc) == 0) ?
-        pixelsForFirstPassFirstProc :
         pixelsForFirstPass - (pixelsForFirstPassFirstProc * (PAR_Size() - 1));
     pixelsForLastPassFirstProc = pixelsForLastPass / PAR_Size();
     while (PAR_Size() > 1 && (pixelsForLastPassFirstProc + 1) * (PAR_Size() - 1) < pixelsForLastPass)
         pixelsForLastPassFirstProc++;
     pixelsForLastPassLastProc =
-        ((pixelsForLastPass % pixelsForLastPassFirstProc) == 0) ?
-        pixelsForLastPassFirstProc :
         pixelsForLastPass - (pixelsForLastPassFirstProc * (PAR_Size() - 1));
 
     numPasses = numPixels / actualPixelsPerIteration;

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -98,6 +98,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>The X Ray Image Query now clips results beyond the far clipping plane.</li>
   <li>The Verdict mesh quality library that is builtin to VisIt was enhanced to handle generate hexahedra. This improves expressions and queries that use the Verdict library.</li>
+  <li>Fixed a bug with the X Ray Image Query where VisIt would in some rare instances either crash or create an image that was too dark when running in parallel.</li>
 </ul>
 </ul>
 


### PR DESCRIPTION
### Description

Resolves #18430

I fixed a bug with the XRay Filter where it would in rare situations underestimate the number of pixels for the last processor to operate on. This resulted in some uninitialized pixels in the output, which may lead to an incorrect range calculation resulting in a black image or an image that is too dark. In the case of a NAN this would lead to a black image. It could also lead to out of range array writes, which could lead to a crash.

Note that the ticket mentions that the crash occurs when the number of processors is larger than the number of domains. The bug fixed in this PR doesn't need the number of processors to be larger than the number of domains. It depends on a combination of the image size and the number of processors. It's probably more likely to be encountered with a large number of processors, which you would use when having a large number of domains.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I generated a test case that would incorrectly generate an all black image when run with 48 processors producing a 300x300 image. With my change the image was the same as the one generated in serial.
Here is the script.
```
OpenDatabase("/usr/gapps/visit/data/curv3d.silo")

AddPlot("Pseudocolor", "d")
DrawPlots()

# old style argument passing
Query("XRay Image", 1, ".", 1, 0.0, 2.5, 10.0, 0, 0, 10., 10., 300, 300, ("d", "p"))

quit()
```
Here is the command used to run the script in parallel.
```
bin/visit -cli -nowin -np 48 -l srun -s ../doit.py
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
