### PR TITLE
Fix a couple of bugs with build_visit and run-build-visit

### DIFF
--- a/scripts/run-build-visit
+++ b/scripts/run-build-visit
@@ -88,10 +88,6 @@
 #    Removed '--qt6' as it is part of the required group and we no
 #    longer support other versions.
 #
-#    Eric Brugger, Mon Jun 16 11:23:50 PDT 2025
-#    Added '--llvm' wherever '--mesagl' was used since mesagl depends on
-#    llvm and llvm is no longer part of the optional group.
-#
 #-----------------------------------------------------------------------
 
 #
@@ -269,13 +265,13 @@ if [ "$poodle" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/include \
-       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel \
+       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
        --qwt --no-pyside --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
 elif [ "$rzwhippet" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/include \
-       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel \
+       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
         --qwt --no-pyside --no-gdal --no-visit --makeflags -j20 \
         --thirdparty-path ${dest_dir}
 elif [ "$lassen" = true ]; then
@@ -283,7 +279,7 @@ elif [ "$lassen" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/include \
-       ./${build_visit_script} --group ${dest_group} --required --optional --llvm --mesagl \
+       ./${build_visit_script} --group ${dest_group} --required --optional --mesagl \
        --no-anari --no-boost --no-gdal --no-openexr --no-ospray --no-pidx --no-pyside \
        --meson --ninja --xcb --xkbcommon --qwt --parallel \
        --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
@@ -291,7 +287,7 @@ elif [ "$rzvernal" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/include \
-       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel \
+       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
        --qwt --no-pyside --no-gdal --no-uintah --no-visit --makeflags -j24 --thirdparty-path ${dest_dir}
 elif [ "$crossroads" = true ]; then
    env C_COMPILER=gcc \
@@ -300,7 +296,7 @@ elif [ "$crossroads" = true ]; then
        PAR_COMPILER_CXX=mpic++ \
        PAR_INCLUDE=-I/opt/cray/pe/mpich/8.1.28/ofi/intel/2022.1/include \
        PAR_LIBS="-L/opt/cray/pe/mpich/8.1.28/ofi/intel/2022.1/lib -Wl,-rpath=/opt/cray/pe/mpich/8.1.28/ofi/intel/intel/lib" \
-       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl \
+       ./$build_visit_script --group ${dest_group} --required --optional --mesagl \
        --no-adios --no-anari --no-gdal --no-nektarpp --no-pyside \
        --meson --ninja --xcb --xkbcommon --qwt --parallel \
        --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
@@ -309,7 +305,7 @@ elif [ "$tuolumne" = true ]; then
        CXX=g++ \
        PAR_COMPILER=cc \
        PAR_COMPILER_CXX=CC \
-       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel --no-moab --no-icet \
+       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel --no-moab --no-icet \
        --qwt --no-pyside --no-gdal --no-uintah --no-pidx --no-visit --makeflags -j24 --thirdparty-path ${dest_dir}
 else
    echo "case for $machine_name not implemented. Bailing out."

--- a/scripts/run-build-visit
+++ b/scripts/run-build-visit
@@ -88,6 +88,10 @@
 #    Removed '--qt6' as it is part of the required group and we no
 #    longer support other versions.
 #
+#    Eric Brugger, Mon Jun 16 11:23:50 PDT 2025
+#    Added '--llvm' wherever '--mesagl' was used since mesagl depends on
+#    llvm and llvm is no longer part of the optional group.
+#
 #-----------------------------------------------------------------------
 
 #
@@ -265,13 +269,13 @@ if [ "$poodle" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1/include \
-       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
+       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel \
        --qwt --no-pyside --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
 elif [ "$rzwhippet" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/include \
-       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
+       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel \
         --qwt --no-pyside --no-gdal --no-visit --makeflags -j20 \
         --thirdparty-path ${dest_dir}
 elif [ "$lassen" = true ]; then
@@ -279,7 +283,7 @@ elif [ "$lassen" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/spectrum-mpi/ibm/spectrum-mpi-rolling-release/include \
-       ./${build_visit_script} --group ${dest_group} --required --optional --mesagl \
+       ./${build_visit_script} --group ${dest_group} --required --optional --llvm --mesagl \
        --no-anari --no-boost --no-gdal --no-openexr --no-ospray --no-pidx --no-pyside \
        --meson --ninja --xcb --xkbcommon --qwt --parallel \
        --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
@@ -287,7 +291,7 @@ elif [ "$rzvernal" = true ]; then
    env PAR_COMPILER=/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/bin/mpicc \
        PAR_COMPILER_CXX=/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/bin/mpicxx \
        PAR_INCLUDE=-I/usr/tce/packages/cray-mpich/cray-mpich-8.1.28-gcc-12.2.1-magic/include \
-       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel \
+       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel \
        --qwt --no-pyside --no-gdal --no-uintah --no-visit --makeflags -j24 --thirdparty-path ${dest_dir}
 elif [ "$crossroads" = true ]; then
    env C_COMPILER=gcc \
@@ -296,7 +300,7 @@ elif [ "$crossroads" = true ]; then
        PAR_COMPILER_CXX=mpic++ \
        PAR_INCLUDE=-I/opt/cray/pe/mpich/8.1.28/ofi/intel/2022.1/include \
        PAR_LIBS="-L/opt/cray/pe/mpich/8.1.28/ofi/intel/2022.1/lib -Wl,-rpath=/opt/cray/pe/mpich/8.1.28/ofi/intel/intel/lib" \
-       ./$build_visit_script --group ${dest_group} --required --optional --mesagl \
+       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl \
        --no-adios --no-anari --no-gdal --no-nektarpp --no-pyside \
        --meson --ninja --xcb --xkbcommon --qwt --parallel \
        --no-visit --makeflags -j16 --thirdparty-path ${dest_dir}
@@ -305,7 +309,7 @@ elif [ "$tuolumne" = true ]; then
        CXX=g++ \
        PAR_COMPILER=cc \
        PAR_COMPILER_CXX=CC \
-       ./$build_visit_script --group ${dest_group} --required --optional --mesagl --parallel --no-moab --no-icet \
+       ./$build_visit_script --group ${dest_group} --required --optional --llvm --mesagl --parallel --no-moab --no-icet \
        --qwt --no-pyside --no-gdal --no-uintah --no-pidx --no-visit --makeflags -j24 --thirdparty-path ${dest_dir}
 else
    echo "case for $machine_name not implemented. Bailing out."

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -7,6 +7,7 @@ function bv_mesagl_enable
 {
     DO_MESAGL="yes"
     bv_glu_enable
+    bv_llvm_enable
 }
 
 function bv_mesagl_disable

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -6,6 +6,7 @@ function bv_osmesa_initialize
 function bv_osmesa_enable
 {
     DO_OSMESA="yes"
+    bv_llvm_enable
 }
 
 function bv_osmesa_disable

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -6,11 +6,7 @@ function bv_qt6_initialize
 
 function bv_qt6_enable
 { 
-    if [[ "$DO_QT" == "no" ]] ; then
-        DO_QT6="yes"
-    else
-        DO_QT6="no"
-    fi
+    DO_QT6="yes"
 }
 
 function bv_qt6_disable


### PR DESCRIPTION
### Description

I fixed a bug in `build_visit` where `bv_qt6_enable` didn't work properly setting `DO_QT6` since it was dependent on `DO_QT` being set to `on` and it was unset.

I added `--llvm` to `run-build-visit` wherever `--mesagl` was used since mesagl is dependent on llvm and llvm is no longer part of the optional group.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran `run-build-visit` on rzwhippet and it ran properly. I didn't test all the other machines but I assume they are ok as well since the change for the other systems is the same as rzwhippet and it fairly simple.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
