### PR TITLE
Updated bv_anari to use ANARI v0.14.1 to support the ignoreAmbientLighting flag

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_anari.sh
+++ b/src/tools/dev/scripts/bv_support/bv_anari.sh
@@ -49,13 +49,14 @@ function bv_anari_depends_on
 #add information about how to get library..
 function bv_anari_info
 {
-    export ANARI_VERSION=${ANARI_VERSION:-"0.13.1"}
-    export ANARI_SHORT_VERSION=${ANARI_SHORT_VERSION:-"0.13"}
+    export ANARI_VERSION=${ANARI_VERSION:-"0.14.1"}
+    export ANARI_SHORT_VERSION=${ANARI_SHORT_VERSION:-"0.14"}
     export ANARI_FILE=${ANARI_FILE:-"ANARI-SDK-${ANARI_VERSION}.tar.gz"}
     export ANARI_COMPATIBILITY_VERSION=${ANARI_SHORT_VERSION}
+    export ANARI_URL=${ANARI_URL:-"https://github.com/KhronosGroup/ANARI-SDK/archive/refs/tags/v0.14.1.tar.gz"}
     export ANARI_SRC_DIR=${ANARI_SRC_DIR:-"ANARI-SDK-${ANARI_VERSION}"}
     export ANARI_INSTALL_DIR=${ANARI_INSTALL_DIR:-"anari"}
-    export ANARI_SHA256_CHECKSUM="b8979ab0dea22cf71c2eacf9421b0cf3fe5807224147c63686d6ed07e65873f4"
+    export ANARI_SHA256_CHECKSUM="a1df9e917bdb0b6edb0ad4b8e59e1171468a446f850559c74ad5731317201e16"
 }
 
 #print variables used by this module


### PR DESCRIPTION
### Description

Resolves #20463. Updated `bv_anari` to use [ANARI v0.14.1](https://github.com/KhronosGroup/ANARI-SDK/releases/tag/v0.14.1) to support the `ignoreAmbientLighting` flag

The helide back-end now has an `ignoreAmbientLighting` flag that is set to true by default allowing an image to be rendered regardless of the ambient lighting setting. This flag is exposed to the user through the UI as shown below.

![helide_update](https://github.com/user-attachments/assets/4dd6b570-d241-4f29-887f-02bfdc624ce3)

