### PR TITLE
Session file save takes session file names in directory into account

### DIFF
--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -778,6 +778,8 @@ QvisFileOpenWindow::selectFileChanged(void)
         }
     }
 
+    std::cout << "selectFileChanged" << std::endl;
+
     if (count)
         okButton->setEnabled(true);
     else
@@ -1029,6 +1031,8 @@ QvisFileOpenWindow::SetShowFilename(bool value)
 void 
 QvisFileOpenWindow::filenameEditChanged()
 {
+    std::cout << "filenameEditChanged" << std::endl;
+
     if(hideFileFormat)
         fileList->clearSelection();
     QString text(filenameEdit->text());

--- a/src/gui/QvisFileOpenWindow.C
+++ b/src/gui/QvisFileOpenWindow.C
@@ -778,8 +778,6 @@ QvisFileOpenWindow::selectFileChanged(void)
         }
     }
 
-    std::cout << "selectFileChanged" << std::endl;
-
     if (count)
         okButton->setEnabled(true);
     else
@@ -1031,8 +1029,6 @@ QvisFileOpenWindow::SetShowFilename(bool value)
 void 
 QvisFileOpenWindow::filenameEditChanged()
 {
-    std::cout << "filenameEditChanged" << std::endl;
-
     if(hideFileFormat)
         fileList->clearSelection();
     QString text(filenameEdit->text());

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -4624,12 +4624,12 @@ QvisGUIApplication::SaveSessionAs()
                     .arg(sessionCount,4,10,QLatin1Char('0'));
         }
 
-        ifstream ifile(defaultFile.toStdString());
-        if (!ifile.fail())
-        {
-            sessionCount ++;
-            keepTrying = true;
-        }
+        // ifstream ifile(defaultFile.toStdString());
+        // if (!ifile.fail())
+        // {
+        //     sessionCount ++;
+        //     keepTrying = true;
+        // }
     }
 
     // Get the name of the file that the user saved.

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -4593,27 +4593,43 @@ QvisGUIApplication::SaveSession()
 void
 QvisGUIApplication::SaveSessionAs()
 {
-    // Create the name of a VisIt session file to use.
+    std::cout << "QvisGUIApplication::SaveSessionAs()" << std::endl;
     QString defaultFile;
-    if(sessionHost.empty())
+
+    bool keepTrying = true;
+
+    while (keepTrying)
     {
-        defaultFile = QString("%1visit%2.session")
-            .arg(sessionDir.c_str())
-            .arg(sessionCount,4,10,QLatin1Char('0'));
-    }
-    else
-    {
-#ifdef _WIN32
-        if (sessionDir.substr(0,2) == "\\\\")
+        keepTrying = false;
+
+        // Create the name of a VisIt session file to use.
+        if(sessionHost.empty())
+        {
             defaultFile = QString("%1visit%2.session")
                 .arg(sessionDir.c_str())
                 .arg(sessionCount,4,10,QLatin1Char('0'));
+        }
         else
-#endif
-        defaultFile = QString("%1:%2visit%3.session")
-                .arg(sessionHost.c_str())
-                .arg(sessionDir.c_str())
-                .arg(sessionCount,4,10,QLatin1Char('0'));
+        {
+    #ifdef _WIN32
+            if (sessionDir.substr(0,2) == "\\\\")
+                defaultFile = QString("%1visit%2.session")
+                    .arg(sessionDir.c_str())
+                    .arg(sessionCount,4,10,QLatin1Char('0'));
+            else
+    #endif
+            defaultFile = QString("%1:%2visit%3.session")
+                    .arg(sessionHost.c_str())
+                    .arg(sessionDir.c_str())
+                    .arg(sessionCount,4,10,QLatin1Char('0'));
+        }
+
+        ifstream ifile(defaultFile.toStdString());
+        if (!ifile.fail())
+        {
+            sessionCount ++;
+            keepTrying = true;
+        }
     }
 
     // Get the name of the file that the user saved.

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -4593,67 +4593,42 @@ QvisGUIApplication::SaveSession()
 void
 QvisGUIApplication::SaveSessionAs()
 {
-    std::cout << "QvisGUIApplication::SaveSessionAs()" << std::endl;
     QString defaultFile;
 
+    bool keepTrying = true;
+    while (keepTrying)
+    {
+        keepTrying = false;
 
-    // Create the name of a VisIt session file to use.
-    if(sessionHost.empty())
-    {
-        defaultFile = QString("%1visit%2.session")
-            .arg(sessionDir.c_str())
-            .arg(sessionCount,4,10,QLatin1Char('0'));
-    }
-    else
-    {
-#ifdef _WIN32
-        if (sessionDir.substr(0,2) == "\\\\")
+        // Create the name of a VisIt session file to use.
+        if(sessionHost.empty())
+        {
             defaultFile = QString("%1visit%2.session")
                 .arg(sessionDir.c_str())
                 .arg(sessionCount,4,10,QLatin1Char('0'));
+        }
         else
-#endif
-        defaultFile = QString("%1:%2visit%3.session")
-                .arg(sessionHost.c_str())
-                .arg(sessionDir.c_str())
-                .arg(sessionCount,4,10,QLatin1Char('0'));
+        {
+    #ifdef _WIN32
+            if (sessionDir.substr(0,2) == "\\\\")
+                defaultFile = QString("%1visit%2.session")
+                    .arg(sessionDir.c_str())
+                    .arg(sessionCount,4,10,QLatin1Char('0'));
+            else
+    #endif
+            defaultFile = QString("%1:%2visit%3.session")
+                    .arg(sessionHost.c_str())
+                    .arg(sessionDir.c_str())
+                    .arg(sessionCount,4,10,QLatin1Char('0'));
+        }
+
+        ifstream ifile(defaultFile.toStdString());
+        if (!ifile.fail())
+        {
+            sessionCount ++;
+            keepTrying = true;
+        }
     }
-
-    // bool keepTrying = true;
-
-    // while (keepTrying)
-    // {
-    //     keepTrying = false;
-
-    // //     // Create the name of a VisIt session file to use.
-    // //     if(sessionHost.empty())
-    // //     {
-    // //         defaultFile = QString("%1visit%2.session")
-    // //             .arg(sessionDir.c_str())
-    // //             .arg(sessionCount,4,10,QLatin1Char('0'));
-    // //     }
-    // //     else
-    // //     {
-    // // #ifdef _WIN32
-    // //         if (sessionDir.substr(0,2) == "\\\\")
-    // //             defaultFile = QString("%1visit%2.session")
-    // //                 .arg(sessionDir.c_str())
-    // //                 .arg(sessionCount,4,10,QLatin1Char('0'));
-    // //         else
-    // // #endif
-    // //         defaultFile = QString("%1:%2visit%3.session")
-    // //                 .arg(sessionHost.c_str())
-    // //                 .arg(sessionDir.c_str())
-    // //                 .arg(sessionCount,4,10,QLatin1Char('0'));
-    // //     }
-
-    //     // ifstream ifile(defaultFile.toStdString());
-    //     // if (!ifile.fail())
-    //     // {
-    //     //     sessionCount ++;
-    //     //     keepTrying = true;
-    //     // }
-    // }
 
     // Get the name of the file that the user saved.
     QualifiedFilename qfilename;

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -4596,41 +4596,64 @@ QvisGUIApplication::SaveSessionAs()
     std::cout << "QvisGUIApplication::SaveSessionAs()" << std::endl;
     QString defaultFile;
 
-    bool keepTrying = true;
 
-    while (keepTrying)
+    // Create the name of a VisIt session file to use.
+    if(sessionHost.empty())
     {
-        keepTrying = false;
-
-        // Create the name of a VisIt session file to use.
-        if(sessionHost.empty())
-        {
+        defaultFile = QString("%1visit%2.session")
+            .arg(sessionDir.c_str())
+            .arg(sessionCount,4,10,QLatin1Char('0'));
+    }
+    else
+    {
+#ifdef _WIN32
+        if (sessionDir.substr(0,2) == "\\\\")
             defaultFile = QString("%1visit%2.session")
                 .arg(sessionDir.c_str())
                 .arg(sessionCount,4,10,QLatin1Char('0'));
-        }
         else
-        {
-    #ifdef _WIN32
-            if (sessionDir.substr(0,2) == "\\\\")
-                defaultFile = QString("%1visit%2.session")
-                    .arg(sessionDir.c_str())
-                    .arg(sessionCount,4,10,QLatin1Char('0'));
-            else
-    #endif
-            defaultFile = QString("%1:%2visit%3.session")
-                    .arg(sessionHost.c_str())
-                    .arg(sessionDir.c_str())
-                    .arg(sessionCount,4,10,QLatin1Char('0'));
-        }
-
-        // ifstream ifile(defaultFile.toStdString());
-        // if (!ifile.fail())
-        // {
-        //     sessionCount ++;
-        //     keepTrying = true;
-        // }
+#endif
+        defaultFile = QString("%1:%2visit%3.session")
+                .arg(sessionHost.c_str())
+                .arg(sessionDir.c_str())
+                .arg(sessionCount,4,10,QLatin1Char('0'));
     }
+
+    // bool keepTrying = true;
+
+    // while (keepTrying)
+    // {
+    //     keepTrying = false;
+
+    // //     // Create the name of a VisIt session file to use.
+    // //     if(sessionHost.empty())
+    // //     {
+    // //         defaultFile = QString("%1visit%2.session")
+    // //             .arg(sessionDir.c_str())
+    // //             .arg(sessionCount,4,10,QLatin1Char('0'));
+    // //     }
+    // //     else
+    // //     {
+    // // #ifdef _WIN32
+    // //         if (sessionDir.substr(0,2) == "\\\\")
+    // //             defaultFile = QString("%1visit%2.session")
+    // //                 .arg(sessionDir.c_str())
+    // //                 .arg(sessionCount,4,10,QLatin1Char('0'));
+    // //         else
+    // // #endif
+    // //         defaultFile = QString("%1:%2visit%3.session")
+    // //                 .arg(sessionHost.c_str())
+    // //                 .arg(sessionDir.c_str())
+    // //                 .arg(sessionCount,4,10,QLatin1Char('0'));
+    // //     }
+
+    //     // ifstream ifile(defaultFile.toStdString());
+    //     // if (!ifile.fail())
+    //     // {
+    //     //     sessionCount ++;
+    //     //     keepTrying = true;
+    //     // }
+    // }
 
     // Get the name of the file that the user saved.
     QualifiedFilename qfilename;

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -4587,6 +4587,10 @@ QvisGUIApplication::SaveSession()
 //
 //   Kathleen Biagas, Thu Jan 21, 2021
 //   Replace QString::asprintf with QString.arg as suggested by Qt docs.
+// 
+//   Justin Privitera, Fri Jul 11 13:20:38 PDT 2025
+//   We take existing files in the directory we are going to save into account,
+//   updating the session count as needed.
 //
 // ****************************************************************************
 

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -55,6 +55,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed an error appearing which states that the properties from a disabled light were modified even though no changes were made and "Apply" was pressed. Now, the error will only appear when a change was made and the light is still disabled as well as listing with all modified lights.</li>
   <li>Fixed bug with xmledit where changing a Field's type to 'att' or 'attvector' crashed the tool.</li>
   <li>Disabled rich text paste support in the Commands Window and Expressions Editor. Avoids battles with cut and pasted text from editors that embed formatting, such as vscode.</li>
+  <li>Save session file now takes existing session file names into account to avoid naming collisions.</li>
 </ul>
 
 <a name="CLI_changes"></a>


### PR DESCRIPTION
### Description

Resolves #20140 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
Session file save now examines the filenames in the directory where you are saving and updates the session counter until the new filename is not already taken by an existing filename.

Some considerations:
 - I have noticed on my branch and on develop that the "ok" button is grayed out until after you click "refresh", after which point you can go ahead and save. This is not the same in 3.4.2. I am not sure what causes this but I imagine it was #20322. I opened a ticket to investigate this further: #20478
 - The session counter only counts up, so if you change directories the number will not go down. This is the same as it was before, only now we look at the current directory first and count up.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [x] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rzhound toss4; it works as expected.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
