### PR TITLE
build_visit: use cmake build for cmake based projects

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -256,7 +256,7 @@ function build_adios2
         # Build ADIOS2
         #
         info "Building ADIOS2-$bt . . . (~5 minutes)"
-        ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+        ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
         if [[ $? != 0 ]] ; then
             warn "ADIOS2 build failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -256,7 +256,7 @@ function build_adios2
         # Build ADIOS2
         #
         info "Building ADIOS2-$bt . . . (~5 minutes)"
-        $MAKE $MAKE_OPT_FLAGS
+        ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
         if [[ $? != 0 ]] ; then
             warn "ADIOS2 build failed.  Giving up"
             return 1
@@ -266,7 +266,7 @@ function build_adios2
         # Install into the VisIt third party location.
         #
         info "Installing ADIOS2-$bt"
-        $MAKE install
+        ${CMAKE_COMMAND} install .
         if [[ $? != 0 ]] ; then
             warn "ADIOS2 install failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_anari.sh
+++ b/src/tools/dev/scripts/bv_support/bv_anari.sh
@@ -198,11 +198,11 @@ function build_anari
     # Now build ANARI
     #
     info "Building ANARI . . ."
-    env DYLD_LIBRARY_PATH=`pwd`/bin $MAKE $MAKE_OPT_FLAGS || \
+    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || \
         error "ANARI did not build correctly.  Giving up."
 
     info "Installing ANARI . . . "
-    $MAKE install || error "ANARI did not install correctly."
+    ${CMAKE_COMMAND} install . || error "ANARI did not install correctly."
 
     chmod -R ug+w,a+rX ${VISITDIR}/${ANARI_INSTALL_DIR}
 

--- a/src/tools/dev/scripts/bv_support/bv_anari.sh
+++ b/src/tools/dev/scripts/bv_support/bv_anari.sh
@@ -198,7 +198,7 @@ function build_anari
     # Now build ANARI
     #
     info "Building ANARI . . ."
-    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || \
+    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || \
         error "ANARI did not build correctly.  Giving up."
 
     info "Installing ANARI . . . "

--- a/src/tools/dev/scripts/bv_support/bv_blosc2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_blosc2.sh
@@ -96,7 +96,7 @@ function build_blosc2
     # Build Blosc2
     #
     info "Building Blosc2 . . . (~5 minutes)"
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "Blosc2 build failed.  Giving up"
         return 1
@@ -106,7 +106,7 @@ function build_blosc2
     # Install into the VisIt third party location.
     #
     info "Installing Blosc2"
-    $MAKE install
+    ${CMAKE_COMMAND} install .
     if [[ $? != 0 ]] ; then
         warn "Blosc2 install failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_blosc2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_blosc2.sh
@@ -96,7 +96,7 @@ function build_blosc2
     # Build Blosc2
     #
     info "Building Blosc2 . . . (~5 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Blosc2 build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_blosc2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_blosc2.sh
@@ -96,7 +96,7 @@ function build_blosc2
     # Build Blosc2
     #
     info "Building Blosc2 . . . (~5 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Blosc2 build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_conduit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_conduit.sh
@@ -285,7 +285,7 @@ function build_conduit
     # Build Conduit
     #
     info "Building Conduit . . . (~5 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Conduit build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_conduit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_conduit.sh
@@ -285,7 +285,7 @@ function build_conduit
     # Build Conduit
     #
     info "Building Conduit . . . (~5 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Conduit build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_conduit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_conduit.sh
@@ -285,7 +285,7 @@ function build_conduit
     # Build Conduit
     #
     info "Building Conduit . . . (~5 minutes)"
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "Conduit build failed.  Giving up"
         return 1
@@ -295,7 +295,7 @@ function build_conduit
     # Install into the VisIt third party location.
     #
     info "Installing Conduit"
-    $MAKE install
+    ${CMAKE_COMMAND} install .
     if [[ $? != 0 ]] ; then
         warn "Conduit install failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_damaris.sh
+++ b/src/tools/dev/scripts/bv_support/bv_damaris.sh
@@ -163,7 +163,7 @@ function build_damaris
     #
     # Building Damaris
     #
-    $MAKE
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
 
     if [[ $? != 0 ]] ; then
         warn "Failed to build Damaris.  Giving up."
@@ -173,7 +173,7 @@ function build_damaris
     #
     # Installing Damaris
     #
-    $MAKE install
+    ${CMAKE_COMMAND} install .
 
     if [[ $? != 0 ]] ; then
         warn "Failed to install Damaris.  Giving up."

--- a/src/tools/dev/scripts/bv_support/bv_damaris.sh
+++ b/src/tools/dev/scripts/bv_support/bv_damaris.sh
@@ -163,7 +163,7 @@ function build_damaris
     #
     # Building Damaris
     #
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
 
     if [[ $? != 0 ]] ; then
         warn "Failed to build Damaris.  Giving up."

--- a/src/tools/dev/scripts/bv_support/bv_fms.sh
+++ b/src/tools/dev/scripts/bv_support/bv_fms.sh
@@ -121,7 +121,7 @@ function build_fms
     # Build FMS
     #
     info "Building FMS . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "FMS build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_fms.sh
+++ b/src/tools/dev/scripts/bv_support/bv_fms.sh
@@ -121,7 +121,7 @@ function build_fms
     # Build FMS
     #
     info "Building FMS . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "FMS build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_fms.sh
+++ b/src/tools/dev/scripts/bv_support/bv_fms.sh
@@ -121,7 +121,7 @@ function build_fms
     # Build FMS
     #
     info "Building FMS . . . (~2 minutes)"
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "FMS build failed.  Giving up"
         return 1
@@ -131,7 +131,7 @@ function build_fms
     # Install into the VisIt third party location.
     #
     info "Installing FMS"
-    $MAKE install
+    ${CMAKE_COMMAND} install .
 
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/fms"

--- a/src/tools/dev/scripts/bv_support/bv_icet.sh
+++ b/src/tools/dev/scripts/bv_support/bv_icet.sh
@@ -162,7 +162,7 @@ function build_icet
     # Now build IceT.
     #
     info "Building IceT . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "IceT did not build correctly.  Giving up."
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_icet.sh
+++ b/src/tools/dev/scripts/bv_support/bv_icet.sh
@@ -162,7 +162,7 @@ function build_icet
     # Now build IceT.
     #
     info "Building IceT . . . (~2 minutes)"
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "IceT did not build correctly.  Giving up."
         return 1
@@ -170,7 +170,7 @@ function build_icet
 
     info "Installing IceT . . ."
 
-    $MAKE install
+    ${CMAKE_COMMAND} install .
     if [[ $? != 0 ]] ; then
         warn "IceT: 'make install' failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_icet.sh
+++ b/src/tools/dev/scripts/bv_support/bv_icet.sh
@@ -162,7 +162,7 @@ function build_icet
     # Now build IceT.
     #
     info "Building IceT . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "IceT did not build correctly.  Giving up."
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -240,7 +240,7 @@ function build_mfem
     # Build mfem
     #
     info "Building mfem . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "mfem build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -240,7 +240,7 @@ function build_mfem
     # Build mfem
     #
     info "Building mfem . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "mfem build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -240,7 +240,7 @@ function build_mfem
     # Build mfem
     #
     info "Building mfem . . . (~2 minutes)"
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "mfem build failed.  Giving up"
         return 1
@@ -250,7 +250,7 @@ function build_mfem
     # Install into the VisIt third party location.
     #
     info "Installing mfem"
-    $MAKE install
+    ${CMAKE_COMMAND} install .
 
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/mfem"

--- a/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
+++ b/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
@@ -352,7 +352,7 @@ function build_nektarpp
     # Build NEKTAR_PLUS_PLUS
     #
     info "Making Nektar++ . . ."
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "Nektar++ build failed.  Giving up"
         return 1
@@ -362,7 +362,7 @@ function build_nektarpp
     # Install into the VisIt third party location.
     #
     info "Installing Nektar++ . . ."
-    $MAKE install
+    ${CMAKE_COMMAND} install .
     if [[ $? != 0 ]] ; then
         warn "Nektar++ install failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
+++ b/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
@@ -352,7 +352,7 @@ function build_nektarpp
     # Build NEKTAR_PLUS_PLUS
     #
     info "Making Nektar++ . . ."
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Nektar++ build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
+++ b/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
@@ -352,7 +352,7 @@ function build_nektarpp
     # Build NEKTAR_PLUS_PLUS
     #
     info "Making Nektar++ . . ."
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Nektar++ build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -121,10 +121,10 @@ function build_ninja
     # Build ninja
     #
     info "Building ninja . . . (~2 minutes)"
-    $MAKE $MAKE_OPT_FLAGS || error "Ninja did not build correctly. Giving up."
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS  || error "Ninja did not build correctly. Giving up."
 
     info "Installing Ninja . . . (~2 minutes)"
-    $MAKE install || error "Ninja did not install correctly."
+    ${CMAKE_COMMAND} install . || error "Ninja did not install correctly."
 
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/ninja"

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -121,7 +121,7 @@ function build_ninja
     # Build ninja
     #
     info "Building ninja . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS  || error "Ninja did not build correctly. Giving up."
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS  || error "Ninja did not build correctly. Giving up."
 
     info "Installing Ninja . . . (~2 minutes)"
     ${CMAKE_COMMAND} install . || error "Ninja did not install correctly."

--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -213,11 +213,11 @@ function build_ospray_in_source
     # Now build OSPRay
     #
     info "Building OSPRay (~10 minute)"
-    env DYLD_LIBRARY_PATH=`pwd`/bin $MAKE $MAKE_OPT_FLAGS || \
+    env DYLD_LIBRARY_PATH=`pwd`/bin {CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || \
         error "OSPRay did not build correctly.  Giving up."
 
     info "Installing OSPRay . . . "
-    $MAKE install || error "OSPRay did not install correctly."
+    ${CMAKE_COMMAND} install . || error "OSPRay did not install correctly."
 }
 
 function build_ospray
@@ -320,8 +320,7 @@ function build_ospray
     # Now build OSPRAY.
     #
     info "Building OSPRAY . . . (~5 minutes)"
-    #    $MAKE $MAKE_OPT_FLAGS
-    ${CMAKE_BIN} --build .
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
 
     #
     # On Darwin, the build can fail in a cmake -E copy_directory due to

--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -213,7 +213,7 @@ function build_ospray_in_source
     # Now build OSPRay
     #
     info "Building OSPRay (~10 minute)"
-    env DYLD_LIBRARY_PATH=`pwd`/bin {CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || \
+    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || \
         error "OSPRay did not build correctly.  Giving up."
 
     info "Installing OSPRay . . . "
@@ -320,7 +320,7 @@ function build_ospray
     # Now build OSPRAY.
     #
     info "Building OSPRAY . . . (~5 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
 
     #
     # On Darwin, the build can fail in a cmake -E copy_directory due to
@@ -335,7 +335,7 @@ function build_ospray
             ln -sf ../../../tbb/src/lib/libtbb.12.dylib .
             ln -sf ../../../tbb/src/lib/libtbb.dylib .
             popd 1>/dev/null 2>&1
-            ${CMAKE_BIN} --build .
+            ${CMAKE_COMMAND} --build .
             if [[ $? != 0 ]] ; then
                 warn "OSPRAY build failed. Giving up"
                 return 1

--- a/src/tools/dev/scripts/bv_support/bv_pidx.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pidx.sh
@@ -285,7 +285,7 @@ function build_pidx
     # Build PIDX
     #
     info "Making pidx . . ."
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "pidx build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_pidx.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pidx.sh
@@ -285,7 +285,7 @@ function build_pidx
     # Build PIDX
     #
     info "Making pidx . . ."
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "pidx build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_pidx.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pidx.sh
@@ -285,7 +285,7 @@ function build_pidx
     # Build PIDX
     #
     info "Making pidx . . ."
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "pidx build failed.  Giving up"
         return 1
@@ -295,7 +295,7 @@ function build_pidx
     # Install into the VisIt third party location.
     #
     info "Installing pidx . . ."
-    $MAKE install
+    ${CMAKE_COMMAND} install .
     if [[ $? != 0 ]] ; then
         warn "pidx install failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_qt6.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt6.sh
@@ -446,7 +446,7 @@ function build_qt6_base
     # Build Qt. Config options above make sure we only build the libs & tools.
     #
     info "Building Qt6 base . . . "
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
 
     if [[ $? != 0 ]] ; then
         warn "Qt6 base build failed.  Giving up"
@@ -506,7 +506,7 @@ function build_qt6_tools
         ${QT6_INSTALL_DIR}/bin/qt-configure-module  ../${QT6_TOOLS_SOURCE_DIR}
 
     info "Building Qt6 tools . . . "
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
 
     info "Installing Qt6 tools . . . "
     ${CMAKE_COMMAND} --install .
@@ -550,7 +550,7 @@ function build_qt6_svg
         ${QT6_INSTALL_DIR}/bin/qt-configure-module  ../${QT6_SVG_SOURCE_DIR}
 
     info "Building Qt6 svg . . . "
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
 
     info "Installing Qt6 svg . . . "
     ${CMAKE_COMMAND} --install .

--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -387,12 +387,12 @@ function build_visit
     #
     info "Building VisIt . . . (~50 minutes)"
     if [[ "${PY_BUILD_SPHINX}" == "yes" ]] ; then
-        $MAKE $MAKE_OPT_FLAGS manuals
+        ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS --target manuals
         if [[ $? != 0 ]] ; then
             warn "Building the VisIt manuals failed.  Continuing"
         fi
     fi
-    $MAKE $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "VisIt build failed.  Giving up"
         return 1
@@ -403,7 +403,7 @@ function build_visit
     # Package VisIt
     #
     info "Packaging VisIt ... (~10 minutes)"
-    $MAKE $MAKE_OPT_FLAGS package
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS --target package
     if [[ $? != 0 ]] ; then
         warn "VisIt package failed.  Giving up"
         return 1
@@ -416,7 +416,7 @@ function build_visit
     # Install VisIt
     #
     if [[ "${VISIT_INSTALL_PREFIX}" != "" ]] ; then
-        $MAKE $MAKE_OPT_FLAGS install
+        ${CMAKE_COMMAND} install .
         if [[ $? != 0 ]] ; then
             warn "VisIt installation failed.  Giving up"
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_visit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_visit.sh
@@ -387,12 +387,12 @@ function build_visit
     #
     info "Building VisIt . . . (~50 minutes)"
     if [[ "${PY_BUILD_SPHINX}" == "yes" ]] ; then
-        ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS --target manuals
+        ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS --target manuals
         if [[ $? != 0 ]] ; then
             warn "Building the VisIt manuals failed.  Continuing"
         fi
     fi
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "VisIt build failed.  Giving up"
         return 1
@@ -403,7 +403,7 @@ function build_visit
     # Package VisIt
     #
     info "Packaging VisIt ... (~10 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS --target package
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS --target package
     if [[ $? != 0 ]] ; then
         warn "VisIt package failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1952,11 +1952,11 @@ function build_vtk
     # Now build VTK.
     #
     info "Building VTK . . . (~20 minutes)"
-    env DYLD_LIBRARY_PATH=`pwd`/bin $MAKE $MAKE_OPT_FLAGS || \
+    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || \
         error "VTK did not build correctly.  Giving up."
 
     info "Installing VTK . . . "
-    $MAKE install || error "VTK did not install correctly."
+    ${CMAKE_COMMAND} install . install || error "VTK did not install correctly."
 
     # Filter out an include that references the user's VTK build directory
     configdir="${vtk_inst_path}/lib/cmake/vtk-${VTK_SHORT_VERSION}"

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -1952,7 +1952,7 @@ function build_vtk
     # Now build VTK.
     #
     info "Building VTK . . . (~20 minutes)"
-    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || \
+    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || \
         error "VTK did not build correctly.  Giving up."
 
     info "Installing VTK . . . "

--- a/src/tools/dev/scripts/bv_support/bv_vtkm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtkm.sh
@@ -228,10 +228,10 @@ function build_vtkm
     # Build vtkm
     #
     info "Building VTKm . . . (~2 minutes)"
-    $MAKE $MAKE_OPT_FLAGS || error "VTKm did not build correctly. Giving up."
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || error "VTKm did not build correctly. Giving up."
 
     info "Installing VTKm . . . (~2 minutes)"
-    $MAKE install || error "VTKm did not install correctly."
+    ${CMAKE_COMMAND} install . || error "VTKm did not install correctly."
 
     if [[ "$DO_GROUP" == "yes" ]] ; then
         chmod -R ug+w,a+rX "$VISITDIR/vtkm"

--- a/src/tools/dev/scripts/bv_support/bv_vtkm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtkm.sh
@@ -228,7 +228,7 @@ function build_vtkm
     # Build vtkm
     #
     info "Building VTKm . . . (~2 minutes)"
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS || error "VTKm did not build correctly. Giving up."
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || error "VTKm did not build correctly. Giving up."
 
     info "Installing VTKm . . . (~2 minutes)"
     ${CMAKE_COMMAND} install . || error "VTKm did not install correctly."

--- a/src/tools/dev/scripts/bv_support/bv_xdmf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xdmf.sh
@@ -277,7 +277,7 @@ function build_xdmf
     #
     info "Building Xdmf . . . (~3 minutes)"
 
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Xdmf build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_xdmf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xdmf.sh
@@ -277,7 +277,7 @@ function build_xdmf
     #
     info "Building Xdmf . . . (~3 minutes)"
 
-    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
     if [[ $? != 0 ]] ; then
         warn "Xdmf build failed.  Giving up"
         return 1

--- a/src/tools/dev/scripts/bv_support/bv_xdmf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xdmf.sh
@@ -277,7 +277,7 @@ function build_xdmf
     #
     info "Building Xdmf . . . (~3 minutes)"
 
-    $MAKE
+    ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
     if [[ $? != 0 ]] ; then
         warn "Xdmf build failed.  Giving up"
         return 1
@@ -285,7 +285,7 @@ function build_xdmf
 
     # Install Xdmf
     info "Installing Xdmf"
-    $MAKE install
+    ${CMAKE_COMMAND} install .
     if [[ $? != 0 ]] ; then
         warn "Xdmf install failed.  Giving up"
         return 1


### PR DESCRIPTION
### Description

Resolves #20021

Updates cmake-based tpl builds in build_visit to use `cmake --build` and `cmake --install`, instead of `make` and `make install`, to allow for alternate cmake generators. 

Specifically: 

```
$MAKE $MAKE_OPT_FLAGS
$MAKE install
```

becomes:

```
${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS 
${CMAKE_COMMAND} install .
```


Q: About `--makeflags` and it how it becomes `$MAKE_OPT_FLAGS`

It is used like the following:

```
$MAKE $MAKE_OPT_FLAGS
```

This makes me think we expect `--makeflags` to be something like `-j10`.

However, the existing cmake build invocation pattern is:

```
 ${CMAKE_COMMAND} --build . --parallel $MAKE_OPT_FLAGS
```

cmake also accepts `-j`, see output from `cmake --build`


```
  --parallel [<jobs>], -j [<jobs>]
                 = Build in parallel using the given number of jobs. 
                   If <jobs> is omitted the native build tool's 
                   default number is used.
                   The CMAKE_BUILD_PARALLEL_LEVEL environment variable
                   specifies a default parallel level when this option
                   is not given.
```

So are we passing `--parallel -j10`, if so should we drop the parallel?
