### PR TITLE
added option to the mesh plot to plot generated zones

### DIFF
--- a/src/plots/Mesh/Mesh.xml
+++ b/src/plots/Mesh/Mesh.xml
@@ -80,6 +80,9 @@
       <Field name="showInternal" label="Show Internal" type="bool">
         false
       </Field>
+      <Field name="showGenerated" label="Show generated zones" type="bool">
+        false
+      </Field>
       <Field name="pointSizePixels" label="Point size pixels" type="int">
         2
       </Field>

--- a/src/plots/Mesh/MeshAttributes.C
+++ b/src/plots/Mesh/MeshAttributes.C
@@ -1397,6 +1397,9 @@ MeshAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
 //    Kathleen Biagas, Wed Jun  10 10:00:03 PDT 2020
 //    Added test for changing point type.
 //
+//    Cyrus Harrison, Fri Jul 18 14:30:07 PDT 2025
+//    Added test for changing show generated.
+//
 // ****************************************************************************
 
 bool
@@ -1418,6 +1421,7 @@ MeshAttributes::ChangesRequireRecalculation(const MeshAttributes &obj,
 
     return ( needSecondaryVar || changingPointType ||
             (smoothingLevel != obj.smoothingLevel) ||
+            (showGenerated != obj.showGenerated) ||
             (showInternal != obj.showInternal && spatDim == 3));
 }
 

--- a/src/plots/Mesh/MeshAttributes.C
+++ b/src/plots/Mesh/MeshAttributes.C
@@ -186,6 +186,7 @@ void MeshAttributes::Init()
     pointType = Point;
     opaqueMeshIsAppropriate = true;
     showInternal = false;
+    showGenerated = false;
     pointSizePixels = 2;
     opacity = 1;
 
@@ -223,6 +224,7 @@ void MeshAttributes::Copy(const MeshAttributes &obj)
     pointType = obj.pointType;
     opaqueMeshIsAppropriate = obj.opaqueMeshIsAppropriate;
     showInternal = obj.showInternal;
+    showGenerated = obj.showGenerated;
     pointSizePixels = obj.pointSizePixels;
     opacity = obj.opacity;
 
@@ -400,6 +402,7 @@ MeshAttributes::operator == (const MeshAttributes &obj) const
             (pointType == obj.pointType) &&
             (opaqueMeshIsAppropriate == obj.opaqueMeshIsAppropriate) &&
             (showInternal == obj.showInternal) &&
+            (showGenerated == obj.showGenerated) &&
             (pointSizePixels == obj.pointSizePixels) &&
             (opacity == obj.opacity));
 }
@@ -570,6 +573,7 @@ MeshAttributes::SelectAll()
     Select(ID_pointType,               (void *)&pointType);
     Select(ID_opaqueMeshIsAppropriate, (void *)&opaqueMeshIsAppropriate);
     Select(ID_showInternal,            (void *)&showInternal);
+    Select(ID_showGenerated,           (void *)&showGenerated);
     Select(ID_pointSizePixels,         (void *)&pointSizePixels);
     Select(ID_opacity,                 (void *)&opacity);
 }
@@ -690,6 +694,12 @@ MeshAttributes::CreateNode(DataNode *parentNode, bool completeSave, bool forceAd
     {
         addToParent = true;
         node->AddNode(new DataNode("showInternal", showInternal));
+    }
+
+    if(completeSave || !FieldsEqual(ID_showGenerated, &defaultObject))
+    {
+        addToParent = true;
+        node->AddNode(new DataNode("showGenerated", showGenerated));
     }
 
     if(completeSave || !FieldsEqual(ID_pointSizePixels, &defaultObject))
@@ -838,6 +848,8 @@ MeshAttributes::SetFromNode(DataNode *parentNode)
         SetOpaqueMeshIsAppropriate(node->AsBool());
     if((node = searchNode->GetNode("showInternal")) != 0)
         SetShowInternal(node->AsBool());
+    if((node = searchNode->GetNode("showGenerated")) != 0)
+        SetShowGenerated(node->AsBool());
     if((node = searchNode->GetNode("pointSizePixels")) != 0)
         SetPointSizePixels(node->AsInt());
     if((node = searchNode->GetNode("opacity")) != 0)
@@ -944,6 +956,13 @@ MeshAttributes::SetShowInternal(bool showInternal_)
 {
     showInternal = showInternal_;
     Select(ID_showInternal, (void *)&showInternal);
+}
+
+void
+MeshAttributes::SetShowGenerated(bool showGenerated_)
+{
+    showGenerated = showGenerated_;
+    Select(ID_showGenerated, (void *)&showGenerated);
 }
 
 void
@@ -1066,6 +1085,12 @@ MeshAttributes::GetShowInternal() const
     return showInternal;
 }
 
+bool
+MeshAttributes::GetShowGenerated() const
+{
+    return showGenerated;
+}
+
 int
 MeshAttributes::GetPointSizePixels() const
 {
@@ -1138,6 +1163,7 @@ MeshAttributes::GetFieldName(int index) const
     case ID_pointType:               return "pointType";
     case ID_opaqueMeshIsAppropriate: return "opaqueMeshIsAppropriate";
     case ID_showInternal:            return "showInternal";
+    case ID_showGenerated:           return "showGenerated";
     case ID_pointSizePixels:         return "pointSizePixels";
     case ID_opacity:                 return "opacity";
     default:  return "invalid index";
@@ -1178,6 +1204,7 @@ MeshAttributes::GetFieldType(int index) const
     case ID_pointType:               return FieldType_glyphtype;
     case ID_opaqueMeshIsAppropriate: return FieldType_bool;
     case ID_showInternal:            return FieldType_bool;
+    case ID_showGenerated:           return FieldType_bool;
     case ID_pointSizePixels:         return FieldType_int;
     case ID_opacity:                 return FieldType_opacity;
     default:  return FieldType_unknown;
@@ -1218,6 +1245,7 @@ MeshAttributes::GetFieldTypeName(int index) const
     case ID_pointType:               return "glyphtype";
     case ID_opaqueMeshIsAppropriate: return "bool";
     case ID_showInternal:            return "bool";
+    case ID_showGenerated:           return "bool";
     case ID_pointSizePixels:         return "int";
     case ID_opacity:                 return "opacity";
     default:  return "invalid index";
@@ -1314,6 +1342,11 @@ MeshAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
     case ID_showInternal:
         {  // new scope
         retval = (showInternal == obj.showInternal);
+        }
+        break;
+    case ID_showGenerated:
+        {  // new scope
+        retval = (showGenerated == obj.showGenerated);
         }
         break;
     case ID_pointSizePixels:

--- a/src/plots/Mesh/MeshAttributes.code
+++ b/src/plots/Mesh/MeshAttributes.code
@@ -1,4 +1,3 @@
-Target: xml2atts
 Function: ChangesRequireRecalculation
 Declaration: bool ChangesRequireRecalculation(const MeshAttributes &, const int);
 Definition:
@@ -181,3 +180,4 @@ MeshViewerEnginePluginInfo::SetAutonomousColors(AttributeSubject *atts,
     if (attsChanged)
         SetClientAtts(atts);
 }
+

--- a/src/plots/Mesh/MeshAttributes.code
+++ b/src/plots/Mesh/MeshAttributes.code
@@ -29,6 +29,9 @@ Definition:
 //    Kathleen Biagas, Wed Jun  10 10:00:03 PDT 2020
 //    Added test for changing point type.
 //
+//    Cyrus Harrison, Fri Jul 18 14:30:07 PDT 2025
+//    Added test for changing show generated.
+//
 // ****************************************************************************
 
 bool
@@ -50,6 +53,7 @@ MeshAttributes::ChangesRequireRecalculation(const MeshAttributes &obj,
 
     return ( needSecondaryVar || changingPointType ||
             (smoothingLevel != obj.smoothingLevel) ||
+            (showGenerated != obj.showGenerated) ||
             (showInternal != obj.showInternal && spatDim == 3));
 }
 

--- a/src/plots/Mesh/MeshAttributes.h
+++ b/src/plots/Mesh/MeshAttributes.h
@@ -97,6 +97,7 @@ public:
     void SetPointType(GlyphType pointType_);
     void SetOpaqueMeshIsAppropriate(bool opaqueMeshIsAppropriate_);
     void SetShowInternal(bool showInternal_);
+    void SetShowGenerated(bool showGenerated_);
     void SetPointSizePixels(int pointSizePixels_);
     void SetOpacity(double opacity_);
 
@@ -118,6 +119,7 @@ public:
     GlyphType            GetPointType() const;
     bool                 GetOpaqueMeshIsAppropriate() const;
     bool                 GetShowInternal() const;
+    bool                 GetShowGenerated() const;
     int                  GetPointSizePixels() const;
     double               GetOpacity() const;
 
@@ -172,6 +174,7 @@ public:
         ID_pointType,
         ID_opaqueMeshIsAppropriate,
         ID_showInternal,
+        ID_showGenerated,
         ID_pointSizePixels,
         ID_opacity,
         ID__LAST
@@ -192,6 +195,7 @@ private:
     GlyphType      pointType;
     bool           opaqueMeshIsAppropriate;
     bool           showInternal;
+    bool           showGenerated;
     int            pointSizePixels;
     double         opacity;
 
@@ -199,6 +203,6 @@ private:
     static const char *TypeMapFormatString;
     static const private_tmfs_t TmfsStruct;
 };
-#define MESHATTRIBUTES_TMFS "biaiiidaibsibbid"
+#define MESHATTRIBUTES_TMFS "biaiiidaibsibbbid"
 
 #endif

--- a/src/plots/Mesh/MeshAttributes.java
+++ b/src/plots/Mesh/MeshAttributes.java
@@ -26,7 +26,7 @@ import llnl.visit.ColorAttribute;
 
 public class MeshAttributes extends AttributeSubject implements Plugin
 {
-    private static int MeshAttributes_numAdditionalAtts = 16;
+    private static int MeshAttributes_numAdditionalAtts = 17;
 
     // Enum values
     public final static int SMOOTHINGLEVEL_NONE = 0;
@@ -64,6 +64,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
         pointType = 6;
         opaqueMeshIsAppropriate = true;
         showInternal = false;
+        showGenerated = false;
         pointSizePixels = 2;
         opacity = 1;
     }
@@ -86,6 +87,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
         pointType = 6;
         opaqueMeshIsAppropriate = true;
         showInternal = false;
+        showGenerated = false;
         pointSizePixels = 2;
         opacity = 1;
     }
@@ -108,6 +110,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
         pointType = obj.pointType;
         opaqueMeshIsAppropriate = obj.opaqueMeshIsAppropriate;
         showInternal = obj.showInternal;
+        showGenerated = obj.showGenerated;
         pointSizePixels = obj.pointSizePixels;
         opacity = obj.opacity;
 
@@ -141,6 +144,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
                 (pointType == obj.pointType) &&
                 (opaqueMeshIsAppropriate == obj.opaqueMeshIsAppropriate) &&
                 (showInternal == obj.showInternal) &&
+                (showGenerated == obj.showGenerated) &&
                 (pointSizePixels == obj.pointSizePixels) &&
                 (opacity == obj.opacity));
     }
@@ -233,16 +237,22 @@ public class MeshAttributes extends AttributeSubject implements Plugin
         Select(13);
     }
 
+    public void SetShowGenerated(boolean showGenerated_)
+    {
+        showGenerated = showGenerated_;
+        Select(14);
+    }
+
     public void SetPointSizePixels(int pointSizePixels_)
     {
         pointSizePixels = pointSizePixels_;
-        Select(14);
+        Select(15);
     }
 
     public void SetOpacity(double opacity_)
     {
         opacity = opacity_;
-        Select(15);
+        Select(16);
     }
 
     // Property getting methods
@@ -260,6 +270,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
     public int GetPointType() { return pointType; }
     public boolean        GetOpaqueMeshIsAppropriate() { return opaqueMeshIsAppropriate; }
     public boolean        GetShowInternal() { return showInternal; }
+    public boolean        GetShowGenerated() { return showGenerated; }
     public int            GetPointSizePixels() { return pointSizePixels; }
     public double         GetOpacity() { return opacity; }
 
@@ -295,8 +306,10 @@ public class MeshAttributes extends AttributeSubject implements Plugin
         if(WriteSelect(13, buf))
             buf.WriteBool(showInternal);
         if(WriteSelect(14, buf))
-            buf.WriteInt(pointSizePixels);
+            buf.WriteBool(showGenerated);
         if(WriteSelect(15, buf))
+            buf.WriteInt(pointSizePixels);
+        if(WriteSelect(16, buf))
             buf.WriteDouble(opacity);
     }
 
@@ -349,9 +362,12 @@ public class MeshAttributes extends AttributeSubject implements Plugin
             SetShowInternal(buf.ReadBool());
             break;
         case 14:
-            SetPointSizePixels(buf.ReadInt());
+            SetShowGenerated(buf.ReadBool());
             break;
         case 15:
+            SetPointSizePixels(buf.ReadInt());
+            break;
+        case 16:
             SetOpacity(buf.ReadDouble());
             break;
         }
@@ -402,6 +418,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
         str = str + intToString("pointType", pointType, indent) + "\n";
         str = str + boolToString("opaqueMeshIsAppropriate", opaqueMeshIsAppropriate, indent) + "\n";
         str = str + boolToString("showInternal", showInternal, indent) + "\n";
+        str = str + boolToString("showGenerated", showGenerated, indent) + "\n";
         str = str + intToString("pointSizePixels", pointSizePixels, indent) + "\n";
         str = str + doubleToString("opacity", opacity, indent) + "\n";
         return str;
@@ -423,6 +440,7 @@ public class MeshAttributes extends AttributeSubject implements Plugin
     private int pointType;
     private boolean        opaqueMeshIsAppropriate;
     private boolean        showInternal;
+    private boolean        showGenerated;
     private int            pointSizePixels;
     private double         opacity;
 }

--- a/src/plots/Mesh/PyMeshAttributes.C
+++ b/src/plots/Mesh/PyMeshAttributes.C
@@ -189,6 +189,11 @@ PyMeshAttributes_ToString(const MeshAttributes *atts, const char *prefix, const 
     else
         snprintf(tmpStr, 1000, "%sshowInternal = 0\n", prefix);
     str += tmpStr;
+    if(atts->GetShowGenerated())
+        snprintf(tmpStr, 1000, "%sshowGenerated = 1\n", prefix);
+    else
+        snprintf(tmpStr, 1000, "%sshowGenerated = 0\n", prefix);
+    str += tmpStr;
     snprintf(tmpStr, 1000, "%spointSizePixels = %d\n", prefix, atts->GetPointSizePixels());
     str += tmpStr;
     snprintf(tmpStr, 1000, "%sopacity = %g\n", prefix, atts->GetOpacity());
@@ -1044,6 +1049,66 @@ MeshAttributes_GetShowInternal(PyObject *self, PyObject *args)
 }
 
 /*static*/ PyObject *
+MeshAttributes_SetShowGenerated(PyObject *self, PyObject *args)
+{
+    PyMeshAttributesObject *obj = (PyMeshAttributesObject *)self;
+
+    PyObject *packaged_args = 0;
+
+    // Handle args packaged into a tuple of size one
+    // if we think the unpackaged args matches our needs
+    if (PySequence_Check(args) && PySequence_Size(args) == 1)
+    {
+        packaged_args = PySequence_GetItem(args, 0);
+        if (PyNumber_Check(packaged_args))
+            args = packaged_args;
+    }
+
+    if (PySequence_Check(args))
+    {
+        Py_XDECREF(packaged_args);
+        return PyErr_Format(PyExc_TypeError, "expecting a single number arg");
+    }
+
+    if (!PyNumber_Check(args))
+    {
+        Py_XDECREF(packaged_args);
+        return PyErr_Format(PyExc_TypeError, "arg is not a number type");
+    }
+
+    long val = PyLong_AsLong(args);
+    bool cval = bool(val);
+
+    if (val == -1 && PyErr_Occurred())
+    {
+        Py_XDECREF(packaged_args);
+        PyErr_Clear();
+        return PyErr_Format(PyExc_TypeError, "arg not interpretable as C++ bool");
+    }
+    if (fabs(double(val))>1.5E-7 && fabs((double(long(cval))-double(val))/double(val))>1.5E-7)
+    {
+        Py_XDECREF(packaged_args);
+        return PyErr_Format(PyExc_ValueError, "arg not interpretable as C++ bool");
+    }
+
+    Py_XDECREF(packaged_args);
+
+    // Set the showGenerated in the object.
+    obj->data->SetShowGenerated(cval);
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+/*static*/ PyObject *
+MeshAttributes_GetShowGenerated(PyObject *self, PyObject *args)
+{
+    PyMeshAttributesObject *obj = (PyMeshAttributesObject *)self;
+    PyObject *retval = PyInt_FromLong(obj->data->GetShowGenerated()?1L:0L);
+    return retval;
+}
+
+/*static*/ PyObject *
 MeshAttributes_SetPointSizePixels(PyObject *self, PyObject *args)
 {
     PyMeshAttributesObject *obj = (PyMeshAttributesObject *)self;
@@ -1194,6 +1259,8 @@ PyMethodDef PyMeshAttributes_methods[MESHATTRIBUTES_NMETH] = {
     {"GetPointType", MeshAttributes_GetPointType, METH_VARARGS},
     {"SetShowInternal", MeshAttributes_SetShowInternal, METH_VARARGS},
     {"GetShowInternal", MeshAttributes_GetShowInternal, METH_VARARGS},
+    {"SetShowGenerated", MeshAttributes_SetShowGenerated, METH_VARARGS},
+    {"GetShowGenerated", MeshAttributes_GetShowGenerated, METH_VARARGS},
     {"SetPointSizePixels", MeshAttributes_SetPointSizePixels, METH_VARARGS},
     {"GetPointSizePixels", MeshAttributes_GetPointSizePixels, METH_VARARGS},
     {"SetOpacity", MeshAttributes_SetOpacity, METH_VARARGS},
@@ -1295,6 +1362,8 @@ PyMeshAttributes_getattro(PyObject *self, PyObject *attr_name)
 
     if(strcmp(name, "showInternal") == 0)
         return MeshAttributes_GetShowInternal(self, NULL);
+    if(strcmp(name, "showGenerated") == 0)
+        return MeshAttributes_GetShowGenerated(self, NULL);
     if(strcmp(name, "pointSizePixels") == 0)
         return MeshAttributes_GetPointSizePixels(self, NULL);
     if(strcmp(name, "opacity") == 0)
@@ -1340,6 +1409,8 @@ PyMeshAttributes_setattro(PyObject *self, PyObject *attr_name, PyObject *args)
         obj = MeshAttributes_SetPointType(self, args);
     else if(strcmp(name, "showInternal") == 0)
         obj = MeshAttributes_SetShowInternal(self, args);
+    else if(strcmp(name, "showGenerated") == 0)
+        obj = MeshAttributes_SetShowGenerated(self, args);
     else if(strcmp(name, "pointSizePixels") == 0)
         obj = MeshAttributes_SetPointSizePixels(self, args);
     else if(strcmp(name, "opacity") == 0)

--- a/src/plots/Mesh/PyMeshAttributes.h
+++ b/src/plots/Mesh/PyMeshAttributes.h
@@ -11,7 +11,7 @@
 //
 // Functions exposed to the VisIt module.
 //
-#define MESHATTRIBUTES_NMETH 33
+#define MESHATTRIBUTES_NMETH 35
 void           PyMeshAttributes_StartUp(MeshAttributes *subj, void *data);
 void           PyMeshAttributes_CloseDown();
 PyMethodDef *  PyMeshAttributes_GetMethodTable(int *nMethods);

--- a/src/plots/Mesh/QvisMeshPlotWindow.C
+++ b/src/plots/Mesh/QvisMeshPlotWindow.C
@@ -155,13 +155,13 @@ QvisMeshPlotWindow::CreateWindowContents()
     showInternalToggle = new QCheckBox(tr("Show internal zones"), central);
     connect(showInternalToggle, SIGNAL(toggled(bool)),
             this, SLOT(showInternalToggled(bool)));
-    zoneLayout->addWidget(showInternalToggle, 0, 0, 1, 2);
+    zoneLayout->addWidget(showInternalToggle, 0, 0, 1, 1);
 
     // Create the showGenerated toggle
     showGeneratedToggle = new QCheckBox(tr("Show generated zones"), central);
     connect(showGeneratedToggle, SIGNAL(toggled(bool)),
             this, SLOT(showGeneratedToggled(bool)));
-    zoneLayout->addWidget(showGeneratedToggle, 0, 0, 1, 2);
+    zoneLayout->addWidget(showGeneratedToggle, 0, 1, 1, 1);
 
     //
     // Create the color stuff
@@ -594,12 +594,11 @@ QvisMeshPlotWindow::UpdateWindow(bool doAll)
             showInternalToggle->setChecked(meshAtts->GetShowInternal());
             showInternalToggle->blockSignals(false);
             break;
-        // TODO TODO TODO TODO
-        // case MeshAttributes::ID_showGenerated:
-        //     showGeneratedToggle->blockSignals(true);
-        //     showGeneratedToggle->setChecked(meshAtts->GetShowGenerated());
-        //     showGeneratedToggle->blockSignals(false);
-        //     break;
+        case MeshAttributes::ID_showGenerated:
+            showGeneratedToggle->blockSignals(true);
+            showGeneratedToggle->setChecked(meshAtts->GetShowGenerated());
+            showGeneratedToggle->blockSignals(false);
+            break;
         case MeshAttributes::ID_pointSizePixels:
             pointControl->blockSignals(true);
             pointControl->SetPointSizePixels(meshAtts->GetPointSizePixels());
@@ -684,7 +683,7 @@ QvisMeshPlotWindow::Apply(bool ignore)
 {
     if(AutoUpdate() || ignore)
     {
-        // Get the current aslice attributes and tell the other
+        // Get the current mesh plot attributes and tell the other
         // observers about them.
         GetCurrentValues(-1);
         meshAtts->Notify();

--- a/src/plots/Mesh/QvisMeshPlotWindow.C
+++ b/src/plots/Mesh/QvisMeshPlotWindow.C
@@ -132,6 +132,9 @@ QvisMeshPlotWindow::~QvisMeshPlotWindow()
 //   Kathleen Biagas, Tue Apr 18 16:34:41 PDT 2023
 //   Support Qt6: buttonClicked -> idClicked.
 //
+//   Cyrus Harrison, Thu Jul 17 07:55:39 PDT 2025
+//   Added showGeneratedToggle.
+//
 // ****************************************************************************
 
 void
@@ -153,6 +156,12 @@ QvisMeshPlotWindow::CreateWindowContents()
     connect(showInternalToggle, SIGNAL(toggled(bool)),
             this, SLOT(showInternalToggled(bool)));
     zoneLayout->addWidget(showInternalToggle, 0, 0, 1, 2);
+
+    // Create the showGenerated toggle
+    showGeneratedToggle = new QCheckBox(tr("Show generated zones"), central);
+    connect(showGeneratedToggle, SIGNAL(toggled(bool)),
+            this, SLOT(showGeneratedToggled(bool)));
+    zoneLayout->addWidget(showGeneratedToggle, 0, 0, 1, 2);
 
     //
     // Create the color stuff
@@ -585,6 +594,12 @@ QvisMeshPlotWindow::UpdateWindow(bool doAll)
             showInternalToggle->setChecked(meshAtts->GetShowInternal());
             showInternalToggle->blockSignals(false);
             break;
+        // TODO TODO TODO TODO
+        // case MeshAttributes::ID_showGenerated:
+        //     showGeneratedToggle->blockSignals(true);
+        //     showGeneratedToggle->setChecked(meshAtts->GetShowGenerated());
+        //     showGeneratedToggle->blockSignals(false);
+        //     break;
         case MeshAttributes::ID_pointSizePixels:
             pointControl->blockSignals(true);
             pointControl->SetPointSizePixels(meshAtts->GetPointSizePixels());
@@ -825,6 +840,33 @@ QvisMeshPlotWindow::showInternalToggled(bool val)
     SetUpdate(false);
     Apply();
 }
+
+
+// ****************************************************************************
+// Method: QvisMeshPlotWindow::showGenerated
+//
+// Purpose:
+//   This is a Qt slot function that is called when the showGenerated toggle is
+//   toggled.
+//
+// Arguments:
+//   val : The new showGenerated toggle state.
+//
+// Programmer: Cyrus Harrison
+// Creation:   Thu Jul 17 07:55:39 PDT 2025
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+QvisMeshPlotWindow::showGeneratedToggled(bool val)
+{
+    meshAtts->SetShowGenerated(val);
+    SetUpdate(false);
+    Apply();
+}
+
 
 
 // ****************************************************************************

--- a/src/plots/Mesh/QvisMeshPlotWindow.h
+++ b/src/plots/Mesh/QvisMeshPlotWindow.h
@@ -69,6 +69,9 @@ class QvisOpacitySlider;
 //   Kathleen Biagas, Thu Apr 23 13:12:22 PDT 2015
 //   Removed never-implemented outlineOnly and errorTolerance widgets.
 // 
+//   Cyrus Harrison, Thu Jul 17 07:55:39 PDT 2025
+//   Added toogle to show generated zones.
+//
 // ****************************************************************************
 
 class QvisMeshPlotWindow : public QvisPostableWindowObserver
@@ -93,6 +96,7 @@ private slots:
     void lineWidthChanged(int newWidth);
     void legendToggled(bool val);
     void showInternalToggled(bool val);
+    void showGeneratedToggled(bool val);
     void meshColorChanged(const QColor &color);
     void opaqueModeChanged(int val);
     void opaqueColorChanged(const QColor &color);
@@ -115,6 +119,7 @@ private:
     QButtonGroup           *opaqueModeGroup;
     QCheckBox              *legendToggle;
     QCheckBox              *showInternalToggle;
+    QCheckBox              *showGeneratedToggle;
     QButtonGroup           *meshColorButtons;
     QvisColorButton        *meshColor;
     QLabel                 *opaqueColorLabel;

--- a/src/plots/Mesh/avtMeshFilter.C
+++ b/src/plots/Mesh/avtMeshFilter.C
@@ -324,7 +324,12 @@ avtMeshFilter::ExecuteDataTree(avtDataRepresentation *inDR)
 
         if (topoDim == 2)
         {
-            lineFilter->UseOriginalCellsOn();
+            // don't use orignal cells to screen if we want to see
+            // generated zones
+            if(!atts.GetShowGenerated())
+            {
+                lineFilter->UseOriginalCellsOn();
+            }
             lineFilter->SetInputData((vtkPolyData*)revisedInput3);
             lineFilter->Update();
             outDS = lineFilter->GetOutput();

--- a/src/test/tests/plots/mesh.py
+++ b/src/test/tests/plots/mesh.py
@@ -423,8 +423,30 @@ def TestCustomColor():
     DeleteAllPlots()
     CloseDatabase(silo_data_path("arbpoly-zoohybrid.silo"))
 
+def TestGeneratedZones():
+    TestSection("Testing display of generated zones")
+    dbfile = data_path("mfem_test_data/escher-p3.mfem_root")
+    OpenDatabase(dbfile)
+    AddPlot("Mesh", "main")
+    AddOperator("MultiresControl")
+    mc_atts  = MultiresControlAttributes()
+    mc_atts.resolution = 3
+    SetOperatorOptions(mc_atts)
+    DrawPlots()
+    Test("mesh_generated_zones_off")
+    m = MeshAttributes()
+    m.showGenerated = 1
+    SetPlotOptions(m)
+    Test("mesh_generated_zones_on")
+    DeleteAllPlots()
+    CloseDatabase(dbfile)
+
 def Main():
     TurnOffAllAnnotations()
+    # TODO
+    # on my macOS machine this test only works if run first
+    # Ohterwise it fails to open the mfem file very strange ...
+    TestGeneratedZones()
     TestRandomColor()
     TestCurve()
     TestPointMesh()
@@ -432,6 +454,7 @@ def Main():
     TestRect3d()
     TestAutoOpaqueFlag()
     TestCustomColor()
+
 
 # Added to allow this test to be run with compression too.
 # Another .py file sources this file with 'useCompression'

--- a/test/baseline/plots/mesh/mesh_generated_zones_off.png
+++ b/test/baseline/plots/mesh/mesh_generated_zones_off.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f312a00b58c065f921f1b471902153c506b1e8b5cd11b318752a936cfa399912
+size 2948

--- a/test/baseline/plots/mesh/mesh_generated_zones_on.png
+++ b/test/baseline/plots/mesh/mesh_generated_zones_on.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01cd5447b6ac96be3230b54ba8762a386525cb6d10481553dbda5438ea7e86ed
+size 5885


### PR DESCRIPTION
### Description

Adds `Show generate zones` option to the mesh plot.
<img width="561" height="687" alt="Screenshot 2025-07-18 at 2 57 26 PM" src="https://github.com/user-attachments/assets/ce351314-d6d1-4cc3-8f9f-50f89ed4e19c" />

Default is off.

When this option is on, we skip using the original zone ids to screen mesh lines.

Use for this is best demonstrated with mfem multi res data.

Off:
<img width="363" height="350" alt="Screenshot 2025-07-18 at 2 58 40 PM" src="https://github.com/user-attachments/assets/f9d84d12-621a-4f1b-ada8-2c245993ce28" />

On:
[
<img width="400" height="385" alt="Screenshot 2025-07-18 at 2 58 44 PM" src="https://github.com/user-attachments/assets/64fa51e7-7582-45e5-9de3-de3cc92161c8" />
](url)

 
Resolves #18550

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
