### PR TITLE
use one test process for poodle regression run

### DIFF
--- a/src/tools/dev/scripts/regressiontest_poodle
+++ b/src/tools/dev/scripts/regressiontest_poodle
@@ -516,7 +516,7 @@ for m in \$modes; do
 
 
     # Run the test
-    ./run_visit_test_suite.sh  --parallel-launch "srun" -o \$resDir -m "\$m" -n 2 --cmake $cmakeCmd >> ../../buildlog 2>&1
+    ./run_visit_test_suite.sh  --parallel-launch "srun" -o \$resDir -m "\$m" -n 1 --cmake $cmakeCmd >> ../../buildlog 2>&1
 
     # Move the results to the consolidation directory
     mv \$resDir/html \$dateTag/\$theMode


### PR DESCRIPTION
### Description
Adj nightly regression test suite run logic to avoid multi process error.
