### PR TITLE
Fix slice along boundary

### DIFF
--- a/src/visit_vtk/full/vtkSlicer.C
+++ b/src/visit_vtk/full/vtkSlicer.C
@@ -771,11 +771,6 @@ vtkSlicer::SliceDataset(vtkDataSet *in_ds, vtkPolyData *out_pd,
     plane->SetNormal(Normal[0], Normal[1], Normal[2]);
 
     vtkVisItCutter *cutter = vtkVisItCutter::New();
-    // the flag 'useVTKFilter' doesn't really make sense here
-    // We want to tell the cutter to use an unstructured-grid specific
-    // cutting method instead of passing along to vtkPlaneCutter which
-    // garbles CellData when polygonal/polyhedral cells are present.
-    // The flag should be renamed when we strip support for VTK 9.2.6
     cutter->SetUnstructuredGridBypass(useUGridBypass);
     cutter->SetCutFunction(plane);
     cutter->SetInputData(in_ds);

--- a/src/visit_vtk/full/vtkVisItCutter.C
+++ b/src/visit_vtk/full/vtkVisItCutter.C
@@ -63,6 +63,22 @@ int vtkVisItCutter::RequestData(
       // correctly for these cell types.
       this->UnstructuredGridCutter(input, output);
   }
+  else if (vtkPolyData::SafeDownCast(input))
+  {
+      vtkPolyData *pd = vtkPolyData::SafeDownCast(input);
+      if(pd->GetNumberOfVerts() == pd->GetNumberOfCells())
+      {
+          // call vtkCutter::RequestData to handle the data for a pointset.
+          return this->Superclass::RequestData(request, inputVector, outputVector);
+      }
+      else
+      {
+          // bypasses the 'executePlaneCutter' for PolyData, due to failure
+          // when slice plane lies along boundary of the data,
+          this->DataSetCutter(input, output);
+      }
+
+  }
   else
   {
       // call vtkCutter::RequestData to handle the data.

--- a/src/visit_vtk/full/vtkVisItCutter.C
+++ b/src/visit_vtk/full/vtkVisItCutter.C
@@ -63,9 +63,8 @@ int vtkVisItCutter::RequestData(
       // correctly for these cell types.
       this->UnstructuredGridCutter(input, output);
   }
-  else if (vtkPolyData::SafeDownCast(input))
+  else if (vtkPolyData *pd = vtkPolyData::SafeDownCast(input))
   {
-      vtkPolyData *pd = vtkPolyData::SafeDownCast(input);
       if(pd->GetNumberOfVerts() == pd->GetNumberOfCells())
       {
           // call vtkCutter::RequestData to handle the data for a pointset.


### PR DESCRIPTION
### Description

Resolves #20505 
The failure was related to changes I made for the vtk95 update in vtkVisItCutter and vtkSlicer.
I added another path in vtkVisItCutter that bypasses the vtkCutter logic to handle vtkPolyData (non point-set) differently, similar to what was done for vtkUnstructuredGrid.

This particular instance, the slice plane lies along the boundary of the mesh, and the slice was failing even though the mesh touched the boundary.



### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ 

### How Has This Been Tested?

Ran pick.py test and the PickBoundary portion no longer fails with a crash or empty plot.

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

