### PR TITLE
Fix pluginVsInstall test on Windows.

### DIFF
--- a/src/CMake/FindVTKm.cmake
+++ b/src/CMake/FindVTKm.cmake
@@ -83,8 +83,11 @@ IF (VISIT_VTKM_DIR)
    endfunction()
 
    get_target_property(VTKM_INT_LL vtkm::filter INTERFACE_LINK_LIBRARIES)
+   # pluginVsInstall test for Slice on Windows revealed need for this module
+   # and its link dependencies to be installed, too.
+   get_target_property(VTKM_DIY_LL vtkm::diy INTERFACE_LINK_LIBRARIES)
    set(addl_ll)
-   foreach(vtkmll ${VTKM_INT_LL})
+   foreach(vtkmll ${VTKM_INT_LL} ${VTKM_DIY_LL})
        get_lib_loc_and_install(${vtkmll})
        get_target_property(VTKM_LL_DEP ${vtkmll} INTERFACE_LINK_LIBRARIES)
        if(VTKM_LL_DEP)

--- a/src/operators/Isovolume/CMakeLists.txt
+++ b/src/operators/Isovolume/CMakeLists.txt
@@ -78,7 +78,7 @@ ENDIF(NOT VISIT_SERVER_COMPONENTS_ONLY AND NOT VISIT_ENGINE_ONLY AND NOT VISIT_D
 ADD_LIBRARY(EIsovolumeOperator_ser ${LIBE_SOURCES})
 TARGET_LINK_LIBRARIES(EIsovolumeOperator_ser visitcommon avtpipeline_ser avtexpressions_ser avtfilters_ser )
 if(HAVE_LIBVTKM)
-    target_link_libraries(EIsovolumeOperator_ser  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_entity_extraction vtkm::filter_field_conversion vtkm::worklet)
+    target_link_libraries(EIsovolumeOperator_ser  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_entity_extraction vtkm::filter_field_conversion vtkm::worklet vtkm::vtkmdiympi_nompi)
 endif()
 
 SET(INSTALLTARGETS ${INSTALLTARGETS} EIsovolumeOperator_ser)
@@ -87,7 +87,7 @@ IF(VISIT_PARALLEL)
     ADD_PARALLEL_LIBRARY(EIsovolumeOperator_par ${LIBE_SOURCES})
     TARGET_LINK_LIBRARIES(EIsovolumeOperator_par visitcommon avtpipeline_par avtexpressions_par avtfilters_par )
     if(HAVE_LIBVTKM)
-        target_link_libraries(EIsovolumeOperator_par  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_entity_extraction vtkm::filter_field_conversion vtkm::worklet)
+        target_link_libraries(EIsovolumeOperator_par  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_entity_extraction vtkm::filter_field_conversion vtkm::worklet vtkm::vtkmdiympi_nompi)
     endif()
 
     SET(INSTALLTARGETS ${INSTALLTARGETS} EIsovolumeOperator_par)

--- a/src/operators/Isovolume/Isovolume.code
+++ b/src/operators/Isovolume/Isovolume.code
@@ -1,4 +1,4 @@
 Target: xml2cmake
 Condition:       HAVE_LIBVTKM
-ELinkLibraries:  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_entity_extraction vtkm::filter_field_conversion vtkm::worklet
+ELinkLibraries:  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_entity_extraction vtkm::filter_field_conversion vtkm::worklet vtkm::vtkmdiympi_nompi
 

--- a/src/operators/Slice/CMakeLists.txt
+++ b/src/operators/Slice/CMakeLists.txt
@@ -78,7 +78,7 @@ ENDIF(NOT VISIT_SERVER_COMPONENTS_ONLY AND NOT VISIT_ENGINE_ONLY AND NOT VISIT_D
 ADD_LIBRARY(ESliceOperator_ser ${LIBE_SOURCES})
 TARGET_LINK_LIBRARIES(ESliceOperator_ser visitcommon avtpipeline_ser avtexpressions_ser avtfilters_ser )
 if(HAVE_LIBVTKM)
-    target_link_libraries(ESliceOperator_ser  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::worklet vtkm::filter_vector_analysis)
+    target_link_libraries(ESliceOperator_ser  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_multi_block vtkm::worklet vtkm::filter_vector_analysis vtkm::vtkmdiympi_nompi)
 endif()
 
 SET(INSTALLTARGETS ${INSTALLTARGETS} ESliceOperator_ser)
@@ -87,7 +87,7 @@ IF(VISIT_PARALLEL)
     ADD_PARALLEL_LIBRARY(ESliceOperator_par ${LIBE_SOURCES})
     TARGET_LINK_LIBRARIES(ESliceOperator_par visitcommon avtpipeline_par avtexpressions_par avtfilters_par )
     if(HAVE_LIBVTKM)
-        target_link_libraries(ESliceOperator_par  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::worklet vtkm::filter_vector_analysis)
+        target_link_libraries(ESliceOperator_par  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_multi_block vtkm::worklet vtkm::filter_vector_analysis vtkm::vtkmdiympi_nompi)
     endif()
 
     SET(INSTALLTARGETS ${INSTALLTARGETS} ESliceOperator_par)

--- a/src/operators/Slice/SliceAttributes.code
+++ b/src/operators/Slice/SliceAttributes.code
@@ -394,5 +394,5 @@ SliceAttributes::SetValue(const std::string &name, const bool &value)
 
 Target: xml2cmake
 Condition:       HAVE_LIBVTKM
-ELinkLibraries:  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::worklet vtkm::filter_vector_analysis
+ELinkLibraries:  vtkm::cont vtkm::filter_core vtkm::filter_contour vtkm::filter_multi_block vtkm::worklet vtkm::filter_vector_analysis vtkm::vtkmdiympi_nompi
 

--- a/src/tools/dev/xml/GenerateCMake.h
+++ b/src/tools/dev/xml/GenerateCMake.h
@@ -201,6 +201,9 @@
 //    Eric Brugger, Wed Jul 16 15:29:56 PDT 2025
 //    Modify 'FilterConditionalLibs` for VTKm 2.3.0.
 //
+//    Kathleen Biagas, Thu Jul 24, 2025 
+//    vtkm::vtkmdiympi_nompi needs to be handled differently. 
+//
 // ****************************************************************************
 
 class CMakeGeneratorPlugin : public Plugin
@@ -303,8 +306,15 @@ class CMakeGeneratorPlugin : public Plugin
             {
                 // for plugin-vs-install, need to
                 // replace 'vtkm::' with 'vtkm_' and append the version
-                tmp.replace(QString("vtkm::"), QString("vtkm_"));
-                tmp.append(vtkmversion);
+                if(tmp.contains(QString("nompi")))
+                {
+                    tmp.replace(QString("vtkm::"), QString(""));
+                }
+                else
+                {
+                    tmp.replace(QString("vtkm::"), QString("vtkm_"));
+                    tmp.append(vtkmversion);
+                }
             }
             libs += " " + tmp;
         }


### PR DESCRIPTION
Because we aren't using the vtkm:: cmake targets when building a plugin against install, the indirect dependencies aren't being pulled in.  Slice needed two libraries to successfully build against install. Since Isovolume also uses vtkm, I tested pluginVsInstall with it and adjusted its vtkm library list accordingly.

Modified FindVTKm.cmake to ensure more of the libraries are installed.
Modified GenerateCMake.h to handle vtkmdiympi_nompi differently, as it isn't named the same as other libs.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Ran pluginVsInstall tests successfully on Windows and toss4.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
