### PR TITLE
Fix bug with command recording of the Expression window.

### DIFF
--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -126,6 +126,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a memory bug in AMR plugin when reading velocity magnitude.</li>
   <li>In the PVLD plugin, show SPH in metadata at the first time step even when there are no SPH particles initially.</li>
   <li>Fixed a viewer crash with transparency.</li>
+  <li>Fixed a command recording bug with the Expression window where all the operator generated expressions would get recorded.</li>
 </ul>
 
 <a name="Build_features"></a>

--- a/src/visitpy/common/Logging.C
+++ b/src/visitpy/common/Logging.C
@@ -1042,6 +1042,9 @@ static std::string log_SetAppearanceRPC(ViewerRPC *rpc)
 //    Kathleen Bonnell, Thu Aug  3 09:25:00 PDT 2006
 //    Added CurveMeshVar
 //
+//    Eric Brugger, Tue Aug  5 13:59:39 PDT 2025
+//    Added code to skip the recording of operator generated expressions.
+//
 //*****************************************************************************
 
 static std::string log_ProcessExpressionsRPC(ViewerRPC *rpc)
@@ -1053,7 +1056,7 @@ static std::string log_ProcessExpressionsRPC(ViewerRPC *rpc)
     for(int i = 0; i < list->GetNumExpressions(); ++i)
     {
         const Expression &expr = list->GetExpressions(i);
-        if(expr.GetFromDB())
+        if(expr.GetFromDB() || expr.GetFromOperator())
             continue;
 
         const char *fx = 0;


### PR DESCRIPTION
### Description

Resolves #17561

I fixed a bug with command recording for the Expression window where all the operator generated expressions would get recorded. It no longer records the operator generated expressions.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

Using VisIt 3.4.2 I verified the bug by doing the following:
1) Opened globe.silo.
2) Turned on command recording.
3) Defined a new expression.
4) Turned off command recording and confirmed that the operator generated expressions were recorded in addition to the expression I just defined.

I did the same with the changes in place and when I turned off command recording, only the newly added expression was recorded.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
