### PR TITLE
Fix too large main window on Windows

### DIFF
--- a/src/gui/QvisMainWindow.C
+++ b/src/gui/QvisMainWindow.C
@@ -354,6 +354,11 @@
 //   Kathleen Biagas, Wed Apr 19 14:45:53 PDT 2023
 //   Replace '+' operator for '|' for QKeySequence.
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 #include <InstallationFunctions.h>
 QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
@@ -749,7 +754,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
     spinModeAct = winPopup->addAction(tr("Spin mode"),
                                      this, SLOT(toggleSpinMode()));
 
-    if(qApp->primaryScreen()->geometry().height() < MIN_WINDOW_HEIGHT_BEFORE_POSTING_MAIN)
+    if(qApp->primaryScreen()->availableGeometry().height() < MIN_WINDOW_HEIGHT_BEFORE_POSTING_MAIN)
     {
         splitter = 0;
 
@@ -765,7 +770,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
         pmw->ContentsWidget()->setMinimumHeight(400);
         CreateMainContents(pmw);
 
-        SetDefaultSplitterSizes(qApp->primaryScreen()->geometry().height());
+        SetDefaultSplitterSizes(qApp->primaryScreen()->availableGeometry().height());
 
         // Post the window
         pmw->post(true);
@@ -791,7 +796,7 @@ QvisMainWindow::QvisMainWindow(int orientation, const char *captionString)
         notepad = new QvisNotepadArea(splitter);
 
         // May want to read these from the config file but here are the defaults.
-        SetDefaultSplitterSizes(qApp->primaryScreen()->geometry().height());
+        SetDefaultSplitterSizes(qApp->primaryScreen()->availableGeometry().height());
     }
 
     // Add the Help menu

--- a/src/gui/QvisScreenPositionEdit.C
+++ b/src/gui/QvisScreenPositionEdit.C
@@ -256,6 +256,11 @@ QvisScreenPositionEdit::newScreenPosition(double x, double y)
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
@@ -273,9 +278,9 @@ QvisScreenPositionEdit::popup()
     // Fix the X dimension.
     if(menuX < 0)
         menuX = 0;
-    else if(menuX + menuW > QApplication::primaryScreen()->geometry().width())
+    else if(menuX + menuW > QApplication::primaryScreen()->availableGeometry().width())
     {
-        int extrapixels = QApplication::primaryScreen()->geometry().width() - menuX - menuW;
+        int extrapixels = QApplication::primaryScreen()->availableGeometry().width() - menuX - menuW;
         menuX -= (extrapixels + 5);
     }
 

--- a/src/gui/QvisWindowBase.C
+++ b/src/gui/QvisWindowBase.C
@@ -281,14 +281,19 @@ QvisWindowBase::SetFromNode(DataNode *parentNode, const int *borders)
 // Modifications:
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
-//   
+//
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
 QvisWindowBase::FitToScreen(int &x, int &y, int &w, int &h)
 {
-    const int screenW = qApp->primaryScreen()->geometry().width();
-    const int screenH = qApp->primaryScreen()->geometry().height();
+    const int screenW = qApp->primaryScreen()->availableGeometry().width();
+    const int screenH = qApp->primaryScreen()->availableGeometry().height();
 
     if(x + w > screenW)
     {

--- a/src/gui/SplashScreen.C
+++ b/src/gui/SplashScreen.C
@@ -499,14 +499,19 @@ SplashScreen::CreateAboutButtons()
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
 SplashScreen::show()
 {
     // Figure out where to put the window
-    int     W = qApp->primaryScreen()->geometry().width();
-    int     H = qApp->primaryScreen()->geometry().height();
+    int     W = qApp->primaryScreen()->availableGeometry().width();
+    int     H = qApp->primaryScreen()->availableGeometry().height();
     move((W - pictures[0].width()) / 2, (H - pictures[0].height()) / 2);
 
     // Show the window

--- a/src/plots/Volume/QvisVolumePlotWindow.C
+++ b/src/plots/Volume/QvisVolumePlotWindow.C
@@ -3027,6 +3027,11 @@ QvisVolumePlotWindow::controlPointMoved(int, float)
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
@@ -3046,14 +3051,14 @@ QvisVolumePlotWindow::popupColorSelect(int index, const QPoint &p)
     // Fix the X dimension.
     if(menuX < 0)
         menuX = 0;
-    else if(menuX + menuW > QApplication::primaryScreen()->geometry().width())
+    else if(menuX + menuW > QApplication::primaryScreen()->availableGeometry().width())
         menuX -= (menuW + 5);
 
     // Fix the Y dimension.
     if(menuY < 0)
         menuY = 0;
-    else if(menuY + menuH > QApplication::primaryScreen()->geometry().height())
-        menuY -= ((menuY + menuH) - QApplication::primaryScreen()->geometry().height());
+    else if(menuY + menuH > QApplication::primaryScreen()->availableGeometry().height())
+        menuY -= ((menuY + menuH) - QApplication::primaryScreen()->availableGeometry().height());
 
     // Show the popup menu.
     colorSelect->move(menuX, menuY);

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -58,6 +58,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Disabled rich text paste support in the Commands Window and Expressions Editor. Avoids battles with cut and pasted text from editors that embed formatting, such as vscode.</li>
   <li>Fixed a bug causing Color Table Window tags to be duplicated when loading a session file.</li>
   <li>Save session file now takes existing session file names into account to avoid naming collisions.</li>
+  <li>Fixed a bug where bottom of main GUI window would be hidden behind the Windows taskbar.</li>
 </ul>
 
 <a name="CLI_changes"></a>

--- a/src/tools/examples/mcurvit/QvisColorButton.C
+++ b/src/tools/examples/mcurvit/QvisColorButton.C
@@ -384,6 +384,11 @@ QvisColorButton::buttonColor() const
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
@@ -421,14 +426,14 @@ QvisColorButton::popupPressed()
         // Fix the X dimension.
         if(menuX < 0)
            menuX = 0;
-        else if(menuX + menuW > QApplication::primaryScreen()->geometry().width())
+        else if(menuX + menuW > QApplication::primaryScreen()->availableGeometry().width())
            menuX -= (menuW + 5);
 
         // Fix the Y dimension.
         if(menuY < 0)
            menuY = 0;
-        else if(menuY + menuH > QApplication::primaryScreen()->geometry().height())
-           menuY -= ((menuY + menuH) - QApplication::primaryScreen()->geometry().height());
+        else if(menuY + menuH > QApplication::primaryScreen()->availableGeometry().height())
+           menuY -= ((menuY + menuH) - QApplication::primaryScreen()->availableGeometry().height());
 
         // Show the popup menu.         
         popup->move(menuX, menuY);

--- a/src/viewer/main/ViewerSubject.C
+++ b/src/viewer/main/ViewerSubject.C
@@ -1909,6 +1909,11 @@ ViewerSubject::ProcessEvents()
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
@@ -1984,7 +1989,7 @@ ViewerSubject::InitializeWorkArea()
                 wmShift[0] = 0;
                 wmShift[1] = 22;
 
-                QRect geom = qApp->primaryScreen()->geometry();
+                QRect geom = qApp->primaryScreen()->availableGeometry();
                 wmScreen[0] = geom.width();
                 wmScreen[1] = geom.height();
                 wmScreen[2] = geom.x();

--- a/src/viewer/main/ui/ViewerConnectionProgressDialog.C
+++ b/src/viewer/main/ui/ViewerConnectionProgressDialog.C
@@ -328,6 +328,11 @@ ViewerConnectionProgressDialog::hide()
 //   Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //   Replace obosolete desktop() with primaryScreen().
 //
+//   Kathleen Biagas, Mon Aug 18, 2025 
+//   Replace 'primaryScreen()->geometry()' with
+//   'primaryScreen()->availableGeometry()' since the latter takes into
+//   account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
@@ -339,8 +344,8 @@ ViewerConnectionProgressDialog::timedShow()
         raise();
         
         // Move the window a little above center.
-        int w = qApp->primaryScreen()->geometry().width();
-        int h = qApp->primaryScreen()->geometry().height();
+        int w = qApp->primaryScreen()->availableGeometry().width();
+        int h = qApp->primaryScreen()->availableGeometry().height();
         int x = (w - width()) / 2;
         int y = (h - height()) / 2 - (height() * 6 / 5);
         move(x, y);

--- a/src/winutil/QvisNoDefaultColorTableButton.C
+++ b/src/winutil/QvisNoDefaultColorTableButton.C
@@ -342,6 +342,11 @@ QvisNoDefaultColorTableButton::getButtonType() const
 //    Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //    Replace obosolete desktop() with primaryScreen().
 //
+//    Kathleen Biagas, Mon Aug 18, 2025 
+//    Replace 'primaryScreen()->geometry()' with
+//    'primaryScreen()->availableGeometry()' since the latter takes into
+//    account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 
 void
@@ -375,14 +380,14 @@ QvisNoDefaultColorTableButton::popupPressed()
         // Fix the X dimension.
         if(menuX < 0)
            menuX = 0;
-        else if(menuX + menuW > QApplication::primaryScreen()->geometry().width())
+        else if(menuX + menuW > QApplication::primaryScreen()->availableGeometry().width())
            menuX -= (menuW + 5);
 
         // Fix the Y dimension.
         if(menuY < 0)
            menuY = 0;
-        else if(menuY + menuH > QApplication::primaryScreen()->geometry().height())
-           menuY -= ((menuY + menuH) - QApplication::primaryScreen()->geometry().height());
+        else if(menuY + menuH > QApplication::primaryScreen()->availableGeometry().height())
+           menuY -= ((menuY + menuH) - QApplication::primaryScreen()->availableGeometry().height());
 
         // Show the popup menu.
         colorTableMenu[buttonType]->exec(QPoint(menuX, menuY));

--- a/src/winutil/WindowMetrics.C
+++ b/src/winutil/WindowMetrics.C
@@ -146,13 +146,18 @@ WindowMetrics::WindowMetrics()
 //    Kathleen Biagas, Wed Apr  5 13:04:35 PDT 2023
 //    Replace obosolete desktop() with primaryScreen().
 //
+//    Kathleen Biagas, Mon Aug 18, 2025 
+//    Replace 'primaryScreen()->geometry()' with
+//    'primaryScreen()->availableGeometry()' since the latter takes into
+//    account window manager reserved space like the Windows taskbar. 
+//
 // ****************************************************************************
 void
 WindowMetrics::CalculateScreen(QWidget *win,
                                int &screenX, int &screenY,
                                int &screenW, int &screenH)
 {
-    QRect rect = qApp->primaryScreen()->geometry();
+    QRect rect = qApp->primaryScreen()->availableGeometry();
     screenX = rect.x();
 #if defined(Q_OS_MAC)
     screenY = 0;
@@ -507,8 +512,8 @@ WindowMetrics::CalculateBorders(QWidget *win,
     int border_width = leaf_attributes.border_width;
     int big_height = 0, big_width = 0;
 
-    int desktop_width  = qApp->primaryScreen()->geometry().width();
-    int desktop_height = qApp->primaryScreen()->geometry().height();
+    int desktop_width  = qApp->primaryScreen()->availableGeometry().width();
+    int desktop_height = qApp->primaryScreen()->availableGeometry().height();
 
     // Start progressing up the tree.
     int count = 0;


### PR DESCRIPTION
### Description

Resolves #20428

I changed all instances of using `primaryScreen()->geometry()`
 to `primaryScreen()->availableGeometry()` since the latter takes into account window manager reserved space like the Windows taskbar.

According to the Qt documentation, `availableGeometry` may behave the same as `geometry` on Linux depending on the window manager.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

I ran VisIt on my Windows laptop (using laptop screen) with taskbar visible, and the main gui window fit within the viewable space (with bottom of the window above the taskbar).
I did the same with the taskbar hidden, and the gui window again fit within the visible space (all the way to the bottom of the screen).
I then performed the same tests with an external monitor with same results.

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
