### PR TITLE
rein in unit launcher test output

### DIFF
--- a/src/tools/dev/scripts/regressiontest_poodle
+++ b/src/tools/dev/scripts/regressiontest_poodle
@@ -178,6 +178,10 @@
 #   Eric Brugger, Mon Mar  3 09:11:37 PST 2025
 #   Include the actual hostname in the name of the sbatch output filename.
 # 
+#   Cyrus Harrison, 
+#   Removed cuda LD_LIBRARY_PATH Wed Sep 10 11:57:45 PDT 2025
+# 
+
 
 # Determine the users name and e-mail address.
 #

--- a/test/baseline/unit/launcher/msub_aprun.txt
+++ b/test/baseline/unit/launcher/msub_aprun.txt
@@ -4,7 +4,7 @@ CASE: msub/aprun
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/aprun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/aprun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/aprun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/aprun -np 8 -nn 1 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=1:ppn=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_ibrun.txt
+++ b/test/baseline/unit/launcher/msub_ibrun.txt
@@ -4,7 +4,7 @@ CASE: msub/ibrun
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/ibrun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/ibrun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/ibrun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/ibrun -np 8 -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_mpiexec.txt
+++ b/test/baseline/unit/launcher/msub_mpiexec.txt
@@ -4,7 +4,7 @@ CASE: msub/mpiexec
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -23,7 +23,7 @@ CASE: msub/mpiexec -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -42,7 +42,7 @@ CASE: msub/mpiexec -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -61,7 +61,7 @@ CASE: msub/mpiexec -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpiexec -np 8 -slpre "echo 'slprecommand'" -slpost "echo 'slpostcommand'" -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_mpirun.txt
+++ b/test/baseline/unit/launcher/msub_mpirun.txt
@@ -4,7 +4,7 @@ CASE: msub/mpirun
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/mpirun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/mpirun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/mpirun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/mpirun -np 8 -sla "-arg1 -arg2" -machinefile machine.txt -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/msub_srun.txt
+++ b/test/baseline/unit/launcher/msub_srun.txt
@@ -4,7 +4,7 @@ CASE: msub/srun
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -21,7 +21,7 @@ CASE: msub/srun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -38,7 +38,7 @@ CASE: msub/srun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -55,7 +55,7 @@ CASE: msub/srun -strace engine_par
 INPUT: visit -engine -norun engine_par -l msub/srun -np 8 -sla "-arg1 -arg2" -hw-pre startx -hw-post stopx -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
+msub -v HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins -l nodes=8:ppn=1 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/sbatch.txt
+++ b/test/baseline/unit/launcher/sbatch.txt
@@ -4,7 +4,7 @@ CASE: sbatch
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -19,7 +19,7 @@ CASE: sbatch -totalview engine_par
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -34,7 +34,7 @@ CASE: sbatch -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -49,7 +49,7 @@ CASE: sbatch -strace engine_par
 INPUT: visit -engine -norun engine_par -l sbatch -np 8 -p pbatch -b bdivp -nn 1 -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh

--- a/test/baseline/unit/launcher/sbatch_aprun.txt
+++ b/test/baseline/unit/launcher/sbatch_aprun.txt
@@ -4,7 +4,7 @@ CASE: sbatch/aprun
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -19,7 +19,7 @@ CASE: sbatch/aprun -totalview engine_par
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600 -totalview engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -34,7 +34,7 @@ CASE: sbatch/aprun -valgrind engine_par
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600 -valgrind engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh
@@ -49,7 +49,7 @@ CASE: sbatch/aprun -strace engine_par
 INPUT: visit -engine -norun engine_par -l sbatch/aprun -np 8 -p pbatch -b bdivp -nn 1 -sla "-arg1 -arg2" -host 127.0.0.1 -port 5600 -strace engine_par
 
 RESULTS:
-sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib:/usr/tce/packages/texlive/texlive-20220321/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
+sbatch --export=HOME=$HOME,LIBPATH=$VISITDIR/lib,LD_LIBRARY_PATH=$VISITDIR/lib/mesagl:$VISITDIR/lib,VISITHOME=$VISITDIR,VISITARCHHOME=$VISITDIR/,VISITPLUGINDIR=$HOME/.visit/$VERSION/$PLATFORM/plugins:$VISITDIR/plugins,PYTHONHOME=$VISITDIR/lib/python --partition=pbatch --account=bdivp --ntasks=8 --nodes=1 --tasks-per-node=8 $LAUNCHSCRIPT
 
 Contents of $LAUNCHSCRIPT:
 #!/bin/sh


### PR DESCRIPTION
More test suite fixes.

- Remove cuda LD_LIB_PATH, we are not running on a cuda system
- Strip text live entry b/c that doens't seem to exist in batch.