### PR TITLE
Updated volume rendering to use AnariAttributes

### DIFF
--- a/src/plots/Volume/PyVolumeAttributes.C
+++ b/src/plots/Volume/PyVolumeAttributes.C
@@ -9,6 +9,7 @@
 #include <Py2and3Support.h>
 #include <PyColorControlPointList.h>
 #include <PyGaussianControlPointList.h>
+#include <PyAnariAttributes.h>
 
 // ****************************************************************************
 // Module: PyVolumeAttributes
@@ -413,53 +414,10 @@ PyVolumeAttributes_ToString(const VolumeAttributes *atts, const char *prefix, co
         snprintf(tmpStr, 1000, ")\n");
         str += tmpStr;
     }
-    if(atts->GetAnariRendering())
-        snprintf(tmpStr, 1000, "%sanariRendering = 1\n", prefix);
-    else
-        snprintf(tmpStr, 1000, "%sanariRendering = 0\n", prefix);
-    str += tmpStr;
-    snprintf(tmpStr, 1000, "%sanariLibrary = \"%s\"\n", prefix, atts->GetAnariLibrary().c_str());
-    str += tmpStr;
-    snprintf(tmpStr, 1000, "%sanariLibrarySubtype = \"%s\"\n", prefix, atts->GetAnariLibrarySubtype().c_str());
-    str += tmpStr;
-    snprintf(tmpStr, 1000, "%sanariRendererSubtype = \"%s\"\n", prefix, atts->GetAnariRendererSubtype().c_str());
-    str += tmpStr;
-    if(atts->GetUsingUsdDevice())
-        snprintf(tmpStr, 1000, "%susingUsdDevice = 1\n", prefix);
-    else
-        snprintf(tmpStr, 1000, "%susingUsdDevice = 0\n", prefix);
-    str += tmpStr;
-    {   const stringVector &anariRendererParameters = atts->GetAnariRendererParameters();
-        snprintf(tmpStr, 1000, "%sanariRendererParameters = (", prefix);
-        str += tmpStr;
-        for(size_t i = 0; i < anariRendererParameters.size(); ++i)
-        {
-            snprintf(tmpStr, 1000, "\"%s\"", anariRendererParameters[i].c_str());
-            str += tmpStr;
-            if(i < anariRendererParameters.size() - 1)
-            {
-                snprintf(tmpStr, 1000, ", ");
-                str += tmpStr;
-            }
-        }
-        snprintf(tmpStr, 1000, ")\n");
-        str += tmpStr;
-    }
-    {   const stringVector &anariUSDParameters = atts->GetAnariUSDParameters();
-        snprintf(tmpStr, 1000, "%sanariUSDParameters = (", prefix);
-        str += tmpStr;
-        for(size_t i = 0; i < anariUSDParameters.size(); ++i)
-        {
-            snprintf(tmpStr, 1000, "\"%s\"", anariUSDParameters[i].c_str());
-            str += tmpStr;
-            if(i < anariUSDParameters.size() - 1)
-            {
-                snprintf(tmpStr, 1000, ", ");
-                str += tmpStr;
-            }
-        }
-        snprintf(tmpStr, 1000, ")\n");
-        str += tmpStr;
+    { // new scope
+        std::string objPrefix(prefix);
+        objPrefix += "anariAttributes.";
+        str += PyAnariAttributes_ToString(&atts->GetAnariAttributes(), objPrefix.c_str(), forLogging);
     }
     return str;
 }
@@ -3252,407 +3210,35 @@ VolumeAttributes_GetMaterialProperties(PyObject *self, PyObject *args)
 }
 
 /*static*/ PyObject *
-VolumeAttributes_SetAnariRendering(PyObject *self, PyObject *args)
+VolumeAttributes_SetAnariAttributes(PyObject *self, PyObject *args)
 {
     PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
 
-    PyObject *packaged_args = 0;
+    PyObject *newValue = NULL;
+    if(!PyArg_ParseTuple(args, "O", &newValue))
+        return NULL;
+    if(!PyAnariAttributes_Check(newValue))
+        return PyErr_Format(PyExc_TypeError, "Field anariAttributes can be set only with AnariAttributes objects");
 
-    // Handle args packaged into a tuple of size one
-    // if we think the unpackaged args matches our needs
-    if (PySequence_Check(args) && PySequence_Size(args) == 1)
-    {
-        packaged_args = PySequence_GetItem(args, 0);
-        if (PyNumber_Check(packaged_args))
-            args = packaged_args;
-    }
-
-    if (PySequence_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "expecting a single number arg");
-    }
-
-    if (!PyNumber_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "arg is not a number type");
-    }
-
-    long val = PyLong_AsLong(args);
-    bool cval = bool(val);
-
-    if (val == -1 && PyErr_Occurred())
-    {
-        Py_XDECREF(packaged_args);
-        PyErr_Clear();
-        return PyErr_Format(PyExc_TypeError, "arg not interpretable as C++ bool");
-    }
-    if (fabs(double(val))>1.5E-7 && fabs((double(long(cval))-double(val))/double(val))>1.5E-7)
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_ValueError, "arg not interpretable as C++ bool");
-    }
-
-    Py_XDECREF(packaged_args);
-
-    // Set the anariRendering in the object.
-    obj->data->SetAnariRendering(cval);
+    obj->data->SetAnariAttributes(*PyAnariAttributes_FromPyObject(newValue));
 
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 /*static*/ PyObject *
-VolumeAttributes_GetAnariRendering(PyObject *self, PyObject *args)
+VolumeAttributes_GetAnariAttributes(PyObject *self, PyObject *args)
 {
     PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    PyObject *retval = PyInt_FromLong(obj->data->GetAnariRendering()?1L:0L);
-    return retval;
-}
+    // Since the new object will point to data owned by this object,
+    // we need to increment the reference count.
+    Py_INCREF(self);
 
-/*static*/ PyObject *
-VolumeAttributes_SetAnariLibrary(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
+    PyObject *retval = PyAnariAttributes_Wrap(&obj->data->GetAnariAttributes());
+    // Set the object's parent so the reference to the parent can be decref'd
+    // when the child goes out of scope.
+    PyAnariAttributes_SetParent(retval, self);
 
-    PyObject *packaged_args = 0;
-
-    // Handle args packaged as first member of a tuple of size one
-    // if we think the unpackaged args matches our needs
-    if (PySequence_Check(args) && PySequence_Size(args) == 1)
-    {
-        packaged_args = PySequence_GetItem(args, 0);
-        if (PyUnicode_Check(packaged_args))
-            args = packaged_args;
-    }
-
-    if (!PyUnicode_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "arg is not a unicode string");
-    }
-
-    char const *val = PyUnicode_AsUTF8(args);
-    std::string cval = std::string(val);
-
-    if (val == 0 && PyErr_Occurred())
-    {
-        Py_XDECREF(packaged_args);
-        PyErr_Clear();
-        return PyErr_Format(PyExc_TypeError, "arg not interpretable as utf8 string");
-    }
-
-    Py_XDECREF(packaged_args);
-
-    // Set the anariLibrary in the object.
-    obj->data->SetAnariLibrary(cval);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_GetAnariLibrary(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    PyObject *retval = PyString_FromString(obj->data->GetAnariLibrary().c_str());
-    return retval;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_SetAnariLibrarySubtype(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-
-    PyObject *packaged_args = 0;
-
-    // Handle args packaged as first member of a tuple of size one
-    // if we think the unpackaged args matches our needs
-    if (PySequence_Check(args) && PySequence_Size(args) == 1)
-    {
-        packaged_args = PySequence_GetItem(args, 0);
-        if (PyUnicode_Check(packaged_args))
-            args = packaged_args;
-    }
-
-    if (!PyUnicode_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "arg is not a unicode string");
-    }
-
-    char const *val = PyUnicode_AsUTF8(args);
-    std::string cval = std::string(val);
-
-    if (val == 0 && PyErr_Occurred())
-    {
-        Py_XDECREF(packaged_args);
-        PyErr_Clear();
-        return PyErr_Format(PyExc_TypeError, "arg not interpretable as utf8 string");
-    }
-
-    Py_XDECREF(packaged_args);
-
-    // Set the anariLibrarySubtype in the object.
-    obj->data->SetAnariLibrarySubtype(cval);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_GetAnariLibrarySubtype(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    PyObject *retval = PyString_FromString(obj->data->GetAnariLibrarySubtype().c_str());
-    return retval;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_SetAnariRendererSubtype(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-
-    PyObject *packaged_args = 0;
-
-    // Handle args packaged as first member of a tuple of size one
-    // if we think the unpackaged args matches our needs
-    if (PySequence_Check(args) && PySequence_Size(args) == 1)
-    {
-        packaged_args = PySequence_GetItem(args, 0);
-        if (PyUnicode_Check(packaged_args))
-            args = packaged_args;
-    }
-
-    if (!PyUnicode_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "arg is not a unicode string");
-    }
-
-    char const *val = PyUnicode_AsUTF8(args);
-    std::string cval = std::string(val);
-
-    if (val == 0 && PyErr_Occurred())
-    {
-        Py_XDECREF(packaged_args);
-        PyErr_Clear();
-        return PyErr_Format(PyExc_TypeError, "arg not interpretable as utf8 string");
-    }
-
-    Py_XDECREF(packaged_args);
-
-    // Set the anariRendererSubtype in the object.
-    obj->data->SetAnariRendererSubtype(cval);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_GetAnariRendererSubtype(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    PyObject *retval = PyString_FromString(obj->data->GetAnariRendererSubtype().c_str());
-    return retval;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_SetUsingUsdDevice(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-
-    PyObject *packaged_args = 0;
-
-    // Handle args packaged into a tuple of size one
-    // if we think the unpackaged args matches our needs
-    if (PySequence_Check(args) && PySequence_Size(args) == 1)
-    {
-        packaged_args = PySequence_GetItem(args, 0);
-        if (PyNumber_Check(packaged_args))
-            args = packaged_args;
-    }
-
-    if (PySequence_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "expecting a single number arg");
-    }
-
-    if (!PyNumber_Check(args))
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_TypeError, "arg is not a number type");
-    }
-
-    long val = PyLong_AsLong(args);
-    bool cval = bool(val);
-
-    if (val == -1 && PyErr_Occurred())
-    {
-        Py_XDECREF(packaged_args);
-        PyErr_Clear();
-        return PyErr_Format(PyExc_TypeError, "arg not interpretable as C++ bool");
-    }
-    if (fabs(double(val))>1.5E-7 && fabs((double(long(cval))-double(val))/double(val))>1.5E-7)
-    {
-        Py_XDECREF(packaged_args);
-        return PyErr_Format(PyExc_ValueError, "arg not interpretable as C++ bool");
-    }
-
-    Py_XDECREF(packaged_args);
-
-    // Set the usingUsdDevice in the object.
-    obj->data->SetUsingUsdDevice(cval);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_GetUsingUsdDevice(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    PyObject *retval = PyInt_FromLong(obj->data->GetUsingUsdDevice()?1L:0L);
-    return retval;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_SetAnariRendererParameters(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-
-    stringVector vec;
-
-    if (PyUnicode_Check(args))
-    {
-        char const *val = PyUnicode_AsUTF8(args);
-        std::string cval = std::string(val);
-        if (val == 0 && PyErr_Occurred())
-        {
-            PyErr_Clear();
-            return PyErr_Format(PyExc_TypeError, "arg not interpretable as C++ string");
-        }
-        vec.resize(1);
-        vec[0] = cval;
-    }
-    else if (PySequence_Check(args))
-    {
-        vec.resize(PySequence_Size(args));
-        for (Py_ssize_t i = 0; i < PySequence_Size(args); i++)
-        {
-            PyObject *item = PySequence_GetItem(args, i);
-
-            if (!PyUnicode_Check(item))
-            {
-                Py_DECREF(item);
-                return PyErr_Format(PyExc_TypeError, "arg %d is not a unicode string", (int) i);
-            }
-
-            char const *val = PyUnicode_AsUTF8(item);
-            std::string cval = std::string(val);
-
-            if (val == 0 && PyErr_Occurred())
-            {
-                Py_DECREF(item);
-                PyErr_Clear();
-                return PyErr_Format(PyExc_TypeError, "arg %d not interpretable as C++ string", (int) i);
-            }
-            Py_DECREF(item);
-
-            vec[i] = cval;
-        }
-    }
-    else
-        return PyErr_Format(PyExc_TypeError, "arg(s) must be one or more string(s)");
-
-    obj->data->GetAnariRendererParameters() = vec;
-    // Mark the anariRendererParameters in the object as modified.
-    obj->data->SelectAnariRendererParameters();
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_GetAnariRendererParameters(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    // Allocate a tuple the with enough entries to hold the anariRendererParameters.
-    const stringVector &anariRendererParameters = obj->data->GetAnariRendererParameters();
-    PyObject *retval = PyTuple_New(anariRendererParameters.size());
-    for(size_t i = 0; i < anariRendererParameters.size(); ++i)
-        PyTuple_SET_ITEM(retval, i, PyString_FromString(anariRendererParameters[i].c_str()));
-    return retval;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_SetAnariUSDParameters(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-
-    stringVector vec;
-
-    if (PyUnicode_Check(args))
-    {
-        char const *val = PyUnicode_AsUTF8(args);
-        std::string cval = std::string(val);
-        if (val == 0 && PyErr_Occurred())
-        {
-            PyErr_Clear();
-            return PyErr_Format(PyExc_TypeError, "arg not interpretable as C++ string");
-        }
-        vec.resize(1);
-        vec[0] = cval;
-    }
-    else if (PySequence_Check(args))
-    {
-        vec.resize(PySequence_Size(args));
-        for (Py_ssize_t i = 0; i < PySequence_Size(args); i++)
-        {
-            PyObject *item = PySequence_GetItem(args, i);
-
-            if (!PyUnicode_Check(item))
-            {
-                Py_DECREF(item);
-                return PyErr_Format(PyExc_TypeError, "arg %d is not a unicode string", (int) i);
-            }
-
-            char const *val = PyUnicode_AsUTF8(item);
-            std::string cval = std::string(val);
-
-            if (val == 0 && PyErr_Occurred())
-            {
-                Py_DECREF(item);
-                PyErr_Clear();
-                return PyErr_Format(PyExc_TypeError, "arg %d not interpretable as C++ string", (int) i);
-            }
-            Py_DECREF(item);
-
-            vec[i] = cval;
-        }
-    }
-    else
-        return PyErr_Format(PyExc_TypeError, "arg(s) must be one or more string(s)");
-
-    obj->data->GetAnariUSDParameters() = vec;
-    // Mark the anariUSDParameters in the object as modified.
-    obj->data->SelectAnariUSDParameters();
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-/*static*/ PyObject *
-VolumeAttributes_GetAnariUSDParameters(PyObject *self, PyObject *args)
-{
-    PyVolumeAttributesObject *obj = (PyVolumeAttributesObject *)self;
-    // Allocate a tuple the with enough entries to hold the anariUSDParameters.
-    const stringVector &anariUSDParameters = obj->data->GetAnariUSDParameters();
-    PyObject *retval = PyTuple_New(anariUSDParameters.size());
-    for(size_t i = 0; i < anariUSDParameters.size(); ++i)
-        PyTuple_SET_ITEM(retval, i, PyString_FromString(anariUSDParameters[i].c_str()));
     return retval;
 }
 
@@ -3751,20 +3337,8 @@ PyMethodDef PyVolumeAttributes_methods[VOLUMEATTRIBUTES_NMETH] = {
     {"GetLowGradientLightingClampValue", VolumeAttributes_GetLowGradientLightingClampValue, METH_VARARGS},
     {"SetMaterialProperties", VolumeAttributes_SetMaterialProperties, METH_VARARGS},
     {"GetMaterialProperties", VolumeAttributes_GetMaterialProperties, METH_VARARGS},
-    {"SetAnariRendering", VolumeAttributes_SetAnariRendering, METH_VARARGS},
-    {"GetAnariRendering", VolumeAttributes_GetAnariRendering, METH_VARARGS},
-    {"SetAnariLibrary", VolumeAttributes_SetAnariLibrary, METH_VARARGS},
-    {"GetAnariLibrary", VolumeAttributes_GetAnariLibrary, METH_VARARGS},
-    {"SetAnariLibrarySubtype", VolumeAttributes_SetAnariLibrarySubtype, METH_VARARGS},
-    {"GetAnariLibrarySubtype", VolumeAttributes_GetAnariLibrarySubtype, METH_VARARGS},
-    {"SetAnariRendererSubtype", VolumeAttributes_SetAnariRendererSubtype, METH_VARARGS},
-    {"GetAnariRendererSubtype", VolumeAttributes_GetAnariRendererSubtype, METH_VARARGS},
-    {"SetUsingUsdDevice", VolumeAttributes_SetUsingUsdDevice, METH_VARARGS},
-    {"GetUsingUsdDevice", VolumeAttributes_GetUsingUsdDevice, METH_VARARGS},
-    {"SetAnariRendererParameters", VolumeAttributes_SetAnariRendererParameters, METH_VARARGS},
-    {"GetAnariRendererParameters", VolumeAttributes_GetAnariRendererParameters, METH_VARARGS},
-    {"SetAnariUSDParameters", VolumeAttributes_SetAnariUSDParameters, METH_VARARGS},
-    {"GetAnariUSDParameters", VolumeAttributes_GetAnariUSDParameters, METH_VARARGS},
+    {"SetAnariAttributes", VolumeAttributes_SetAnariAttributes, METH_VARARGS},
+    {"GetAnariAttributes", VolumeAttributes_GetAnariAttributes, METH_VARARGS},
     {NULL, NULL}
 };
 
@@ -3963,20 +3537,8 @@ PyVolumeAttributes_getattro(PyObject *self, PyObject *attr_name)
         return VolumeAttributes_GetLowGradientLightingClampValue(self, NULL);
     if(strcmp(name, "materialProperties") == 0)
         return VolumeAttributes_GetMaterialProperties(self, NULL);
-    if(strcmp(name, "anariRendering") == 0)
-        return VolumeAttributes_GetAnariRendering(self, NULL);
-    if(strcmp(name, "anariLibrary") == 0)
-        return VolumeAttributes_GetAnariLibrary(self, NULL);
-    if(strcmp(name, "anariLibrarySubtype") == 0)
-        return VolumeAttributes_GetAnariLibrarySubtype(self, NULL);
-    if(strcmp(name, "anariRendererSubtype") == 0)
-        return VolumeAttributes_GetAnariRendererSubtype(self, NULL);
-    if(strcmp(name, "usingUsdDevice") == 0)
-        return VolumeAttributes_GetUsingUsdDevice(self, NULL);
-    if(strcmp(name, "anariRendererParameters") == 0)
-        return VolumeAttributes_GetAnariRendererParameters(self, NULL);
-    if(strcmp(name, "anariUSDParameters") == 0)
-        return VolumeAttributes_GetAnariUSDParameters(self, NULL);
+    if(strcmp(name, "anariAttributes") == 0)
+        return VolumeAttributes_GetAnariAttributes(self, NULL);
 
     PyObject *meth = Py_FindMethod(PyVolumeAttributes_methods, self, (char*)name);
     if (meth) return meth;
@@ -4082,20 +3644,8 @@ PyVolumeAttributes_setattro(PyObject *self, PyObject *attr_name, PyObject *args)
         obj = VolumeAttributes_SetLowGradientLightingClampValue(self, args);
     else if(strcmp(name, "materialProperties") == 0)
         obj = VolumeAttributes_SetMaterialProperties(self, args);
-    else if(strcmp(name, "anariRendering") == 0)
-        obj = VolumeAttributes_SetAnariRendering(self, args);
-    else if(strcmp(name, "anariLibrary") == 0)
-        obj = VolumeAttributes_SetAnariLibrary(self, args);
-    else if(strcmp(name, "anariLibrarySubtype") == 0)
-        obj = VolumeAttributes_SetAnariLibrarySubtype(self, args);
-    else if(strcmp(name, "anariRendererSubtype") == 0)
-        obj = VolumeAttributes_SetAnariRendererSubtype(self, args);
-    else if(strcmp(name, "usingUsdDevice") == 0)
-        obj = VolumeAttributes_SetUsingUsdDevice(self, args);
-    else if(strcmp(name, "anariRendererParameters") == 0)
-        obj = VolumeAttributes_SetAnariRendererParameters(self, args);
-    else if(strcmp(name, "anariUSDParameters") == 0)
-        obj = VolumeAttributes_SetAnariUSDParameters(self, args);
+    else if(strcmp(name, "anariAttributes") == 0)
+        obj = VolumeAttributes_SetAnariAttributes(self, args);
 
     if (obj == &NULL_PY_OBJ && PyObject_GenericSetAttr(self, attr_name, args) == 0)
     {

--- a/src/plots/Volume/PyVolumeAttributes.h
+++ b/src/plots/Volume/PyVolumeAttributes.h
@@ -11,7 +11,7 @@
 //
 // Functions exposed to the VisIt module.
 //
-#define VOLUMEATTRIBUTES_NMETH 107
+#define VOLUMEATTRIBUTES_NMETH 95
 void           PyVolumeAttributes_StartUp(VolumeAttributes *subj, void *data);
 void           PyVolumeAttributes_CloseDown();
 PyMethodDef *  PyVolumeAttributes_GetMethodTable(int *nMethods);

--- a/src/plots/Volume/QvisVolumePlotWindow.C
+++ b/src/plots/Volume/QvisVolumePlotWindow.C
@@ -2244,23 +2244,8 @@ QvisVolumePlotWindow::UpdateWindow(bool doAll)
             osprayMaxContribution->blockSignals(false);
             break;
 #ifdef HAVE_ANARI
-        case VolumeAttributes::ID_anariRendering:
-            anariVolumeWidget->SetChecked(volumeAtts->GetAnariRendering());
-            break;
-        case VolumeAttributes::ID_anariLibrary:
-            anariVolumeWidget->UpdateLibraryName(volumeAtts->GetAnariLibrary());
-            break;
-        case VolumeAttributes::ID_anariLibrarySubtype:
-            anariVolumeWidget->UpdateLibrarySubtypes(volumeAtts->GetAnariLibrarySubtype());
-            break;
-        case VolumeAttributes::ID_anariRendererSubtype:
-            anariVolumeWidget->UpdateRendererSubtypes(volumeAtts->GetAnariRendererSubtype());
-            break;
-        case VolumeAttributes::ID_anariRendererParameters:
-            anariVolumeWidget->UpdateRendererParameters(volumeAtts->GetAnariRendererParameters());
-            break;
-        case VolumeAttributes::ID_anariUSDParameters:
-            anariVolumeWidget->UpdateUSDParameters(volumeAtts->GetAnariUSDParameters());
+        case VolumeAttributes::ID_anariAttributes:
+            anariVolumeWidget->UpdateAnariAttributes(volumeAtts->GetAnariAttributes());
             break;
 #endif
         }

--- a/src/plots/Volume/Volume.xml
+++ b/src/plots/Volume/Volume.xml
@@ -242,22 +242,7 @@
         0.000000
         15.000000
       </Field>
-      <Field name="anariRendering" label="ANARI Rendering" type="bool">
-        false
-      </Field>
-      <Field name="anariLibrary" label="ANARI Back-end Device" type="string">
-      </Field>
-      <Field name="anariLibrarySubtype" label="ANARI Back-end Device Subtype" type="string">
-      </Field>
-      <Field name="anariRendererSubtype" label="ANARI Renderer Subtype" type="string">
-        default
-      </Field>
-      <Field name="usingUsdDevice" label="Using USD Device" type="bool">
-        false
-      </Field>
-      <Field name="anariRendererParameters" label="ANARI Renderer Parameters" type="stringVector">
-      </Field>
-      <Field name="anariUSDParameters" label="ANARI USD Parameters" type="stringVector">
+      <Field name="anariAttributes" label="ANARI attributes" type="att" subtype="AnariAttributes">
       </Field>
       <Function name="ChangesRequireRecalculation" user="true" member="true">
       </Function>

--- a/src/plots/Volume/VolumeAttributes.C
+++ b/src/plots/Volume/VolumeAttributes.C
@@ -450,9 +450,6 @@ void VolumeAttributes::Init()
     materialProperties[1] = 0.75;
     materialProperties[2] = 0;
     materialProperties[3] = 15;
-    anariRendering = false;
-    anariRendererSubtype = "default";
-    usingUsdDevice = false;
 
     VolumeAttributes::SelectAll();
 }
@@ -524,13 +521,7 @@ void VolumeAttributes::Copy(const VolumeAttributes &obj)
     for(int i = 0; i < 4; ++i)
         materialProperties[i] = obj.materialProperties[i];
 
-    anariRendering = obj.anariRendering;
-    anariLibrary = obj.anariLibrary;
-    anariLibrarySubtype = obj.anariLibrarySubtype;
-    anariRendererSubtype = obj.anariRendererSubtype;
-    usingUsdDevice = obj.usingUsdDevice;
-    anariRendererParameters = obj.anariRendererParameters;
-    anariUSDParameters = obj.anariUSDParameters;
+    anariAttributes = obj.anariAttributes;
 
     VolumeAttributes::SelectAll();
 }
@@ -745,13 +736,7 @@ VolumeAttributes::operator == (const VolumeAttributes &obj) const
             (lowGradientLightingClampFlag == obj.lowGradientLightingClampFlag) &&
             (lowGradientLightingClampValue == obj.lowGradientLightingClampValue) &&
             materialProperties_equal &&
-            (anariRendering == obj.anariRendering) &&
-            (anariLibrary == obj.anariLibrary) &&
-            (anariLibrarySubtype == obj.anariLibrarySubtype) &&
-            (anariRendererSubtype == obj.anariRendererSubtype) &&
-            (usingUsdDevice == obj.usingUsdDevice) &&
-            (anariRendererParameters == obj.anariRendererParameters) &&
-            (anariUSDParameters == obj.anariUSDParameters));
+            (anariAttributes == obj.anariAttributes));
 }
 
 // ****************************************************************************
@@ -940,13 +925,7 @@ VolumeAttributes::SelectAll()
     Select(ID_lowGradientLightingClampFlag,    (void *)&lowGradientLightingClampFlag);
     Select(ID_lowGradientLightingClampValue,   (void *)&lowGradientLightingClampValue);
     Select(ID_materialProperties,              (void *)materialProperties, 4);
-    Select(ID_anariRendering,                  (void *)&anariRendering);
-    Select(ID_anariLibrary,                    (void *)&anariLibrary);
-    Select(ID_anariLibrarySubtype,             (void *)&anariLibrarySubtype);
-    Select(ID_anariRendererSubtype,            (void *)&anariRendererSubtype);
-    Select(ID_usingUsdDevice,                  (void *)&usingUsdDevice);
-    Select(ID_anariRendererParameters,         (void *)&anariRendererParameters);
-    Select(ID_anariUSDParameters,              (void *)&anariUSDParameters);
+    Select(ID_anariAttributes,                 (void *)&anariAttributes);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1261,46 +1240,16 @@ VolumeAttributes::CreateNode(DataNode *parentNode, bool completeSave, bool force
         node->AddNode(new DataNode("materialProperties", materialProperties, 4));
     }
 
-    if(completeSave || !FieldsEqual(ID_anariRendering, &defaultObject))
+    if(completeSave || !FieldsEqual(ID_anariAttributes, &defaultObject))
     {
-        addToParent = true;
-        node->AddNode(new DataNode("anariRendering", anariRendering));
-    }
-
-    if(completeSave || !FieldsEqual(ID_anariLibrary, &defaultObject))
-    {
-        addToParent = true;
-        node->AddNode(new DataNode("anariLibrary", anariLibrary));
-    }
-
-    if(completeSave || !FieldsEqual(ID_anariLibrarySubtype, &defaultObject))
-    {
-        addToParent = true;
-        node->AddNode(new DataNode("anariLibrarySubtype", anariLibrarySubtype));
-    }
-
-    if(completeSave || !FieldsEqual(ID_anariRendererSubtype, &defaultObject))
-    {
-        addToParent = true;
-        node->AddNode(new DataNode("anariRendererSubtype", anariRendererSubtype));
-    }
-
-    if(completeSave || !FieldsEqual(ID_usingUsdDevice, &defaultObject))
-    {
-        addToParent = true;
-        node->AddNode(new DataNode("usingUsdDevice", usingUsdDevice));
-    }
-
-    if(completeSave || !FieldsEqual(ID_anariRendererParameters, &defaultObject))
-    {
-        addToParent = true;
-        node->AddNode(new DataNode("anariRendererParameters", anariRendererParameters));
-    }
-
-    if(completeSave || !FieldsEqual(ID_anariUSDParameters, &defaultObject))
-    {
-        addToParent = true;
-        node->AddNode(new DataNode("anariUSDParameters", anariUSDParameters));
+        DataNode *anariAttributesNode = new DataNode("anariAttributes");
+        if(anariAttributes.CreateNode(anariAttributesNode, completeSave, false))
+        {
+            addToParent = true;
+            node->AddNode(anariAttributesNode);
+        }
+        else
+            delete anariAttributesNode;
     }
 
 
@@ -1569,20 +1518,8 @@ VolumeAttributes::SetFromNode(DataNode *parentNode)
         SetLowGradientLightingClampValue(node->AsDouble());
     if((node = searchNode->GetNode("materialProperties")) != 0)
         SetMaterialProperties(node->AsDoubleArray());
-    if((node = searchNode->GetNode("anariRendering")) != 0)
-        SetAnariRendering(node->AsBool());
-    if((node = searchNode->GetNode("anariLibrary")) != 0)
-        SetAnariLibrary(node->AsString());
-    if((node = searchNode->GetNode("anariLibrarySubtype")) != 0)
-        SetAnariLibrarySubtype(node->AsString());
-    if((node = searchNode->GetNode("anariRendererSubtype")) != 0)
-        SetAnariRendererSubtype(node->AsString());
-    if((node = searchNode->GetNode("usingUsdDevice")) != 0)
-        SetUsingUsdDevice(node->AsBool());
-    if((node = searchNode->GetNode("anariRendererParameters")) != 0)
-        SetAnariRendererParameters(node->AsStringVector());
-    if((node = searchNode->GetNode("anariUSDParameters")) != 0)
-        SetAnariUSDParameters(node->AsStringVector());
+    if((node = searchNode->GetNode("anariAttributes")) != 0)
+        anariAttributes.SetFromNode(node);
     if(colorControlPoints.GetNumControlPoints() < 2)
          SetDefaultColorControlPoints();
 
@@ -1912,52 +1849,10 @@ VolumeAttributes::SetMaterialProperties(const double *materialProperties_)
 }
 
 void
-VolumeAttributes::SetAnariRendering(bool anariRendering_)
+VolumeAttributes::SetAnariAttributes(const AnariAttributes &anariAttributes_)
 {
-    anariRendering = anariRendering_;
-    Select(ID_anariRendering, (void *)&anariRendering);
-}
-
-void
-VolumeAttributes::SetAnariLibrary(const std::string &anariLibrary_)
-{
-    anariLibrary = anariLibrary_;
-    Select(ID_anariLibrary, (void *)&anariLibrary);
-}
-
-void
-VolumeAttributes::SetAnariLibrarySubtype(const std::string &anariLibrarySubtype_)
-{
-    anariLibrarySubtype = anariLibrarySubtype_;
-    Select(ID_anariLibrarySubtype, (void *)&anariLibrarySubtype);
-}
-
-void
-VolumeAttributes::SetAnariRendererSubtype(const std::string &anariRendererSubtype_)
-{
-    anariRendererSubtype = anariRendererSubtype_;
-    Select(ID_anariRendererSubtype, (void *)&anariRendererSubtype);
-}
-
-void
-VolumeAttributes::SetUsingUsdDevice(bool usingUsdDevice_)
-{
-    usingUsdDevice = usingUsdDevice_;
-    Select(ID_usingUsdDevice, (void *)&usingUsdDevice);
-}
-
-void
-VolumeAttributes::SetAnariRendererParameters(const stringVector &anariRendererParameters_)
-{
-    anariRendererParameters = anariRendererParameters_;
-    Select(ID_anariRendererParameters, (void *)&anariRendererParameters);
-}
-
-void
-VolumeAttributes::SetAnariUSDParameters(const stringVector &anariUSDParameters_)
-{
-    anariUSDParameters = anariUSDParameters_;
-    Select(ID_anariUSDParameters, (void *)&anariUSDParameters);
+    anariAttributes = anariAttributes_;
+    Select(ID_anariAttributes, (void *)&anariAttributes);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2264,76 +2159,16 @@ VolumeAttributes::GetMaterialProperties()
     return materialProperties;
 }
 
-bool
-VolumeAttributes::GetAnariRendering() const
+const AnariAttributes &
+VolumeAttributes::GetAnariAttributes() const
 {
-    return anariRendering;
+    return anariAttributes;
 }
 
-const std::string &
-VolumeAttributes::GetAnariLibrary() const
+AnariAttributes &
+VolumeAttributes::GetAnariAttributes()
 {
-    return anariLibrary;
-}
-
-std::string &
-VolumeAttributes::GetAnariLibrary()
-{
-    return anariLibrary;
-}
-
-const std::string &
-VolumeAttributes::GetAnariLibrarySubtype() const
-{
-    return anariLibrarySubtype;
-}
-
-std::string &
-VolumeAttributes::GetAnariLibrarySubtype()
-{
-    return anariLibrarySubtype;
-}
-
-const std::string &
-VolumeAttributes::GetAnariRendererSubtype() const
-{
-    return anariRendererSubtype;
-}
-
-std::string &
-VolumeAttributes::GetAnariRendererSubtype()
-{
-    return anariRendererSubtype;
-}
-
-bool
-VolumeAttributes::GetUsingUsdDevice() const
-{
-    return usingUsdDevice;
-}
-
-const stringVector &
-VolumeAttributes::GetAnariRendererParameters() const
-{
-    return anariRendererParameters;
-}
-
-stringVector &
-VolumeAttributes::GetAnariRendererParameters()
-{
-    return anariRendererParameters;
-}
-
-const stringVector &
-VolumeAttributes::GetAnariUSDParameters() const
-{
-    return anariUSDParameters;
-}
-
-stringVector &
-VolumeAttributes::GetAnariUSDParameters()
-{
-    return anariUSDParameters;
+    return anariAttributes;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2371,33 +2206,9 @@ VolumeAttributes::SelectMaterialProperties()
 }
 
 void
-VolumeAttributes::SelectAnariLibrary()
+VolumeAttributes::SelectAnariAttributes()
 {
-    Select(ID_anariLibrary, (void *)&anariLibrary);
-}
-
-void
-VolumeAttributes::SelectAnariLibrarySubtype()
-{
-    Select(ID_anariLibrarySubtype, (void *)&anariLibrarySubtype);
-}
-
-void
-VolumeAttributes::SelectAnariRendererSubtype()
-{
-    Select(ID_anariRendererSubtype, (void *)&anariRendererSubtype);
-}
-
-void
-VolumeAttributes::SelectAnariRendererParameters()
-{
-    Select(ID_anariRendererParameters, (void *)&anariRendererParameters);
-}
-
-void
-VolumeAttributes::SelectAnariUSDParameters()
-{
-    Select(ID_anariUSDParameters, (void *)&anariUSDParameters);
+    Select(ID_anariAttributes, (void *)&anariAttributes);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2469,13 +2280,7 @@ VolumeAttributes::GetFieldName(int index) const
     case ID_lowGradientLightingClampFlag:    return "lowGradientLightingClampFlag";
     case ID_lowGradientLightingClampValue:   return "lowGradientLightingClampValue";
     case ID_materialProperties:              return "materialProperties";
-    case ID_anariRendering:                  return "anariRendering";
-    case ID_anariLibrary:                    return "anariLibrary";
-    case ID_anariLibrarySubtype:             return "anariLibrarySubtype";
-    case ID_anariRendererSubtype:            return "anariRendererSubtype";
-    case ID_usingUsdDevice:                  return "usingUsdDevice";
-    case ID_anariRendererParameters:         return "anariRendererParameters";
-    case ID_anariUSDParameters:              return "anariUSDParameters";
+    case ID_anariAttributes:                 return "anariAttributes";
     default:  return "invalid index";
     }
 }
@@ -2545,13 +2350,7 @@ VolumeAttributes::GetFieldType(int index) const
     case ID_lowGradientLightingClampFlag:    return FieldType_bool;
     case ID_lowGradientLightingClampValue:   return FieldType_double;
     case ID_materialProperties:              return FieldType_doubleArray;
-    case ID_anariRendering:                  return FieldType_bool;
-    case ID_anariLibrary:                    return FieldType_string;
-    case ID_anariLibrarySubtype:             return FieldType_string;
-    case ID_anariRendererSubtype:            return FieldType_string;
-    case ID_usingUsdDevice:                  return FieldType_bool;
-    case ID_anariRendererParameters:         return FieldType_stringVector;
-    case ID_anariUSDParameters:              return FieldType_stringVector;
+    case ID_anariAttributes:                 return FieldType_att;
     default:  return FieldType_unknown;
     }
 }
@@ -2621,13 +2420,7 @@ VolumeAttributes::GetFieldTypeName(int index) const
     case ID_lowGradientLightingClampFlag:    return "bool";
     case ID_lowGradientLightingClampValue:   return "double";
     case ID_materialProperties:              return "doubleArray";
-    case ID_anariRendering:                  return "bool";
-    case ID_anariLibrary:                    return "string";
-    case ID_anariLibrarySubtype:             return "string";
-    case ID_anariRendererSubtype:            return "string";
-    case ID_usingUsdDevice:                  return "bool";
-    case ID_anariRendererParameters:         return "stringVector";
-    case ID_anariUSDParameters:              return "stringVector";
+    case ID_anariAttributes:                 return "att";
     default:  return "invalid index";
     }
 }
@@ -2889,39 +2682,9 @@ VolumeAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
         retval = materialProperties_equal;
         }
         break;
-    case ID_anariRendering:
+    case ID_anariAttributes:
         {  // new scope
-        retval = (anariRendering == obj.anariRendering);
-        }
-        break;
-    case ID_anariLibrary:
-        {  // new scope
-        retval = (anariLibrary == obj.anariLibrary);
-        }
-        break;
-    case ID_anariLibrarySubtype:
-        {  // new scope
-        retval = (anariLibrarySubtype == obj.anariLibrarySubtype);
-        }
-        break;
-    case ID_anariRendererSubtype:
-        {  // new scope
-        retval = (anariRendererSubtype == obj.anariRendererSubtype);
-        }
-        break;
-    case ID_usingUsdDevice:
-        {  // new scope
-        retval = (usingUsdDevice == obj.usingUsdDevice);
-        }
-        break;
-    case ID_anariRendererParameters:
-        {  // new scope
-        retval = (anariRendererParameters == obj.anariRendererParameters);
-        }
-        break;
-    case ID_anariUSDParameters:
-        {  // new scope
-        retval = (anariUSDParameters == obj.anariUSDParameters);
+        retval = (anariAttributes == obj.anariAttributes);
         }
         break;
     default: retval = false;

--- a/src/plots/Volume/VolumeAttributes.code
+++ b/src/plots/Volume/VolumeAttributes.code
@@ -651,3 +651,6 @@ VolumeAttributes_SetMaterialProperties(PyObject *self, PyObject *args)
     return Py_None;
 }
 
+Target: xml2cmake
+Condition: VISIT_SLIVR
+Definitions: -DVISIT_SLIVR

--- a/src/plots/Volume/VolumeAttributes.code
+++ b/src/plots/Volume/VolumeAttributes.code
@@ -651,6 +651,3 @@ VolumeAttributes_SetMaterialProperties(PyObject *self, PyObject *args)
     return Py_None;
 }
 
-Target: xml2cmake
-Condition: VISIT_SLIVR
-Definitions: -DVISIT_SLIVR

--- a/src/plots/Volume/VolumeAttributes.h
+++ b/src/plots/Volume/VolumeAttributes.h
@@ -9,6 +9,7 @@
 
 #include <ColorControlPointList.h>
 #include <GaussianControlPointList.h>
+#include <AnariAttributes.h>
 
 // ****************************************************************************
 // Class: VolumeAttributes
@@ -126,11 +127,7 @@ public:
     void SelectOpacityVariable();
     void SelectFreeformOpacity();
     void SelectMaterialProperties();
-    void SelectAnariLibrary();
-    void SelectAnariLibrarySubtype();
-    void SelectAnariRendererSubtype();
-    void SelectAnariRendererParameters();
-    void SelectAnariUSDParameters();
+    void SelectAnariAttributes();
 
     // Property setting methods
     void SetOSPRayEnabledFlag(bool OSPRayEnabledFlag_);
@@ -178,13 +175,7 @@ public:
     void SetLowGradientLightingClampFlag(bool lowGradientLightingClampFlag_);
     void SetLowGradientLightingClampValue(double lowGradientLightingClampValue_);
     void SetMaterialProperties(const double *materialProperties_);
-    void SetAnariRendering(bool anariRendering_);
-    void SetAnariLibrary(const std::string &anariLibrary_);
-    void SetAnariLibrarySubtype(const std::string &anariLibrarySubtype_);
-    void SetAnariRendererSubtype(const std::string &anariRendererSubtype_);
-    void SetUsingUsdDevice(bool usingUsdDevice_);
-    void SetAnariRendererParameters(const stringVector &anariRendererParameters_);
-    void SetAnariUSDParameters(const stringVector &anariUSDParameters_);
+    void SetAnariAttributes(const AnariAttributes &anariAttributes_);
 
     // Property getting methods
     bool                           GetOSPRayEnabledFlag() const;
@@ -237,18 +228,8 @@ public:
     double                         GetLowGradientLightingClampValue() const;
     const double                   *GetMaterialProperties() const;
           double                   *GetMaterialProperties();
-    bool                           GetAnariRendering() const;
-    const std::string              &GetAnariLibrary() const;
-          std::string              &GetAnariLibrary();
-    const std::string              &GetAnariLibrarySubtype() const;
-          std::string              &GetAnariLibrarySubtype();
-    const std::string              &GetAnariRendererSubtype() const;
-          std::string              &GetAnariRendererSubtype();
-    bool                           GetUsingUsdDevice() const;
-    const stringVector             &GetAnariRendererParameters() const;
-          stringVector             &GetAnariRendererParameters();
-    const stringVector             &GetAnariUSDParameters() const;
-          stringVector             &GetAnariUSDParameters();
+    const AnariAttributes          &GetAnariAttributes() const;
+          AnariAttributes          &GetAnariAttributes();
 
     // Persistence methods
     virtual bool CreateNode(DataNode *node, bool completeSave, bool forceAdd);
@@ -371,13 +352,7 @@ public:
         ID_lowGradientLightingClampFlag,
         ID_lowGradientLightingClampValue,
         ID_materialProperties,
-        ID_anariRendering,
-        ID_anariLibrary,
-        ID_anariLibrarySubtype,
-        ID_anariRendererSubtype,
-        ID_usingUsdDevice,
-        ID_anariRendererParameters,
-        ID_anariUSDParameters,
+        ID_anariAttributes,
         ID__LAST
     };
 
@@ -427,18 +402,12 @@ private:
     bool                     lowGradientLightingClampFlag;
     double                   lowGradientLightingClampValue;
     double                   materialProperties[4];
-    bool                     anariRendering;
-    std::string              anariLibrary;
-    std::string              anariLibrarySubtype;
-    std::string              anariRendererSubtype;
-    bool                     usingUsdDevice;
-    stringVector             anariRendererParameters;
-    stringVector             anariUSDParameters;
+    AnariAttributes          anariAttributes;
 
     // Static class format string for type map.
     static const char *TypeMapFormatString;
     static const private_tmfs_t TmfsStruct;
 };
-#define VOLUMEATTRIBUTES_TMFS "bibbbbbbiidddbbafiaiiisUbfbfbfbfbiiiidiifibdDbsssbs*s*"
+#define VOLUMEATTRIBUTES_TMFS "bibbbbbbiidddbbafiaiiisUbfbfbfbfbiiiidiifibdDa"
 
 #endif

--- a/src/plots/Volume/VolumeAttributes.java
+++ b/src/plots/Volume/VolumeAttributes.java
@@ -9,7 +9,7 @@ import llnl.visit.CommunicationBuffer;
 import llnl.visit.Plugin;
 import llnl.visit.ColorControlPointList;
 import llnl.visit.GaussianControlPointList;
-import java.util.Vector;
+import llnl.visit.AnariAttributes;
 
 // ****************************************************************************
 // Class: VolumeAttributes
@@ -28,7 +28,7 @@ import java.util.Vector;
 
 public class VolumeAttributes extends AttributeSubject implements Plugin
 {
-    private static int VolumeAttributes_numAdditionalAtts = 52;
+    private static int VolumeAttributes_numAdditionalAtts = 46;
 
     // Enum values
     public final static int RENDERER_SERIAL = 0;
@@ -134,13 +134,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         materialProperties[1] = 0.75;
         materialProperties[2] = 0;
         materialProperties[3] = 15;
-        anariRendering = false;
-        anariLibrary = new String("");
-        anariLibrarySubtype = new String("");
-        anariRendererSubtype = new String("default");
-        usingUsdDevice = false;
-        anariRendererParameters = new Vector();
-        anariUSDParameters = new Vector();
+        anariAttributes = new AnariAttributes();
     }
 
     public VolumeAttributes(int nMoreFields)
@@ -198,13 +192,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         materialProperties[1] = 0.75;
         materialProperties[2] = 0;
         materialProperties[3] = 15;
-        anariRendering = false;
-        anariLibrary = new String("");
-        anariLibrarySubtype = new String("");
-        anariRendererSubtype = new String("default");
-        usingUsdDevice = false;
-        anariRendererParameters = new Vector();
-        anariUSDParameters = new Vector();
+        anariAttributes = new AnariAttributes();
     }
 
     public VolumeAttributes(VolumeAttributes obj)
@@ -264,19 +252,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         for(i = 0; i < obj.materialProperties.length; ++i)
             materialProperties[i] = obj.materialProperties[i];
 
-        anariRendering = obj.anariRendering;
-        anariLibrary = new String(obj.anariLibrary);
-        anariLibrarySubtype = new String(obj.anariLibrarySubtype);
-        anariRendererSubtype = new String(obj.anariRendererSubtype);
-        usingUsdDevice = obj.usingUsdDevice;
-        anariRendererParameters = new Vector(obj.anariRendererParameters.size());
-        for(i = 0; i < obj.anariRendererParameters.size(); ++i)
-            anariRendererParameters.addElement(new String((String)obj.anariRendererParameters.elementAt(i)));
-
-        anariUSDParameters = new Vector(obj.anariUSDParameters.size());
-        for(i = 0; i < obj.anariUSDParameters.size(); ++i)
-            anariUSDParameters.addElement(new String((String)obj.anariUSDParameters.elementAt(i)));
-
+        anariAttributes = new AnariAttributes(obj.anariAttributes);
 
         SelectAll();
     }
@@ -305,24 +281,6 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         for(i = 0; i < 4 && materialProperties_equal; ++i)
             materialProperties_equal = (materialProperties[i] == obj.materialProperties[i]);
 
-        // Compare the elements in the anariRendererParameters vector.
-        boolean anariRendererParameters_equal = (obj.anariRendererParameters.size() == anariRendererParameters.size());
-        for(i = 0; (i < anariRendererParameters.size()) && anariRendererParameters_equal; ++i)
-        {
-            // Make references to String from Object.
-            String anariRendererParameters1 = (String)anariRendererParameters.elementAt(i);
-            String anariRendererParameters2 = (String)obj.anariRendererParameters.elementAt(i);
-            anariRendererParameters_equal = anariRendererParameters1.equals(anariRendererParameters2);
-        }
-        // Compare the elements in the anariUSDParameters vector.
-        boolean anariUSDParameters_equal = (obj.anariUSDParameters.size() == anariUSDParameters.size());
-        for(i = 0; (i < anariUSDParameters.size()) && anariUSDParameters_equal; ++i)
-        {
-            // Make references to String from Object.
-            String anariUSDParameters1 = (String)anariUSDParameters.elementAt(i);
-            String anariUSDParameters2 = (String)obj.anariUSDParameters.elementAt(i);
-            anariUSDParameters_equal = anariUSDParameters1.equals(anariUSDParameters2);
-        }
         // Create the return value
         return ((OSPRayEnabledFlag == obj.OSPRayEnabledFlag) &&
                 (OSPRayRenderType == obj.OSPRayRenderType) &&
@@ -369,13 +327,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
                 (lowGradientLightingClampFlag == obj.lowGradientLightingClampFlag) &&
                 (lowGradientLightingClampValue == obj.lowGradientLightingClampValue) &&
                 materialProperties_equal &&
-                (anariRendering == obj.anariRendering) &&
-                (anariLibrary.equals(obj.anariLibrary)) &&
-                (anariLibrarySubtype.equals(obj.anariLibrarySubtype)) &&
-                (anariRendererSubtype.equals(obj.anariRendererSubtype)) &&
-                (usingUsdDevice == obj.usingUsdDevice) &&
-                anariRendererParameters_equal &&
-                anariUSDParameters_equal);
+                (anariAttributes.equals(obj.anariAttributes)));
     }
 
     public String GetName() { return "Volume"; }
@@ -665,46 +617,10 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         Select(44);
     }
 
-    public void SetAnariRendering(boolean anariRendering_)
+    public void SetAnariAttributes(AnariAttributes anariAttributes_)
     {
-        anariRendering = anariRendering_;
+        anariAttributes = anariAttributes_;
         Select(45);
-    }
-
-    public void SetAnariLibrary(String anariLibrary_)
-    {
-        anariLibrary = anariLibrary_;
-        Select(46);
-    }
-
-    public void SetAnariLibrarySubtype(String anariLibrarySubtype_)
-    {
-        anariLibrarySubtype = anariLibrarySubtype_;
-        Select(47);
-    }
-
-    public void SetAnariRendererSubtype(String anariRendererSubtype_)
-    {
-        anariRendererSubtype = anariRendererSubtype_;
-        Select(48);
-    }
-
-    public void SetUsingUsdDevice(boolean usingUsdDevice_)
-    {
-        usingUsdDevice = usingUsdDevice_;
-        Select(49);
-    }
-
-    public void SetAnariRendererParameters(Vector anariRendererParameters_)
-    {
-        anariRendererParameters = anariRendererParameters_;
-        Select(50);
-    }
-
-    public void SetAnariUSDParameters(Vector anariUSDParameters_)
-    {
-        anariUSDParameters = anariUSDParameters_;
-        Select(51);
     }
 
     // Property getting methods
@@ -753,13 +669,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
     public boolean                  GetLowGradientLightingClampFlag() { return lowGradientLightingClampFlag; }
     public double                   GetLowGradientLightingClampValue() { return lowGradientLightingClampValue; }
     public double[]                 GetMaterialProperties() { return materialProperties; }
-    public boolean                  GetAnariRendering() { return anariRendering; }
-    public String                   GetAnariLibrary() { return anariLibrary; }
-    public String                   GetAnariLibrarySubtype() { return anariLibrarySubtype; }
-    public String                   GetAnariRendererSubtype() { return anariRendererSubtype; }
-    public boolean                  GetUsingUsdDevice() { return usingUsdDevice; }
-    public Vector                   GetAnariRendererParameters() { return anariRendererParameters; }
-    public Vector                   GetAnariUSDParameters() { return anariUSDParameters; }
+    public AnariAttributes          GetAnariAttributes() { return anariAttributes; }
 
     // Write and read methods.
     public void WriteAtts(CommunicationBuffer buf)
@@ -855,19 +765,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         if(WriteSelect(44, buf))
             buf.WriteDoubleArray(materialProperties);
         if(WriteSelect(45, buf))
-            buf.WriteBool(anariRendering);
-        if(WriteSelect(46, buf))
-            buf.WriteString(anariLibrary);
-        if(WriteSelect(47, buf))
-            buf.WriteString(anariLibrarySubtype);
-        if(WriteSelect(48, buf))
-            buf.WriteString(anariRendererSubtype);
-        if(WriteSelect(49, buf))
-            buf.WriteBool(usingUsdDevice);
-        if(WriteSelect(50, buf))
-            buf.WriteStringVector(anariRendererParameters);
-        if(WriteSelect(51, buf))
-            buf.WriteStringVector(anariUSDParameters);
+            anariAttributes.Write(buf);
     }
 
     public void ReadAtts(int index, CommunicationBuffer buf)
@@ -1012,25 +910,8 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
             SetMaterialProperties(buf.ReadDoubleArray());
             break;
         case 45:
-            SetAnariRendering(buf.ReadBool());
-            break;
-        case 46:
-            SetAnariLibrary(buf.ReadString());
-            break;
-        case 47:
-            SetAnariLibrarySubtype(buf.ReadString());
-            break;
-        case 48:
-            SetAnariRendererSubtype(buf.ReadString());
-            break;
-        case 49:
-            SetUsingUsdDevice(buf.ReadBool());
-            break;
-        case 50:
-            SetAnariRendererParameters(buf.ReadStringVector());
-            break;
-        case 51:
-            SetAnariUSDParameters(buf.ReadStringVector());
+            anariAttributes.Read(buf);
+            Select(45);
             break;
         }
     }
@@ -1167,13 +1048,7 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
         str = str + boolToString("lowGradientLightingClampFlag", lowGradientLightingClampFlag, indent) + "\n";
         str = str + doubleToString("lowGradientLightingClampValue", lowGradientLightingClampValue, indent) + "\n";
         str = str + doubleArrayToString("materialProperties", materialProperties, indent) + "\n";
-        str = str + boolToString("anariRendering", anariRendering, indent) + "\n";
-        str = str + stringToString("anariLibrary", anariLibrary, indent) + "\n";
-        str = str + stringToString("anariLibrarySubtype", anariLibrarySubtype, indent) + "\n";
-        str = str + stringToString("anariRendererSubtype", anariRendererSubtype, indent) + "\n";
-        str = str + boolToString("usingUsdDevice", usingUsdDevice, indent) + "\n";
-        str = str + stringVectorToString("anariRendererParameters", anariRendererParameters, indent) + "\n";
-        str = str + stringVectorToString("anariUSDParameters", anariUSDParameters, indent) + "\n";
+        str = str + indent + "anariAttributes = {\n" + anariAttributes.toString(indent + "    ") + indent + "}\n";
         return str;
     }
 
@@ -1224,12 +1099,6 @@ public class VolumeAttributes extends AttributeSubject implements Plugin
     private boolean                  lowGradientLightingClampFlag;
     private double                   lowGradientLightingClampValue;
     private double[]                 materialProperties;
-    private boolean                  anariRendering;
-    private String                   anariLibrary;
-    private String                   anariLibrarySubtype;
-    private String                   anariRendererSubtype;
-    private boolean                  usingUsdDevice;
-    private Vector                   anariRendererParameters; // vector of String objects
-    private Vector                   anariUSDParameters; // vector of String objects
+    private AnariAttributes          anariAttributes;
 }
 

--- a/src/plots/Volume/anari/AnariVolumeWidget.C
+++ b/src/plots/Volume/anari/AnariVolumeWidget.C
@@ -99,6 +99,7 @@ AnariVolumeWidget::AnariVolumeWidget(QvisVolumePlotWindow *qrw,
     : QWidget(parent)
     , renderingWindow(qrw)
     , volumeAttributes(va)
+    , anariAttributes(&(va->GetAnariAttributes()))
     , dynamicLayouts(nullptr)
     , dynamicLayoutMap()
     , topRows(0)
@@ -849,6 +850,33 @@ AnariVolumeWidget::GetParameterInfo(anari::Device device,
 //----------------------------------------------------------------------------
 
 // ****************************************************************************
+// Method: AnariVolumeWidget::UpdateAnariAttributes
+//
+// Purpose:
+//   Updates the ANARI volume widget with the given attributes.
+//
+// Arguments:
+//   attrs the AnariAttributes object containing the new settings
+//
+// Programmer: Kevin Griffin
+// Creation:
+//
+// Modifications:
+//
+// ****************************************************************************
+
+void
+AnariVolumeWidget::UpdateAnariAttributes(const AnariAttributes &attrs)
+{
+    SetChecked(attrs.GetAnariRendering());
+    UpdateLibraryName(attrs.GetAnariLibrary());
+    UpdateLibrarySubtypes(attrs.GetAnariLibrarySubtype());
+    UpdateRendererSubtypes(attrs.GetAnariRendererSubtype());
+    UpdateRendererParameters(attrs.GetAnariRendererParameters());
+    UpdateUSDParameters(attrs.GetAnariUSDParameters());
+}
+
+// ****************************************************************************
 // Method: AnariVolumeWidget::UpdateLibrarySubtypes
 //
 // Purpose:
@@ -1074,7 +1102,7 @@ AnariVolumeWidget::SetChecked(const bool val)
 void
 AnariVolumeWidget::renderingToggled(bool val)
 {
-    volumeAttributes->SetAnariRendering(val);
+    anariAttributes->SetAnariRendering(val);
     
     if(!val)
     {
@@ -1110,7 +1138,7 @@ AnariVolumeWidget::renderingToggled(bool val)
 void
 AnariVolumeWidget::libraryChanged()
 {
-    volumeAttributes->SetUsingUsdDevice(false);
+    anariAttributes->SetUsingUsdDevice(false);
     std::string libname = libraryName->text().trimmed().toStdString();
     
     if(libname.empty())
@@ -1180,14 +1208,14 @@ AnariVolumeWidget::libraryChanged()
             librarySubtypes->addItem("default");
             librarySubtypes->blockSignals(false);
             auto libSubtype =  librarySubtypes->currentText().toStdString();
-            volumeAttributes->SetAnariLibrarySubtype(libSubtype);
+            anariAttributes->SetAnariLibrarySubtype(libSubtype);
 
             rendererSubtypes->blockSignals(true);
             rendererSubtypes->clear();
             rendererSubtypes->addItem("default");
             rendererSubtypes->blockSignals(false);
             auto rendererSubtype = rendererSubtypes->currentText().toStdString();
-            volumeAttributes->SetAnariRendererSubtype(rendererSubtype);
+            anariAttributes->SetAnariRendererSubtype(rendererSubtype);
 
             // Reset to blank widget
             emit currentBackendChanged(0);
@@ -1217,7 +1245,7 @@ void
 AnariVolumeWidget::librarySubtypeChanged(const QString &subtype)
 {
     auto libSubtype = subtype.toStdString();
-    volumeAttributes->SetAnariLibrarySubtype(libSubtype);
+    anariAttributes->SetAnariLibrarySubtype(libSubtype);
     auto libname = libraryName->text().trimmed().toStdString();
 
     auto anariLibrary = anari::loadLibrary(libname.c_str(), anari_visit::StatusCallback);
@@ -1243,7 +1271,7 @@ AnariVolumeWidget::librarySubtypeChanged(const QString &subtype)
         }
 
         auto rendererSubtype =  rendererSubtypes->currentText().toStdString();
-        volumeAttributes->SetAnariRendererSubtype(rendererSubtype);
+        anariAttributes->SetAnariRendererSubtype(rendererSubtype);
         rendererSubtypes->blockSignals(false);
 
         // Create Dynamic Widget
@@ -1285,7 +1313,7 @@ void
 AnariVolumeWidget::rendererSubtypeChanged(const QString &subtype)
 {
     auto rendererSubtype = subtype.toStdString();
-    volumeAttributes->SetAnariRendererSubtype(rendererSubtype);
+    anariAttributes->SetAnariRendererSubtype(rendererSubtype);
 
     auto libname = libraryName->text().trimmed().toStdString();
     auto libSubtype = librarySubtypes->currentText().toStdString();
@@ -1497,13 +1525,13 @@ AnariVolumeWidget::UpdateRenderingAttributes(const bool updateApply)
         }
     }
 
-    if(!this->volumeAttributes->GetUsingUsdDevice())
+    if(!this->anariAttributes->GetUsingUsdDevice())
     {
-        volumeAttributes->SetAnariRendererParameters(params);
+        anariAttributes->SetAnariRendererParameters(params);
     }
     else
     {
-        volumeAttributes->SetAnariUSDParameters(params);
+        anariAttributes->SetAnariUSDParameters(params);
     }
 
     renderingWindow->SetApply(updateApply);
@@ -1525,8 +1553,8 @@ AnariVolumeWidget::UpdateRenderingAttributes(const bool updateApply)
 void AnariVolumeWidget::ClearAnariParameterAttributes()
 {
     stringVector params;
-    volumeAttributes->SetAnariRendererParameters(params);
-    volumeAttributes->SetAnariUSDParameters(params);
+    anariAttributes->SetAnariRendererParameters(params);
+    anariAttributes->SetAnariUSDParameters(params);
 }
 
 // ****************************************************************************
@@ -1549,16 +1577,16 @@ void AnariVolumeWidget::ClearAnariParameterAttributes()
 void
 AnariVolumeWidget::UpdateLibraryUI(anari::Library anariLibrary, const std::string &libname)
 {
-    volumeAttributes->SetAnariLibrary(libname);
+    anariAttributes->SetAnariLibrary(libname);
     auto backendType = GetBackendType(libname);
 
     if(backendType == BackendType::USD)
     {
-        volumeAttributes->SetUsingUsdDevice(true);
+        anariAttributes->SetUsingUsdDevice(true);
     }
     else
     {
-        volumeAttributes->SetUsingUsdDevice(false);
+        anariAttributes->SetUsingUsdDevice(false);
     }
 
     // Update back-end subtypes
@@ -1580,7 +1608,7 @@ AnariVolumeWidget::UpdateLibraryUI(anari::Library anariLibrary, const std::strin
 
     librarySubtypes->blockSignals(false);
     auto libSubtype =  librarySubtypes->currentText().toStdString();
-    volumeAttributes->SetAnariLibrarySubtype(libSubtype);
+    anariAttributes->SetAnariLibrarySubtype(libSubtype);
 
     auto anariDevice = anari::newDevice(anariLibrary, libSubtype.c_str());
 
@@ -1603,7 +1631,7 @@ AnariVolumeWidget::UpdateLibraryUI(anari::Library anariLibrary, const std::strin
     }
 
     auto rendererSubtype = rendererSubtypes->currentText().toStdString();
-    volumeAttributes->SetAnariRendererSubtype(rendererSubtype);
+    anariAttributes->SetAnariRendererSubtype(rendererSubtype);
     rendererSubtypes->blockSignals(false);
 
     // Create Dynamic Widget

--- a/src/plots/Volume/anari/AnariVolumeWidget.h
+++ b/src/plots/Volume/anari/AnariVolumeWidget.h
@@ -13,6 +13,7 @@
 #include <memory>
 
 class VolumeAttributes;
+class AnariAttributes;
 class QvisVolumePlotWindow;
 class QGroupBox;
 class QComboBox;
@@ -49,16 +50,7 @@ public:
     ~AnariVolumeWidget() = default;
 
     int GetRowCount() const { return (topRows + bottomRows); }
-
-    // General
-    void SetChecked(const bool);
-    void UpdateLibraryName(const std::string);
-    void UpdateLibrarySubtypes(const std::string);
-    void UpdateRendererSubtypes(const std::string);
-
-    // Dynamic
-    void UpdateRendererParameters(const stringVector &);
-    void UpdateUSDParameters(const stringVector &);
+    void UpdateAnariAttributes(const AnariAttributes &);
 
 signals:
     void currentBackendChanged(int);
@@ -78,6 +70,13 @@ private slots:
     void checkBoxToggled(bool);
 
 private:
+    void SetChecked(const bool);
+    void UpdateLibraryName(const std::string);
+    void UpdateLibrarySubtypes(const std::string);
+    void UpdateRendererSubtypes(const std::string);
+
+    void UpdateRendererParameters(const stringVector &);
+    void UpdateUSDParameters(const stringVector &);
     QWidget *CreateGeneralWidget(int &);
     QWidget *CreateUSDWidget(int &);
     void CreateDynamicWidget(anari::Device, const char *, const std::string &, bool isUSD = false);
@@ -91,6 +90,7 @@ private:
 
     QvisVolumePlotWindow *renderingWindow;
     VolumeAttributes *volumeAttributes;
+    AnariAttributes *anariAttributes;
     QStackedLayout *dynamicLayouts; // Caches the dynamic widgets
 
     // Mapping of dynamic widget key (backend:subtype:renderer) to index in

--- a/src/plots/Volume/avtVisItVTKRenderer.C
+++ b/src/plots/Volume/avtVisItVTKRenderer.C
@@ -631,7 +631,7 @@ avtVisItVTKRenderer::UpdateRenderingState(vtkDataSet * in_ds,
         m_OSPRayEnabled = m_atts.GetOSPRayEnabledFlag();
 
         if (m_volumeMapper != nullptr)
-            m_volumeMapper->Delete(); m_atts.GetResampleCentering();
+            m_volumeMapper->Delete();
 
         // Create the volume mapper.
 #ifdef HAVE_OSPRAY
@@ -646,9 +646,10 @@ avtVisItVTKRenderer::UpdateRenderingState(vtkDataSet * in_ds,
     }
 #ifdef HAVE_ANARI
     else if((m_atts.GetRendererType() == VolumeAttributes::ANARI) &&
-            (m_anariEnabled != m_atts.GetAnariRendering()))
+            (m_anariEnabled != m_atts.GetAnariAttributes().GetAnariRendering()))
     {
-        m_anariEnabled = m_atts.GetAnariRendering();
+        AnariAttributes anariAtts = m_atts.GetAnariAttributes();
+        m_anariEnabled = anariAtts.GetAnariRendering();
 
         if (m_volumeMapper != nullptr)
         {
@@ -673,16 +674,16 @@ avtVisItVTKRenderer::UpdateRenderingState(vtkDataSet * in_ds,
             {
                 // ANARI Device Settings
                 auto vtkAD = anariPass->GetAnariDevice();
-                std::string libraryName = !m_atts.GetAnariLibrary().empty() ? m_atts.GetAnariLibrary()
-                                                                            : "environment";                
+                std::string libraryName = !anariAtts.GetAnariLibrary().empty() ? anariAtts.GetAnariLibrary()
+                                                                               : "environment";                
                 vtkAD->SetupAnariDeviceFromLibrary(libraryName.c_str(),
-                                                    m_atts.GetAnariLibrarySubtype().c_str());
+                                                   anariAtts.GetAnariLibrarySubtype().c_str());
                                                 
                 // ANARI Render Settings
                 auto vtkAR = anariPass->GetAnariRenderer();
-                vtkAR->SetSubtype(m_atts.GetAnariRendererSubtype().c_str());
+                vtkAR->SetSubtype(anariAtts.GetAnariRendererSubtype().c_str());
                 
-                if(!m_atts.GetUsingUsdDevice())
+                if(!anariAtts.GetUsingUsdDevice())
                 {
                     SetAnariRendererParameters(anariPass);
                 }
@@ -881,11 +882,12 @@ avtVisItVTKRenderer::SetAnariRendererParameters(vtkAnariPass * const anariPass)
         return;
     }
 
-    auto rendererParams = m_atts.GetAnariRendererParameters();
+    AnariAttributes anariAtts = m_atts.GetAnariAttributes();
+    auto rendererParams = anariAtts.GetAnariRendererParameters();
     const ANARIParameter *parameterList =
             static_cast<const ANARIParameter*>(anariGetObjectInfo(anariDevice,
                                                                   ANARI_RENDERER,
-                                                                  m_atts.GetAnariRendererSubtype().c_str(),
+                                                                  anariAtts.GetAnariRendererSubtype().c_str(),
                                                                   "parameter",
                                                                   ANARI_PARAMETER_LIST));
     
@@ -1013,14 +1015,15 @@ avtVisItVTKRenderer::SetAnariUSDParameters(vtkAnariPass * const anariPass)
         return;
     }
 
+    AnariAttributes anariAtts = m_atts.GetAnariAttributes();
     const ANARIParameter *parameterList =
             static_cast<const ANARIParameter*>(anariGetObjectInfo(anariDevice,
                                                                   ANARI_DEVICE,
-                                                                  m_atts.GetAnariLibrarySubtype().c_str(),
+                                                                  anariAtts.GetAnariLibrarySubtype().c_str(),
                                                                   "parameter",
                                                                   ANARI_PARAMETER_LIST));
 
-    auto usdParams = m_atts.GetAnariUSDParameters();
+    auto usdParams = anariAtts.GetAnariUSDParameters();
 
     for (const auto& usdParam : usdParams)
     {


### PR DESCRIPTION
### Description

Resolves #20588. Updated ANARI volume rendering classes to use `AnariAttributes`. 

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* [X] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

1. Open `noise.silo`
2. Add _Volume -> chromeVf_ (or any variable of your choosing)
3. Select `ANARI` as the **Rendering Method**
4. Enable **ANARI Rendering**
5. Click Apply

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [X] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
