### PR TITLE
osmesa env updates for internal launcher

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -5,6 +5,7 @@ import socket
 import stat
 import subprocess
 import time
+import glob
 
 ###############################################################################
 # Class: JobSubmitter
@@ -3203,6 +3204,9 @@ class MainLauncher(object):
     #   Kathleen Biagas, Tue Mar 18, 2025
     #   Removed support for ultrawrapper.
     #
+    #   Cyrus Harrison, Fri Sep 19 10:20:16 PDT 2025
+    #   Updates to osmesa env support for VTK 9.5, remove R Support
+    #
     ############################################################################
 
     def SetupEnvironment(self):
@@ -3218,11 +3222,6 @@ class MainLauncher(object):
                 SETENV(k, self.visitlibdir)
             else:
                 SETENV(k, self.joinpaths([self.visitlibdir, GETENV("%s_VISITORIG" % k)]))
-
-        # Set R_HOME in case R has been installed it will be in this location..
-        visitrdir = os.path.join(self.visitlibdir, "r_support", "R")
-        if os.path.exists(visitrdir):
-            SETENV("R_HOME", visitrdir)
 
         # Get the private plugin directory.
         visitprivateplugins = self.PrivatePlugins()
@@ -3327,8 +3326,11 @@ class MainLauncher(object):
         #
         # OSMesa GL Settings
         #
-        osmesa_gl_dir = os.path.join(self.visitlibdir,"osmesa")
-        osmesa_gl_lib = os.path.join(osmesa_gl_dir,"libGL.so.1")
+        # Look for osmesa
+        osmesa_gl_lib = ""
+        osmesa_gl_lib_matches = glob.glob(os.path.join(self.visitlibdir,"libOSMesa.so.*"))
+        if len(osmesa_gl_lib_matches) !=0:
+            osmesa_gl_lib = osmesa_gl_lib_matches[0]
         #
         # if we have osmesa, use it for the engine & viewer -nowin
         #
@@ -3337,12 +3339,15 @@ class MainLauncher(object):
             # if we get an explicit osmesa flag, make sure to use mesa
             #
             # if we are using OSMesa in the viewer or engine we need to set VISIT_MESA_LIB
-            # and adjust the LD_LIBRARY_PATH so VTK can pick up OSMesa instead of standard GL
+            # and for vtk 9.5 +, we select osmesa via env var.
             #
             if ( (self.generalArgs.osmesa) or
                  (self.generalArgs.exe_name == "viewer" and self.generalArgs.nowin == 1) or
                  (self.generalArgs.exe_name.startswith("engine") and not self.generalArgs.hw_accel)):
-                SETENV("LD_LIBRARY_PATH", self.joinpaths([osmesa_gl_dir, GETENV("LD_LIBRARY_PATH")]))
+                SETENV("VTK_DEFAULT_OPENGL_WINDOW","vtkOSOpenGLRenderWindow")
+                # osmesa will be in visit's lib dir, make sure this is in LD_LIBRARY_PATH
+                SETENV("LD_LIBRARY_PATH", self.joinpaths([self.visitlibdir, GETENV("LD_LIBRARY_PATH")]))
+                # this is used by libsim to dlload the proper gl
                 SETENV("VISIT_MESA_LIB",osmesa_gl_lib)
         elif self.generalArgs.osmesa:
             self.error("Can't launch using osmesa. '-osmesa' specified, but the osmesa library is not available.")
@@ -3367,6 +3372,9 @@ class MainLauncher(object):
     #   Kathleen Biagas, Tue Mar 18, 2025
     #   Removed support for ultrawrapper.
     #
+    #   Cyrus Harrison, Fri Sep 19 10:20:16 PDT 2025
+    #   Updates to osmesa env support for VTK 9.5
+    #
     ############################################################################
 
     def PrintEnvironment(self, file, set, eq, allowempty):
@@ -3377,7 +3385,7 @@ class MainLauncher(object):
         # The environment variables whose values we're printing.
         vars = ["LIBPATH", "VISITHOME", "VISITARCHHOME", 
                 "VISITPLUGINDIR","TRAP_FPE",
-                "MESA_GLX_FX","VISIT_MESA_LIB"]
+                "MESA_GLX_FX","VISIT_MESA_LIB","VTK_DEFAULT_OPENGL_WINDOW"]
         # vars = vars + ["PYTHONHOME"] # don't set PYTHONHOME
         # A dictionary of extra vars whose source is different 
         diffvars = {}


### PR DESCRIPTION
### Description

Resolves #20581.

Modifies internallaucher to use VTK 9.5 env var to select use of osmesa.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->
Launcher fix
### How Has This Been Tested?
Tested on Tuolumne 


### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
