### PR TITLE
Fix a bug where RPATHs were no longer being stripped from installations.

### DIFF
--- a/src/CMake/SetupBLT.cmake
+++ b/src/CMake/SetupBLT.cmake
@@ -47,6 +47,20 @@ set(ENABLE_TESTS OFF CACHE BOOL "")
 message(STATUS "Setting up BLT")
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 
+#
+# Override some options related to RPATHS.
+#
+
+# BLT sets CMAKE_INSTALL_RPATH_USE_LINK_PATH to TRUE, which
+# turns on saving automatically generated RPATHS in installations.
+# We don't want RPATHS in installations.
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+
+# BLT sets CMAKE_INSTALL_RPATH to "${CMAKE_INSTALL_PREFIX}/lib",
+# which usually results in /usr/local/lib, which we don't want.
+set(CMAKE_INSTALL_RPATH "")
+
+
 # next message helps bracket messages sent by BLT.
 message(STATUS "Done setting up BLT")
 

--- a/src/CMake/VisItMacros.cmake
+++ b/src/CMake/VisItMacros.cmake
@@ -21,6 +21,11 @@
 #    Kathleen Biagas, Thu May 2, 2024
 #    Use VISIT_PLUGIN_DIR when setting RUNTIME_OUTPUT_DIR for plugins.
 #
+#    Eric Brugger, Mon Sep 22 16:41:58 PDT 2025
+#    I changed the logic to create the INSTALL_RPATH for parallel
+#    libraries to generate a semicolon separated list instead of a
+#    space separated list.
+#
 #*****************************************************************************
 
 if(WIN32)
@@ -65,13 +70,13 @@ function(ADD_PARALLEL_LIBRARY target)
         if(VISIT_PARALLEL_RPATH)
             set(PAR_RPATHS "")
             foreach(X ${CMAKE_INSTALL_RPATH})
-                set(PAR_RPATHS "${PAR_RPATHS} ${X}")
+                list(APPEND PAR_RPATHS ${X})
             endforeach()
             foreach(X ${VISIT_PARALLEL_RPATH})
-                set(PAR_RPATHS "${PAR_RPATHS} ${X}")
+                list(APPEND PAR_RPATHS ${X})
             endforeach()
             set_property(TARGET ${target}
-                     APPEND PROPERTY INSTALL_RPATH ${PAR_RPATHS})
+                     APPEND PROPERTY INSTALL_RPATH "${PAR_RPATHS}")
         endif()
       endif()
 

--- a/src/CMake/VisItParallel.cmake
+++ b/src/CMake/VisItParallel.cmake
@@ -2,6 +2,14 @@
 # Project developers.  See the top-level LICENSE file for dates and other
 # details.  No copyright assignment is required to contribute to VisIt.
 
+#****************************************************************************
+#  Modifications:
+#    Eric Brugger, Mon Sep 22 16:41:58 PDT 2025
+#    I changed the logic to create the INSTALL_RPATH for parallel
+#    executables to generate a semicolon separated list instead of a
+#    space separated list.
+#
+#****************************************************************************
 
 function(DETECT_MPI_SETTINGS COMP mlibs mflags mlflags mrpath)
     # Unset any variables that may have been set before by FindMPI
@@ -80,13 +88,13 @@ function(ADD_PARALLEL_EXECUTABLE target)
         if(VISIT_PARALLEL_RPATH)
             set(PAR_RPATHS "")
             foreach(X ${CMAKE_INSTALL_RPATH})
-                set(PAR_RPATHS "${PAR_RPATHS} ${X}")
+                list(APPEND PAR_RPATHS ${X})
             endforeach()
             foreach(X ${VISIT_PARALLEL_RPATH})
-                set(PAR_RPATHS "${PAR_RPATHS} ${X}")
+                list(APPEND PAR_RPATHS ${X})
             endforeach()
             set_target_properties(${target} PROPERTIES
-                INSTALL_RPATH ${PAR_RPATHS}
+                INSTALL_RPATH "${PAR_RPATHS}"
             )
         endif()
       endif()

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -136,6 +136,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a command recording bug with the Expression window where all the operator generated expressions would get recorded.</li>
   <li>Added a descriptive error message for when a movie encoding format is not supported on the current platform.</li>
   <li>Fixed a bug where rendering with shadows would result in an all black image except for the annotations when the image contained transparent geometry.</li>
+  <li>Fixed a bug where RPATHs weren't stripped from distributions. This could lead to issues for users that didn't build the distribution. It could also cause issues when a distribution is installed on a machine different from where it was built.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
### Description

Resolves #20584

BLT sets some CMake settings that results in RPATHs not being stripped from installations. I added code after we initialized BLT to restore those settings so that distributions would be stripped of their RPATHs except for those related to running in parallel.

When I was looking at the RPATHs in the current installations I also noticed that the RPATHs that were set for running in parallel had spaces in them. Here is the RPATH from a 3.4.2 installation. Notice that the third path has a leading space and a space between the first and second paths.
```
readelf -d libEPseudocolorPlot_par.so | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib:/usr/local/lib: /usr/local/lib /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib:/usr/workspace/visit/visit/thirdparty_shared/3.4.2/toss4/vtk/9.2.6/linux-x86_64_gcc-10.3/lib64:/usr/workspace/visit/visit/thirdparty_shared/3.4.2/toss4/zlib/1.2.13/linux-x86_64_gcc-10.3/lib:/usr/workspace/visit/visit/thirdparty_shared/3.4.2/toss4/ospray/3.0.0/linux-x86_64_gcc-10.3/ospray/lib64:/usr/workspace/visit/visit/thirdparty_shared/3.4.2/toss4/mesagl/17.3.9/linux-x86_64_gcc-10.3/lib]
```
When setting the `INSTALL_RPATH` in CMake, it expects a list of semicolon separated paths. We were passing a list of space separated paths. I fixed the logic to pass a list of semicolon separated paths.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built a distribution and installed it. I then checked the RPATHs of a plot plugin, a library and an executable. I did this for both serial and parallel versions of the libraries and executables. The parallel versions should have the path to MPI and the serial versions shouldn't have anything.
```
readelf -d libEPseudocolorPlot_par.so | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib:/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib]
```
```
readelf -d libEPseudocolorPlot_ser.so | grep RPATH
```
```
readelf -d libengine_par.so | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib:/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib]
```
```
readelf -d libengine_ser.so | grep RPATH
```
```
readelf -d engine_par | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib:/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1/lib]
```
```
readelf -d engine_ser | grep RPATH
```
Note that for some reason the path to MPI is in the RPATH twice. I checked the `cmake_install.cmake` and it only listed the path once. That is the file that creates the installation and modifies the RPATH. I assume it is a CMake bug and it doesn't hurt anything.

I also ran the distribution in both serial and parallel to make sure it worked fine.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
