### PR TITLE
Add a command line option to enable compositing debugging in the scalable rendering.

### DIFF
--- a/src/doc/getting_started/Startup_Options.rst
+++ b/src/doc/getting_started/Startup_Options.rst
@@ -371,6 +371,8 @@ USAGE: visit [options]::
                              the leading letter (A-E) indicating most to least
                              recent. The clobber_vlogs flag causes VisIt to remove
                              all debug logs and begin creating them anew.
+        -compositer-debug    Dump intermediate image results during the
+                             compositing process of scalable rendering.
         -vtk-debug           Turn on debugging of VTK objects used in pipelines.
         -pid                 Append process ids to the names of log files.
         -timing              Save timing data to files.

--- a/src/doc/using_visit/MakingItPretty/Rendering_Options.rst
+++ b/src/doc/using_visit/MakingItPretty/Rendering_Options.rst
@@ -91,7 +91,7 @@ Depth Cueing
 VisIt supports depth cueing when scalable rendering is being used.
 Depth cueing can be useful for increasing the realism of your visualization.
 Depth cueing causes objects to be blended with the background with increasing distance from the camera.
-Depth cueing is are applied after the shadows have been applied and before the transparent geometry is rendered.
+Depth cueing is applied after the shadows have been applied and before the transparent geometry is rendered.
 This means that transparent geometry won't be impacted by depth cueing.
 The controls to turn on depth cueing can be found about a third of the way from the top of the **Advanced** tab (see :numref:`Figure %s <fig-MakingItPretty-RenderingOptionsAdvanced>`).
 To turn on depth cueing, you must turn on scalable rendering by clicking on the **Always** radio button under the **Use scalable rendering** label.

--- a/src/engine/main/Engine.C
+++ b/src/engine/main/Engine.C
@@ -2048,6 +2048,9 @@ Engine::ProcessInput()
 //    Kathleen Biagas, Wed Aug 17, 2022
 //    Incorporate ARSanderson's OSPRAY 2.8.0 work for VTK 9.
 //
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    Added "-compositer-debug" to enable programmable compositing debug.
+//
 // ****************************************************************************
 
 void
@@ -2249,6 +2252,10 @@ Engine::ProcessCommandLine(int argc, char **argv)
                 i+= nskip;
 #endif
             }
+        }
+        else if (strcmp(argv[i], "-compositer-debug") == 0)
+        {
+            NetworkManager::EnableProgrammableCompositerDebug();
         }
         else if (strcmp(argv[i], "-vtk-debug") == 0)
         {

--- a/src/engine/main/NetworkManager.C
+++ b/src/engine/main/NetworkManager.C
@@ -93,7 +93,6 @@
 #include <PlotPluginInfo.h>
 #include <StackTimer.h>
 #include <FileFunctions.h>
-//#define ProgrammableCompositerDEBUG
 //#define NetworkManagerDEBUG
 //#define NetworkManagerTIME
 #include <ProgrammableCompositer.h>
@@ -226,6 +225,8 @@ static avtDataBinning *GetDataBinningCallbackBridge(void *arg, const char *name)
 //
 // Static data members of the NetworkManager class.
 //
+bool                       NetworkManager::programmableCompositerDebug = false;
+
 InitializeProgressCallback NetworkManager::initializeProgressCallback = NULL;
 void                      *NetworkManager::initializeProgressCallbackArgs=NULL;
 ProgressCallback           NetworkManager::progressCallback = NULL;
@@ -2990,6 +2991,9 @@ NetworkManager::RenderValues(intVector plotIds, bool getZBuffer, int windowID, b
 //    names and be named such that their sort order matches the order in
 //    which they are generated. I renumbered the rendering passes.
 //
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    Added the ability to enable programmable compositing debug at runtime.
+//
 // ****************************************************************************
 //
 avtDataObject_p
@@ -3025,10 +3029,8 @@ NetworkManager::RenderInternal()
     // ************************************************************
     RenderPostProcess(pass);
 
-#ifdef ProgrammableCompositerDEBUG
-    if (PAR_Rank() == 0)
+    if (programmableCompositerDebug && PAR_Rank() == 0)
         writeVTK("pass_5.vtk", pass->GetImage());
-#endif
 
     avtDataObject_p output;
     CopyTo(output, pass);
@@ -7148,6 +7150,9 @@ NetworkManager::RenderingStages()
 //    names and be named such that their sort order matches the order in
 //    which they are generated. I renumbered the rendering passes.
 //
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    Added the ability to enable programmable compositing debug at runtime.
+//
 // ****************************************************************************
 
 avtImage_p
@@ -7233,9 +7238,8 @@ NetworkManager::RenderGeometry()
                 renderState.viewportedMode, /*read z=*/true,
                 /*read a=*/renderState.orderComposite);
 
-#ifdef ProgrammableCompositerDEBUG
-            writeVTK("pass_1a_opaque_partial.vtk", ri,gi,bi,ai,zi,w,h);
-#endif
+            if (programmableCompositerDebug)
+                writeVTK("pass_1a_opaque_partial.vtk", ri,gi,bi,ai,zi,w,h);
 
             if (renderState.orderComposite)
             {
@@ -7299,11 +7303,11 @@ NetworkManager::RenderGeometry()
 
             if ((rank == 0) || renderState.allReducePass1 || renderState.orderComposite)
             {
+                if (programmableCompositerDebug)
+                    writeVTK("pass_1b_opaque_composited.vtk", ro,go,bo,ao,zo,w,h);
+
                 output = new avtImage(NULL);
                 Merge(output, ro,go,bo,ao, zo, w,h, true);
-#ifdef ProgrammableCompositerDEBUG
-                writeVTK("pass_1b_opaque_composited.vtk", ro,go,bo,ao,zo,w,h);
-#endif
             }
 
             zcomp->Clear();
@@ -7355,9 +7359,8 @@ NetworkManager::RenderGeometry()
             compositer->AddImageInput(output, 0, 0);
             compositer->Execute();
             output = compositer->GetTypedOutput();
-#ifdef ProgrammableCompositerDEBUG
-            writeVTK("pass_1c_opaque_composited.vtk", output->GetImage());
-#endif
+            if (programmableCompositerDebug)
+                writeVTK("pass_1c_opaque_composited.vtk", output->GetImage());
             delete compositer;
         }
     }
@@ -7404,6 +7407,9 @@ NetworkManager::RenderGeometry()
 //    Enhanced the output of intermediate images to have more descriptive
 //    names and be named such that their sort order matches the order in
 //    which they are generated. I renumbered the rendering passes.
+//
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    Added the ability to enable programmable compositing debug at runtime.
 //
 // ****************************************************************************
 
@@ -7464,9 +7470,8 @@ NetworkManager::RenderTranslucent(avtImage_p& input)
             /*mode=*/renderState.viewportedMode,
             /*read z=*/false, /*read a=*/true);
 
-#ifdef ProgrammableCompositerDEBUG
-        writeVTK("pass_4a_trans_in.vtk", ri,gi,bi,ai,zi,w,h);
-#endif
+        if (programmableCompositerDebug)
+            writeVTK("pass_4a_trans_in.vtk", ri,gi,bi,ai,zi,w,h);
 
         viswin->DisableAlphaChannel();
 
@@ -7513,9 +7518,8 @@ NetworkManager::RenderTranslucent(avtImage_p& input)
                         /*mode=*/renderState.viewportedMode,
                         /*read z=*/false, /*read a=*/false);
 
-#ifdef ProgrammableCompositerDEBUG
-                    writeVTK("pass_4b_trans_background.vtk", rbi,gbi,bbi,abi,zbi,w,h);
-#endif
+                    if (programmableCompositerDebug)
+                        writeVTK("pass_4b_trans_background.vtk", rbi,gbi,bbi,abi,zbi,w,h);
 
                     acomp->ApplyBackgroundImage(rbi, gbi, bbi);
                 }
@@ -7530,9 +7534,8 @@ NetworkManager::RenderTranslucent(avtImage_p& input)
             float *ro = NULL, *go = NULL, *bo = NULL, *ao = NULL, *zo = NULL;
             acomp->GetOutput(ro,go,bo,ao, zo, true);
 
-#ifdef ProgrammableCompositerDEBUG
-            writeVTK("pass_4c_trans_order_composited.vtk", ro,go,bo,ao,zo, w,h);
-#endif
+            if (programmableCompositerDebug)
+                writeVTK("pass_4c_trans_order_composited.vtk", ro,go,bo,ao,zo, w,h);
 
             output = new avtImage(NULL);
             Merge(output, ro,go,bo,ao, zo, w,h, true);
@@ -7556,9 +7559,8 @@ NetworkManager::RenderTranslucent(avtImage_p& input)
             renderState.viewportedMode,
             /*z=*/false, /*a=*/false);
 
-#ifdef ProgrammableCompositerDEBUG
-        writeVTK("pass_4d_trans_partial.vtk", rgb->GetImage());
-#endif
+        if (programmableCompositerDebug)
+            writeVTK("pass_4d_trans_partial.vtk", rgb->GetImage());
 
         CallProgressCallback("NetworkManager", "render pass 4", 1, 1);
         CallProgressCallback("NetworkManager", "composite pass 4", 0, 1);
@@ -7576,10 +7578,9 @@ NetworkManager::RenderTranslucent(avtImage_p& input)
         if ((rank == 0) || renderState.allReducePass2)
             output->GetImage().SetZBufferVTK(input->GetImage().GetZBufferVTK());
 
-#ifdef ProgrammableCompositerDEBUG
-        if ((rank == 0) || renderState.allReducePass2)
+        if (programmableCompositerDebug &&
+            ((rank == 0) || renderState.allReducePass2))
             writeVTK("pass_4e_trans_composited.vtk", output->GetImage());
-#endif
 
         delete comp;
     }
@@ -7684,6 +7685,9 @@ NetworkManager::StopTimer()
 //    names and be named such that their sort order matches the order in
 //    which they are generated. I renumbered the rendering passes.
 //
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    Added the ability to enable programmable compositing debug at runtime.
+//
 // ****************************************************************************
 
 void
@@ -7742,9 +7746,8 @@ NetworkManager::RenderShadows(avtImage_p& input) const
                                   /*viewport=*/renderState.viewportedMode, /*z=*/true
                                   );
 
-#ifdef ProgrammableCompositerDEBUG
-        writeVTK("pass_2a_shadow_partial.vtk", myLightImage->GetImage());
-#endif
+        if (programmableCompositerDebug)
+            writeVTK("pass_2a_shadow_partial.vtk", myLightImage->GetImage());
 
         avtWholeImageCompositer *wic = new avtWholeImageCompositerWithZ();
         wic->SetShouldOutputZBuffer(true);
@@ -7764,9 +7767,8 @@ NetworkManager::RenderShadows(avtImage_p& input) const
 
         if (PAR_Rank() == 0)
         {
-#ifdef ProgrammableCompositerDEBUG
-            writeVTK("pass_2b_shadow_composited.vtk", lightImage->GetImage());
-#endif
+            if (programmableCompositerDebug)
+                writeVTK("pass_2b_shadow_composited.vtk", lightImage->GetImage());
             CallProgressCallback("NetworkManager", "Synch'ing up shadows", 0, 1);
 
             double shadow_strength = renderState.windowInfo->
@@ -7775,9 +7777,8 @@ NetworkManager::RenderShadows(avtImage_p& input) const
             avtSoftwareShader::AddShadows(lightImage, input, light_view,
                                           cur_view, shadow_strength);
 
-#ifdef ProgrammableCompositerDEBUG
-            writeVTK("pass_2c_shadow_applied.vtk", input->GetImage());
-#endif
+            if (programmableCompositerDebug)
+                writeVTK("pass_2c_shadow_applied.vtk", input->GetImage());
 
             CallProgressCallback("NetworkManager", "Synch'ing up shadows", 1, 1);
         }
@@ -7815,6 +7816,9 @@ NetworkManager::RenderShadows(avtImage_p& input) const
 //    names and be named such that their sort order matches the order in
 //    which they are generated. I renumbered the rendering passes.
 //
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    Added the ability to enable programmable compositing debug at runtime.
+//
 // ****************************************************************************
 
 void
@@ -7838,9 +7842,8 @@ NetworkManager::RenderDepthCues(avtImage_p& input) const
              renderAtts.GetEndCuePoint(),
              annoAtts.GetBackgroundColor().GetColor());
 
-#ifdef ProgrammableCompositerDEBUG
-        writeVTK("pass_3_depth_cues.vtk", input->GetImage());
-#endif
+        if (programmableCompositerDebug)
+            writeVTK("pass_3_depth_cues.vtk", input->GetImage());
     }
     CallProgressCallback("NetworkManager", "Applying depth cueing", 1,1);
 }

--- a/src/engine/main/NetworkManager.h
+++ b/src/engine/main/NetworkManager.h
@@ -437,6 +437,9 @@ typedef void   (*ProgressCallback)(void *, const char *, const char *,int,int);
 //    Change ExportDatabase atts arg from 'const &' to * so that actual dir
 //    name used can be returned in them.
 //
+//    Eric Brugger, Tue Sep 23 10:13:44 PDT 2025
+//    I added EnableProgrammableCompositerDebug.
+//
 // ****************************************************************************
 
 class ENGINE_MAIN_API NetworkManager : public EngineBase
@@ -566,6 +569,8 @@ class ENGINE_MAIN_API NetworkManager : public EngineBase
                                           long long &);
 
     void          SetCreateVisWindow(void (*cb)(int, VisWindow *&, bool &, void *), void *cbdata);
+
+    static void   EnableProgrammableCompositerDebug(void) {programmableCompositerDebug = true;};
 
  protected:
     bool               ValidNetworkId(int id) const;
@@ -748,6 +753,8 @@ class ENGINE_MAIN_API NetworkManager : public EngineBase
 
     ProgrammableCompositer<unsigned char> *zcomp;
     ProgrammableCompositer<float> *acomp;
+
+    static bool                 programmableCompositerDebug;
 
     static InitializeProgressCallback
                                 initializeProgressCallback;

--- a/src/engine/main/ProgrammableCompositer.h
+++ b/src/engine/main/ProgrammableCompositer.h
@@ -294,7 +294,6 @@ void AddPointData(vtkDataSet *d, const char *name, T *p, size_t n, int keep, int
 }
 
 
-#ifdef ProgrammableCompositerDEBUG
 #include <vtkImageData.h>
 #include <vtkDataArray.h>
 #include <vtkPointData.h>
@@ -377,10 +376,6 @@ void writeVTK(const char *file, avtImageRepresentation &aim)
     dw->Delete();
     id->Delete();
 }
-#endif
-
-
-
 
 
 

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -49,7 +49,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Advanced features added in version 3.5</font></b></p>
 <ul>
   <li>Ghost Zone exchange was enhanced to handle not only scalars, material species, and vectors as before, but also tensors, symmetric tensors, and array variables.</li>
-  <li>Advanced Feature 2</li>
+  <li>The <code>-compositer-debug</code> command line option was added, which dumps intermediate image results during the compositing process of scalable rendering.</li>
 </ul>
 
 <a name="GUI_changes"></a>

--- a/src/resources/usage/visitusageplus.txt
+++ b/src/resources/usage/visitusageplus.txt
@@ -279,6 +279,8 @@
                              the leading letter (A-E) indicating most to least
                              recent. The clobber_vlogs flag causes VisIt to remove
                              all debug logs and begin creating them anew.
+        -compositer-debug    Dump intermediate image results during the
+                             compositing process of scalable rendering.
         -vtk-debug           Turn on debugging of vtk objects used in pipelines.
         -pid                 Append process ids to the names of log files.
         -timing              Save timing data to files.


### PR DESCRIPTION
### Description

Resolves #20614

I added the command line option `-compositer-debug` that enables compositing debugging in scalable rendering.

I also fixed a typo in the Rendering Options documentation from a previous commit that Cyrus caught.

### Type of change

* [X] New feature~~

### How Has This Been Tested?

I ran VisIt normally in parallel with scalable rendering to verify that the it doesn't output the debugging information in normal usage. Here is the log of that.
```
rzwhippet17{brugger}173: ls
README	test.py  visit0000.session  visit0000.session.gui
rzwhippet17{brugger}174: cat test.py
OpenDatabase("/usr/gapps/visit/data/multi_ucd3d.silo")

ra = GetRenderingAttributes()
ra.scalableActivationMode = ra.Always
ra.doShadowing = 1
SetRenderingAttributes(ra)

light = LightAttributes()
light.enabledFlag = 1
light.type = light.Camera
light.direction = (-0.817, 0.164, -0.552)
light.color = (255, 255, 255, 255)
light.brightness = 1
SetLight(0, light)

AddPlot("Pseudocolor", "d")
pc = PseudocolorAttributes()
pc.opacityType = pc.Constant
pc.opacity = 0.25
SetPlotOptions(pc)

v = View3DAttributes()
v.viewNormal = (-0.0259038, -0.871847, 0.489093)
v.focus = (0, 2.5, 10)
v.viewUp = (-0.32163, 0.470512, 0.821689)
v.viewAngle = 30
v.parallelScale = 11.4564
v.nearPlane = -22.9129
v.farPlane = 22.9129
v.imagePan = (0, 0)
v.imageZoom = 1
v.perspective = 1
SetView3D(v)

DrawPlots()

quit()
rzwhippet17{brugger}175: /usr/workspace/brugger/visit_dev_git/visit/build/bin/visit -np 2 -nn 1 -p pdebug -l srun -t 30:00 -s test.py
Running: gui -dv -s test.py -engineargs -l;srun;-np;2;-nn;1;-p;pdebug;-t;30:00 -launchengine localhost
Running: viewer -dv -s test.py -engineargs -l;srun;-np;2;-nn;1;-p;pdebug;-t;30:00 -launchengine localhost -geometry 1558x1173+362+27 -borders 29,5,5,5 -shift 17,27 -preshift -12,2 -defer -host rzwhippet17.llnl.gov -port 5600
Running: mdserver -dv -host 127.0.0.1 -port 5601
Running: srun -n 2 -N 1 -p pdebug -t 30:00 /usr/WS1/brugger/visit_dev_git/visit/build/exe/engine_par -dv -host rzwhippet17 -port 5600
srun: job 4462050 queued and waiting for resources
srun: job 4462050 has been allocated resources
Running: xterm -geometry 120x40 -title "VisIt cli" -e "/usr/WS1/brugger/visit_dev_git/visit/build/bin/visit -cli -dv -reverse_launch -host 127.0.0.1 -port 5600 -key b69fc7d321396e9993e2"
rzwhippet17{brugger}176: ls
README	test.py  visit0000.session  visit0000.session.gui  visitlog.py
```
I then ran the same command with `-compositer-debug` and verified that the debug files were generated. Here is the log.
```
rzwhippet17{brugger}177: ls
README	test.py  visit0000.session  visit0000.session.gui  visitlog.py
rzwhippet17{brugger}178: /usr/workspace/brugger/visit_dev_git/visit/build/bin/visit -np 2 -nn 1 -p pdebug -l srun -t 30:00 -s test.py -compositer-debug
Running: gui -dv -s test.py -compositer-debug -engineargs -l;srun;-np;2;-nn;1;-p;pdebug;-t;30:00 -launchengine localhost
Running: viewer -dv -s test.py -compositer-debug -engineargs -l;srun;-np;2;-nn;1;-p;pdebug;-t;30:00 -launchengine localhost -geometry 1558x1173+362+27 -borders 29,5,5,5 -shift 17,27 -preshift -12,2 -defer -host rzwhippet17.llnl.gov -port 5600
Running: mdserver -dv -compositer-debug -host 127.0.0.1 -port 5601
Running: srun -n 2 -N 1 -p pdebug -t 30:00 /usr/WS1/brugger/visit_dev_git/visit/build/exe/engine_par -dv -compositer-debug -host rzwhippet17 -port 5600
srun: job 4462177 queued and waiting for resources
srun: job 4462177 has been allocated resources
Running: xterm -geometry 120x40 -title "VisIt cli" -e "/usr/WS1/brugger/visit_dev_git/visit/build/bin/visit -cli -dv -reverse_launch -compositer-debug -host 127.0.0.1 -port 5600 -key 4c7d4de117f75487e980"
rzwhippet17{brugger}179: ls -l
total 202388
-rw------- 1 brugger brugger 17594610 Sep 23 16:34 0_pass_1a_opaque_partial.vtk
-rw------- 1 brugger brugger 17594610 Sep 23 16:34 0_pass_1b_opaque_composited.vtk
-rw------- 1 brugger brugger 17578626 Sep 23 16:34 0_pass_2a_shadow_partial.vtk
-rw------- 1 brugger brugger 17565013 Sep 23 16:34 0_pass_2b_shadow_composited.vtk
-rw------- 1 brugger brugger 17594615 Sep 23 16:34 0_pass_2c_shadow_applied.vtk
-rw------- 1 brugger brugger 14972744 Sep 23 16:34 0_pass_4d_trans_partial.vtk
-rw------- 1 brugger brugger 17598924 Sep 23 16:34 0_pass_4e_trans_composited.vtk
-rw------- 1 brugger brugger 17598924 Sep 23 16:34 0_pass_5.vtk
-rw------- 1 brugger brugger 17594610 Sep 23 16:34 1_pass_1a_opaque_partial.vtk
-rw------- 1 brugger brugger 17594610 Sep 23 16:34 1_pass_1b_opaque_composited.vtk
-rw------- 1 brugger brugger 17582306 Sep 23 16:34 1_pass_2a_shadow_partial.vtk
-rw------- 1 brugger brugger 14972593 Sep 23 16:34 1_pass_4d_trans_partial.vtk
-rw------- 1 brugger brugger      403 Sep 15 08:46 README
-rw------- 1 brugger brugger      799 Sep 23 16:30 test.py
-rw------- 1 brugger brugger   486064 Sep 12 16:47 visit0000.session
-rw------- 1 brugger brugger     4262 Sep 12 11:50 visit0000.session.gui
-rw------- 1 brugger brugger      215 Sep 23 16:34 visitlog.py
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
