### PR TITLE
Set the LD_LIBRARY_PATH appropriately for MPI on rzadams in the LLNL custom launcher.

### DIFF
--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -265,6 +265,9 @@ class JobSubmitter_jsrun_LLNL(JobSubmitter):
 #   Eric Brugger, Mon Aug 26 10:54:18 PDT 2024
 #   Added an LLNL specific job launcher for jsrun.
 #
+#   Eric Brugger, Fri Sep 26 16:14:02 PDT 2025
+#   Added logic to set the LD_LIBRARY_PATH appropriately for MPI on rzadams.
+#
 ###############################################################################
 
 class LLNLLauncher(MainLauncher):
@@ -305,6 +308,13 @@ class LLNLLauncher(MainLauncher):
             self.generalArgs.host = "130.106.204.1"
         elif self.generalArgs.host == "agate5.llnl.gov":
             self.generalArgs.host = "130.106.204.3"
+
+        # Set the LD_LIBRARY_PATH on rzadams to add some paths that are
+        # missing for MPI. The paths are included on tuolumne.
+        if self.sectorname() == "rzadams":
+            ld_library_path = GETENV("LD_LIBRARY_PATH")
+            new_ld_library_path = self.joinpaths(["/opt/cray/pe/lib64:/opt/cray/lib64:/opt/cray/pe/papi/7.2.0.2/lib64:/opt/cray/libfabric/2.1/lib64", ld_library_path])
+            SETENV("LD_LIBRARY_PATH", new_ld_library_path)
 
         #
         # TODO: This is for trinity, what do we need (if anything) for crossroads (xr-fe)?


### PR DESCRIPTION
### Description

Resolves #20374

I set the `LD_LIBRARY_PATH` appropriately for MPI on rzadams in the LLNL custom launcher. The path was set to add standard paths present in the `LD_LIBRARY_PATH` on tuolumne that were missing on rzadams.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I made the change to the custom launcher installed in public on the RZ. Before the change I got the error in the ticket referenced above and after the change the error went away and the parallel engine launched successfully.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
