### PR TITLE
Pipe vtkLogger output to debug logs

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -55,7 +55,6 @@
 #endif
 
 #ifdef HAVE_ANARI
-    #include <vtkLogger.h>
     #include <vtkAnariSceneGraph.h>
     #include <vtkAnariVisItViewNodeFactory.h>
     #include <vtkViewNodeFactory.h>
@@ -285,6 +284,9 @@ vtkStandardNewMacro(vtkBackgroundPass);
 //   Kathleen Biagas, Thu Aug 28 15:37:48 PDT 2025
 //   Removes surfaceRepresentation, no longer used.
 //
+//   Kathleen Biagas, Wed Oct 1, 2025
+//   Removed vtkLogger settings, now handled in InitVTKLite.
+//
 // ****************************************************************************
 
 VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
@@ -359,20 +361,6 @@ VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
 
     anariRendering = false;
 #ifdef HAVE_ANARI
-    // For VisIt debug levels 1-3
-    auto vtkVerbosity = vtkLogger::Verbosity::VERBOSITY_ERROR;
-
-    if(DebugStream::Level4())
-    {
-        vtkVerbosity = vtkLogger::Verbosity::VERBOSITY_WARNING;
-    }
-    else if(DebugStream::Level5())
-    {
-        vtkVerbosity = vtkLogger::Verbosity::VERBOSITY_INFO;
-    }
-
-    vtkLogger::SetStderrVerbosity(vtkVerbosity);
-
     anariAttributes = AnariAttributes();
     anariPass = CreateAnariPass();
 #endif

--- a/src/engine/main/Engine.C
+++ b/src/engine/main/Engine.C
@@ -780,6 +780,11 @@ public:
 //   Kathleen Biagas, Wed June 18, 2025
 //   Remove vtkOffScreenRenderingFactory, no longer needed (VTK 9.5)
 //
+//   Kathleen Biagas, Wed Oct 1, 2025
+//   Add a component-name string argument to InitVTK::Initialize.
+//   It will be used for creating a vtkLogger callback to write their log
+//   info to VisIt's debug log.
+//
 // ****************************************************************************
 
 void
@@ -793,7 +798,13 @@ Engine::InitializeCompute()
     }
 
     int setupTimer = visitTimer->StartTimer();
-    InitVTK::Initialize();
+    std::string compName("engine");
+#ifdef PARALLEL
+    compName += std::string("_par_") + std::to_string(PAR_Rank());
+#else
+    compName += std::string("_ser");
+#endif
+    InitVTK::Initialize(compName);
     InitVTKRendering::Initialize();
 #ifdef HAVE_LIBVTKM
     vtkm::cont::Initialize();

--- a/src/mdserver/main/main.C
+++ b/src/mdserver/main/main.C
@@ -112,6 +112,11 @@ bool ProcessCommandLine(int argc, char *argv[]);
 //    Justin Privitera, Wed Aug 24 11:08:51 PDT 2022
 //    Call `avtConduitBlueprintDataAdaptor::Initialize();`.
 //
+//    Kathleen Biagas, Wed Oct 1, 2025
+//    Add a component-name string argument to InitVTKLite::Initialize.
+//    It will be used for creating a vtkLogger callback to write their log
+//    info to VisIt's debug log.
+//
 // ****************************************************************************
 
 int
@@ -122,7 +127,7 @@ MDServerMain(int argc, char *argv[])
     // Initialize error logging
     VisItInit::SetComponentName("mdserver");
     VisItInit::Initialize(argc, argv);
-    InitVTKLite::Initialize();
+    InitVTKLite::Initialize("mdserver");
     avtDatabase::SetOnlyServeUpMetaData(true);
 #ifdef HAVE_CONDUIT
     avtConduitBlueprintDataAdaptor::Initialize();

--- a/src/viewer/main/VisItViewer.C
+++ b/src/viewer/main/VisItViewer.C
@@ -143,6 +143,10 @@ VisItViewer::Finalize()
 // Creation:   Mon Aug 18 16:32:59 PDT 2008
 //
 // Modifications:
+//   Kathleen Biagas, Wed Oct 1, 2025
+//   Add a component-name string argument to InitVTK::Initialize.
+//   It will be used for creating a vtkLogger callback to write their log
+//   info to VisIt's debug log.
 //
 // ****************************************************************************
 
@@ -155,7 +159,7 @@ VisItViewer::VisItViewer() : visitHome()
     // Initialize the error logging.
     //
     VisItInit::ComponentRegisterErrorFunction(ViewerErrorCallback, (void*)viewer);
-    InitVTK::Initialize();
+    InitVTK::Initialize("viewer");
     InitVTKRendering::Initialize();
     avtCallback::RegisterWarningCallback(ViewerWarningCallback,
                                          (void*)viewer);

--- a/src/visit_vtk/full/InitVTK.C
+++ b/src/visit_vtk/full/InitVTK.C
@@ -12,7 +12,6 @@
 #include <vtkObjectFactory.h>
 #include <vtkVersion.h>
 #include <vtkVisItCellDataToPointData.h>
-#include <vtkLogger.h>
 #include <visit-config.h>
 
 
@@ -107,21 +106,23 @@ vtkVisItObjectFactory::vtkVisItObjectFactory()
 //    Kathleen Biagas, Thu Jul 17, 2025
 //    Stifle vtkLogger output to terminal by setting its verbosity level OFF.
 //    Avoids lots of console output, even from vtkWarning or vtkDebug macros
-//    which we capture in our debug logs.
+//    which we capture in our debug logs. 
+//
+//    Kathleen Biagas, Wed Oct 1, 2025
+//    Move vtkLogger logic to InitVTKLite.  Pass component argument
+//    to InitVTKLite::Initialize.
 //
 // ****************************************************************************
 
 void
-InitVTK::Initialize(void)
+InitVTK::Initialize(const std::string &component)
 {
-    InitVTKLite::Initialize();
+    InitVTKLite::Initialize(component);
 
     // Register the factory that allows VisIt objects to override vtk objects.
     vtkVisItObjectFactory *factory = vtkVisItObjectFactory::New();
     vtkObjectFactory::RegisterFactory(factory);
     factory->Delete();
-
-    vtkLogger::SetStderrVerbosity(vtkLogger::Verbosity::VERBOSITY_OFF);
 }
 
 

--- a/src/visit_vtk/full/InitVTK.h
+++ b/src/visit_vtk/full/InitVTK.h
@@ -9,6 +9,7 @@
 #ifndef INIT_VTK_H
 #define INIT_VTK_H
 #include <visit_vtk_exports.h>
+#include <string>
 
 // ****************************************************************************
 //  Module: InitVTK
@@ -19,11 +20,17 @@
 //  Programmer: Hank Childs
 //  Creation:   April 24, 2001
 //
+//  Modifications:
+//    Kathleen Biagas, Wed Oct 1, 2025
+//    Add optional string argument. It will be passed to
+//    InitVTKLite::Initialize, and used to create a callback to write their
+//    log info to VisIt's debug log.
+//
 // ****************************************************************************
 
 namespace InitVTK
 {
-    VISIT_VTK_API void Initialize();
+    VISIT_VTK_API void Initialize(const std::string & = "");
 }
 
 #endif

--- a/src/visit_vtk/lightweight/InitVTKLite.C
+++ b/src/visit_vtk/lightweight/InitVTKLite.C
@@ -11,11 +11,24 @@
 #include <vtkObjectFactory.h>
 #include <vtkDebugStream.h>
 #include <vtkVersion.h>
+#include <vtkLogger.h>
+#include <DebugStream.h>
 
 //
 // Include any classes that will override vtk classes.
 //
 
+
+//
+// A callback for use with vtkLogger, allows capturing to debug logs.
+// userData should be one of our DebugStreams.
+// Currently only using DebugStream::Stream1().
+//
+auto vtk_logger_callback = [](void* userData, const vtkLogger::Message& message)
+{
+    std::ostream& s = *reinterpret_cast<std::ostream*>(userData);
+    s << message.preamble << message.message << std::endl;
+};
 
 //
 // A factory that will allow VisIt to override any vtkObject
@@ -75,13 +88,43 @@ vtkVisItFactory::vtkVisItFactory()
 //    Hank Childs, Thu Jan 22 16:47:27 PST 2004
 //    Renamed to InitVTKLite.
 //
+//    Kathleen Biagas, Wed Oct 1, 2025
+//    Turn off writing to stderr for vtkLogger.
+//    Redirect vtkLogger output to DebugStream1() via callback,
+//    if logging turned on.
+//
 // ****************************************************************************
 
 void
-InitVTKLite::Initialize(void)
+InitVTKLite::Initialize(const std::string &component)
 {
     vtkDebugStream::Initialize();
 
+    // Prevent vtk logger from writing to stderr.
+    vtkLogger::SetStderrVerbosity(vtkLogger::Verbosity::VERBOSITY_OFF);
+    if(DebugStream::Level1())
+    {
+        // for debug levels 1-2, 
+        auto verbosityLevel = vtkLogger::Verbosity::VERBOSITY_ERROR;
+
+        // Change the verbosity based on debug level.
+        if(DebugStream::Level3())
+        {
+            verbosityLevel = vtkLogger::Verbosity::VERBOSITY_WARNING;
+        }
+        else if(DebugStream::Level5())
+        {
+            verbosityLevel = vtkLogger::Verbosity::VERBOSITY_INFO;
+        }
+
+        // only write to debug1 to prevent multiple versions of the
+        // same message
+        std::string callbackId = component + "_vtkLog";
+        vtkLogger::AddCallback(callbackId.c_str(),
+                               vtk_logger_callback,
+                               &DebugStream::Stream1(),
+                               verbosityLevel);
+    }
 #if 0
     // Register the factory that allows VisIt objects to override vtk objects.
     vtkVisItFactory *factory = vtkVisItFactory::New();
@@ -89,5 +132,4 @@ InitVTKLite::Initialize(void)
     factory->Delete();
 #endif
 }
-
 

--- a/src/visit_vtk/lightweight/InitVTKLite.C
+++ b/src/visit_vtk/lightweight/InitVTKLite.C
@@ -102,19 +102,20 @@ InitVTKLite::Initialize(const std::string &component)
 
     // Prevent vtk logger from writing to stderr.
     vtkLogger::SetStderrVerbosity(vtkLogger::Verbosity::VERBOSITY_OFF);
+
     if(DebugStream::Level1())
     {
-        // for debug levels 1-2, 
+        // for debug levels 1-2,
         auto verbosityLevel = vtkLogger::Verbosity::VERBOSITY_ERROR;
 
         // Change the verbosity based on debug level.
-        if(DebugStream::Level3())
-        {
-            verbosityLevel = vtkLogger::Verbosity::VERBOSITY_WARNING;
-        }
-        else if(DebugStream::Level5())
+        if(DebugStream::Level5())
         {
             verbosityLevel = vtkLogger::Verbosity::VERBOSITY_INFO;
+        }
+        else if(DebugStream::Level3())
+        {
+            verbosityLevel = vtkLogger::Verbosity::VERBOSITY_WARNING;
         }
 
         // only write to debug1 to prevent multiple versions of the
@@ -125,6 +126,7 @@ InitVTKLite::Initialize(const std::string &component)
                                &DebugStream::Stream1(),
                                verbosityLevel);
     }
+
 #if 0
     // Register the factory that allows VisIt objects to override vtk objects.
     vtkVisItFactory *factory = vtkVisItFactory::New();

--- a/src/visit_vtk/lightweight/InitVTKLite.h
+++ b/src/visit_vtk/lightweight/InitVTKLite.h
@@ -10,6 +10,7 @@
 #define INIT_VTK_LITE_H
 
 #include <visit_vtk_light_exports.h>
+#include <string>
 
 // ****************************************************************************
 //  Module: InitVTKLite
@@ -20,11 +21,16 @@
 //  Programmer: Hank Childs
 //  Creation:   January 22, 2004
 //
+//  Modifications:
+//    Kathleen Biagas, Wed Oct 1, 2025
+//    Add string argument. It will be used for creating a vtkLogger
+//    callback to write their log info to VisIt's debug log.
+//
 // ****************************************************************************
 
 namespace InitVTKLite
 {
-    VISIT_VTK_LIGHT_API void Initialize();
+    VISIT_VTK_LIGHT_API void Initialize(const std::string &);
 }
 
 #endif


### PR DESCRIPTION
### Description

Resolves #20632.

I added logic to add callbacks to vtkLogger for mdserver, engine and viewer  components that will allow vtkLogger output to be written to the debug log files for the components.

Verbosity level for vtkLogger output is determined by the VisIt Debug log  level:
`-debug 1`  will set ERROR verbosity level, meaning only error level vtkLogger messages will be written.
`-debug 3`  will set WARNING verbosity level, meaning warning and error level vtkLogger messages will be written.
`-debug 5`  will set INFO verbosity level, meaning info, warning, and error level vtkLogger messages will be written.  

vtkLogger output is only written to the debug1 stream (since that will propagate to all other levels if they are enabled).

vtkLogger output to stderr is turned off.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

1) I ran the reproducer in #17308 to ensure the warnings generated are not written to the terminal.
2) I temporarily modified avt/Plotter/vtk/vtkPointMapper to add vtkLog(ERROR), vtkLog(WARNING) and vtkLog(INFO) messages, then ran VisIt with `-debug 1` to ensure I only saw the ERROR Message in the viewer log file then ran VisIt again with `-debug 3` to see the ERROR and WARNING messages. Then again with `-debug 5` to see all three levels of messages: ERROR, WARNING, and INFO.
3) Just to be sure the engine log files are also working I added similar logic to visit_vtk/full/vtkVisItContourFilter to add vtkLog calls, ran VisIt with the different debug levels and ensured only the appropriate vtkLog file messages were written to the engine logs.

I performed these tests on Windows and Poodle.


- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
