### PR TITLE
Task/brugger1/2025 10 03 adios2 rzadams

### DIFF
--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -269,7 +269,7 @@ class JobSubmitter_jsrun_LLNL(JobSubmitter):
 #   Added logic to set the LD_LIBRARY_PATH appropriately for MPI on rzadams.
 #
 #   Eric Brugger, Thu Oct  2 16:39:43 PDT 2025
-#   Added logic to set the LD_LIBBRARY_PATH to include the path to libfi.so
+#   Added logic to set the LD_LIBRARY_PATH to include the path to libfi.so
 #   on elcap, rzadams and tuolumne.
 #
 ###############################################################################

--- a/src/resources/hosts/llnl/customlauncher
+++ b/src/resources/hosts/llnl/customlauncher
@@ -268,6 +268,10 @@ class JobSubmitter_jsrun_LLNL(JobSubmitter):
 #   Eric Brugger, Fri Sep 26 16:14:02 PDT 2025
 #   Added logic to set the LD_LIBRARY_PATH appropriately for MPI on rzadams.
 #
+#   Eric Brugger, Thu Oct  2 16:39:43 PDT 2025
+#   Added logic to set the LD_LIBBRARY_PATH to include the path to libfi.so
+#   on elcap, rzadams and tuolumne.
+#
 ###############################################################################
 
 class LLNLLauncher(MainLauncher):
@@ -334,6 +338,15 @@ class LLNLLauncher(MainLauncher):
         if sys_type == "toss_4_x86_64" or sys_type == "toss_4_x86_64_ib":
             mpi_ld_library_paths = ["/usr/tce/packages/mvapich2-tce/mvapich2-2.3.6-gcc-10.3.1/lib"]
             SETENV("LD_LIBRARY_PATH", self.joinpaths(mpi_ld_library_paths))
+
+        #
+        # Set the LD_LIBRARY_PATH to include the path to libfi.so, which is
+        # used by ADIOS2, on elcap, rzadams and tuolumne.
+        #
+        if sys_type == "toss_4_x86_64_ib_cray":
+            ld_library_path = GETENV("LD_LIBRARY_PATH")
+            new_ld_library_path = self.joinpaths(["/opt/cray/pe/cce/20.0.0/cce/x86_64/lib", ld_library_path])
+            SETENV("LD_LIBRARY_PATH", new_ld_library_path)
 
         # Unset LD_PRELOAD
         UNSETENV("LD_PRELOAD")


### PR DESCRIPTION
### Description

Resolves #20417

I added logic to the LLNL custom launcher to add the path to `libfi.so` to the `LD_LIBRARY_PATH` on elcap, rzadams and tuolumne. This fixes an issue with the mdserver outputting an error message related to the ADIOS2 plugin on those systems.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I built a distribution on rzadams and then installed it in my local space. I updated the host profile to point to my installation. I then ran VisIt and the error message from the ADIOS2 metadata plugin disappeared. I then opened the ADIOS2 test data from our test suite and successfully plotted data from multiple data files.

I then copied the distribution and ADIOS2 data files to tuolumne and did the same thing there. Everything worked there as expected as well.

I didn't see the error message when running the public version of VisIt on rzadams, but was able to see it with a private installation of the latest development branch. The currently installed version on rzadams doesn't show the problem because it has RPATHs for all the  libraries and executables, whereas the development branch now strips out all the RPATHs except those related to MPI. My only explanation for why a user encountered this is that our third party library installation had its permissions set at one time such that users couldn't read them.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
