### PR TITLE
Fix viewer crash caused by dereferencing an invalid pointer.

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -2701,16 +2701,19 @@ VisWinRendering::SetMSAASamples(int numSamples)
 // Creation:   August 26, 2025
 //
 // Modifications:
+//   Kathleen Biagas, Thu Oct 16, 2025.
+//   Check of olgWin is valid, prevent possible crash.
 //
 // ****************************************************************************
-//
+
 bool
 VisWinRendering::MSAAAvailable()
 {
 #ifdef GL_MAX_SAMPLES
     vtkOpenGLRenderWindow* oglWin = vtkOpenGLRenderWindow::SafeDownCast(GetRenderWindow());
     int msamples = 0;
-    oglWin->GetState()->vtkglGetIntegerv(GL_MAX_SAMPLES, &msamples);
+    if(oglWin)
+        oglWin->GetState()->vtkglGetIntegerv(GL_MAX_SAMPLES, &msamples);
     return (msamples > 1);
 #endif
     return false;

--- a/src/gui/QvisRenderingWindow.C
+++ b/src/gui/QvisRenderingWindow.C
@@ -165,6 +165,9 @@ QvisRenderingWindow::~QvisRenderingWindow()
 //   Kathleen Biagas, Thu Aug 28 15:52:57 PDT 2025
 //   Removed objectRepresentation widget, no longer used.
 //
+//   Kathleen Biagas, Thu Oct 15, 2025
+//   Removed remnant of widgets associated with objectRepresentation.
+//
 // ****************************************************************************
 
 QWidget *
@@ -503,17 +506,6 @@ QvisRenderingWindow::CreateBasicPage()
             this, SLOT(processMultiresolutionSmallestCellText()));
 
     mrLayout->addRow(multiresolutionSmallestCellLabel, multiresolutionSmallestCellLineEdit);
-
-    //
-    // Create the surface rep widgets.
-    //
-    QGroupBox *drawObj = new QGroupBox(tr("Draw objects as"));
-    drawObj->setCheckable(false);
-    basicLayout->addWidget(drawObj);
-
-    QGridLayout *objLayout = new QGridLayout();
-    objLayout->setContentsMargins(10,10,10,10);
-    drawObj->setLayout(objLayout);
 
     //
     // Create the stereo widgets.


### PR DESCRIPTION
Could occur when VisIt loads a config file where new rendering attributes had been saved. Also removed extraneous widgets from Rendering window that should have been removed with a previous change.
