### PR TITLE
Fix crash when a single curve had more than 100000  points.

### DIFF
--- a/src/avt/Filters/avtCurveConstructorFilter.C
+++ b/src/avt/Filters/avtCurveConstructorFilter.C
@@ -319,7 +319,8 @@ void avtCurveConstructorFilter::Execute()
 //    multi-curve output.
 //
 //    Kathleen Biagas, Mon Oct 27, 2025
-//    Ensure ouputArray is cleared in the case it contains too many points.
+//    Changed logic surrounding outputArray: don't add anything to it if
+//    the size will be more than 100000 items.
 //
 // ****************************************************************************
 
@@ -508,16 +509,20 @@ avtCurveConstructorFilter::CreateSingleOutput(avtDataTree_p inTree, const string
     }
     nPoints = sortedXC->GetNumberOfTuples();
     outGrid->SetDimensions(nPoints, 1, 1);
-    outputArray.clear();
-    for (int i = 0; i < nPoints; i++)
-    {
-        outputArray.push_back(sortedXC->GetTuple1(i));
-        outputArray.push_back(sortedVal->GetTuple1(i));
-    }
+
     string varname = (!label.empty() ? label : (pipelineVariable != NULL ? pipelineVariable : "Curve"));
+
+    outputArray.clear();
     // Limit outputArray size that we send back to the client.
-    if(outputArray.size() < 100000)
+    if(nPoints*2 < 100000)
     {
+        for (int i = 0; i < nPoints; i++)
+        {
+            outputArray.push_back(sortedXC->GetTuple1(i));
+            outputArray.push_back(sortedVal->GetTuple1(i));
+        }
+
+        // if there will be more than 1 output curve
         if (count > 1)
         {
             outputInfo[varname] = outputArray;
@@ -526,7 +531,6 @@ avtCurveConstructorFilter::CreateSingleOutput(avtDataTree_p inTree, const string
     }
     else
     {
-        outputArray.clear();
         debug5 << "Curve constructor filter does not send curves that contain "
                   "more than 100K values to the client." << endl;
     }

--- a/src/avt/Filters/avtCurveConstructorFilter.C
+++ b/src/avt/Filters/avtCurveConstructorFilter.C
@@ -318,6 +318,9 @@ void avtCurveConstructorFilter::Execute()
 //    Utilize same varname for single-curve output as would be used for
 //    multi-curve output.
 //
+//    Kathleen Biagas, Mon Oct 27, 2025
+//    Ensure ouputArray is cleared in the case it contains too many points.
+//
 // ****************************************************************************
 
 vtkDataSet *
@@ -523,6 +526,7 @@ avtCurveConstructorFilter::CreateSingleOutput(avtDataTree_p inTree, const string
     }
     else
     {
+        outputArray.clear();
         debug5 << "Curve constructor filter does not send curves that contain "
                   "more than 100K values to the client." << endl;
     }

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -142,6 +142,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed crash loading SILO files when compiled with version 4.11 of the SILO library.</li>
   <li>Fixed a bug with global mesh expressions causing them to only work on single domain data. They now function across all domains in parallel and in serial.</li>
   <li>Eliminated a couple of memory leaks. The first was in the operator that removes ghost zones and calculates external faces. The second was in the Resample operator.</li>
+  <li>Fixed a crash with Curve plot when Curve contained more than 100000 points.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
### Description

Resolves #20681.

VisIt saves curves in PlotInfoAttributes for easy access via cli, but only if there are less than 100000 points. The logic testing for number of points was flawed due to changes related to saving multiple curves.  Logic was fixed to prevent the crash.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

Can now successfully draw a Curve plot with the data that has more than 100000 points for the curve.


### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
