### PR TITLE
Re-add ICET_FULLPATH_LIB to Volume plot

### DIFF
--- a/src/plots/Volume/CMakeLists.txt
+++ b/src/plots/Volume/CMakeLists.txt
@@ -137,6 +137,13 @@ IF(VISIT_PARALLEL)
 ENDIF(VISIT_PARALLEL)
 
 
+if(ICET_FOUND)
+    target_link_libraries(EVolumePlot_ser ${ICET_FULLPATH_LIB})
+    if(PARALLEL)
+       target_link_libraries(EVolumePlot_par ${ICET_FULLPATH_LIB})
+    endif()
+endif()
+
 if(HAVE_ANARI)
     target_sources(GVolumePlot PUBLIC
         anari/AnariVolumeWidget.C)

--- a/src/plots/Volume/VolumeAttributes.code
+++ b/src/plots/Volume/VolumeAttributes.code
@@ -25,6 +25,13 @@ if(ICET_FOUND)
     add_definitions(-DHAVE_ICET)
 endif()
 Postfix:
+if(ICET_FOUND)
+    target_link_libraries(EVolumePlot_ser ${ICET_FULLPATH_LIB})
+    if(PARALLEL)
+       target_link_libraries(EVolumePlot_par ${ICET_FULLPATH_LIB})
+    endif()
+endif()
+
 if(HAVE_ANARI)
     target_sources(GVolumePlot PUBLIC
         anari/AnariVolumeWidget.C)


### PR DESCRIPTION
### Description

Resolves #20686

Adds back into VolumePlot's CMakeLists.txt the use of ICET_FULLPATH_LIB for linking with engine components.


### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~
### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
