### PR TITLE
Fixed anari volume memory leak found during hackathon

### DIFF
--- a/src/plots/Volume/avtVisItVTKRenderer.C
+++ b/src/plots/Volume/avtVisItVTKRenderer.C
@@ -664,10 +664,26 @@ avtVisItVTKRenderer::UpdateRenderingState(vtkDataSet * in_ds,
         if(m_anariEnabled)
         {
             LOCAL_DEBUG << "ANARI Volume Mapper " << std::endl;
+            vtkAnariVolumeMapper *anariVolumeMapper = nullptr;
 
-            vtkAnariVolumeMapper *anariVolumeMapper = vtkAnariVolumeMapper::New();
-            m_volumeMapper = anariVolumeMapper;
+            if(m_volumeMapper != nullptr &&
+               m_volumeMapper->IsA("vtkAnariVolumeMapper"))
+            {
+                debug5 << "Reusing existing ANARI Volume Mapper " << std::endl;
+                anariVolumeMapper = vtkAnariVolumeMapper::SafeDownCast(m_volumeMapper);
+            }
+            else
+            {
+                if(m_volumeMapper != nullptr)
+                {
+                    m_volumeMapper->Delete();
+                }
 
+                debug5 << "Creating new ANARI Volume Mapper " << std::endl;
+                anariVolumeMapper = vtkAnariVolumeMapper::New();
+                m_volumeMapper = anariVolumeMapper;
+            }
+            
             if(!anariVolumeMapper->GetInitialized())
             {
                 anariVolumeMapper->Init();


### PR DESCRIPTION
### Description

Fixed ANARI volume rendering memory leak found during the [TACC Open Hackathon](https://www.openhackathons.org/s/siteevent/a0C5e000008dWhsEAE/se000284).

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?
Optionally `export ANARI_LIBRARY=helide` (or any ANARI compliant back-end) before starting VisIt. If not, VisIt will warn you and then default to using helide.

1. Open `noise.silo`
2. Add _Pseudocolor -> hardyglobal_ (or any variable of your choosing)
3. Select `ANARI` as the **Rendering Method**
4. Enable **ANARI Rendering**
5. Update the rendering options as needed
6. Click Apply

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [X] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
