### PR TITLE
Fix a memory leak in VisWinRendering.

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -287,6 +287,11 @@ vtkStandardNewMacro(vtkBackgroundPass);
 //   Kathleen Biagas, Wed Oct 1, 2025
 //   Removed vtkLogger settings, now handled in InitVTKLite.
 //
+//   Eric Brugger, Fri Oct 31 10:52:11 PDT 2025
+//   Added the render event vtkCallbackCommand pointer to the class so
+//   that it could be explicitly deleted since it wasn't getting deleted
+//   using a vtkSmartPointer.
+//
 // ****************************************************************************
 
 VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
@@ -309,7 +314,8 @@ VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
     scalableAutoThreshold(RenderingAttributes::DEFAULT_SCALABLE_ACTIVATION_MODE),
     compactDomainsActivationMode(RenderingAttributes::DEFAULT_COMPACT_DOMAINS_ACTIVATION_MODE),
     compactDomainsAutoThreshold(RenderingAttributes:: DEFAULT_COMPACT_DOMAINS_AUTO_THRESHOLD),
-    setRenderUpdate(true)
+    setRenderUpdate(true),
+    command(NULL)
 {
     background = vtkRenderer::New();
     background->SetInteractive(0);
@@ -381,8 +387,13 @@ VisWinRendering::VisWinRendering(VisWindowColleagueProxy &p) :
 //    Moved the deletion of the render window to the end to the end of the
 //    routine to avoid a crash.
 //
-//   Kathleen Biagas, Wed Aug 17, 2022
-//   Incorporate ARSanderson's OSPRAY 2.8.0 work for VTK 9.
+//    Kathleen Biagas, Wed Aug 17, 2022
+//    Incorporate ARSanderson's OSPRAY 2.8.0 work for VTK 9.
+//
+//    Eric Brugger, Fri Oct 31 10:52:11 PDT 2025
+//    Added the render event vtkCallbackCommand pointer to the class so
+//    that it could be explicitly deleted since it wasn't getting deleted
+//    using a vtkSmartPointer.
 //
 // ****************************************************************************
 
@@ -402,6 +413,11 @@ VisWinRendering::~VisWinRendering()
     {
         foreground->Delete();
         foreground = nullptr;
+    }
+    if (command != nullptr)
+    {
+        command->Delete();
+        command = nullptr;
     }
 #if defined(HAVE_OSPRAY)
     if (osprayPass != nullptr)
@@ -443,6 +459,11 @@ VisWinRendering::~VisWinRendering()
 //    Burlen Loring, Thu Oct  8 10:38:18 PDT 2015
 //    fix a compiler warning
 //
+//    Eric Brugger, Fri Oct 31 10:52:11 PDT 2025
+//    Added the render event vtkCallbackCommand pointer to the class so
+//    that it could be explicitly deleted since it wasn't getting deleted
+//    using a vtkSmartPointer.
+//
 // ****************************************************************************
 
 static void renderEventCallback(vtkObject*, unsigned long, void* clientdata, void* calldata)
@@ -466,7 +487,7 @@ VisWinRendering::InitializeRenderWindow(vtkRenderWindow *renWin)
         renWin->SetStereoCapableWindow(1);
     }
 
-    vtkSmartPointer<vtkCallbackCommand> command = vtkCallbackCommand::New();
+    command = vtkCallbackCommand::New();
     command->SetCallback(renderEventCallback);
     command->SetClientData(this);
 

--- a/src/avt/VisWindow/Colleagues/VisWinRendering.h
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.h
@@ -27,6 +27,7 @@
 #include <AnariAttributes.h>
 #endif
 
+class vtkCallbackCommand;
 class vtkInteractorStyle;
 class vtkPolyDataMapper2D;
 class vtkRenderer;
@@ -239,6 +240,11 @@ class VisWindowColleagueProxy;
 //
 //    Kevin Griffin, Tue Sep 16, 2025
 //    Switched to using AnariAttributes.
+//
+//    Eric Brugger, Fri Oct 31 10:52:11 PDT 2025
+//    Added the render event vtkCallbackCommand pointer to the class so
+//    that it could be explicitly deleted since it wasn't getting deleted
+//    using a vtkSmartPointer.
 //
 // ****************************************************************************
 
@@ -524,6 +530,7 @@ class VISWINDOW_API VisWinRendering : public VisWinColleague
     int                           compactDomainsAutoThreshold;
 
     // render options
+    vtkCallbackCommand           *command {nullptr};
     bool                          setRenderUpdate;
     void                          InitializeRenderWindow(vtkRenderWindow *);
     void                          ResetCounters();


### PR DESCRIPTION
### Description

I fixed a memory leak in `VisWinRendering` with a pointer to a `vtkCallbackCommand`. It was stored using a `vtkSmartPointer`, but it wasn't getting deleted for some reason. I changed it to a normal pointer and added code to explicitly delete it in the destructor.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I used valgrind to check for memory leaks. I opened `rect3d.silo`, created a pseudocolor plot of "d" and exited. Here is the output from the `valgrind` showing the leak.
```
==3813172== 72 bytes in 1 blocks are definitely lost in loss record 1,225 of 1,325
==3813172==    at 0x4C39913: operator new(unsigned long) (vg_replace_malloc.c:483)
==3813172==    by 0x620E500: vtkCallbackCommand::New() (vtkCallbackCommand.h:38)
==3813172==    by 0x62100FB: VisWinRendering::InitializeRenderWindow(vtkRenderWindow*) (VisWinRendering.C:469)
==3813172==    by 0x6217878: VisWinRenderingWithoutWindow::VisWinRenderingWithoutWindow(VisWindowColleagueProxy&) (VisWinRenderingWithoutWindow.C:65)
==3813172==    by 0x6256AAD: VisWindow::VisWindow() (VisWindow.C:93)
==3813172==    by 0x41591CE: NetworkManager_CreateVisWindow(int, VisWindow*&, bool&, void*) (NetworkManager.C:240)
==3813172==    by 0x416C736: NetworkManager::NewVisWindow(int) (NetworkManager.C:5440)
==3813172==    by 0x4161FC6: NetworkManager::SetWindowAttributes(WindowAttributes const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) (NetworkManager.C:3138)
==3813172==    by 0x413999A: EngineRPCExecutor<SetWinAnnotAttsRPC>::Execute(SetWinAnnotAttsRPC*) (Executors.h:780)
==3813172==    by 0x414CB5E: EngineRPCExecutor<SetWinAnnotAttsRPC>::Update(Subject*) (EngineRPCExecutor.h:33)
==3813172==    by 0xE8CB3A4: Subject::Notify() (Subject.C:159)
==3813172==    by 0xE771CF1: AttributeSubject::Notify() (AttributeSubject.C:65)
==3813172==    by 0xE909247: Xfer::Process() (Xfer.C:382)
==3813172==    by 0x41436F7: Engine::ProcessInput() (Engine.C:1908)
==3813172==    by 0x414358A: Engine::EventLoop() (Engine.C:1852)
==3813172==    by 0x4024F9: EngineMain(int, char**) (main.C:268)
==3813172==    by 0x40265E: main (main.C:331)
```
Here is the leak summary.
```
==3813172== LEAK SUMMARY:
==3813172==    definitely lost: 272 bytes in 10 blocks
==3813172==    indirectly lost: 0 bytes in 0 blocks
==3813172==      possibly lost: 21,297 bytes in 202 blocks
==3813172==    still reachable: 258,081 bytes in 1,208 blocks
==3813172==         suppressed: 0 bytes in 0 blocks
==3813172==
==3813172== For lists of detected and suppressed errors, rerun with: -s
==3813172== ERROR SUMMARY: 161 errors from 161 contexts (suppressed: 0 from 0)
```
After my change, the leak disappeared from the output and the leak summary showed 1 less leak corresponding to the leak I fixed.
```
==4150187== LEAK SUMMARY:
==4150187==    definitely lost: 200 bytes in 9 blocks
==4150187==    indirectly lost: 0 bytes in 0 blocks
==4150187==      possibly lost: 21,297 bytes in 202 blocks
==4150187==    still reachable: 258,081 bytes in 1,208 blocks
==4150187==         suppressed: 0 bytes in 0 blocks
==4150187==
==4150187== For lists of detected and suppressed errors, rerun with: -s
==4150187== ERROR SUMMARY: 160 errors from 160 contexts (suppressed: 0 from 0)
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
