### PR TITLE
Enable blueprint with optional mfem dep

### DIFF
--- a/src/avt/Blueprint/CMakeLists.txt
+++ b/src/avt/Blueprint/CMakeLists.txt
@@ -8,6 +8,9 @@
 #    Justin Privitera, Wed Mar 22 16:09:52 PDT 2023
 #    Added visit_vtk to include dirs and target link libs.
 #
+#    Ryan Krattiger, Fri Oct 31 13:37:05 CST 2025
+#    Blueprints with optional MFEM dependency
+#
 #****************************************************************************
 
 set(AVTBLUEPRINT_SOURCES
@@ -25,12 +28,19 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     )
 
 # Add link directories
-link_directories(${LIBRARY_OUTPUT_DIRECTORY} ${CONDUIT_LIBRARY_DIR} ${MFEM_LIBRARY_DIR})
+link_directories(${LIBRARY_OUTPUT_DIRECTORY} ${CONDUIT_LIBRARY_DIR})
 
 add_library(avtblueprint ${AVTBLUEPRINT_SOURCES})
 
 set(vtklibs lightweight_visit_vtk VTK::CommonCore VTK::FiltersCore)
 
-target_link_libraries(avtblueprint visitcommon avtmfem ${CONDUIT_LIB} ${MFEM_LIB} ${vtklibs})
+target_link_libraries(avtblueprint visitcommon ${CONDUIT_LIB} ${vtklibs})
+if (MFEM_FOUND)
+    target_link_libraries(avtblueprint avtmfem ${MFEM_LIB})
+    link_directories(${LIBRARY_OUTPUT_DIRECTORY} ${MFEM_LIBRARY_DIR})
+endif ()
+target_include_directories(avtblueprint PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+)
 
 VISIT_INSTALL_TARGETS(avtblueprint)

--- a/src/avt/Blueprint/CMakeLists.txt
+++ b/src/avt/Blueprint/CMakeLists.txt
@@ -37,12 +37,17 @@ add_library(avtblueprint ${AVTBLUEPRINT_SOURCES})
 
 set(vtklibs lightweight_visit_vtk VTK::CommonCore VTK::FiltersCore)
 
-target_link_libraries(avtblueprint visitcommon ${CONDUIT_LIB} ${vtklibs})
-if (MFEM_FOUND)
-    target_link_libraries(avtblueprint avtmfem ${MFEM_LIB})
-endif ()
+target_link_libraries(avtblueprint PUBLIC
+    visitcommon
+    ${CONDUIT_LIB}
+    ${vtklibs}
+    $<$<BOOL:"${MFEM_FOUND}">:avtmfem ${MFEM_LIB}>
+)
+
 target_include_directories(avtblueprint PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    ${CONDUIT_INCLUDE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<$<BOOL:"${MFEM_FOUND}">:${MFEM_INCLUDE_DIR}>
 )
 
 VISIT_INSTALL_TARGETS(avtblueprint)

--- a/src/avt/Blueprint/CMakeLists.txt
+++ b/src/avt/Blueprint/CMakeLists.txt
@@ -29,6 +29,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 
 # Add link directories
 link_directories(${LIBRARY_OUTPUT_DIRECTORY} ${CONDUIT_LIBRARY_DIR})
+if (MFEM_FOUND)
+    link_directories(${MFEM_LIBRARY_DIR})
+endif ()
 
 add_library(avtblueprint ${AVTBLUEPRINT_SOURCES})
 
@@ -37,7 +40,6 @@ set(vtklibs lightweight_visit_vtk VTK::CommonCore VTK::FiltersCore)
 target_link_libraries(avtblueprint visitcommon ${CONDUIT_LIB} ${vtklibs})
 if (MFEM_FOUND)
     target_link_libraries(avtblueprint avtmfem ${MFEM_LIB})
-    link_directories(${LIBRARY_OUTPUT_DIRECTORY} ${MFEM_LIBRARY_DIR})
 endif ()
 target_include_directories(avtblueprint PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>

--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
@@ -36,7 +36,6 @@
 #include <vtkVisItUtility.h>
 
 using namespace conduit;
-using namespace mfem;
 
 
 #include <avtMFEMDataAdaptor.h>
@@ -2782,6 +2781,10 @@ ConduitElementShapeSize(const std::string &shape_name)
     return res;
 }
 
+#ifdef HAVE_LIBMFEM
+
+using namespace mfem;
+
 // ****************************************************************************
 mfem::Geometry::Type
 ElementShapeNameToMFEMShape(const std::string &shape_name)
@@ -3452,3 +3455,5 @@ avtConduitBlueprintDataAdaptor::BlueprintToMFEM::FieldToMFEMQuadratureFunction(
 
    return res;
 }
+
+#endif // HAVE_LIBMFEM

--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
@@ -38,8 +38,6 @@
 using namespace conduit;
 
 
-#include <avtMFEMDataAdaptor.h>
-
 // ****************************************************************************
 //  Method: Initialize
 //
@@ -2784,6 +2782,8 @@ ConduitElementShapeSize(const std::string &shape_name)
 #ifdef HAVE_LIBMFEM
 
 using namespace mfem;
+
+#include <avtMFEMDataAdaptor.h>
 
 // ****************************************************************************
 mfem::Geometry::Type

--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.h
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.h
@@ -4,6 +4,7 @@
 
 #ifndef AVT_CONDUIT_BLUEPRINT_DATA_ADAPTOR_H
 #define AVT_CONDUIT_BLUEPRINT_DATA_ADAPTOR_H
+#include <visit-config.h>
 #include <avtblueprint_exports.h>
 #include <conduit.hpp>
 

--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.h
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.h
@@ -10,7 +10,9 @@
 //-----------------------------------------------------------------------------
 // mfem includes
 //-----------------------------------------------------------------------------
+#ifdef HAVE_LIBMFEM
 #include <mfem.hpp>
+#endif
 
 //-----------------------------------------------------------------------------
 // vtk forward decls
@@ -107,6 +109,7 @@ public:
                                        const int ndims);
     };
 
+#ifdef HAVE_LIBMFEM
     class AVTBLUEPRINT_API BlueprintToMFEM
     {
     public:
@@ -119,6 +122,7 @@ public:
         static mfem::QuadratureFunction *FieldToMFEMQuadratureFunction(mfem::Mesh *mesh,
                                                                        const conduit::Node &field);
     };
+#endif
 };
 
 #endif

--- a/src/avt/CMakeLists.txt
+++ b/src/avt/CMakeLists.txt
@@ -10,6 +10,9 @@
 #   Brad Whitlock, Thu Jan 20 08:48:38 PST 2011
 #   Do not build QtVisWindow on engine-only or server-components-only builds.
 #
+#   Ryan Krattiger, Fri Oct 31 13:37:05 CST 2025
+#   Blueprints with optional MFEM dependency
+#
 #****************************************************************************
 
 IF(VISIT_DBIO_ONLY)
@@ -42,7 +45,7 @@ ELSE(VISIT_DBIO_ONLY)
     if(MFEM_FOUND)
         add_subdirectory(MFEM)
     endif()
-    if(CONDUIT_FOUND AND MFEM_FOUND)
+    if(CONDUIT_FOUND)
         add_subdirectory(Blueprint)
     endif()
 

--- a/src/databases/Blueprint/avtBlueprintFileFormat.C
+++ b/src/databases/Blueprint/avtBlueprintFileFormat.C
@@ -11,6 +11,7 @@
 //-----------------------------------------------------------------------------
 // visit includes
 //-----------------------------------------------------------------------------
+#include <visit-config.h>
 #include "avtDatabaseMetaData.h"
 #include "avtResolutionSelection.h"
 
@@ -57,7 +58,9 @@
 //-----------------------------------------------------------------------------
 // mfem includes
 //-----------------------------------------------------------------------------
+#ifdef HAVE_LIBMFEM
 #include "mfem.hpp"
+#endif
 
 
 #ifdef PARALLEL
@@ -78,7 +81,9 @@
 
 using std::string;
 using namespace conduit;
+#ifdef HAVE_LIBMFEM
 using namespace mfem;
+#endif
 
 const std::string avtBlueprintFileFormat::DISPLAY_NAME("display_name");
 
@@ -1160,9 +1165,14 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
 
         if(n_topo.has_child("grid_function"))
         {
+#ifdef HAVE_LIBMFEM
             BP_PLUGIN_INFO(mesh_topo_name << " is an mfem mesh");
             is_mfem_mesh = true;
             topo_names_to_gf_names[topo_name] = n_topo["grid_function"].as_string();
+#else
+            BP_PLUGIN_EXCEPTION1(InvalidVariableException,
+                "Detected mfem mesh, but mfem blueprints are not enabled");
+#endif
         }
 
         string coordset_name = n_topo["coordset"].as_string();
@@ -1259,6 +1269,7 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
         // check for assocated quad func meshes
         if(topos_to_quad_func_topos.count(topo_name) )
         {
+#ifdef HAVE_LIBMFEM
             BP_PLUGIN_INFO("Adding quadtrature function meshes for topology: " << topo_name );
             // loop over all qf topos assoc'd with this main topo
             // add a mesh for each
@@ -1275,10 +1286,20 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
                 m_mesh_and_topo_info[mesh_qf_name]["topo"] = qf_topo;
                 m_mesh_and_topo_info[mesh_qf_name]["quad_func"] = "true";
             }
+#else
+            BP_PLUGIN_EXCEPTION1(InvalidVariableException,
+                "Detected quadtrature function mesh which requires mfem support");
+#endif
         }
 
         if(is_mfem_mesh)
         {
+#ifndef HAVE_LIBMFEM
+            std::ostringstream err_oss;
+            err_oss << "avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata: "
+                        << "detected an mfem mesh when mfem is disabled"
+            BP_PLUGIN_EXCEPTION1(VisItException, err_oss.str());
+#endif
             // if we have a mfem mesh, add extra element_color variable
             md->Add(new avtScalarMetaData(mesh_topo_name + "/element_coloring",
                                           mesh_topo_name,
@@ -1374,6 +1395,7 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
             }
             else if (n_field.has_child("basis"))
             {
+#ifdef HAVE_LIBMFEM
                 // if any of the fields are mfem grid funcs, we may have to
                 // treat the mesh as an mfem mesh, even if it lacks a basis func
                 m_mfem_mesh_map[var_topo_name] = true;
@@ -1420,6 +1442,10 @@ avtBlueprintFileFormat::AddBlueprintMeshAndFieldMetadata(avtDatabaseMetaData *md
                         cent = AVT_ZONECENT;
                     }
                 }
+#else
+                BP_PLUGIN_EXCEPTION1(InvalidVariableException,
+                    "Detected mfem grid functions which require mfem support");
+#endif
             }
 
             // special 1D case

--- a/src/engine/main/CMakeLists.txt
+++ b/src/engine/main/CMakeLists.txt
@@ -151,18 +151,11 @@ target_link_libraries(engine_ser
     avtpipeline_ser
 )
 
-if(CONDUIT_FOUND AND MFEM_FOUND)
-    LINK_DIRECTORIES(
-        ${MFEM_LIBRARY_DIR}
-        ${CONDUIT_LIBRARY_DIR}
-        )
+if(TARGET avtblueprint)
     INCLUDE_DIRECTORIES(
-        ${MFEM_INCLUDE_DIR}
-        ${CONDUIT_INCLUDE_DIR}
         ${VISIT_SOURCE_DIR}/avt/Blueprint
         )
-    TARGET_LINK_LIBRARIES(engine_ser 
-        ${MFEM_LIB} 
+    TARGET_LINK_LIBRARIES(engine_ser
         avtblueprint
         )
 endif()


### PR DESCRIPTION
### Description

The checks in the code only check for HAVE_CONDUIT to use conduit blueprints. MFem is currently treated as a hard dependency in configure but a optional dependency in code. So allow blueprints to be enabled even when mfem is not found.

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Other

### How Has This Been Tested?

Local build with spack recipe (in progress)

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis

CC: @cyrush 