### PR TITLE
Fix crash running xml2cmake when code file has Conditions.

### DIFF
--- a/src/tools/dev/xml/Conditional.h
+++ b/src/tools/dev/xml/Conditional.h
@@ -29,6 +29,10 @@
 //    to the actual ones currently being used.
 //     Should be easy to update when new keys are needed.
 //
+//    Kathleen Biagas, Tue Nov  4 16:38:29 PST 2025
+//    When loopling through 'keys' in ParseCondition, use # of keys instead of
+//    'sizeof(keys)'.  Prevents crash.
+//
 // ****************************************************************************
 
 class Conditional
@@ -65,7 +69,7 @@ class Conditional
     bool ParseCondition(QString &buff)
     {
         bool success = false;
-        for (size_t i = 0; i < sizeof(keys) && !success; ++i)
+        for (size_t i = 0; i < 5 && !success; ++i)
         {
             QString key(keys[i]);
             if (buff.left(key.size()) == key)

--- a/src/tools/dev/xmledit/XMLEditConditional.C
+++ b/src/tools/dev/xmledit/XMLEditConditional.C
@@ -424,6 +424,8 @@ XMLEditConditional::mlinklibsChanged()
 //  Creation:    Oct 21, 2025 
 //
 //  Modifications:
+//    Kathleen Biagas, Tue Nov  4 16:39:54 PST 2025
+//    Add missing setting of VLinkLibraries in conditional.
 //
 // ****************************************************************************
 
@@ -457,6 +459,8 @@ XMLEditConditional::elinklibsChanged()
     int index = conditionList->currentRow();
     if (index == -1)
         return;
+    Conditional *c = codeFile->conditions[index];
+    c->keyVals["ELinkLibraries:"] = elinklibs->text();
 }
 
 // ****************************************************************************


### PR DESCRIPTION
### Description

Discovered when running plugin vs install tests in my CMake branch against all plot plugins on Linux.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Volume plot was the one triggering the crash, so after the fix I tried xml2cmake from build and install of VisIt with success.


### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
-~~ [ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
-~~ [ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
-~~ [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
