### PR TITLE
Fix MFEM tests

### DIFF
--- a/src/databases/MFEM/avtMFEMFileFormat.C
+++ b/src/databases/MFEM/avtMFEMFileFormat.C
@@ -294,6 +294,9 @@ avtMFEMFileFormat::FetchDataFromCatFile(string const &cat_path, string const &ob
 //
 //    Cyrus Harrison, Fri Sep 26 09:06:42 PDT 2025
 //    Add support for Quadrature Functions
+// 
+//    Justin Privitera, Fri Nov  7 14:12:05 PST 2025
+//    Fixed a bug causing the LOD to be set to the maximum.
 //
 // ****************************************************************************
 void

--- a/src/databases/MFEM/avtMFEMFileFormat.C
+++ b/src/databases/MFEM/avtMFEMFileFormat.C
@@ -354,7 +354,6 @@ avtMFEMFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
         vector<string> field_names;
         vector<string> qf_mesh_names;
         dset.Fields(field_names);
-        bool have_qf = false;
 
         std::string qf_mesh_base_name =  dset_names[i] + "_quad_func_o";
 
@@ -362,11 +361,11 @@ avtMFEMFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData *md)
         {
             JSONRootEntry &field = dset.Field(field_names[j]);
 
-            int ilod = md->GetMeshes(i).LODs;
+            int ilod = 0;
             if(field.HasTag("lod"))
             {
                 std::string slod = field.Tag("lod");
-                ilod = std::min(ilod,atoi(slod.c_str()));
+                ilod = atoi(slod.c_str());
             }
 
             selectedLOD = std::max(selectedLOD,ilod);


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->
mfem database was using the max lods setting to set the LOD. A fix by Cyrus exposed this bug, as another bug prevented it from taking place before. Now we use a default of 0 for LOD instead of the max.
this will heal the mfem tests

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
built and ran on rzhound toss4 all mfem tests pass

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
