### PR TITLE
dpi fixes for 2d axes and curve legend

### DIFF
--- a/src/avt/Plotter/vtk/vtkLineLegend.C
+++ b/src/avt/Plotter/vtk/vtkLineLegend.C
@@ -172,6 +172,11 @@ vtkLineLegend::RenderOverlay(vtkViewport *viewport)
 
 
 // Build the title for this actor 
+//
+// Modifications:
+//   Cyrus Harrison, Tue Nov 11 13:04:39 PST 2025
+//   Use dpi aware font scaling
+//
 //-----------------------------------------------------------------------------
 void 
 vtkLineLegend::BuildTitle(vtkViewport *viewport)
@@ -189,9 +194,8 @@ vtkLineLegend::BuildTitle(vtkViewport *viewport)
   //
   // Set the font properties.
   //
-  int fontSize = (int)(FontHeight * viewSize[1]); 
   vtkTextProperty *tprop = this->TitleMapper->GetTextProperty();
-  tprop->SetFontSize(fontSize);
+  tprop->SetFontSize(int(GetDPIScaledFontSize(viewport,FontHeight)));
   tprop->SetBold(this->Bold);
   tprop->SetItalic(this->Italic);
   tprop->SetShadow(this->Shadow);
@@ -584,5 +588,35 @@ vtkLineLegend::ShallowCopy(vtkProp *prop)
 
   // Now do superclass
   this->Superclass::ShallowCopy(prop);
+}
+
+
+// ****************************************************************************
+// Method: vtkLineLegend::GetDPIScaledFontSize
+//
+// Purpose:
+//   Helper for font size scaling that takes into account DPI settings
+//
+// Arguments:
+//   viewport    Pointer to vtk viewport
+//   fontHeight  Desired font height
+//
+// Returns:  Scaled font size
+//
+// Programmer: Cyrus Harrison
+// Creation:   Mon Nov 10 11:03:28 PST 2025
+//
+// Modifications:
+//
+// ****************************************************************************
+double
+vtkLineLegend::GetDPIScaledFontSize(vtkViewport *viewport,
+                                    double fontHeight)
+{
+  // Desired size seems relative to common dpi (72)
+  // divide DPI to avoid extra large fonts
+  vtkWindow *win = viewport->GetVTKWindow();
+  double desiredSizePixels = (viewport->GetSize()[1] * fontHeight * 72.0 / double(win->GetDPI()));
+  return desiredSizePixels;// * 1.05;
 }
 

--- a/src/avt/Plotter/vtk/vtkLineLegend.h
+++ b/src/avt/Plotter/vtk/vtkLineLegend.h
@@ -164,6 +164,8 @@ protected:
 private:
   vtkLineLegend(const vtkLineLegend&);
   void operator=(const vtkLineLegend&);
+  double         GetDPIScaledFontSize(vtkViewport *viewport,
+                                      double fontHeight);
 };
 
 

--- a/src/avt/Plotter/vtk/vtkVisItAxisActor2D.C
+++ b/src/avt/Plotter/vtk/vtkVisItAxisActor2D.C
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vtkTextProperty.h>
 #include <vtkProperty2D.h>
 #include <vtkViewport.h>
+#include <vtkWindow.h>
 #include <DebugStream.h>
 #include <vectortypes.h>
 
@@ -289,7 +290,6 @@ vtkVisItAxisActor2D::~vtkVisItAxisActor2D()
 int vtkVisItAxisActor2D::RenderOpaqueGeometry(vtkViewport *viewport)
 {
   int i, renderedSomething=0;
-
   this->BuildAxis(viewport);
   
   // Everything is built, just have to render
@@ -528,10 +528,15 @@ void vtkVisItAxisActor2D::PrintSelf(ostream& os, vtkIndent indent)
 //   Mark C. Miller, Sun Apr 27 19:37:51 PDT 2025
 //   Fixed segv involving restricting labelCount<200 in loop variable around
 //   line 823.
+//
+//   Cyrus Harrison, Tue Nov 11 12:51:04 PST 2025
+//   Use dpi aware font scaling for titles and labels.
+//
 // ****************************************************************************
 
 void vtkVisItAxisActor2D::BuildAxis(vtkViewport *viewport)
 {
+
   int i, *x;
   vtkIdType ptIds[2];
   double p1[3], p2[3];
@@ -546,13 +551,6 @@ void vtkVisItAxisActor2D::BuildAxis(vtkViewport *viewport)
 
   bool propsModified = (this->TitleTextProperty->GetMTime() > this->BuildTime) ||
                        (this->LabelTextProperty->GetMTime() > this->BuildTime);
-
-  if (this->GetMTime() < this->BuildTime &&
-      viewport->GetMTime() < this->BuildTime &&
-      !propsModified)
-    {
-    return; //already built
-    }
 
   // Check to see whether we have to rebuild everything
   if (this->GetMTime() < this->BuildTime &&
@@ -575,9 +573,9 @@ void vtkVisItAxisActor2D::BuildAxis(vtkViewport *viewport)
   // Initialize and get important info
   this->Axis->Initialize();
   this->AxisActor->SetProperty(this->GetProperty());
-  
+
   size = viewport->GetSize();
-  
+
   // Compute the location of tick marks and labels
   if ( this->AdjustLabels )
     {
@@ -819,7 +817,8 @@ void vtkVisItAxisActor2D::BuildAxis(vtkViewport *viewport)
           tprop->SetColor(this->LabelTextProperty->GetColor());
       else
           tprop->SetColor(this->GetProperty()->GetColor());
-      tprop->SetFontSize((int)(this->LabelFontHeight*size[1]));
+
+      tprop->SetFontSize((int)(GetDPIScaledFontSize(viewport,this->LabelFontHeight)));
       labelCount++;
       }
 
@@ -871,7 +870,8 @@ void vtkVisItAxisActor2D::BuildAxis(vtkViewport *viewport)
         titleTprop->SetColor(this->TitleTextProperty->GetColor());
     else
         titleTprop->SetColor(this->GetProperty()->GetColor());
-    titleTprop->SetFontSize((int)(this->TitleFontHeight*size[1]));
+
+    titleTprop->SetFontSize((int)(GetDPIScaledFontSize(viewport,this->TitleFontHeight)));
 
     if (verticalOrientation)
       {
@@ -1692,4 +1692,33 @@ vtkVisItAxisActor2D::SetFontFamily(int val)
     }
     if(modified)
         this->Modified();
+}
+
+// ****************************************************************************
+// Method: vtkVisItAxisActor2D::GetDPIScaledFontSize
+//
+// Purpose:
+//   Helper for font size scaling that takes into account DPI settings
+//
+// Arguments:
+//   viewport    Pointer to vtk viewport
+//   fontHeight  Desired font height
+//
+// Returns:  Scaled font size
+//
+// Programmer: Cyrus Harrison
+// Creation:   Mon Nov 10 11:03:28 PST 2025
+//
+// Modifications:
+//
+// ****************************************************************************
+double
+vtkVisItAxisActor2D::GetDPIScaledFontSize(vtkViewport *viewport,
+                                           double fontHeight)
+{
+  // Desired size seems relative to common dpi (72)
+  // divide DPI to avoid extra large fonts
+  vtkWindow *win = viewport->GetVTKWindow();
+  double desiredSizePixels = (viewport->GetSize()[1] * fontHeight * 72.0 / double(win->GetDPI()));
+  return desiredSizePixels;// * 1.05;
 }

--- a/src/avt/Plotter/vtk/vtkVisItAxisActor2D.C
+++ b/src/avt/Plotter/vtk/vtkVisItAxisActor2D.C
@@ -536,7 +536,6 @@ void vtkVisItAxisActor2D::PrintSelf(ostream& os, vtkIndent indent)
 
 void vtkVisItAxisActor2D::BuildAxis(vtkViewport *viewport)
 {
-
   int i, *x;
   vtkIdType ptIds[2];
   double p1[3], p2[3];

--- a/src/avt/Plotter/vtk/vtkVisItAxisActor2D.h
+++ b/src/avt/Plotter/vtk/vtkVisItAxisActor2D.h
@@ -401,7 +401,8 @@ private:
   void BuildAxis(vtkViewport *viewport);
 
   void           SetNumberOfLabelsBuilt(const int);
-
+  double         GetDPIScaledFontSize(vtkViewport *viewport,
+                                      double fontHeight);
   vtkTextActor  *TitleActor;
 
   vtkTextActor **LabelActors;

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -64,6 +64,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug causing Color Table Window tags to be duplicated when loading a session file.</li>
   <li>Save session file now takes existing session file names into account to avoid naming collisions.</li>
   <li>Fixed a bug where bottom of main GUI window would be hidden behind the Windows taskbar.</li>
+  <li>Fixed bugs with viewer text annotation sizes and layout when moving viewer windows between displays with different DPIs.</li>
 </ul>
 
 <a name="CLI_changes"></a>


### PR DESCRIPTION
### Description

Resolves #20714 

standard dpi
<img width="1122" height="1068" alt="Screenshot 2025-11-11 at 2 06 24 PM" src="https://github.com/user-attachments/assets/b84467fb-76f6-49b2-a7cd-cf974485d6f8" />

high dpi

<img width="1122" height="1068" alt="Screenshot 2025-11-11 at 2 06 22 PM" src="https://github.com/user-attachments/assets/d1f5a63d-5d0a-427c-96a0-ce732e4c0b58" />


Note like the legend case, the spacing between text elements isn't great for the high dpi case (see how axis titles are too close to the axis labels)


### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on macOS between retina display and external monitor 

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
