### PR TITLE
Fix some memory leaks in the label plot.

### DIFF
--- a/src/avt/Plotter/avtMapper2D.C
+++ b/src/avt/Plotter/avtMapper2D.C
@@ -46,11 +46,14 @@ avtMapper2D::avtMapper2D() : avtMapperBase()
 //  Creation:   April 13, 2017
 //
 //  Modifications:
+//    Eric Brugger, Tue Nov 11 13:41:42 PST 2025
+//    Call ClearSelf to free memory.
 //
 // ****************************************************************************
 
 avtMapper2D::~avtMapper2D()
 {
+    ClearSelf();
 }
 
 

--- a/src/plots/Label/vtkLabelMapperBase.C
+++ b/src/plots/Label/vtkLabelMapperBase.C
@@ -130,14 +130,21 @@ vtkLabelMapperBase::vtkLabelMapperBase() :
 //   Brad Whitlock, Mon Oct 25 16:12:27 PST 2004
 //   Changed the routine to release the display lists.
 //
+//   Eric Brugger, Tue Nov 11 13:41:42 PST 2025
+//   Removed unnecessary deletions and deletions that were casuing a crash.
+//   Added necessary deletions.
+//
 // ****************************************************************************
 
 vtkLabelMapperBase::~vtkLabelMapperBase()
 {
-    this->NodeLabelProperty->Delete();
-    this->CellLabelProperty->Delete();
-    // vtkSmartPointer handles deletion of the vtk objects.
-    this->TextMappers.clear(); 
+    ClearLabelCaches();
+
+    if (this->LabelBins)
+    {
+        delete[] this->LabelBins;
+        this->LabelBins = NULL;
+    }
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
### Description

I found and fixed some significant memory leaks in the label plot.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran VisIt with `valgrind` using the following script.
```
OpenDatabase("rect3d.silo")
AddPlot("Label", "quadmesh3d")
DrawPlots()
SaveWindow()
DeleteAllPlots()
```
Here is the memory usage summary from before my changes.
```
\==2115924== LEAK SUMMARY:
==2115924==    definitely lost: 288 bytes in 5 blocks
==2115924==    indirectly lost: 916,674 bytes in 405 blocks
==2115924==      possibly lost: 285,329 bytes in 204 blocks
==2115924==    still reachable: 358,823 bytes in 1,835 blocks
==2115924==         suppressed: 0 bytes in 0 blocks
==2115924== 
==2115924== For lists of detected and suppressed errors, rerun with: -s
==2115924== ERROR SUMMARY: 165 errors from 165 contexts (suppressed: 0 from 0)
```
Here is the memory usage summary from after my changes.
```
==2280251== LEAK SUMMARY:
==2280251==    definitely lost: 264 bytes in 2 blocks
==2280251==    indirectly lost: 0 bytes in 0 blocks
==2280251==      possibly lost: 21,297 bytes in 202 blocks
==2280251==    still reachable: 358,823 bytes in 1,835 blocks
==2280251==         suppressed: 0 bytes in 0 blocks
==2280251== 
==2280251== For lists of detected and suppressed errors, rerun with: -s
==2280251== ERROR SUMMARY: 160 errors from 160 contexts (suppressed: 0 from 0)
```

I ran the tests in `tests/plots/label.py` and got no errors.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
