### PR TITLE
Fix some memory leaks in the curve constructor filter.

### DIFF
--- a/src/avt/Filters/avtCurveConstructorFilter.C
+++ b/src/avt/Filters/avtCurveConstructorFilter.C
@@ -151,7 +151,10 @@ avtCurveConstructorFilter::~avtCurveConstructorFilter()
 //    Kathleen Biagas, Tue Dec 19, 2023
 //    Consolidate logic for no-labels and labels.
 //    Add varname and count to CreateSingleOutput.
-
+//
+//    Eric Brugger, Fri Nov 14 15:51:38 PST 2025
+//    Fix some memory leaks.
+//
 // ****************************************************************************
 
 void avtCurveConstructorFilter::Execute()
@@ -288,6 +291,13 @@ void avtCurveConstructorFilter::Execute()
     }
 
     SetOutputDataTree(outTree);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (ds[i] != NULL)
+            ds[i]->Delete();
+    }
+    delete [] ds;
 }
 
 


### PR DESCRIPTION
### Description

I fixed some leaks in the curve constructor filter. It's used by the curve plot and some curve related queries.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I ran `valgrind` on the engine using the following script and comparing the before and after memory usage.
```
OpenDatabase("/usr/workspace/brugger/visit_dev_git/visit/build/testdata/curve_test_data/distribution.ultra")

AddPlot("Curve", "Exponential Distribution")
c = CurveAttributes()
c.curveColorSource = c.Custom
c.curveColor = (255, 0, 0, 255)
SetPlotOptions(c)
DrawPlots()
SaveWindow()
DeleteAllPlots()
```
Here is the `valgrind` leak summary before the change.
```
==3406634== LEAK SUMMARY:
==3406634==    definitely lost: 16 bytes in 2 blocks
==3406634==    indirectly lost: 1,056,615 bytes in 65 blocks
==3406634==      possibly lost: 21,297 bytes in 202 blocks
==3406634==    still reachable: 358,823 bytes in 1,835 blocks
==3406634==         suppressed: 0 bytes in 0 blocks
==3406634== 
==3406634== For lists of detected and suppressed errors, rerun with: -s
==3406634== ERROR SUMMARY: 160 errors from 160 contexts (suppressed: 0 from 0)
```
Here is the `valgrind` leak summary after the change.
```
==3407919== LEAK SUMMARY:
==3407919==    definitely lost: 8 bytes in 1 blocks
==3407919==    indirectly lost: 0 bytes in 0 blocks
==3407919==      possibly lost: 21,297 bytes in 202 blocks
==3407919==    still reachable: 358,823 bytes in 1,835 blocks
==3407919==         suppressed: 0 bytes in 0 blocks
==3407919== 
==3407919== For lists of detected and suppressed errors, rerun with: -s
==3407919== ERROR SUMMARY: 159 errors from 159 contexts (suppressed: 0 from 0)
```

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~[ ] I have updated the release notes.~~
- ~[ ] I have made corresponding changes to the documentation.~~
- ~[ ] I have added debugging support to my changes.~~
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~[ ] I have added new baselines for any new tests to the repo.~~
- ~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
