### PR TITLE
More fixes to annot text sizes

### DIFF
--- a/src/avt/Plotter/vtk/vtkVisItTextActor.C
+++ b/src/avt/Plotter/vtk/vtkVisItTextActor.C
@@ -111,6 +111,30 @@ vtkVisItTextActor::ComputeScaledFont(vtkViewport *viewport)
 }
 
 // ****************************************************************************
+// Method: vtkVisItTextActor::RenderOpaqueGeometry
+//
+// Purpose:
+//   Render text, make sure viewport changes are refle
+//
+// Arguments:
+//   viewport    Pointer to vtk viewport
+//
+// Modifications:
+//
+// ****************************************************************
+
+int vtkVisItTextActor::RenderOpaqueGeometry(vtkViewport *viewport)
+{
+  // the text size is relative to the viewport
+  // so if the viewport has changed, our text has as well
+  if(viewport->GetMTime() > this->GetMTime())
+  {
+    this->Modified();
+  }
+  return vtkTextActor::RenderOpaqueGeometry(viewport);
+}
+
+// ****************************************************************************
 // Method: vtkVisItTextActor::GetDPIScaledFontSize
 //
 // Purpose:
@@ -126,6 +150,8 @@ vtkVisItTextActor::ComputeScaledFont(vtkViewport *viewport)
 // Creation:   Mon Nov 10 11:03:28 PST 2025
 //
 // Modifications:
+//   Cyrus Harrison, Wed Nov 19 11:13:41 PST 2025
+//   Use direct scaling, avoid extra 1.05 scaling.
 //
 // ****************************************************************************
 double
@@ -135,6 +161,5 @@ vtkVisItTextActor::GetDPIScaledFontSize(vtkViewport *viewport,
   // Desired size seems relative to common dpi (72)
   // divide DPI to avoid extra large fonts
   vtkWindow *win = viewport->GetVTKWindow();
-  double desiredSizePixels = (viewport->GetSize()[1] * fontHeight * 72.0 / double(win->GetDPI()));
-  return desiredSizePixels * 1.05;
+  return (viewport->GetSize()[1] * fontHeight * 72.0 / double(win->GetDPI()));;
 }

--- a/src/avt/Plotter/vtk/vtkVisItTextActor.h
+++ b/src/avt/Plotter/vtk/vtkVisItTextActor.h
@@ -19,6 +19,8 @@
 // Creation:   Mon Sep 19 15:20:50 PDT 2011
 //
 // Modifications:
+//   Cyrus Harrison, Wed Nov 19 11:32:07 PST 2025
+//   Add RenderOpaqueGeometry() to allow us to resize on viewport change
 //
 // ****************************************************************************
 
@@ -33,7 +35,7 @@ public:
 
   void SetTextHeight(float val);
   vtkGetMacro(TextHeight, float);
-
+  int RenderOpaqueGeometry(vtkViewport* viewport) override;
   void ComputeScaledFont(vtkViewport *viewport) override;
 
 protected:

--- a/src/avt/VisWindow/Colleagues/VisWinLegends.C
+++ b/src/avt/VisWindow/Colleagues/VisWinLegends.C
@@ -27,7 +27,12 @@ using std::vector;
 const double   VisWinLegends::leftColumnPosition  = 0.05;
 const double   VisWinLegends::rightColumnPosition = 0.80;
 const double   /*VisWinLegends::*/dbInfoVOffset   = 0.065;
-const double   VisWinLegends::dbInfoHeight        = (0.055 * 0.45);
+// Note:
+//  The 4.0 / 3.0 scale to the initial value here is to match a prior heurstic
+//  that was baked into all text scaling. This scaling was removed in favor
+//  of scaling that properly reflects height % of the viewport,
+//  it is here to perseve the initial value
+const double   VisWinLegends::dbInfoHeight        = (0.055 * 0.45 * 4.0 / 3.0);
 
 // ****************************************************************************
 //  Method: VisWinLegends constructor
@@ -406,7 +411,7 @@ VisWinLegends::UpdateDBInfo(vector<avtActor_p> &lst)
         }
         CreateDatabaseInfo(info,dbname,atts);
         dbInfoActor->SetInput(info);
-        dbInfoActor->SetTextHeight(dbInfoHeight * dbInfoTextAttributes.scale);    
+        dbInfoActor->SetTextHeight(dbInfoHeight * dbInfoTextAttributes.scale);
         
         double x = leftColumnPosition;
         double y = 0.98 - dbInfoVOffset;

--- a/src/avt/VisWindow/Colleagues/VisWinUserInfo.C
+++ b/src/avt/VisWindow/Colleagues/VisWinUserInfo.C
@@ -9,7 +9,7 @@
 #include <time.h>
 
 #include <vtkRenderer.h>
-#include <vtkTextActor.h>
+#include <vtkVisItTextActor.h>
 #include <vtkTextProperty.h>
 
 #include <VisWinUserInfo.h>
@@ -49,6 +49,9 @@ const float VisWinUserInfo::defaultUserInfoWidth = 0.2;
 //    Tom Fogal, Fri Jan 28 15:25:43 MST 2011
 //    Account for VTK API change.
 //
+//    Cyrus Harrison, Wed Nov 19 11:40:12 PST 2025
+//    Use vtkVisItTextActor to all db info to adapt to viewport changes.
+//
 // ****************************************************************************
 
 VisWinUserInfo::VisWinUserInfo(VisWindowColleagueProxy &p) 
@@ -59,7 +62,7 @@ VisWinUserInfo::VisWinUserInfo(VisWindowColleagueProxy &p)
     //
     // Create and position the actors.
     //
-    infoActor = vtkTextActor::New();
+    infoActor = vtkVisItTextActor::New();
     infoActor->SetTextScaleMode(vtkTextActor::TEXT_SCALE_MODE_PROP);
     UpdateUserText();
 

--- a/src/avt/VisWindow/Colleagues/VisWinUserInfo.h
+++ b/src/avt/VisWindow/Colleagues/VisWinUserInfo.h
@@ -14,7 +14,7 @@
 #include <VisWinColleague.h>
 
 
-class vtkTextActor;
+class vtkVisItTextActor;
 
 class VisWindowColleagueProxy;
 
@@ -50,6 +50,9 @@ class VisWindowColleagueProxy;
 //    Brad Whitlock, Wed Jan 30 15:14:50 PST 2008
 //    Added SetTextAttributes.
 //
+//    Cyrus Harrison, Wed Nov 19 11:40:12 PST 2025
+//    Use vtkVisItTextActor to all db info to adapt to viewport changes.
+//
 // ****************************************************************************
 
 class VISWINDOW_API VisWinUserInfo : public VisWinColleague
@@ -68,7 +71,7 @@ class VISWINDOW_API VisWinUserInfo : public VisWinColleague
     void                 SetTextAttributes(const VisWinTextAttributes &textAtts);
 
   protected:
-    vtkTextActor        *infoActor;
+    vtkVisItTextActor   *infoActor;
     char                *infoString;
     VisWinTextAttributes textAttributes;
 

--- a/src/avt/VisWindow/Colleagues/avtText2DColleague.C
+++ b/src/avt/VisWindow/Colleagues/avtText2DColleague.C
@@ -33,7 +33,10 @@
 //
 //    Tom Fogal, Fri Jan 28 15:26:59 MST 2011
 //    VTK API change.
-//   
+//
+//    Cyrus Harrison, Wed Nov 19 11:45:59 PST 2025
+//    Change default text annot size to 4% (to match old 3% with 4/3 scaling)
+//
 // ****************************************************************************
 
 avtText2DColleague::avtText2DColleague(VisWindowColleagueProxy &m) 
@@ -47,7 +50,7 @@ avtText2DColleague::avtText2DColleague(VisWindowColleagueProxy &m)
     //
     textActor = vtkVisItTextActor::New();
     textActor->SetTextScaleMode(vtkTextActor::TEXT_SCALE_MODE_VIEWPORT);
-    textActor->SetTextHeight(0.03);
+    textActor->SetTextHeight(0.04);
     SetText("2D text annotation");
     vtkCoordinate *pos = textActor->GetPositionCoordinate();
     pos->SetCoordinateSystemToNormalizedViewport();


### PR DESCRIPTION
### Description

* Remove the 1.05 text scaling in favor of scaling that matches height %.
* Modify user and db info text annotations to adapt and refresh when the viewport size changes. 

- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
