### PR TITLE
remove export db par baselines

### DIFF
--- a/test/baseline/databases/export_db/parallel/export_db_2_00.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_00.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d5719c865fc04ec7660861263cef8f35ea04878ded33f71e0a49d4fed937cbc
-size 13788

--- a/test/baseline/databases/export_db/parallel/export_db_2_01.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_01.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb6213e0c8da7352ecb0892ff994f0f6ca6bfdf801bba43f52542e1c6c7ffc31
-size 9508

--- a/test/baseline/databases/export_db/parallel/export_db_2_02.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_02.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44da0711a6833c5a7f766a9cd8eceff7e8f92373060b3199dddc07e0f3e5508e
-size 10345

--- a/test/baseline/databases/export_db/parallel/export_db_2_03.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_03.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e44db44416b1948c1ee7ba21dee7a8d7b1baf3b0ae699a626305988ca2a86281
-size 9512

--- a/test/baseline/databases/export_db/parallel/export_db_2_04.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_04.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:135cab0f80af674b981e75c92f3172a91c17d0299c7e999ca2b26b275d432a95
-size 15159

--- a/test/baseline/databases/export_db/parallel/export_db_2_05.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_05.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1f663d1d6bbc0dfd371971791ff1c4beb1a996c71cb1def7f79b4a8b5792522
-size 16409

--- a/test/baseline/databases/export_db/parallel/export_db_2_06.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_06.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55be55fb40d8885cbc291108d3a0eeb67a3f36cd29dcec992caaed3009738aca
-size 14908

--- a/test/baseline/databases/export_db/parallel/export_db_2_07.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_07.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ed42152e9941a85fc13154e581681182b7fff7c6774f395f439d931c6c4e38c
-size 12662

--- a/test/baseline/databases/export_db/parallel/export_db_2_08.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_08.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9ad0a5c17ba80124e44d6e676d4e8f50b24aed797cbfc320624a415ffd3623b
-size 5582

--- a/test/baseline/databases/export_db/parallel/export_db_2_09.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_09.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d87417e6b1d5be160fc2e4a6d79f81e01606b6bab2e5e647caa7b092f40b2f84
-size 10326

--- a/test/baseline/databases/export_db/parallel/export_db_2_10.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_10.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb6213e0c8da7352ecb0892ff994f0f6ca6bfdf801bba43f52542e1c6c7ffc31
-size 9508

--- a/test/baseline/databases/export_db/parallel/export_db_2_11.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44da0711a6833c5a7f766a9cd8eceff7e8f92373060b3199dddc07e0f3e5508e
-size 10345

--- a/test/baseline/databases/export_db/parallel/export_db_2_12.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_12.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e44db44416b1948c1ee7ba21dee7a8d7b1baf3b0ae699a626305988ca2a86281
-size 9512

--- a/test/baseline/databases/export_db/parallel/export_db_2_13.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_13.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:135cab0f80af674b981e75c92f3172a91c17d0299c7e999ca2b26b275d432a95
-size 15159

--- a/test/baseline/databases/export_db/parallel/export_db_2_14.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_14.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1f663d1d6bbc0dfd371971791ff1c4beb1a996c71cb1def7f79b4a8b5792522
-size 16409

--- a/test/baseline/databases/export_db/parallel/export_db_2_15.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_15.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55be55fb40d8885cbc291108d3a0eeb67a3f36cd29dcec992caaed3009738aca
-size 14908

--- a/test/baseline/databases/export_db/parallel/export_db_2_16.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_16.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ed42152e9941a85fc13154e581681182b7fff7c6774f395f439d931c6c4e38c
-size 12662

--- a/test/baseline/databases/export_db/parallel/export_db_2_17.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_17.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9ad0a5c17ba80124e44d6e676d4e8f50b24aed797cbfc320624a415ffd3623b
-size 5582

--- a/test/baseline/databases/export_db/parallel/export_db_2_18.png
+++ b/test/baseline/databases/export_db/parallel/export_db_2_18.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d87417e6b1d5be160fc2e4a6d79f81e01606b6bab2e5e647caa7b092f40b2f84
-size 10326


### PR DESCRIPTION
### Description

I was confused with my last baseline update b/c the nature of the export db test.

`test2` is only run in parallel cases, so I missed the mode specific baselines.

Since the test results are parallel by default, we don't need mode specific baselines -- this PR removes them.


