### PR TITLE
Update visit-copy-test-results.py to handle missing baseline directories.

### DIFF
--- a/src/tools/dev/scripts/visit-copy-test-results.py
+++ b/src/tools/dev/scripts/visit-copy-test-results.py
@@ -17,12 +17,18 @@ mode_dirs = ["dane_trunk_serial", "dane_trunk_parallel", "dane_trunk_scalable_pa
 ##############################################################################
 def calc_base_dirs():
     #
+    # Check that the mode directory exists. If it doesn't, create it.
+    #
+    mode_dir = os.path.join(out_dir, "baselines", mode_dirs[imode])
+    if (not os.path.exists(mode_dir)):
+        os.mkdir(mode_dir)
+
+    #
     # Get the list of baseline directories
     #
-    global out_dir
     global base_dirs
     base_dirs = []
-    for dir in os.listdir(os.path.join(out_dir, "baselines", mode_dirs[imode])):
+    for dir in os.listdir(mode_dir):
         base_dirs.append(dir)
 
     base_dirs.sort(reverse = True)


### PR DESCRIPTION
### Description

Updated the script that copies the new results to the dashboard to handle the case where there are no baseline directories. This would happen when switching to a new machine for running the test suite.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I used the new script to update the dashboard from last nights test suite run.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
