### PR TITLE
avoid texlive in dane run script

### DIFF
--- a/src/tools/dev/scripts/regressiontest_dane
+++ b/src/tools/dev/scripts/regressiontest_dane
@@ -408,6 +408,9 @@ rm -f runit_${testHost}
 cat <<EOF > runit_${testHost}
 #!/bin/sh
 
+# avoid default texlive in PATH
+ml unload texlive
+
 # So the script uses the correct git.
 export PATH=/usr/tce/bin:$PATH
 


### PR DESCRIPTION
Resolves issue with unneeded path appearing in dane launcher unit test results