### PR TITLE
bv: remove fallback lfs fetch cast to avoid lfs costs

### DIFF
--- a/src/tools/dev/scripts/build_visit
+++ b/src/tools/dev/scripts/build_visit
@@ -21,6 +21,10 @@
 #     Where possible, perform work on all groups instead of duplicating the
 #     same code for 'reqlibs', 'optlibs' and 'explicitlibs'.
 #
+#     Cyrus Harrison, Fri Jan  9 12:09:47 PST 2026
+#     Removed direct lfs path (avoiding extra lfs costs), see
+#     https://github.com/visit-dav/visit/issues/19340
+#
 # *****************************************************************************
 
 # To create your own modular file, see the docs at
@@ -61,9 +65,6 @@ export bv_PREFIX=$bv_PATH/bv_support/
 export build_version=""
 export visitroot="https://github.com/visit-dav/visit/releases/download/"
 export thirdpartyroot="https://github.com/visit-dav/third-party/releases/download/"
-
-# for use when running a develop verison of build_visit
-export thirdpartyroot_dev="https://github.com/visit-dav/third-party/raw/master/lib"
 
 #state = "disabled", "enabled", "installed"
 declare -a reqlibs
@@ -393,9 +394,6 @@ function bv_write_unified_file
     echo "export build_version=\"\"" >> $OUTPUT_bv_FILE
     echo "export visitroot=\"https://github.com/visit-dav/visit/releases/download/\"" >> $OUTPUT_bv_FILE
     echo "export thirdpartyroot=\"https://github.com/visit-dav/third-party/releases/download/\"" >> $OUTPUT_bv_FILE
-
-    # for use when running a develop verison of build_visit
-    echo "export thirdpartyroot_dev=\"https://github.com/visit-dav/third-party/raw/master/lib\"" >> $OUTPUT_bv_FILE
 
     echo "declare -a reqlibs" >> $OUTPUT_bv_FILE
     echo "declare -a optlibs" >> $OUTPUT_bv_FILE

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -500,6 +500,10 @@ function verify_checksum_by_lookup
 #                                                                             #
 #   Kathleen Biagas, Monday May 12, 2025                                      #
 #   Return early if file to be downloaded is already present.                 #
+#
+#   Cyrus Harrison, Fri Jan  9 12:09:47 PST 2026                              #
+#   Removed direct lfs path (avoiding extra lfs costs), see                   #
+#   https://github.com/visit-dav/visit/issues/19340                           #
 # *************************************************************************** #
 
 function download_file
@@ -562,16 +566,6 @@ function download_file
                 fi
             fi
         done
-    fi
-
-    # if all else has failed, and running develop version of build_visit,
-    # then also check the master repo.
-    if [[ "$TRUNK_BUILD" == "yes" ]]; then
-        site="${thirdpartyroot_dev}"
-        try_download_file $site/$dfile $dfile
-        if [[ $? == 0 ]] ; then
-            return 0
-        fi
     fi
 
     return 1
@@ -1496,19 +1490,6 @@ function build_hostconf
     done
 
     echo >> $HOSTCONF
-
- #
- # Patch for Ubuntu 11.04
- #
- #if test -d "/usr/lib/x86_64-linux-gnu" ; then
- #    numLibs=$(ls -1 /usr/lib/x86_64-linux-gnu | wc -l)
- #    if (( $numLibs > 10 )) ; then
- #       rm -f $HOSTCONF.tmp
- #       cat $HOSTCONF | sed "s/\/usr\/lib/\/usr\/lib\/x86_64-linux-gnu/" > $HOSTCONF.tmp
- #       rm $HOSTCONF
- #       mv $HOSTCONF.tmp $HOSTCONF
- #    fi
- #fi
 
  cd "$START_DIR"
  echo "Done creating $HOSTCONF"


### PR DESCRIPTION
### Description

Resolves #19340

Also removed a commented out ancient patch for ubuntu 11.01 :-)

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

build_visit change

### How Has This Been Tested?

This code path was not exercised much, so it's not easy to test. 
But it is now gone.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
