### PR TITLE
Restrict workflow permissions to minimum required

### DIFF
--- a/.github/workflows/build_visit_tpls.yaml
+++ b/.github/workflows/build_visit_tpls.yaml
@@ -6,6 +6,9 @@ on:
       - 'src/tools/dev/scripts/bv_support/*'
       - 'src/tools/dev/scripts/build_visit'
 
+permissions:
+  contents: read
+
 jobs:
   test-build_visit_tpls:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_methoddoc_gen.yaml
+++ b/.github/workflows/check_methoddoc_gen.yaml
@@ -10,6 +10,9 @@ on:
       - 'src/doc/python_scripting/functions.rst'
       - 'src/visitpy/common/MethodDoc.C'
 
+permissions:
+  contents: read
+
 jobs:
   check-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Limiting the scope of the GITHUB_TOKEN via the [permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) attribute is best practice to prevent a leaked GITHUB_TOKEN from allowing repository write access.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Visual examination of the scripts run in each workflow.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
