### PR TITLE
Add general regression test scripts

### DIFF
--- a/src/test/py_src/visit_test_main.py
+++ b/src/test/py_src/visit_test_main.py
@@ -2465,6 +2465,9 @@ def TestBatchSimulation(sim):
 #    Cyrus Harrison, Mon Dec  1 14:33:51 PST 2025
 #    Replaced poodle with dane.
 #
+#    Kathleen Biagas, Tue Jan 27, 2026
+#    Add rzwhippet.
+#
 # ----------------------------------------------------------------------------
 class Simulation(object):
     def __init__(self, vdir, s, sim2, np=1, batch=False):
@@ -2504,7 +2507,8 @@ class Simulation(object):
 
             # For now...
             import socket
-            if "dane" in socket.gethostname():
+            if "dane" in socket.gethostname() or \
+               "rzwhippet" in socket.gethostname():
                 do_submit = 0
                 if do_submit:
                     msubscript = os.path.join(os.path.abspath(os.curdir), string.replace(self.sim2, "sim2", "msub"))

--- a/src/test/tests/rendering/scalable.py
+++ b/src/test/tests/rendering/scalable.py
@@ -53,6 +53,9 @@
 #    Cyrus Harrison, Mon Dec  1 14:34:33 PST 2025
 #    Added a case for dane
 #
+#    Kathleen Biagas, Tue Jan 27, 2026
+#    Added a case for rzwhippet until #20776 is addressed.
+#
 # ----------------------------------------------------------------------------
 
 if not sys.platform.startswith("win"):
@@ -83,7 +86,8 @@ if len(engines) > 0:
         # explicitly open a parallel engine, if possible
         # if it fails, the OpenDatabase will start a serial engine
         import socket
-        if "dane" in socket.gethostname():
+        if "dane" in socket.gethostname() or \
+           "rzwhippet" in socket.gethostname():
             haveParallelEngine = OpenComputeEngine("localhost", ("-l", "srun", "-np", "2"))
         else:
             haveParallelEngine = OpenComputeEngine("localhost", ("-np", "2"))

--- a/src/tools/dev/scripts/cron_script_change_perms.sh
+++ b/src/tools/dev/scripts/cron_script_change_perms.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Helper script used to set perms post test suite run
+#
+
+# Change directories to the working directory.
+cd /usr/WS1/visit/test_trunk/
+
+# Set the permissions so that others may access the test directory.
+chgrp -R visit .
+chmod -R g+rwX,o+rX .

--- a/src/tools/dev/scripts/cron_script_run_test_suite.sh
+++ b/src/tools/dev/scripts/cron_script_run_test_suite.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Cron driver script to run visit's test suite
+#
+
+# Change directories to the working directory.
+cd /usr/WS1/visit/test_trunk/nightly_cron
+
+# Get the latest version of the test script
+# Kinda chicken-egg scenario since the first thing we do is git-update, but
+# we need the latest script before that happens.
+
+rm -f regressiontest
+wget https://raw.githubusercontent.com/visit-dav/visit/develop/src/tools/dev/scripts/regressiontest
+
+# Run the test suite.
+chmod 755 regressiontest
+./regressiontest
+

--- a/src/tools/dev/scripts/nightly_crontab
+++ b/src/tools/dev/scripts/nightly_crontab
@@ -1,0 +1,11 @@
+# use /bin/sh to run commands, no matter what /etc/passwd says
+SHELL=/bin/sh
+# mail any output to 'cyrush@llnl.gov', no matter whose crontab this is
+MAILTO=cyrush@llnl.gov
+
+#
+# run at 8:00 PM, every day
+00 20 * * * /usr/WS1/visit/test_trunk/visit/src/tools/dev/scripts/cron_script_run_test_suite.sh >> /usr/WS1/visit/test_trunk/nightly_logs/cron_script_`date +\%Y-\%m-\%d-\%H-\%M`_log  2>&1
+# run at 6:00 AM, every day
+0 7 * * * /usr/WS1/visit/test_trunk/visit/src/tools/dev/scripts/cron_script_change_perms.sh >> /usr/WS1/visit/test_trunk/nightly_logs/change_perms_`date +\%Y-\%m-\%d-\%H-\%M`_log  2>&1
+

--- a/src/tools/dev/scripts/regressiontest
+++ b/src/tools/dev/scripts/regressiontest
@@ -1,0 +1,372 @@
+#!/bin/sh -x
+#
+# Modifications:
+#   Mark C. Miller, Thu Jul 29 23:35:19 PDT 2010
+#   Added option to ignore third party lib problems to cmake invokation.
+#
+#   Eric Brugger, Thu Mar 31 09:38:38 PDT 2011
+#   Modified the script to work with the 2.2RC instead of the 2.0RC.
+#
+#   Eric Brugger, Tue Apr 12 10:53:02 PDT 2011
+#   Removed the specular lighting tests from the skip list.
+#
+#   Jeremy Meredith, Tue Aug  9 17:19:55 EDT 2011
+#   Updated the subversion host/path.
+#
+#   Eric Brugger, Thu Aug 25 11:22:39 PDT 2011
+#   Modified the script to work on edge.
+#
+#   Eric Brugger, Thu Aug 25 14:11:16 PDT 2011
+#   Modified the script to send out the e-mail only after the results
+#   were posted.
+#
+#   Eric Brugger, Wed Jan 25 13:26:36 PST 2012
+#   Modified the command that submits the batch job to run the test suite
+#   to specify that it isn't using any of the Lustre file systems so that
+#   the job will run even if one of the Lustre file systems is down.
+#
+#   Eric Brugger, Fri Jun 22 07:54:19 PDT 2012
+#   I modified the script to use cmake 2.8.8. I also added several failing
+#   tests to the skip list.
+#
+#   Mark C. Miller, Wed Jun 27 12:30:13 PDT 2012
+#   Removed zipwrapper tests from skip list because the tests were updated
+#   to use STL in place of VTK.
+#
+#   Cyrus Harrison, Wed Aug 15 12:31:00 PDT 2012
+#   Update to use python test suite
+#
+#   Eric Brugger, Fri Oct 11 14:10:51 PDT 2013
+#   Change the path to the cmake used to build visit to the latest 2.8.10.2
+#   version.
+#
+#   Eric Brugger, Fri Oct 18 15:01:56 PDT 2013
+#   I changed "make test" to "make testdata" in the data directory since the
+#   name of the target changed.
+#
+#   Eric Brugger, Fri Aug 15 11:02:18 PDT 2014
+#   I added "--parallel-launch srun" to the runtest command to specify srun
+#   as the parallel launch method.
+#
+#   Eric Brugger, Fri Aug 15 12:54:39 PDT 2014
+#   I modified the script to use cmake 2.8.12.2 to configure visit.
+#
+#   Eric Brugger, Wed Oct 29 08:04:01 PDT 2014
+#   I modified the script to use surface.
+#
+#   Eric Brugger, Tue Jan 13 14:09:04 PST 2015
+#   I modified the script to use the account views for submitting the batch
+#   job.
+#
+#   Eric Brugger, Thu Feb 12 08:17:18 PST 2015
+#   I modified the script to use cmake 3.0.2 to configure visit.
+#
+#   Eric Brugger, Fri Sep 11 14:05:18 PDT 2015
+#   I added the command line option "-branch", which takes a branch name.
+#   While I was at it I also modified the script to use 16 cores instead of
+#   12 since it is grabbing an entire node of surface, which has 16 cores.
+#
+#   Eric Brugger, Wed Sep  7 09:17:29 PDT 2016
+#   I updated the script to build using the newly built 2.12 libraries.
+#
+#   Eric Brugger, Mon Jun 25 14:35:01 PDT 2018
+#   I modified the script to run on pascal.
+#
+#   Kathleen Biagas, Thu Nov  8 10:14:27 PST 2018
+#   Added creation and installation of package to the build.
+#   Added cmakeCmd, pass it to test suite.
+#
+#   Eric Brugger, Wed Dec  5 13:06:31 PST 2018
+#   I modified the script to handle the new structure of the src, data and
+#   test directories.
+#
+#   Eric Brugger, Fri Jan  4 09:34:59 PST 2019
+#   I modified the script to work with the GitHub repository.
+#
+#   Eric Brugger, Fri Oct  4 09:12:49 PDT 2019
+#   I modified the installation of visit to no longer add toss3 to the
+#   installation path.
+#
+#   Cyrus Harrison, Tue Nov 26 16:50:14 PST 2019
+#   Directly call visit_test_suite.py instead of old runtest wrapper
+#
+#   Kathleen Biagas, Mon Feb 24 2020
+#   VISIT_BUILD_AVTEXAMPLES renamed to VISIT_ENABLE_AVTEXAMPLES
+#
+#   Eric Brugger, Mon Dec 21 09:11:31 PST 2020
+#   Update cmakeCmd to use CMake 3.14.7, required by new VTKm.
+#
+#   Eric Brugger, Fri Jan  8 11:12:04 PST 2021
+#   I modified the script to also make the manuals before making the package
+#   since the manuals are now required to make the package.
+#
+#   Kathleen Biagas, Thu June 16, 2022
+#   Modified cmakeCmd to use 3.3's 3.18.2 version and to use gcc-7.3
+#   for test_trunk. Modified the test_branch to build 3.2.
+#
+#   Cyrus Harrison, Thu Sep  8 12:42:42 PDT 2022
+#   Use new entry point for visit testing module.
+#
+#   Eric Brugger, Wed Sep 28 10:11:32 PDT 2022
+#   Changed all paths using /usr/workspace/wsa to /usr/WS1 so that the
+#   launcher test would pass. They are both the same directory, but the
+#   current directory when running the tests needs to start with /usr/WS1
+#   for the launcher test to work properly.
+#
+#   Eric Brugger, Wed Feb 15 16:29:23 PST 2023
+#   I corrected the path to the pascal config site file to take into account
+#   that we were now doing out of source builds.
+#
+#   Eric Brugger, Thu Mar  9 13:10:16 PST 2023
+#   I changed the script to run the test scripts directly in the current
+#   directory without scp'ing the scripts to the test machine and running
+#   the scripts on the test machine through ssh. This looses some generality
+#   in that the tests need to be run on the same machine as the script
+#   but avoids some potential authentication issues with scp and ssh. We
+#   currently run the script and the tests on the same machine so this
+#   isn't an issue.
+#
+#   I removed references to nersc, since we no longer involve any nersc
+#   systems in our testing. 
+#
+#   I updated the script to take into account that pascal is now toss4
+#   instead of toss3. This included switching from msub to sbatch, using
+#   a toss4 config site file, and using a toss4 cmake.
+#
+#   Eric Brugger, Fri Mar 10 07:09:59 PST 2023
+#   I reduced the alloted time for the test suite to run from 10 hours to
+#   8 hours. Running the tests with 2 processors reduced the typical time
+#   to complete the tests to 5 1/2 hours, so 8 hours should be plenty. I
+#   also changed the directory to copy the results to the "old_results"
+#   directory outside the repo, which should speed up git operations. I
+#   changed a python reference to python3.
+#
+#   Eric Brugger, Fri Mar 10 14:32:00 PST 2023
+#   I renamed the "linux-x86_64" directory in the visit install to
+#   "linux-x86_64-toss4" so that the launcher script would find the
+#   installation on toss4.
+#
+#   Eric Brugger, Sun Mar 12 16:40:54 PDT 2023
+#   Install git lfs before updating the repository. Added more logging
+#   to the git repository update.
+#
+#   Eric Brugger, Wed Mar 15 13:41:38 PDT 2023
+#   Update the location of where libstripack is copied from.
+#
+#   Eric Brugger, Tue Jun  4 10:30:31 PDT 2024
+#   I moved the setting of the permissions so that others may access the
+#   test directory to another script.
+#
+#   Kathleen Biagas, Tue July 16, 2024 
+#   Added repoDir and buildDir vars to aid in changing directories between
+#   them.  Call `git submodule init` when cloning, and 'git submodule update`
+#   when updating. Don't 'lfs pull' in test and data dir, since it is already
+#   performed at the repo root. Perform the build completely outside the repo
+#   dir. Have make.out, make.err and installlog be local to the build dir.
+#
+#   Justin Privitera, Mon Sep 23 10:18:29 PDT 2024
+#   Update visit-install location.
+#
+#   Eric Brugger, Mon Oct  7 11:15:18 PDT 2024
+#   Updated to run the test suite on poodle instead of pascal. Made
+#   the logic that detects new test results more general.
+#
+#   Eric Brugger, Thu Nov 21 12:15:11 PST 2024
+#   Reorder some git operations when committing changes to GitHub to
+#   avoid unnecessary merges.
+#
+#   Eric Brugger, Mon Mar  3 09:11:37 PST 2025
+#   Include the actual hostname in the name of the sbatch output filename.
+# 
+#   Cyrus Harrison, 
+#   Removed cuda LD_LIBRARY_PATH Wed Sep 10 11:57:45 PDT 2025
+#
+#   Eric Brugger, Fri Oct 31 13:53:46 PDT 2025
+#   I changed some output to go to the buildlog instead of standard out.
+#
+#   Eric Brugger, Fri Nov  7 10:32:18 PST 2025
+#   I changed the time limit on the batch job from 8 to 10 hours. I
+#   increased the number of cores used to build visit from 36 to 56.
+# 
+#   Cyrus Harrison, Mon Dec  1 14:34:33 PST 2025
+#   Changed to run on dane (instead of poodle)
+#
+#   Eric Brugger, Fri Dec 12 14:57:38 PST 2025
+#   Updated the logging so that the checkout, run and post scripts each
+#   create their own log file. The post script now runs after a file
+#   indicating the test run finished appears rather than a fixed amount
+#   of time. Removed the debug option.
+#
+#   Eric Brugger, Tue Dec 30 09:36:22 PST 2025
+#   Add code to allow group read/write access to the dashboard repository
+#   after updating it.
+#
+#   Kathleen Biagas, Tue Jan 27, 2026
+#   Copied from regressiontest_dane, and generalized to be run on any 
+#   supported machine, currently only dane and rzwhippet.
+#   This script no longer creates the other scripts to be run.
+#
+
+
+
+
+
+# Determine the users name and e-mail address.
+#
+user=`whoami`
+
+#
+# Set the user e-mail address.
+#
+userEmail=unknown
+case $user in
+    kbonnell)
+        userEmail=biagas2@llnl.gov
+        ;;
+    brugger)
+        userEmail=brugger1@llnl.gov
+        ;;
+    cyrush)
+        userEmail=cyrush@llnl.gov
+        ;;
+    hrchilds)
+        userEmail=hank@uoregon.edu
+        ;;
+    mcmiller)
+        userEmail=miller86@llnl.gov
+        ;;
+    miller)
+        userEmail=miller86@llnl.gov
+        ;;
+    miller86)
+        userEmail=miller86@llnl.gov
+        ;;
+    harrison37)
+        userEmail=cyrush@llnl.gov
+        ;;
+    cyrush)
+        userEmail=cyrush@llnl.gov
+        ;;
+    justin)
+        userEmail=privitera1@llnl.gov
+        ;;
+esac
+
+if test "$userEmail" = "unknown" ; then
+    echo "Unknown user name. Exiting."
+    exit 1
+fi
+
+#
+# Parse the command line to determine if we should run the test suite
+# on the trunk or RC.
+#
+branch="trunk"
+revision="latest"
+serial="false"
+testDir="/usr/WS1/visit"
+post="true"
+
+for abc
+do
+    case $1 in
+        -trunk)
+            branch="trunk"
+            shift
+            ;;
+        -branch)
+            branch=$2
+            shift 2
+            ;;
+        -serial)
+            serial="true"
+            shift
+            ;;
+        -parallel)
+            serial="false"
+            shift
+            ;;
+        -r)
+            revision=$2
+            shift 2
+            ;;
+        -no-post)
+            post="false"
+            shift
+            ;;
+    esac
+done
+
+testHost=`hostname`
+
+# when the paths are consistent on cz/rz then setting of cmakeCmd can be removed from the if-test
+
+# shorten the testHost
+if [[ $testHost == *"rzwhippet"* ]]; then
+    testHost="rzwhippet"
+    configFile="rzwhippet10.cmake"
+    cmakeCmd="/usr/workspace/visit/visit/thirdparty_shared/3.5.0-python-3.13/toss4/cmake/3.31.8/linux-x86_64_gcc-10.3/bin/cmake"
+elif [[ $testHost == *"dane"* ]]; then
+    testHost="dane"
+    configFile="dane1.cmake"
+    cmakeCmd="/usr/workspace/visit/visit/thirdparty_shared/3.5.0-python3.13/toss4/cmake/3.31.8/linux-x86_64_gcc-10.3/bin/cmake"
+else
+    echo "Unsupported host: $testHost. Valid hosts are dane and rzhwippet."
+    exit 1
+fi
+
+workingDir="test_trunk"
+
+subTag=`date +%Y-%m-%d-%H:%M`
+
+repoDir=$testDir/$workingDir/visit
+scriptDir=$repoDir/src/tools/dev/scripts
+
+logDir=$testDir/$workingDir/nightly_logs
+checkoutLogFile=$logDir/$subTag/checkout_${testHost}_log
+buildLogFile=$logDir/$subTag/build_${testHost}_log
+postLogFile=$logDir/$subTag/post_${testHost}_log
+runFinishedFile=$testDir/$workingDir/nightly_cron/run_finished
+
+# Create the working directory if necessary.
+if test ! -e $testDir/$workingDir; then
+    mkdir $testDir/$workingDir
+fi
+
+# Create the nightly_logs directory if necessary.
+if test ! -e $logDir; then
+    mkdir $logDir
+fi
+
+# Create the log directory for this run.
+mkdir $logDir/$subTag
+
+if test "$testHost" = "dane" ; then
+    hostPartition="pbatch"
+    hostBank="wbronze"
+else
+    # rzwhippet
+    hostPartition="pdebug"
+    hostBank="ecopper"
+fi
+
+
+#
+# Run the script to checkout/update the source code.
+#
+$scriptDir/regressiontest_checkout $subTag $branch $revision > $checkoutLogFile 2>&1
+
+rm -f $runFinishedFile
+
+#
+# Run the script to compile source and run the tests.
+#
+sbatch --partition=$hostPartition --account=$hostBank --time=10:00:00 --ntasks=56 --nodes=1 --tasks-per-node=56 \
+--output=$buildLogFile \
+$scriptDir/regressiontest_buildrun $subTag $serial $testHost $cmakeCmd $configFile
+
+#
+# Run the script to post test results
+#
+
+$scriptDir/regressiontest_postit $subTag $testHost $serial $post > $postLogFile 2>&1

--- a/src/tools/dev/scripts/regressiontest
+++ b/src/tools/dev/scripts/regressiontest
@@ -370,3 +370,4 @@ $scriptDir/regressiontest_buildrun $subTag $serial $testHost $cmakeCmd $configFi
 #
 
 $scriptDir/regressiontest_postit $subTag $testHost $serial $post > $postLogFile 2>&1
+

--- a/src/tools/dev/scripts/regressiontest_buildrun
+++ b/src/tools/dev/scripts/regressiontest_buildrun
@@ -1,0 +1,132 @@
+#!/bin/sh
+
+dateTag=$1
+serial=$2
+testHost=$3
+cmakeCmd=$4
+configFile=$5
+
+visitDir="/usr/WS1/visit/test_trunk"
+repoDir="$visitDir/visit"
+logDirBase="$visitDir/nightly_logs"
+logDir=$logDirBase/$dateTag
+
+# avoid default texlive in PATH
+ml unload texlive
+
+# So the script uses the correct git.
+export PATH=/usr/tce/bin:/usr/bin:/bin
+
+echo "Make configure started at `date`"
+
+cd $visitDir
+
+buildDir=build_$testHost
+# remove old build
+rm -rf $buildDir
+mkdir $buildDir
+cd $buildDir
+export PATH=$PATH:/usr/bin/X11
+
+# In case the gcc version we want isn't the default, make sure to set CC and CXX,
+# otherwise pluginVsInstall tests won't use the right compiler
+
+export CC=/usr/tce/packages/gcc/gcc-10.3.1/bin/gcc
+export CXX=/usr/tce/packages/gcc/gcc-10.3.1/bin/g++
+
+configSite=$repoDir/src/config-site/$configFile
+
+if test "$serial" = "true" ; then
+    sed -i "s/VISIT_PARALLEL ON/VISIT_PARALLEL OFF/" $configSite
+fi
+
+$cmakeCmd \
+    -DVISIT_CONFIG_SITE=$configSite \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DVISIT_BUILD_ALL_PLUGINS:BOOL=ON \
+    -DVISIT_ENABLE_DATA_MANUAL_EXAMPLES:BOOL=ON \
+    -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON \
+    -DVISIT_CREATE_XMLTOOLS_GEN_TARGETS:BOOL=OFF \
+    -DIGNORE_THIRD_PARTY_LIB_PROBLEMS:BOOL=ON \
+    -DCMAKE_CXX_FLAGS_RELEASE:STRING="-fopenmp -O3 -DNDEBUG -Wall -pedantic -Wextra -Wno-long-long -Wno-unused-parameter" \
+    -DCMAKE_C_FLAGS_RELEASE:STRING="-O3 -DNDEBUG -Wall -pedantic -Wextra -Wno-long-long -Wno-unused-parameter" \
+    -S $repoDir/src >>./cmake_configure_log 2>&1
+
+# add the cmake output to output for script that runs this one
+cat ./cmake_configure_log
+
+make -k -j 56 1>./make.out 2>./make.err
+
+make -k manuals >> ./manuals_log 2>&1 
+make -k -j 56 package >> ./package_log 2>&1
+if test 0 -ne 0; then
+    echo "Source build FAILED at `date`"
+    exit 1
+fi
+
+# add the cmake output to output for script that runs this one
+cat ./make.out
+cat ./make.err
+echo "Source build completed at `date`"
+
+# Copy stripack lib for ffp plugin tests
+if test "$testHost" = "dane" ; then
+    cp /usr/workspace/wsa/visit/visit/thirdparty_shared/3.3.2/toss4/stripack/libstripack.so ./lib/.
+fi
+
+
+# Build the test data
+cd testdata
+make -j 8 data
+cd ../
+
+echo "Data build completed at `date`"
+
+echo "Starting install at `date`"
+
+# Install the package
+version=`cat $repoDir/src/VERSION`
+
+$repoDir/scripts/visit-install -c llnl_open $version linux-x86_64 ./_install >> ./install_log 2>&1
+
+#echo "Install completed at `date`"
+
+# Run the test suite
+echo "Test run started at `date`"
+
+if test "$serial" = "true" ; then
+    modes="$testHost,trunk,serial"
+else
+    modes="$testHost,trunk,serial $testHost,trunk,parallel $testHost,trunk,scalable,parallel,icet"
+fi
+
+testDir=$visitDir/$buildDir/test
+
+# Build the code
+export PATH=$PATH:/usr/bin/X11
+
+# for pluginVsInstall
+export CC=/usr/tce/packages/gcc/gcc-10.3.1/bin/gcc
+export CXX=/usr/tce/packages/gcc/gcc-10.3.1/bin/g++
+
+# Run the tests, consolidating the results in one directory
+echo "testDir: $testDir"
+cd $testDir
+mkdir $dateTag output
+for m in $modes; do
+    theMode=`echo $m | tr ',' '_'`
+    resDir=output/$theMode
+    mkdir $resDir
+    echo "runtest with mode = $m at `date`"
+
+    # Run the test
+    ./run_visit_test_suite.sh  --parallel-launch "srun" -o $resDir -m "$m" -n 1 --cmake $cmakeCmd
+
+    # Move the results to the consolidation directory
+    mv $resDir/html $dateTag/$theMode
+    echo "Test $m completed at `date`"
+done
+
+touch /usr/WS1/visit/test_trunk/nightly_cron/run_finished
+
+

--- a/src/tools/dev/scripts/regressiontest_buildrun
+++ b/src/tools/dev/scripts/regressiontest_buildrun
@@ -129,4 +129,3 @@ done
 
 touch /usr/WS1/visit/test_trunk/nightly_cron/run_finished
 
-

--- a/src/tools/dev/scripts/regressiontest_buildrun
+++ b/src/tools/dev/scripts/regressiontest_buildrun
@@ -72,6 +72,8 @@ echo "Source build completed at `date`"
 # Copy stripack lib for ffp plugin tests
 if test "$testHost" = "dane" ; then
     cp /usr/workspace/wsa/visit/visit/thirdparty_shared/3.3.2/toss4/stripack/libstripack.so ./lib/.
+elif test "$testHost" = "rzwhippet" ; then
+    cp /usr/WS1/visit/visit/thirdparty_shared/stripack/libstripack.so ./lib/.
 fi
 
 

--- a/src/tools/dev/scripts/regressiontest_checkout
+++ b/src/tools/dev/scripts/regressiontest_checkout
@@ -65,3 +65,4 @@ fi
 
 echo "Checkout of trunk completed at `date`"
 
+

--- a/src/tools/dev/scripts/regressiontest_checkout
+++ b/src/tools/dev/scripts/regressiontest_checkout
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# So the script uses the correct git.
+export PATH=/usr/tce/bin:/usr/bin:/bin
+
+dateTag=$1
+branch=$2
+version=$3
+
+cd /usr/WS1/visit/test_trunk
+
+echo "Checkout of trunk started at `date`"
+
+# Clone the repository if necessary.
+if test ! -e /usr/WS1/visit/test_trunk/visit; then
+    echo "git clone started at `date`"
+    git clone  --recursive ssh://git@github.com/visit-dav/visit.git
+
+    # Enter the repo and perform commands only needed on a fresh clone
+    cd visit
+    git submodule init
+fi
+
+# Enter the repository.
+cd /usr/WS1/visit/test_trunk/visit
+
+# Update the repository.
+hostname
+git --version
+echo "rm -f .git/index.lock"
+rm -f .git/index.lock
+git checkout develop
+
+# ensure submodule is up to date
+echo "git submodule update"
+git submodule update
+
+echo "git pull"
+git pull
+
+echo "git lfs pull"
+git lfs pull
+
+echo "Repository updated at `date`"
+
+cd /usr/WS1/visit/test_trunk
+
+if test "$branch" = "trunk" ; then
+    if test "$version" = "latest" ; then
+        echo "Using the trunk"
+        # Do nothing.
+    else
+        echo "Using a version on the trunk"
+        # Set to a specific revision
+    fi
+else
+    if test "$version" = "latest" ; then
+        echo "Using a branch"
+        # Set to a specific branch.
+    else
+        echo "Using a specific version on a branch"
+        # Set to a specific revision on a specific branch.
+    fi
+fi
+
+echo "Checkout of trunk completed at `date`"
+

--- a/src/tools/dev/scripts/regressiontest_postit
+++ b/src/tools/dev/scripts/regressiontest_postit
@@ -140,23 +140,6 @@ if test "$post" = "true" ; then
     # log current quota usage
     python3 $scriptDir/visit-check-lc-workspace-quota.py >> /usr/workspace/visit/QUOTA_HISTORY.txt
 
-    # If its the first day of the month, purge test results from 3 months ago.
-    if test "$(date +%d)" = "01" ; then
-        echo "Purging results from 3 months ago at `date`."
-        cd $testDir/old_results
-        month=`date +%m`
-        deleteMonth=$(((month -1 + 12 - 3) % 12 + 1))
-        year=`date +%Y`
-        deleteYear=$((year - 1 + (month + 12 - 4) / 12))
-        d1=$( printf '%04d' $deleteYear )
-        d2=$( printf '%02d' $deleteMonth )
-        dirs="${d1}_${d2}*"
-        echo "$dirs"
-
-        # leaving commented out till it can be vetted
-        # Remove the local copies
-        # rm -f $dirs
-    fi
 fi
 
 

--- a/src/tools/dev/scripts/regressiontest_postit
+++ b/src/tools/dev/scripts/regressiontest_postit
@@ -1,0 +1,161 @@
+#!/bin/sh
+
+# So the script uses the correct git.
+export PATH=/usr/tce/bin:/usr/bin:/bin
+
+if test "$#" -ne 4; then
+    echo "Usage: $0 date_tag test_host serial postit"
+    exit 1
+fi
+
+dateTag=$1
+testHost=$2
+serial=$3
+post=$4
+
+
+testDir="/usr/WS1/visit/test_trunk"
+buildDir="$testDir/build_$testHost"
+repoDir="$testDir/visit"
+scriptDir="$repoDir/src/tools/dev/scripts"
+
+#
+# Check if the test suite completed every "retry_delay" seconds, for a
+# maximum of "retry_count" times.
+#
+finished_file="$testDir/nightly_cron/run_finished"
+retry_count=120
+retry_delay=600
+while [ ! -f "$finished_file" ] && [ $retry_count -gt 0 ]
+do
+    sleep $retry_delay
+    echo "Checking if test suite completed at `date`, retry_count=$retry_count."
+    ((retry_count--))
+done
+
+if [ ! -f "$finished_file" ]; then
+    echo "Test suite never finished, aborting posting of results at `date`."
+    exit 1
+fi
+
+#
+# The test suite completed, let's post the results.
+#
+echo "Posting results at `date`."
+
+
+cd $buildDir/test
+
+# if we don't have a test results directory, exit with failure now
+if test ! -d "$dateTag"; then
+    echo "$dateTag doesn't exist, aborting posting of results at `date`."
+    $scriptDir/visit-notify-test-failure -host $testHost
+    exit 1
+fi
+
+# Determine if the test suite passed or failed.
+if test "$serial" = "true" ; then
+    modes="$testHost,trunk,serial"
+else
+    modes="$testHost,trunk,serial $testHost,trunk,parallel $testHost,trunk,scalable,parallel,icet"
+fi
+
+hasFailed=""
+for m in $modes; do
+    theMode=`echo $m | tr ',' '_'`
+    if test "$hasFailed" = ""; then
+        hasFailed=`cat "$dateTag/$theMode/index.html" | grep -m 1 Failed 2>/dev/null`
+    fi
+    if test "$hasFailed" = ""; then
+        hasFailed=`cat "$dateTag/$theMode/index.html" | grep -m 1 Unacceptable 2>/dev/null`
+    fi
+    if test "$hasFailed" = ""; then
+        hasFailed=`cat "$dateTag/$theMode/index.html" | grep -m 1 OS-Killed 2>/dev/null`
+    fi
+done
+
+if test "$post" = "true" ; then
+    # If the test suite passed then update the revision number indicating the
+    # last pass.
+    cd  $repoDir
+    if test "$hasFailed" = ""; then
+        echo "Updating lastpass_$testHost at `date`."
+        gitHead=`git log -1 | grep "^commit" | cut -d' ' -f2`
+        # First do a "git checkout" on lastpass to restore it in case
+        # it was modified and not committed. Then do a "git pull" to
+        # update develop in case there have been an commits since the
+        # test suite run started. Then update lastpass and push to
+        # GitHub.
+        git checkout src/tools/dev/scripts/lastpass_$testHost
+        rm -f src/tools/dev/scripts/lastpass_$testHost
+        git pull
+        echo "$gitHead" > src/tools/dev/scripts/lastpass_$testHost
+        git add src/tools/dev/scripts/lastpass_$testHost
+        git commit -m "Update the last test suite pass on $testHost."
+        git push
+    fi
+
+    # Copy the results to the dashboard checkout on quartz. 
+    echo "Updating the dashboard at `date`."
+    cd $buildDir/test
+    python3 $scriptDir/visit-copy-test-results.py --host $testHost 
+
+    # Update the main index.html.
+    $scriptDir/visit-update-test-website
+
+    # Check the results into github.
+    cd $buildDir/test
+    newResults=`ls -d ????-??-??-??:??`
+    # should the dashboard have group perms?
+    cd /usr/WS1/visit/dashboard/dashboard
+    # First do a "git pull" to update main in case there have been
+    # any commits since the last update. This is most likely from
+    # removing an old test result. Then add the new results and push
+    # to GitHub.
+    git pull
+    git add $newResults baselines index.html
+    git commit -m "Add new results to the dashboard."
+    git push
+    
+    # Set group read/write permissions so others can update the dashboard.
+    chmod -R g+rwX .
+
+    # Move the new results to old_results.
+    echo "Moving the new results to old_results at `date`."
+    cd $buildDir/test
+    mv $newResults ../../old_results
+
+    # Send out an e-mail notifying the users of the test suite status.
+    #
+    # The visit-notify-test-failure script expects to be in the repo
+    # directory.
+    echo "Sending out the email at `date`."
+    cd $repoDir
+    if test "$hasFailed" = ""; then
+        $scriptDir/visit-notify-test-failure -pass -host $testHost
+    else
+        $scriptDir/visit-notify-test-failure -host $testHost
+    fi
+
+    # log current quota usage
+    python3 $scriptDir/visit-check-lc-workspace-quota.py >> /usr/workspace/visit/QUOTA_HISTORY.txt
+
+    # If its the first day of the month, purge test results from 3 months ago.
+    if test "$(date +%d)" = "01" ; then
+        echo "Purging results from 3 months ago at `date`."
+        cd $testDir/old_results
+        month=`date +%m`
+        deleteMonth=$(((month -1 + 12 - 3) % 12 + 1))
+        year=`date +%Y`
+        deleteYear=$((year - 1 + (month + 12 - 4) / 12))
+        d1=$( printf '%04d' $deleteYear )
+        d2=$( printf '%02d' $deleteMonth )
+        dirs="${d1}_${d2}*"
+        echo "$dirs"
+
+        # leaving commented out till it can be vetted
+        # Remove the local copies
+        # rm -f $dirs
+    fi
+fi
+

--- a/src/tools/dev/scripts/regressiontest_postit
+++ b/src/tools/dev/scripts/regressiontest_postit
@@ -159,3 +159,4 @@ if test "$post" = "true" ; then
     fi
 fi
 
+

--- a/src/tools/dev/scripts/visit-copy-test-results.py
+++ b/src/tools/dev/scripts/visit-copy-test-results.py
@@ -2,13 +2,15 @@ import os
 import hashlib
 import shutil
 import fnmatch
+import argparse
 
-out_dir = "/usr/workspace/wsa/visit/dashboard/dashboard"
-
+out_dir = "/usr/WS1/visit/dashboard/dashboard"
+testHost = "dane"
 base_dirs = []
 
 imode = 0
-mode_dirs = ["dane_trunk_serial", "dane_trunk_parallel", "dane_trunk_scalable_parallel_icet"]
+mode_dirs = []
+
 
 ##############################################################################
 #
@@ -106,7 +108,7 @@ def copy_new_baselines(cur_dir):
     # Process the serial results.
     #
     mode_dir = os.path.join(cur_dir, mode_dirs[imode])
-    
+
     newbase = []
     for file in os.listdir(mode_dir):
         if (is_baseline(cur_dir, file)):
@@ -252,7 +254,7 @@ def copy_failed_file(cur_file, out_file):
             #
             # This is the baseline image. Change the link to point to
             # a baseline.
-            # 
+            #
             image_name = line.split("'")[3]
             base_dir = get_base_dir(image_name)
             new_line = "    <td><a href=\"\" onMouseOver=\"document.b.src='c" + \
@@ -266,7 +268,7 @@ def copy_failed_file(cur_file, out_file):
             #
             # This is the difference image. Change the link to point to
             # a baseline.
-            # 
+            #
             image_name = line.split("'")[1]
             base_dir = get_base_dir(image_name)
             new_line = "    <td><a href=\"\" onMouseOver=\"document.d.src='" + \
@@ -289,7 +291,7 @@ def copy_failed_file(cur_file, out_file):
 def copy_results(cur_dir):
     global imode
     mode_dir = os.path.join(cur_dir, mode_dirs[imode])
-    
+
     #
     # Copy the index.html, the py files, and relevant html files.
     #
@@ -338,7 +340,7 @@ def copy_results(cur_dir):
             line = f.readline()
             line = f.readline()
             #
-            # This is an html file related to a text file difference. 
+            # This is an html file related to a text file difference.
             #
             if (line[29:35] == "Legend"):
                 line1 = f.readline()
@@ -352,7 +354,7 @@ def copy_results(cur_dir):
             line = f.readline()
             line = f.readline()
             #
-            # This is an html file related to a failed test (skipped or not skipped). 
+            # This is an html file related to a failed test (skipped or not skipped).
             #
             if (line[18:24] == "Failed"):
                 print("        Copying failure %s" % file)
@@ -364,8 +366,28 @@ def copy_results(cur_dir):
 #
 # Copy any new output directories to the dashboard.
 #
+# Modifications:
+#   Eric Brugger, Tue Jan 26, 2026
+#   Ensure mode dir exists before processing. Fixes bug when 'serial' is true.
+#
+#   Kathleen Biagas, Tue Jan 27, 2026
+#   Get testHost from args, fill in mode_dirs appropriately.
+#
 ##############################################################################
 def main():
+
+    parser = argparse.ArgumentParser(
+                    prog='visit-copy-test-results',
+                    description='Copies test output to the dashboard',
+                    epilog='')
+    parser.add_argument('--host', required=True)
+    args = parser.parse_args()
+    testHost=args.host
+
+    mode_dirs.append(testHost+"_trunk_serial")
+    mode_dirs.append(testHost+"_trunk_parallel")
+    mode_dirs.append(testHost+"_trunk_scalable_parallel_icet")
+
     dirs = []
     for dir in os.listdir("."):
         if (fnmatch.fnmatch(dir, "????-??-??-??:??")):
@@ -374,12 +396,14 @@ def main():
     dirs.sort()
 
     global imode
-    for dir in dirs:
-        print("Processing %s" % dir)
-        for imode in range(3):
+    for imode in range(3):
+        mode_dir = os.path.join(dir, mode_dirs[imode])
+        if os.path.isdir(mode_dir):
             print("    Doing mode %d" % imode)
             copy_new_baselines(dir)
             copy_results(dir)
+        else:
+            print("    Skipping mode %d" % imode)
 
 if __name__ == "__main__":
     main()

--- a/src/tools/dev/scripts/visit-copy-test-results.py
+++ b/src/tools/dev/scripts/visit-copy-test-results.py
@@ -396,14 +396,15 @@ def main():
     dirs.sort()
 
     global imode
-    for imode in range(3):
-        mode_dir = os.path.join(dir, mode_dirs[imode])
-        if os.path.isdir(mode_dir):
-            print("    Doing mode %d" % imode)
-            copy_new_baselines(dir)
-            copy_results(dir)
-        else:
-            print("    Skipping mode %d" % imode)
+    for dir in dirs:
+        for imode in range(3):
+            mode_dir = os.path.join(dir, mode_dirs[imode])
+            if os.path.isdir(mode_dir):
+                print("    Doing mode %d" % imode)
+                copy_new_baselines(dir)
+                copy_results(dir)
+            else:
+                print("    Skipping mode %d" % imode)
 
 if __name__ == "__main__":
     main()

--- a/src/tools/dev/scripts/visit-notify-test-failure
+++ b/src/tools/dev/scripts/visit-notify-test-failure
@@ -6,12 +6,12 @@ testEmail=""
 # list of users who want email every night with the log file
 #
 logRecipients="miller86@llnl.gov hank@uoregon.edu"
-logRecipients="${logRecipients} brugger1@llnl.gov harrison37@llnl.gov"
+logRecipients="${logRecipients} brugger1@llnl.gov harrison37@llnl.gov biagas2@llnl.gov"
 
 #
 # Parse the command line to determine the host to run on.
 #
-host="surface"
+host="dane"
 status="fail"
 
 for abc


### PR DESCRIPTION
### Description

This adds generalized scripts for running nightly regressions.
Rather than have the 'regressiontest' script create the checkout/build-run/post scripts, have them be separate, already created scripts that accept arguments specifying any needed options like: host, serial, post, dateTag.

The usually nightly generated `checkout_dane`, `runit_dane`,  and `postit_dane` were copied and generalized as `regressiontest_checkout`, `regressiontest_buildrun` and `regressiontest_postit` respectively.

`regressiontest_dane` was copied to `regressiontest`, creation of new scripts removed, and modifcations made for finding and verifying host name is 'supported'. Currently the logic only allows `dane` and `rzwhippet`.

Create a new `nightly_crontab` script that can be used on any machine, added timestamps to the output files.

Fixed `test/tests/rendering/scalable.py` and `test/tests/simulation/domainlist.py` so that `rzwhippet` is a valid host. Prevents hangs/crashes when those tests are run in serial.

NOTE:
I did not remove the dane-specific files until such time as this PR is commited and nightly testing on dane is setup to use the new scripts.


### Type of change

* ~~[ ] Bug fix~~
* [X] New feature
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ 

### How Has This Been Tested?

Sucessfully used 'nightly_crontab' to build src and run the regressions on rzwhippet Tue Jan 26.

'Posting' isn't actually updating the website, so that will need to be looked into.

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

