### PR TITLE
add support to blueprint plugin to read sidre tuple views

### DIFF
--- a/src/databases/Blueprint/avtBlueprintTreeCache.C
+++ b/src/databases/Blueprint/avtBlueprintTreeCache.C
@@ -506,6 +506,10 @@ avtBlueprintTreeCache::IO::LoadBlueprintTree(avtBlueprintTreeCache &tree_cache,
 //    Justin Privitera, Wed Jul 30 16:40:33 PDT 2025
 //    Fix buffer slab read conditional such that the successful read case
 //    does not trigger the failure result.
+//
+//    Cyrus Harrison, Mon Feb  2 16:37:28 PST 2026
+//    Added support for Sidre Tuples.
+//
 //----------------------------------------------------------------------------/
 // TODO CONST FOR INPUT 
 void
@@ -518,7 +522,7 @@ avtBlueprintTreeCache::IO::LoadSidreView(Node &sidre_meta_view,
                                          Node &out)
 {
     // view load cases:
-    //   the view is a scalar or string
+    //   the view is a scalar/tuple or string
     //     simply copy the "value" from the meta view
     //
     //   the view is attached to a buffer
@@ -542,6 +546,11 @@ avtBlueprintTreeCache::IO::LoadSidreView(Node &sidre_meta_view,
         BP_PLUGIN_INFO("loading " << view_path << " as sidre scalar view");
         out.set(sidre_meta_view["value"]);
     }
+    else if(view_state == "TUPLE")
+    {
+        BP_PLUGIN_INFO("loading " << view_path << " as sidre tuple view");
+        out.set(sidre_meta_view["value"]);
+    }
     else if( view_state == "BUFFER" )
     {
         BP_PLUGIN_INFO("loading " << view_path << " as sidre view linked to a buffer");
@@ -551,19 +560,19 @@ avtBlueprintTreeCache::IO::LoadSidreView(Node &sidre_meta_view,
         std::ostringstream buffer_fetch_path_oss;
         buffer_fetch_path_oss << tree_root  
                        << "sidre/buffers/buffer_id_" << buffer_id;
-               
+
         // buffer data path
         std::string buffer_data_fetch_path   = buffer_fetch_path_oss.str() + "/data";
         // we also need the buffer's schema 
         std::string buffer_schema_fetch_path = buffer_fetch_path_oss.str() + "/schema";
 
         Node n_buffer_schema_str;
-        
+
         // TODO: We aren't caching this, but the final result is cached, not sure
         // we need to cache.
-        
+
         tree_cache.Read(file_path,buffer_schema_fetch_path,n_buffer_schema_str);
-       
+
         string buffer_schema_str = n_buffer_schema_str.as_string();
         Schema buffer_schema(buffer_schema_str);
 
@@ -576,11 +585,11 @@ avtBlueprintTreeCache::IO::LoadSidreView(Node &sidre_meta_view,
         // it describes how the view relates to the buffer in the hdf5 file
         Schema view_schema(view_schema_str);
         BP_PLUGIN_INFO("sidre view schema: " << view_schema.to_json());
-        
+
         // if the schema isn't compact, or if we are reading 
         // less elements than the entire buffer, 
         // we need to read a subset of the hdf5 dataset
-      
+
         if(   !view_schema.is_compact() || 
             ( view_schema.dtype().number_of_elements() <
               buffer_schema.dtype().number_of_elements() )
@@ -635,7 +644,7 @@ avtBlueprintTreeCache::IO::LoadSidreView(Node &sidre_meta_view,
         }
         else
         {
-            
+
             tree_cache.Read(file_path,
                             buffer_data_fetch_path,
                             out);
@@ -651,7 +660,7 @@ avtBlueprintTreeCache::IO::LoadSidreView(Node &sidre_meta_view,
                        << "[domain " << tree_id << "] " 
                        << file_path  << ":"
                        << fetch_path);
-        
+
         tree_cache.Read(file_path,
                         fetch_path,
                         out);

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -51,6 +51,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added encoding recipe for gif movie files.</li>
   <li>Changed the preferred movie format encoding to default to mp4 if available.</li>
   <li>Removed extraneous python modules from visit installs to avoid unnecessary security scan blocks.</li>
+  <li>Added support for Sidre Tuple Views to the Blueprint Database Reader.</li>
 </ul>
 
 <a name="Advanced_features"></a>


### PR DESCRIPTION
### Description

Resolves #20810 

Axom changes the sidre spec to use `TUPLE` instead of `SCALAR`

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [x] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on macOS with a new style sidre file. 

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
