### PR TITLE
Fix a memory leak in the zone_centers expression.

### DIFF
--- a/src/avt/Expressions/General/avtZoneCentersExpression.C
+++ b/src/avt/Expressions/General/avtZoneCentersExpression.C
@@ -17,7 +17,6 @@
 #include <vtkDataSet.h>
 #include <vtkPointData.h>
 #include <vtkPoints.h>
-#include <vtkSmartPointer.h>
 
 // ****************************************************************************
 // Method: avtZoneCentersExpression Constructor

--- a/src/avt/Expressions/General/avtZoneCentersExpression.C
+++ b/src/avt/Expressions/General/avtZoneCentersExpression.C
@@ -20,7 +20,7 @@
 #include <vtkSmartPointer.h>
 
 // ****************************************************************************
-// Method: avtZoneCenters Constructor
+// Method: avtZoneCentersExpression Constructor
 //
 // Purpose:
 //  Construct avtZoneCentersExpression
@@ -37,7 +37,7 @@ avtZoneCentersExpression::avtZoneCentersExpression()
 }
 
 // ****************************************************************************
-// Method: avtZoneCenters Destructor
+// Method: avtZoneCentersExpression Destructor
 //
 // Purpose:
 //  Destroy avtZoneCentersExpression
@@ -54,7 +54,7 @@ avtZoneCentersExpression::~avtZoneCentersExpression()
 }
 
 // ****************************************************************************
-// Method: avtZoneCenters Destructor
+// Method: avtZoneCentersExpression::DeriveVariable
 //
 // Purpose:
 //  Calculate the center of each cell in the given vtkDataSet
@@ -63,13 +63,15 @@ avtZoneCentersExpression::~avtZoneCentersExpression()
 // Creation:   Mon Jan 31 16:05:01 EST 2022
 //
 // Modifications:
+//  Eric Brugger, Thu Feb  5 15:37:53 PST 2026
+//  I eliminated the use of vtkSmarkPointer to fix a memory leak.
 //
 // ****************************************************************************
 vtkDataArray *
 avtZoneCentersExpression::DeriveVariable(vtkDataSet *ds, int currentDomainsIndex)
 {
     // Invoke vtkCellCenters filter
-    vtkSmartPointer<vtkCellCenters> cellCenters = vtkCellCenters::New();
+    vtkCellCenters *cellCenters = vtkCellCenters::New();
     cellCenters->SetInputData(ds);
     cellCenters->Update();
 
@@ -95,5 +97,6 @@ avtZoneCentersExpression::DeriveVariable(vtkDataSet *ds, int currentDomainsIndex
         return out;
     }
     out->Register(NULL);
+    cellCenters->Delete();
     return out;
 }

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -156,7 +156,14 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug where RPATHs weren't stripped from distributions. This could lead to issues for users that didn't build the distribution. It could also cause issues when a distribution is installed on a machine different from where it was built.</li>
   <li>Fixed crash loading SILO files when compiled with version 4.11 of the SILO library.</li>
   <li>Fixed a bug with global mesh expressions causing them to only work on single domain data. They now function across all domains in parallel and in serial.</li>
-  <li>Eliminated a couple of memory leaks. The first was in the operator that removes ghost zones and calculates external faces. The second was in the Resample operator.</li>
+  <li>Eliminated many memory leaks. Here is a summary of the fixed leaks.
+    <ul>
+      <li>Fixed a leak in the operator that removes ghost zones and calculates external faces.</li>
+      <li>Fixed a leak in the Resample operator.</li>
+      <li>Fixed a leak with the zone_centers expression.</li>
+      <li>Fixed memory leaks in all the plots.</li>
+    <ul>
+  </li>
   <li>Fixed a crash with Curve plot when Curve contained more than 100000 points.</li>
   <li>Fixed a crash in the PVLD parallel test suite.</li>
   <li>Fixed a problem where the Silo plugin would not honor major_order setting for vector variables (e.g. more than one component) on 2 or 3D point- or quad- meshes.</li>


### PR DESCRIPTION
### Description

I fixed a memory leak in the `zone_centers` expression. I removed the use of a `vtkSmartPointer` on a filter and replaced it with the traditional pointer assignment and then manually using `Delete()` when the filter was no longer needed.

Here is the Valgrind output before the fix,
```
==3649268== LEAK SUMMARY:
==3649268==    definitely lost: 760 bytes in 25 blocks
==3649268==    indirectly lost: 2,853,698 bytes in 335 blocks
==3649268==      possibly lost: 21,553 bytes in 202 blocks
==3649268==    still reachable: 258,141 bytes in 1,206 blocks
==3649268==         suppressed: 0 bytes in 0 blocks
==3649268== 
==3649268== For lists of detected and suppressed errors, rerun with: -s
==3649268== ERROR SUMMARY: 161 errors from 161 contexts (suppressed: 0 from 0)
```
and here is the output after the fix.
```
==3653773== LEAK SUMMARY:
==3653773==    definitely lost: 560 bytes in 24 blocks
==3653773==    indirectly lost: 0 bytes in 0 blocks
==3653773==      possibly lost: 21,553 bytes in 202 blocks
==3653773==    still reachable: 258,141 bytes in 1,206 blocks
==3653773==         suppressed: 0 bytes in 0 blocks
==3653773== 
==3653773== For lists of detected and suppressed errors, rerun with: -s
==3653773== ERROR SUMMARY: 160 errors from 160 contexts (suppressed: 0 from 0)
```
This was done using the script:
```
OpenDatabase("/usr/gapps/visit/data/noise.silo")

DefineScalarExpression("r","zone_centers(Mesh)[0]")

# Add a plot for the expression
AddPlot("Pseudocolor", "r")
DrawPlots()

# Query the variable sum of this expression
SetQueryOutputToValue()
Query("Variable Sum")
query_val = GetQueryOutputValue()

print(f"variable sum is {query_val}")
            
quit()
```

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I tested the change using Valgrind, comparing output before and after the change as described above.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
