### PR TITLE
adjust mfem quad func support

### DIFF
--- a/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
+++ b/src/avt/Blueprint/avtConduitBlueprintDataAdaptor.C
@@ -3424,15 +3424,26 @@ avtConduitBlueprintDataAdaptor::BlueprintToMFEM::FieldToMFEMQuadratureFunction(
 
    // we need basis name to create the proper mfem quad space and quad func
    // the pattern used to encode the quad space params is:
-   // QF_{ORDER}_{VDIM}
+   // QF_{ORDER}_{VDIM} or QF_{TYPE}_{ORDER}_{VDIM}
    // ORDER is the degree of the polynomials for the quad rule
    // VDIM  is the number of components at each quad point (scalar, vector, etc)
-   
+
    int qf_order = 0;
    int qf_vdim  = 0;
+
    std::string qf_name = n_field["basis"].as_string();
    avtMFEMDataAdaptor::ParseQuadratureFunctionBasisString(qf_name, qf_order, qf_vdim);
-   // note: qf_vdim should equal vdim
+
+   // qf_vdim should equal vdim
+   if(qf_vdim != vdim)
+   {
+        // this is a fix for cases where axom mfem data are presented as one value instead 
+        // of a valid bp vector field.
+        vdim = qf_vdim;
+        AVT_CONDUIT_BP_WARNING( "Quadrature Function `values` vector dimension (" << vdim << ")"
+                                 <<  " does not match expected vdim (" << qf_vdim << ")."
+                                 <<  " using expected vdim (" << qf_vdim << ").");
+   }
 
    mfem::QuadratureSpace *quad_space = new mfem::QuadratureSpace(mesh, qf_order);
    mfem::QuadratureFunction *res = new mfem::QuadratureFunction();

--- a/src/avt/MFEM/avtMFEMDataAdaptor.C
+++ b/src/avt/MFEM/avtMFEMDataAdaptor.C
@@ -1602,6 +1602,8 @@ avtMFEMDataAdaptor::CheckBasisStringForQuadratureFunction(const std::string &bas
 //  Creation:   Fri Oct 10 15:09:42 PDT 2025
 //
 //  Modifications:
+//   Cyrus Harrison, Tue Feb 17 09:46:24 PST 2026
+//   Expand the string pattern to support QF_{TYPE}_{ORDER}_{VDIM} style
 //
 // ****************************************************************************
 void
@@ -1610,7 +1612,9 @@ avtMFEMDataAdaptor::ParseQuadratureFunctionBasisString(const std::string &basis,
                                                        int &qf_vdim)
 {
     // the pattern used to encode the quad space params is:
-    // QF_{ORDER}_{VDIM}
+    //  QF_{ORDER}_{VDIM}
+    // or
+    //  QF_{TYPE}_{ORDER}_{VDIM}
     //
     // ORDER is the degree of the polynmials for the quad rule
     // VDIM  is the number of components at each quad point (scalar, vector, etc)
@@ -1620,28 +1624,31 @@ avtMFEMDataAdaptor::ParseQuadratureFunctionBasisString(const std::string &basis,
     // split to parse
     std::vector<std::string> toks = StringHelpers::split(basis,'_');
 
-    // there should be 3 tokens
-    if(toks.size() != 3)
+    // there should be 3 or 4 tokens
+    if(toks.size() != 3 && toks.size() != 4)
     {
         //bad qf basis string
         AVT_MFEM_EXCEPTION1(InvalidVariableException,
                             "Invalid quadrature function basis string: " << basis  << std::endl
-                            << "Expected: QF_{ORDER}_{VDIM}");
+                            << "Expected: QF_{ORDER}_{VDIM} or QF_{TYPE}_{ORDER}_{VDIM}");
     }
 
+    int order_index = toks.size() - 2;
+    int vdim_index  = toks.size() - 1;
+
     // ORDER
-    if(!StringHelpers::StringToInt(toks[1],qf_order))
+    if(!StringHelpers::StringToInt(toks[order_index],qf_order))
     {
         // error
         AVT_MFEM_EXCEPTION1(InvalidVariableException,
-                            "Failed to parse quadrature function order from " << toks[1]);
+                            "Failed to parse quadrature function order from " << toks[order_index]);
     }
     // VDIM
-    if(!StringHelpers::StringToInt(toks[2],qf_vdim))
+    if(!StringHelpers::StringToInt(toks[vdim_index],qf_vdim))
     {
         // error
         AVT_MFEM_EXCEPTION1(InvalidVariableException,
-                            "Failed to parse quadrature function vdim from " << toks[1]);
+                            "Failed to parse quadrature function vdim from " << toks[vdim_index]);
     }
 }
 


### PR DESCRIPTION
### Description

Adds support for a new quad func basis string and works around an issue with axom published data for vector quad funcs.

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [x] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on new set of example data. 

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
~~- [ ] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
