### PR TITLE
Backport VTK ANARI texture and robustness fixes.

### DIFF
--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -193,6 +193,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>VTK-m updated to version 2.3.0.</li>
   <li>Added a patch to bv_vtk.sh that exposes the vtkAnariPass in the ANARI volume mapper and adds panning and zooming capabilities to the ANARI camera.</li>
   <li>Added command line options <code>--print-files</code> and <code>--print-files-html</code>. Both options list all the files that <code>build_visit</code> may download grouped by "Required", "Optional" and "Explicit". The first lists the files as text and the second lists the files as an HTML table.</li>
+  <li>Added a patch to bv_vtk.sh that brings in critical updates from <a href="https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12759">https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12759</a> that fixes texture issues and crashes when switching between ANARI back-ends.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -268,6 +268,1712 @@ EOF
     fi
 }
 
+function apply_vtk95_texture_anari_patches
+{
+    count_patches=5
+    # patch vtkAnari files:
+
+    #1) vtkAnariGlyph3DMapperNode.cxx update
+    current_patch=1
+    patch -p0 << \EOF
+*** Rendering/ANARI/vtkAnariGlyph3DMapperNode.cxx.orig  2025-06-23 14:12:36.000000000 -0500
+--- Rendering/ANARI/vtkAnariGlyph3DMapperNode.cxx       2026-02-19 18:40:29.768743155 -0600
+***************
+*** 277,283 ****
+    anari::Geometry InitializeSpheres(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double pointSize,
+      vtkDataArray* radiusArray, vtkPiecewiseFunction* scaleFunction,
+!     std::vector<vec2>& textureCoords, std::vector<float>& pointValueTextureCoords,
+      std::vector<vec4>& pointColors, int cellFlag) override;
+
+    const char* GetSpheresPostfix() const override;
+--- 277,283 ----
+    anari::Geometry InitializeSpheres(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double pointSize,
+      vtkDataArray* radiusArray, vtkPiecewiseFunction* scaleFunction,
+!     std::vector<vec2>& textureCoords, std::vector<vec2>& pointValueTextureCoords,
+      std::vector<vec4>& pointColors, int cellFlag) override;
+
+    const char* GetSpheresPostfix() const override;
+***************
+*** 332,338 ****
+  anari::Geometry vtkAnariGlyph3DMapperInheritInterface::InitializeSpheres(vtkPolyData* polyData,
+    vtkProperty* property, std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray,
+    double pointSize, vtkDataArray* radiusArray, vtkPiecewiseFunction* scaleFunction,
+!   std::vector<vec2>& textureCoords, std::vector<float>& pointValueTextureCoords,
+    std::vector<vec4>& pointColors, int cellFlag)
+  {
+    using MapperInternals = vtkAnariGlyph3DMapperNodeInternals;
+--- 332,338 ----
+  anari::Geometry vtkAnariGlyph3DMapperInheritInterface::InitializeSpheres(vtkPolyData* polyData,
+    vtkProperty* property, std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray,
+    double pointSize, vtkDataArray* radiusArray, vtkPiecewiseFunction* scaleFunction,
+!   std::vector<vec2>& textureCoords, std::vector<vec2>& pointValueTextureCoords,
+    std::vector<vec4>& pointColors, int cellFlag)
+  {
+    using MapperInternals = vtkAnariGlyph3DMapperNodeInternals;
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk 9.5 ANARI patch ${current_patch}/${count_patches} for vtkAnariGlyph3DMapperNode.cxx failed."
+        return 1
+    fi
+    
+    # 2) vtkAnariPolyDataMapperInheritInterface.h update
+    ((current_patch++))
+    patch -p0 << \EOF
+*** Rendering/ANARI/vtkAnariPolyDataMapperInheritInterface.h.orig   2025-06-23 14:12:36.000000000 -0500
+--- Rendering/ANARI/vtkAnariPolyDataMapperInheritInterface.h        2026-02-19 18:38:29.910100983 -0600
+***************
+*** 66,83 ****
+    virtual anari::Geometry InitializeSpheres(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double pointSize,
+      vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!     std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors, int cellFlag);
+    virtual anari::Geometry InitializeCurves(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double lineWidth,
+      vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!     std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors, int cellFlag);
+    virtual anari::Geometry InitializeCylinders(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double lineWidth,
+      vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!     std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors, int cellFlag);
+    virtual anari::Geometry InitializeTriangles(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, std::vector<vec3>& normals,
+!     std::vector<vec2>& textureCoords, std::vector<float>& pointValueTextureCoords,
+      std::vector<vec4>& pointColors, int cellFlag);
+
+    /**
+--- 66,83 ----
+    virtual anari::Geometry InitializeSpheres(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double pointSize,
+      vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!     std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors, int cellFlag);
+    virtual anari::Geometry InitializeCurves(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double lineWidth,
+      vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!     std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors, int cellFlag);
+    virtual anari::Geometry InitializeCylinders(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, double lineWidth,
+      vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!     std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors, int cellFlag);
+    virtual anari::Geometry InitializeTriangles(vtkPolyData* polyData, vtkProperty* property,
+      std::vector<vec3>& vertices, std::vector<uint32_t>& indexArray, std::vector<vec3>& normals,
+!     std::vector<vec2>& textureCoords, std::vector<vec2>& pointValueTextureCoords,
+      std::vector<vec4>& pointColors, int cellFlag);
+
+    /**
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk 9.5 ANARI patch ${current_patch}/${count_patches} for vtkAnariPolyDataMapperInheritInterface.h failed."
+        return 1
+    fi
+    
+    # 3) vtkAnariPolyDataMapperInheritInterface.cxx update
+    ((current_patch++))
+    patch -p0 << \EOF
+*** Rendering/ANARI/vtkAnariPolyDataMapperInheritInterface.cxx.orig	2025-06-23 14:12:36.000000000 -0500
+--- Rendering/ANARI/vtkAnariPolyDataMapperInheritInterface.cxx	    2026-02-19 18:49:46.478906325 -0600
+***************
+*** 33,39 ****
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeSpheres(vtkPolyData*,
+    vtkProperty*, std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*,
+!   vtkPiecewiseFunction*, std::vector<vec2>&, std::vector<float>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "sphere");
+  }
+--- 33,39 ----
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeSpheres(vtkPolyData*,
+    vtkProperty*, std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*,
+!   vtkPiecewiseFunction*, std::vector<vec2>&, std::vector<vec2>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "sphere");
+  }
+***************
+*** 41,47 ****
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeCurves(vtkPolyData*, vtkProperty*,
+    std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*,
+!   std::vector<vec2>&, std::vector<float>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "curve");
+  }
+--- 41,47 ----
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeCurves(vtkPolyData*, vtkProperty*,
+    std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*,
+!   std::vector<vec2>&, std::vector<vec2>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "curve");
+  }
+***************
+*** 49,55 ****
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeCylinders(vtkPolyData*,
+    vtkProperty*, std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*,
+!   vtkPiecewiseFunction*, std::vector<vec2>&, std::vector<float>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "cylinder");
+  }
+--- 49,55 ----
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeCylinders(vtkPolyData*,
+    vtkProperty*, std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*,
+!   vtkPiecewiseFunction*, std::vector<vec2>&, std::vector<vec2>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "cylinder");
+  }
+***************
+*** 57,63 ****
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeTriangles(vtkPolyData*,
+    vtkProperty*, std::vector<vec3>&, std::vector<uint32_t>&, std::vector<vec3>&, std::vector<vec2>&,
+!   std::vector<float>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "triangle");
+  }
+--- 57,63 ----
+  //----------------------------------------------------------------------------
+  anari::Geometry vtkAnariPolyDataMapperInheritInterface::InitializeTriangles(vtkPolyData*,
+    vtkProperty*, std::vector<vec3>&, std::vector<uint32_t>&, std::vector<vec3>&, std::vector<vec2>&,
+!   std::vector<vec2>&, std::vector<vec4>&, int)
+  {
+    return anari::newObject<anari::Geometry>(this->AnariDevice, "triangle");
+  }
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk 9.5 ANARI patch ${current_patch}/${count_patches} for vtkAnariPolyDataMapperInheritInterface.cxx failed."
+        return 1
+    fi
+
+     # 4) vtkAnariPolyDataMapperNode.cxx update
+    ((current_patch++))
+    patch -p0 << \EOF
+*** Rendering/ANARI/vtkAnariPolyDataMapperNode.cxx.orig	2025-06-23 14:12:36.000000000 -0500
+--- Rendering/ANARI/vtkAnariPolyDataMapperNode.cxx	    2026-02-20 10:26:00.019021590 -0600
+***************
+*** 56,62 ****
+    void Execute(vtkObject* vtkNotUsed(caller), unsigned long vtkNotUsed(eventId),
+      void* vtkNotUsed(callData)) override
+    {
+!     this->RendererNode->InvalidateSceneStructure();
+    }
+  
+    vtkAnariSceneGraph* RendererNode{ nullptr };
+--- 56,65 ----
+    void Execute(vtkObject* vtkNotUsed(caller), unsigned long vtkNotUsed(eventId),
+      void* vtkNotUsed(callData)) override
+    {
+!     if (this->RendererNode)
+!     {
+!       this->RendererNode->InvalidateSceneStructure();
+!     }
+    }
+  
+    vtkAnariSceneGraph* RendererNode{ nullptr };
+***************
+*** 157,163 ****
+     */
+    void RenderSurfaces(anari::Sampler, vtkActor*, vtkPolyData*, std::vector<vec3>&,
+      std::vector<uint32_t>&, bool, double, double, vtkDataArray*, vtkPiecewiseFunction*,
+!     std::vector<vec2>&, std::vector<float>&, std::vector<vec4>&, AttributeArrayCollection&,
+      vtkPolyDataMapperNode::vtkPDConnectivity& conn, int);
+  
+    /**
+--- 160,166 ----
+     */
+    void RenderSurfaces(anari::Sampler, vtkActor*, vtkPolyData*, std::vector<vec3>&,
+      std::vector<uint32_t>&, bool, double, double, vtkDataArray*, vtkPiecewiseFunction*,
+!     std::vector<vec2>&, std::vector<vec2>&, std::vector<vec4>&, AttributeArrayCollection&,
+      vtkPolyDataMapperNode::vtkPDConnectivity& conn, int);
+  
+    /**
+***************
+*** 166,172 ****
+     */
+    anari::Surface RenderAsSpheres(anari::Sampler, vtkProperty*, vtkPolyData*, std::vector<vec3>&,
+      std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*, std::vector<vec2>&,
+!     std::vector<float>&, std::vector<vec4>&, AttributeArrayCollection&, int);
+  
+    /**
+     * Create an ANARI surface with a geometry consisting of individual cylinders, each
+--- 169,175 ----
+     */
+    anari::Surface RenderAsSpheres(anari::Sampler, vtkProperty*, vtkPolyData*, std::vector<vec3>&,
+      std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*, std::vector<vec2>&,
+!     std::vector<vec2>&, std::vector<vec4>&, AttributeArrayCollection&, int);
+  
+    /**
+     * Create an ANARI surface with a geometry consisting of individual cylinders, each
+***************
+*** 174,180 ****
+     */
+    anari::Surface RenderAsCylinders(anari::Sampler, vtkProperty* property, vtkPolyData*,
+      std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*,
+!     std::vector<vec2>&, std::vector<float>&, std::vector<vec4>&, AttributeArrayCollection&, int);
+  
+    /**
+     * Create an ANARI surface with a geometry consisting of curves, each
+--- 177,183 ----
+     */
+    anari::Surface RenderAsCylinders(anari::Sampler, vtkProperty* property, vtkPolyData*,
+      std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*,
+!     std::vector<vec2>&, std::vector<vec2>&, std::vector<vec4>&, AttributeArrayCollection&, int);
+  
+    /**
+     * Create an ANARI surface with a geometry consisting of curves, each
+***************
+*** 182,195 ****
+     */
+    anari::Surface RenderAsCurves(anari::Sampler, vtkProperty* property, vtkPolyData*,
+      std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*,
+!     std::vector<vec2>&, std::vector<float>&, std::vector<vec4>&, AttributeArrayCollection&, int);
+  
+    /**
+     * Create an ANARI surface with a geometry consisting of triangles.
+     */
+    anari::Surface RenderAsTriangles(anari::Sampler anariSampler, vtkProperty* property, vtkPolyData*,
+      std::vector<vec3>&, std::vector<uint32_t>& indexArray, std::vector<vec3>& normals,
+!     std::vector<vec2>& textureCoords, std::vector<float>&, std::vector<vec4>&,
+      AttributeArrayCollection&, int);
+  
+    /**
+--- 185,198 ----
+     */
+    anari::Surface RenderAsCurves(anari::Sampler, vtkProperty* property, vtkPolyData*,
+      std::vector<vec3>&, std::vector<uint32_t>&, double, vtkDataArray*, vtkPiecewiseFunction*,
+!     std::vector<vec2>&, std::vector<vec2>&, std::vector<vec4>&, AttributeArrayCollection&, int);
+  
+    /**
+     * Create an ANARI surface with a geometry consisting of triangles.
+     */
+    anari::Surface RenderAsTriangles(anari::Sampler anariSampler, vtkProperty* property, vtkPolyData*,
+      std::vector<vec3>&, std::vector<uint32_t>& indexArray, std::vector<vec3>& normals,
+!     std::vector<vec2>& textureCoords, std::vector<vec2>&, std::vector<vec4>&,
+      AttributeArrayCollection&, int);
+  
+    /**
+***************
+*** 199,205 ****
+     * So make sure reservedAttribs matches the rest of the logic.
+     */
+    void SetAttributeArrays(AttributeArrayCollection& attributeArrays, anari::Geometry& anariGeometry,
+!     const int reservedAttribs = 1);
+  
+    /**
+     * Sets time metadata on an ANARI geometry.
+--- 202,208 ----
+     * So make sure reservedAttribs matches the rest of the logic.
+     */
+    void SetAttributeArrays(AttributeArrayCollection& attributeArrays, anari::Geometry& anariGeometry,
+!     int reservedAttribs = 1);
+  
+    /**
+     * Sets time metadata on an ANARI geometry.
+***************
+*** 236,242 ****
+    /**
+     * Converts a 2D VTK texture to a 2D ANARI sampler.
+     */
+!   anari::Sampler VTKToAnariSampler(std::string, std::string, mat4 inTransform, vtkImageData*, bool);
+  
+    /**
+     * Extracts individual textures (occlusion, roughness, metallic) from the combined VTK
+--- 239,245 ----
+    /**
+     * Converts a 2D VTK texture to a 2D ANARI sampler.
+     */
+!   anari::Sampler VTKToAnariSampler(std::string, std::string, mat4 inTransform, vtkTexture*);
+  
+    /**
+     * Extracts individual textures (occlusion, roughness, metallic) from the combined VTK
+***************
+*** 291,297 ****
+  
+    std::vector<anari::Surface> Surfaces;
+  
+!   double DataTimeStep = std::numeric_limits<float>::quiet_NaN();
+    std::string ActorName;
+    int TrianglesId = 0;
+    int CylindersId = 0;
+--- 294,300 ----
+  
+    std::vector<anari::Surface> Surfaces;
+  
+!   double DataTimeStep = std::numeric_limits<double>::quiet_NaN();
+    std::string ActorName;
+    int TrianglesId = 0;
+    int CylindersId = 0;
+***************
+*** 393,399 ****
+  
+  //----------------------------------------------------------------------------
+  anari::Sampler vtkAnariPolyDataMapperNodeInternals::ExtractORMFromVTK(std::string name,
+!   int textureIdx, std::string inAttribute, mat4 inTransform, vtkImageData* imageData, bool sRGB)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::ExtractORMFromVTK", vtkAnariProfiling::LIME);
+  
+--- 396,402 ----
+  
+  //----------------------------------------------------------------------------
+  anari::Sampler vtkAnariPolyDataMapperNodeInternals::ExtractORMFromVTK(std::string name,
+!   const int textureIdx, std::string inAttribute, mat4 inTransform, vtkImageData* imageData, bool sRGB)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::ExtractORMFromVTK", vtkAnariProfiling::LIME);
+  
+***************
+*** 418,428 ****
+    anari::setParameter(this->AnariDevice, anariSampler, "filter", "linear");
+  
+    // Get the needed image data attributes
+!   int xsize = (imageData->GetExtent()[1] - imageData->GetExtent()[0]) + 1;
+!   int ysize = (imageData->GetExtent()[3] - imageData->GetExtent()[2]) + 1;
+  
+    if (xsize <= 0 || ysize <= 0)
+    {
+      return nullptr;
+    }
+  
+--- 421,435 ----
+    anari::setParameter(this->AnariDevice, anariSampler, "filter", "linear");
+  
+    // Get the needed image data attributes
+!   const int* const imageSize = imageData->GetDimensions();
+!   const int xsize = imageSize[0];
+!   const int ysize = imageSize[1];
+  
+    if (xsize <= 0 || ysize <= 0)
+    {
++     vtkWarningWithObjectMacro(
++       this->Owner, << "[ExtractORMFromVTK] Invalid image data extent: " << xsize << "x" << ysize);
++     anari::release(this->AnariDevice, anariSampler);
+      return nullptr;
+    }
+  
+***************
+*** 445,456 ****
+  
+  //----------------------------------------------------------------------------
+  anari::Sampler vtkAnariPolyDataMapperNodeInternals::VTKToAnariSampler(
+!   std::string name, std::string inAttribute, mat4 inTransform, vtkImageData* imageData, bool sRGB)
+  {
+!   vtkAnariProfiling startProfiling("VTKAPDMNInternals::VTKToAnariSampler", vtkAnariProfiling::LIME);
+  
+    if (imageData == nullptr)
+    {
+      return nullptr;
+    }
+  
+--- 452,474 ----
+  
+  //----------------------------------------------------------------------------
+  anari::Sampler vtkAnariPolyDataMapperNodeInternals::VTKToAnariSampler(
+!   std::string name, std::string inAttribute, mat4 inTransform, vtkTexture* texture)
+  {
+!   vtkAnariProfiling startProfiling(
+!     "VTKAPDMNInternals::VTKToAnariSampler", vtkAnariProfiling::LIME);
+! 
+!   if (texture == nullptr)
+!   {
+!     return nullptr;
+!   }
+! 
+!   // Update the texture to ensure the image data is current
+!   texture->Update();
+!   vtkImageData* imageData = texture->GetInput();
+  
+    if (imageData == nullptr)
+    {
++     vtkWarningWithObjectMacro(this->Owner, << "[VTKToAnariSampler] Texture has no input image data.");
+      return nullptr;
+    }
+  
+***************
+*** 460,475 ****
+    anari::setParameter(this->AnariDevice, anariSampler, "name", ANARI_STRING, samplerName.c_str());
+    anari::setParameter(this->AnariDevice, anariSampler, "inAttribute", inAttribute);
+    anari::setParameter(this->AnariDevice, anariSampler, "inTransform", inTransform);
+!   anari::setParameter(this->AnariDevice, anariSampler, "wrapMode1", "clampToEdge");
+!   anari::setParameter(this->AnariDevice, anariSampler, "wrapMode2", "clampToEdge");
+!   anari::setParameter(this->AnariDevice, anariSampler, "filter", "linear");
+  
+    // Get the needed image data attributes
+!   int xsize = (imageData->GetExtent()[1] - imageData->GetExtent()[0]) + 1;
+!   int ysize = (imageData->GetExtent()[3] - imageData->GetExtent()[2]) + 1;
+  
+    if (xsize <= 0 || ysize <= 0)
+    {
+      return nullptr;
+    }
+  
+--- 478,513 ----
+    anari::setParameter(this->AnariDevice, anariSampler, "name", ANARI_STRING, samplerName.c_str());
+    anari::setParameter(this->AnariDevice, anariSampler, "inAttribute", inAttribute);
+    anari::setParameter(this->AnariDevice, anariSampler, "inTransform", inTransform);
+! 
+!   std::string wrapMode = "clampToEdge";
+!   switch (texture->GetWrap())
+!   {
+!     case vtkTexture::Repeat:
+!       wrapMode = "repeat";
+!       break;
+!     case vtkTexture::MirroredRepeat:
+!       wrapMode = "mirroredRepeat";
+!       break;
+!     case vtkTexture::ClampToEdge:
+!     case vtkTexture::ClampToBorder:
+!     default:
+!       wrapMode = "clampToEdge";
+!       break;
+!   }
+! 
+!   anari::setParameter(this->AnariDevice, anariSampler, "wrapMode1", wrapMode);
+!   anari::setParameter(this->AnariDevice, anariSampler, "wrapMode2", wrapMode);
+  
+    // Get the needed image data attributes
+!   const int* const imageSize = imageData->GetDimensions();
+!   const int xsize = imageSize[0];
+!   const int ysize = imageSize[1];
+  
+    if (xsize <= 0 || ysize <= 0)
+    {
++     vtkWarningWithObjectMacro(
++       this->Owner, << "[VTKToAnariSampler] Invalid image data extent: " << xsize << "x" << ysize);
++     anari::release(this->AnariDevice, anariSampler);
+      return nullptr;
+    }
+  
+***************
+*** 491,516 ****
+  
+        if (comps > 4)
+        {
+          uint8_t* imageDataPtr = (uint8_t*)imageData->GetScalarPointer(0, 0, 0);
+  
+!         for (int i = 0; i < xsize; i++)
+          {
+!           for (int j = 0; j < ysize; j++)
+            {
+!             for (int k = 0; k < 3; k++)
+              {
+                charData.emplace_back(imageDataPtr[k]);
+              }
+-           }
+  
+!           imageDataPtr += comps;
+          }
+- 
+-         comps = 3;
+        }
+  
+        const auto* appMemory = charData.empty() ? imageData->GetScalarPointer() : charData.data();
+!       auto dataType = sRGB ? anariLinearColorFormats[comps - 1] : anariColorFormats[comps - 1];
+  
+        anari::setParameterArray2D(
+          this->AnariDevice, anariSampler, "image", dataType, appMemory, xsize, ysize);
+--- 529,555 ----
+  
+        if (comps > 4)
+        {
++         const int originalComps = comps;
++         comps = 4;
+          uint8_t* imageDataPtr = (uint8_t*)imageData->GetScalarPointer(0, 0, 0);
+  
+!         for (int i = 0; i < ysize; i++)
+          {
+!           for (int j = 0; j < xsize; j++)
+            {
+!             for (int k = 0; k < comps; k++)
+              {
+                charData.emplace_back(imageDataPtr[k]);
+              }
+  
+!             imageDataPtr += originalComps;
+!           }
+          }
+        }
+  
+        const auto* appMemory = charData.empty() ? imageData->GetScalarPointer() : charData.data();
+!       auto dataType = texture->GetUseSRGBColorSpace() ? anariLinearColorFormats[comps - 1] 
+!                                                       : anariColorFormats[comps - 1];
+  
+        anari::setParameterArray2D(
+          this->AnariDevice, anariSampler, "image", dataType, appMemory, xsize, ysize);
+***************
+*** 525,542 ****
+  
+        if (comps > 4)
+        {
+          for (int i = 0; i < ysize; i++)
+          {
+            for (int j = 0; j < xsize; j++)
+            {
+!             for (int k = 0; k < 3; k++)
+              {
+                floatData.emplace_back(imageData->GetScalarComponentAsFloat(j, i, 0, k));
+              }
+            }
+          }
+- 
+-         comps = 3;
+        }
+  
+        const auto* appMemory = floatData.empty() ? imageData->GetScalarPointer() : floatData.data();
+--- 564,581 ----
+  
+        if (comps > 4)
+        {
++         comps = 4;
++ 
+          for (int i = 0; i < ysize; i++)
+          {
+            for (int j = 0; j < xsize; j++)
+            {
+!             for (int k = 0; k < comps; k++)
+              {
+                floatData.emplace_back(imageData->GetScalarComponentAsFloat(j, i, 0, k));
+              }
+            }
+          }
+        }
+  
+        const auto* appMemory = floatData.empty() ? imageData->GetScalarPointer() : floatData.data();
+***************
+*** 554,575 ****
+  
+        if (comps > 4)
+        {
+          uint16_t* imageDataPtr = reinterpret_cast<uint16_t*>(imageData->GetScalarPointer(0, 0, 0));
+  
+!         for (int i = 0; i < xsize; i++)
+          {
+!           for (int j = 0; j < ysize; j++)
+            {
+!             for (int k = 0; k < 3; k++)
+              {
+                shortData.emplace_back(imageDataPtr[k]);
+              }
+-           }
+  
+!           imageDataPtr += comps;
+          }
+- 
+-         comps = 3;
+        }
+  
+        const auto* appMemory = shortData.empty() ? imageData->GetScalarPointer() : shortData.data();
+--- 593,614 ----
+  
+        if (comps > 4)
+        {
++         const int originalComps = comps;
++         comps = 4;
+          uint16_t* imageDataPtr = reinterpret_cast<uint16_t*>(imageData->GetScalarPointer(0, 0, 0));
+  
+!         for (int i = 0; i < ysize; i++)
+          {
+!           for (int j = 0; j < xsize; j++)
+            {
+!             for (int k = 0; k < comps; k++)
+              {
+                shortData.emplace_back(imageDataPtr[k]);
+              }
+  
+!             imageDataPtr += originalComps;
+!           }
+          }
+        }
+  
+        const auto* appMemory = shortData.empty() ? imageData->GetScalarPointer() : shortData.data();
+***************
+*** 582,588 ****
+        anari::DataType anariColorFormats[4] = { ANARI_FLOAT32, ANARI_FLOAT32_VEC2,
+          ANARI_FLOAT32_VEC3, ANARI_FLOAT32_VEC4 };
+  
+!       comps = comps > 4 ? 3 : comps;
+        std::vector<float> floatData;
+  
+        for (int i = 0; i < ysize; i++)
+--- 621,627 ----
+        anari::DataType anariColorFormats[4] = { ANARI_FLOAT32, ANARI_FLOAT32_VEC2,
+          ANARI_FLOAT32_VEC3, ANARI_FLOAT32_VEC4 };
+  
+!       comps = comps > 4 ? 4 : comps;
+        std::vector<float> floatData;
+  
+        for (int i = 0; i < ysize; i++)
+***************
+*** 612,622 ****
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::MakeMaterial", vtkAnariProfiling::LIME);
+  
+    std::string materialName = this->ActorName + "_material";
+-   const char* vtkMaterialName = property->GetMaterialName();
+- 
+    anari::Material anariMaterial = nullptr;
+  
+!   if (property->GetInterpolation() == VTK_PBR && this->StrToLower(vtkMaterialName) != "matte")
+    {
+      if (this->AnariDeviceExtensions.ANARI_KHR_MATERIAL_PHYSICALLY_BASED)
+      {
+--- 651,659 ----
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::MakeMaterial", vtkAnariProfiling::LIME);
+  
+    std::string materialName = this->ActorName + "_material";
+    anari::Material anariMaterial = nullptr;
+  
+!   if (property->GetInterpolation() == VTK_PBR)
+    {
+      if (this->AnariDeviceExtensions.ANARI_KHR_MATERIAL_PHYSICALLY_BASED)
+      {
+***************
+*** 669,677 ****
+    anari::Material anariMaterial, vtkProperty* vtkProperty, float* color,
+    anari::Sampler baseColorSampler, const char* colorStr)
+  {
+-   vtkTexture* texture = nullptr;
+-   vtkTexture* ormTexture = vtkProperty->GetTexture("materialTex");
+- 
+    mat4 inTransform = { vec4{ 1.0f, 0.0f, 0.0f, 0.0f }, vec4{ 0.0f, 1.0f, 0.0f, 0.0f },
+      vec4{ 0.0f, 0.0f, 1.0f, 0.0f }, vec4{ 0.0f, 0.0f, 0.0f, 1.0f } };
+  
+--- 706,711 ----
+***************
+*** 686,712 ****
+    else
+    {
+      // base color
+!     float materialColor[3] = { 0.0f, 0.0f, 0.0f };
+  
+!     if (baseColorSampler == nullptr && colorStr == nullptr)
+      {
+!       if (color != nullptr)
+        {
+!         for (int i = 0; i < 3; i++)
+!         {
+!           materialColor[i] = color[i];
+!         }
+        }
+!       else
+!       {
+!         double* actorColor = vtkProperty->GetColor();
+  
+!         if (actorColor != nullptr)
+          {
+!           for (int i = 0; i < 3; i++)
+!           {
+!             materialColor[i] = static_cast<float>(actorColor[i]);
+!           }
+          }
+        }
+      }
+--- 720,743 ----
+    else
+    {
+      // base color
+!     float materialColor[3] = { 1.0f, 1.0f, 1.0f };
+  
+!     if (color != nullptr)
+      {
+!       for (int i = 0; i < 3; i++)
+        {
+!         materialColor[i] = color[i];
+        }
+!     }
+!     else
+!     {
+!       double* actorColor = vtkProperty->GetColor();
+  
+!       if (actorColor != nullptr)
+!       {
+!         for (int i = 0; i < 3; i++)
+          {
+!           materialColor[i] = static_cast<float>(actorColor[i]);
+          }
+        }
+      }
+***************
+*** 718,780 ****
+    const float opacity = static_cast<float>(vtkProperty->GetOpacity());
+    anari::setParameter(this->AnariDevice, anariMaterial, "opacity", opacity);
+  
+    // metalness
+    if (ormTexture)
+    {
+      vtkImageData* ormImageData = ormTexture->GetInput();
+      auto metallicSampler =
+        this->ExtractORMFromVTK("metallicTex", 2, "attribute0", inTransform, ormImageData, false);
+!     anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "metallic", metallicSampler);
+    }
+    else
+    {
+-     const float metallic = static_cast<float>(vtkProperty->GetMetallic());
+      anari::setParameter(this->AnariDevice, anariMaterial, "metallic", metallic);
+    }
+  
+    // roughness
+    if (ormTexture)
+    {
+      vtkImageData* ormImageData = ormTexture->GetInput();
+      auto roughnessSampler =
+        this->ExtractORMFromVTK("roughnessTex", 1, "attribute0", inTransform, ormImageData, false);
+!     anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "roughness", roughnessSampler);
+    }
+    else
+    {
+-     const float roughness = static_cast<float>(vtkProperty->GetRoughness());
+      anari::setParameter(this->AnariDevice, anariMaterial, "roughness", roughness);
+    }
+  
+    // normal map for the base layer
+!   texture = vtkProperty->GetTexture("normalTex");
+  
+!   if (texture)
+    {
+-     vtkImageData* normalImageData = texture->GetInput();
+      auto normalSampler =
+!       this->VTKToAnariSampler("normalTex", "attribute0", inTransform, normalImageData, false);
+!     anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "normal", normalSampler);
+    }
+  
+    // emissive
+!   texture = vtkProperty->GetTexture("emissiveTex");
+  
+!   if (texture)
+    {
+-     vtkImageData* emissiveImageData = texture->GetInput();
+      auto emissiveSampler =
+!       this->VTKToAnariSampler("emissiveTex", "attribute0", inTransform, emissiveImageData, true);
+!     anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "emissive", emissiveSampler);
+    }
+  
+    // occlusion map
+    if (ormTexture)
+    {
+!     vtkImageData* ormImageData = texture->GetInput();
+      auto occlusionSampler =
+        this->ExtractORMFromVTK("occlusionTex", 0, "attribute0", inTransform, ormImageData, false);
+!     anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "occlusion", occlusionSampler);
+    }
+  
+    // strength of the specular reflection
+--- 749,844 ----
+    const float opacity = static_cast<float>(vtkProperty->GetOpacity());
+    anari::setParameter(this->AnariDevice, anariMaterial, "opacity", opacity);
+  
++   vtkTexture* ormTexture = vtkProperty->GetTexture("materialTex");
++ 
+    // metalness
++   const float metallic = static_cast<float>(vtkProperty->GetMetallic());
++ 
+    if (ormTexture)
+    {
++     ormTexture->Update();
+      vtkImageData* ormImageData = ormTexture->GetInput();
+      auto metallicSampler =
+        this->ExtractORMFromVTK("metallicTex", 2, "attribute0", inTransform, ormImageData, false);
+!     
+!     if (metallicSampler != nullptr)
+!     {
+!       anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "metallic", metallicSampler);
+!     }
+!     else
+!     {
+!       anari::setParameter(this->AnariDevice, anariMaterial, "metallic", metallic);
+!     }
+    }
+    else
+    {
+      anari::setParameter(this->AnariDevice, anariMaterial, "metallic", metallic);
+    }
+  
+    // roughness
++   const float roughness = static_cast<float>(vtkProperty->GetRoughness());
++   
+    if (ormTexture)
+    {
+      vtkImageData* ormImageData = ormTexture->GetInput();
+      auto roughnessSampler =
+        this->ExtractORMFromVTK("roughnessTex", 1, "attribute0", inTransform, ormImageData, false);
+!     
+!       if (roughnessSampler != nullptr)
+!     {
+!       anari::setAndReleaseParameter(
+!         this->AnariDevice, anariMaterial, "roughness", roughnessSampler);
+!     }
+!     else
+!     {
+!       anari::setParameter(this->AnariDevice, anariMaterial, "roughness", roughness);
+!     }
+    }
+    else
+    {
+      anari::setParameter(this->AnariDevice, anariMaterial, "roughness", roughness);
+    }
+  
+    // normal map for the base layer
+!   vtkTexture* normalTexture = vtkProperty->GetTexture("normalTex");
+  
+!   if (normalTexture)
+    {
+      auto normalSampler =
+!       this->VTKToAnariSampler("normalTex", "attribute0", inTransform, normalTexture);
+! 
+!     if (normalSampler != nullptr)
+!     {
+!       anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "normal", normalSampler);
+!     }
+    }
+  
+    // emissive
+!   vtkTexture* emissiveTexture = vtkProperty->GetTexture("emissiveTex");
+  
+!   if (emissiveTexture)
+    {
+      auto emissiveSampler =
+!       this->VTKToAnariSampler("emissiveTex", "attribute0", inTransform, emissiveTexture);
+! 
+!     if (emissiveSampler != nullptr)
+!     {
+!       anari::setAndReleaseParameter(this->AnariDevice, anariMaterial, "emissive", emissiveSampler);
+!     }
+    }
+  
+    // occlusion map
+    if (ormTexture)
+    {
+!     vtkImageData* ormImageData = ormTexture->GetInput();
+      auto occlusionSampler =
+        this->ExtractORMFromVTK("occlusionTex", 0, "attribute0", inTransform, ormImageData, false);
+!     
+!     if (occlusionSampler != nullptr)
+!     {
+!       anari::setAndReleaseParameter(
+!         this->AnariDevice, anariMaterial, "occlusion", occlusionSampler);
+!     }
+    }
+  
+    // strength of the specular reflection
+***************
+*** 798,812 ****
+    anari::setParameter(this->AnariDevice, anariMaterial, "clearcoatRoughness", coatRoughness);
+  
+    // normal map for the clearcoat layer
+!   texture = vtkProperty->GetTexture("coatNormalTex");
+  
+!   if (texture)
+    {
+-     vtkImageData* coatNormalImageData = texture->GetInput();
+      auto coatNormalSampler = this->VTKToAnariSampler(
+!       "coatNormalTex", "attribute0", inTransform, coatNormalImageData, false);
+!     anari::setAndReleaseParameter(
+!       this->AnariDevice, anariMaterial, "clearCoatNormal", coatNormalSampler);
+    }
+  
+    // index of refraction
+--- 862,879 ----
+    anari::setParameter(this->AnariDevice, anariMaterial, "clearcoatRoughness", coatRoughness);
+  
+    // normal map for the clearcoat layer
+!   vtkTexture* coatNormalTexture = vtkProperty->GetTexture("coatNormalTex");
+  
+!   if (coatNormalTexture)
+    {
+      auto coatNormalSampler = this->VTKToAnariSampler(
+!       "coatNormalTex", "attribute0", inTransform, coatNormalTexture);
+! 
+!     if (coatNormalSampler != nullptr)
+!     {
+!       anari::setAndReleaseParameter(
+!         this->AnariDevice, anariMaterial, "clearCoatNormal", coatNormalSampler);
+!     }
+    }
+  
+    // index of refraction
+***************
+*** 901,906 ****
+--- 968,974 ----
+  
+    if (texture)
+    {
++     texture->Update();
+      return texture->GetInput();
+    }
+  
+***************
+*** 912,918 ****
+    vtkActor* actor, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, bool isTriangleIndex, double pointSize, double lineWidth,
+    vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, vtkPolyDataMapperNode::vtkPDConnectivity& conn,
+    int cellFlag)
+  {
+--- 980,986 ----
+    vtkActor* actor, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, bool isTriangleIndex, double pointSize, double lineWidth,
+    vtkDataArray* scaleArray, vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, vtkPolyDataMapperNode::vtkPDConnectivity& conn,
+    int cellFlag)
+  {
+***************
+*** 934,940 ****
+            attributeArrays, cellFlag);
+        }
+  
+!       this->Surfaces.emplace_back(anariSurface);
+        break;
+      }
+      case VTK_WIREFRAME:
+--- 1002,1011 ----
+            attributeArrays, cellFlag);
+        }
+  
+!       if (anariSurface != nullptr)
+!       {
+!         this->Surfaces.emplace_back(anariSurface);
+!       }
+        break;
+      }
+      case VTK_WIREFRAME:
+***************
+*** 954,964 ****
+            attributeArrays, cellFlag);
+        }
+  
+!       this->Surfaces.emplace_back(anariSurface);
+        break;
+      }
+      default:
+      {
+        if (property->GetEdgeVisibility())
+        {
+          // Edge material
+--- 1025,1041 ----
+            attributeArrays, cellFlag);
+        }
+  
+!       if (anariSurface != nullptr)
+!       {
+!         this->Surfaces.emplace_back(anariSurface);
+!       }
+        break;
+      }
+      default:
+      {
++       double originalColor[3];
++       property->GetColor(originalColor);
++ 
+        if (property->GetEdgeVisibility())
+        {
+          // Edge material
+***************
+*** 969,975 ****
+          const auto useLineWidthForEdgeThickness = property->GetUseLineWidthForEdgeThickness();
+  
+          std::vector<vec2> edgeTextureCoords;
+!         std::vector<float> edgePointValueTextureCoords;
+          std::vector<vec4> edgePointColors;
+  
+          auto anariSurface = this->RenderAsCylinders(nullptr, property, poly, vertices,
+--- 1046,1052 ----
+          const auto useLineWidthForEdgeThickness = property->GetUseLineWidthForEdgeThickness();
+  
+          std::vector<vec2> edgeTextureCoords;
+!         std::vector<vec2> edgePointValueTextureCoords;
+          std::vector<vec4> edgePointColors;
+  
+          auto anariSurface = this->RenderAsCylinders(nullptr, property, poly, vertices,
+***************
+*** 977,983 ****
+            useLineWidthForEdgeThickness ? lineWidth : edgeWidth, scaleArray, scaleFunction,
+            edgeTextureCoords, edgePointValueTextureCoords, edgePointColors, attributeArrays,
+            cellFlag);
+!         this->Surfaces.emplace_back(anariSurface);
+        }
+  
+        std::vector<vec3> vertexNormals;
+--- 1054,1064 ----
+            useLineWidthForEdgeThickness ? lineWidth : edgeWidth, scaleArray, scaleFunction,
+            edgeTextureCoords, edgePointValueTextureCoords, edgePointColors, attributeArrays,
+            cellFlag);
+! 
+!         if (anariSurface != nullptr)
+!         {
+!           this->Surfaces.emplace_back(anariSurface);
+!         }
+        }
+  
+        std::vector<vec3> vertexNormals;
+***************
+*** 1006,1015 ****
+          }
+        }
+  
+        auto anariSurface =
+          this->RenderAsTriangles(anariSampler, property, poly, vertices, indexArray, vertexNormals,
+            textureCoords, pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+!       this->Surfaces.emplace_back(anariSurface);
+      }
+    }
+  }
+--- 1087,1102 ----
+          }
+        }
+  
++       property->SetColor(originalColor);
++ 
+        auto anariSurface =
+          this->RenderAsTriangles(anariSampler, property, poly, vertices, indexArray, vertexNormals,
+            textureCoords, pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+!       
+!       if (anariSurface != nullptr)
+!       {
+!         this->Surfaces.emplace_back(anariSurface);
+!       }
+      }
+    }
+  }
+***************
+*** 1018,1024 ****
+  anari::Surface vtkAnariPolyDataMapperNodeInternals::RenderAsTriangles(anari::Sampler anariSampler,
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, std::vector<vec3>& normals, std::vector<vec2>& textureCoords,
+!   std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsTriangles", vtkAnariProfiling::LIME);
+--- 1105,1111 ----
+  anari::Surface vtkAnariPolyDataMapperNodeInternals::RenderAsTriangles(anari::Sampler anariSampler,
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, std::vector<vec3>& normals, std::vector<vec2>& textureCoords,
+!   std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsTriangles", vtkAnariProfiling::LIME);
+***************
+*** 1115,1121 ****
+  
+    if (updateResponsibility.Texcoords && (numTextureCoords > 0 || numPointValueTextureCoords > 0))
+    {
+-     std::vector<vec2> tcoords;
+      anari::Array1D tcoordsArray = nullptr;
+  
+      if (numPointValueTextureCoords > 0)
+--- 1202,1207 ----
+***************
+*** 1127,1133 ****
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = vec2{ pointValueTextureCoords[i], 0.0f };
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+--- 1213,1219 ----
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = pointValueTextureCoords[i];
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+***************
+*** 1177,1183 ****
+      }
+      else
+      {
+!       int colorRepeatCount = numTriangles / numPointColors;
+        colorRepeatCount = colorRepeatCount <= 0 ? 1 : colorRepeatCount;
+  
+        anari::Array1D colorArray =
+--- 1263,1269 ----
+      }
+      else
+      {
+!       int colorRepeatCount = numTriangles / (numPointColors > 0 ? numPointColors : 1);
+        colorRepeatCount = colorRepeatCount <= 0 ? 1 : colorRepeatCount;
+  
+        anari::Array1D colorArray =
+***************
+*** 1254,1260 ****
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, double lineWidth, vtkDataArray* scaleArray,
+    vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsCylinders", vtkAnariProfiling::LIME);
+--- 1340,1346 ----
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, double lineWidth, vtkDataArray* scaleArray,
+    vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsCylinders", vtkAnariProfiling::LIME);
+***************
+*** 1374,1380 ****
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = vec2{ pointValueTextureCoords[i], 0.0f };
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+--- 1460,1466 ----
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = pointValueTextureCoords[i];
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+***************
+*** 1404,1411 ****
+  
+    if (updateResponsibility.Colors && numPointColors > 0)
+    {
+-     // if(cellFlag == 0)
+-     // {
+      anari::Array1D colorArray =
+        anari::newArray1D(this->AnariDevice, ANARI_FLOAT32_VEC4, numPointColors);
+      {
+--- 1490,1495 ----
+***************
+*** 1479,1485 ****
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, double lineWidth, vtkDataArray* scaleArray,
+    vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsCurves", vtkAnariProfiling::LIME);
+--- 1563,1569 ----
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, double lineWidth, vtkDataArray* scaleArray,
+    vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsCurves", vtkAnariProfiling::LIME);
+***************
+*** 1597,1603 ****
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = vec2{ pointValueTextureCoords[i], 0.0f };
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+--- 1681,1687 ----
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = pointValueTextureCoords[i];
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+***************
+*** 1627,1634 ****
+  
+    if (updateResponsibility.Colors && numPointColors > 0)
+    {
+-     // if(cellFlag == 0)
+-     // {
+      anari::Array1D colorArray =
+        anari::newArray1D(this->AnariDevice, ANARI_FLOAT32_VEC4, numPointColors);
+      {
+--- 1711,1716 ----
+***************
+*** 1701,1707 ****
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, double pointSize, vtkDataArray* scaleArray,
+    vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<float>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsSpheres", vtkAnariProfiling::LIME);
+--- 1783,1789 ----
+    vtkProperty* property, vtkPolyData* poly, std::vector<vec3>& vertices,
+    std::vector<uint32_t>& indexArray, double pointSize, vtkDataArray* scaleArray,
+    vtkPiecewiseFunction* scaleFunction, std::vector<vec2>& textureCoords,
+!   std::vector<vec2>& pointValueTextureCoords, std::vector<vec4>& pointColors,
+    AttributeArrayCollection& attributeArrays, int cellFlag)
+  {
+    vtkAnariProfiling startProfiling("VTKAPDMNInternals::RenderAsSpheres", vtkAnariProfiling::LIME);
+***************
+*** 1825,1831 ****
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = vec2{ pointValueTextureCoords[i], 0.0f };
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+--- 1907,1913 ----
+  
+          for (size_t i = 0; i < numPointValueTextureCoords; i++)
+          {
+!           tcoordsArrayPtr[i] = pointValueTextureCoords[i];
+          }
+  
+          anari::unmap(this->AnariDevice, tcoordsArray);
+***************
+*** 2091,2096 ****
+--- 2173,2196 ----
+          vec4{ static_cast<float>(transform[12]), static_cast<float>(transform[13]),
+            static_cast<float>(transform[14]), static_cast<float>(transform[15]) };
+      }
++     else if (length == 9)
++     {
++       anariSamplerInTransform[0] =
++         vec4{ static_cast<float>(transform[0]), static_cast<float>(transform[1]),
++           static_cast<float>(transform[2]), 0.0f };
++       anariSamplerInTransform[1] =
++         vec4{ static_cast<float>(transform[3]), static_cast<float>(transform[4]),
++           static_cast<float>(transform[5]), 0.0f };
++       anariSamplerInTransform[2] =
++         vec4{ static_cast<float>(transform[6]), static_cast<float>(transform[7]),
++           static_cast<float>(transform[8]), 0.0f };
++       anariSamplerInTransform[3] = vec4{ 0.0f, 0.0f, 0.0f, 1.0f };
++     }
++     else 
++     {
++       vtkWarningWithObjectMacro(
++         actor, "[AnariRenderPoly] Unsupported texture transform length: " << length);
++     }
+    }
+  
+    // cellFlag == 0 => PointData - length must equal the number of points
+***************
+*** 2107,2114 ****
+    if (mapper)
+    {
+      // Geometry
+!     mapper->MapScalars(poly, 1.0, cellFlag);
+!     mapperColors = mapper->GetColorMapColors();
+  
+      // Material
+      mapperColorCoords = mapper->GetColorCoordinates();
+--- 2207,2213 ----
+    if (mapper)
+    {
+      // Geometry
+!     mapperColors = mapper->MapScalars(poly, 1.0, cellFlag);
+  
+      // Material
+      mapperColorCoords = mapper->GetColorCoordinates();
+***************
+*** 2116,2159 ****
+    }
+  
+    // texture
+!   int numTextureCoordinates = 0;
+!   std::vector<vec2> textureCoords;
+    vtkDataArray* da = poly->GetPointData()->GetTCoords();
+  
+    if (da != nullptr)
+    {
+!     numTextureCoordinates = da->GetNumberOfTuples();
+  
+!     for (int i = 0; i < numTextureCoordinates; i++)
+      {
+!       textureCoords.emplace_back(
+          vec2{ static_cast<float>(da->GetTuple(i)[0]), static_cast<float>(da->GetTuple(i)[1]) });
+      }
+  
+!     numTextureCoordinates *= 2;
+    }
+  
+!   bool sRGB = false;
+!   vtkImageData* albedoTextureMap = nullptr; // vColorTextureMap
+!   vtkTexture* texture = nullptr;
+  
+    if (property->GetInterpolation() == VTK_PBR)
+    {
+!     texture = property->GetTexture("albedoTex");
+    }
+    else
+    {
+!     texture = actor->GetTexture();
+!   }
+! 
+!   if (texture != nullptr)
+!   {
+!     sRGB = texture->GetUseSRGBColorSpace();
+!     albedoTextureMap = texture->GetInput();
+    }
+  
+    // Setup Material or Colors
+-   std::vector<float> pointValueTextureCoords;
+    std::vector<vec4> pointColors;
+  
+    if (mapperColors)
+--- 2215,2259 ----
+    }
+  
+    // texture
+!   std::vector<vec2> pointValueTextureCoords;
+    vtkDataArray* da = poly->GetPointData()->GetTCoords();
++   
++   vtkDataArray* cellTCoords = poly->GetCellData()->GetTCoords();
++   std::vector<vec2> cellValueTextureCoords;
+  
+    if (da != nullptr)
+    {
+!     const int numPointValueTextureCoords = da->GetNumberOfTuples();
+  
+!     for (int i = 0; i < numPointValueTextureCoords; i++)
+      {
+!       pointValueTextureCoords.emplace_back(
+          vec2{ static_cast<float>(da->GetTuple(i)[0]), static_cast<float>(da->GetTuple(i)[1]) });
+      }
++   }
+  
+!   if (cellTCoords != nullptr)
+!   {
+!     const int numCellValueTextureCoords = cellTCoords->GetNumberOfTuples();
+!     for (int i = 0; i < numCellValueTextureCoords; i++)
+!     {
+!       cellValueTextureCoords.emplace_back(vec2{ static_cast<float>(cellTCoords->GetTuple(i)[0]),
+!         static_cast<float>(cellTCoords->GetTuple(i)[1]) });
+!     }
+    }
+  
+!   vtkSmartPointer<vtkTexture> tmpAlbedoTex;
+  
+    if (property->GetInterpolation() == VTK_PBR)
+    {
+!     tmpAlbedoTex = property->GetTexture("albedoTex");
+    }
+    else
+    {
+!     tmpAlbedoTex = actor->GetTexture();
+    }
+  
+    // Setup Material or Colors
+    std::vector<vec4> pointColors;
+  
+    if (mapperColors)
+***************
+*** 2171,2184 ****
+          int cflag2 = -1;
+          vtkAbstractArray* scalars = mapper->GetAbstractScalars(poly, mapper->GetScalarMode(),
+            mapper->GetArrayAccessMode(), mapper->GetArrayId(), mapper->GetArrayName(), cflag2);
+-         vtkVariant v = scalars->GetVariantValue(mapper->GetFieldDataTupleId());
+-         vtkIdType idx = s2c->GetAnnotatedValueIndex(v);
+  
+!         if (idx > -1)
+          {
+!           std::string name(s2c->GetAnnotation(idx));
+!           property->SetMaterialName(name.c_str());
+!           useMaterial = true;
+          }
+        }
+  
+--- 2271,2288 ----
+          int cflag2 = -1;
+          vtkAbstractArray* scalars = mapper->GetAbstractScalars(poly, mapper->GetScalarMode(),
+            mapper->GetArrayAccessMode(), mapper->GetArrayId(), mapper->GetArrayName(), cflag2);
+  
+!         if (scalars != nullptr)
+          {
+!           vtkVariant v = scalars->GetVariantValue(mapper->GetFieldDataTupleId());
+!           vtkIdType idx = s2c->GetAnnotatedValueIndex(v);
+! 
+!           if (idx > -1)
+!           {
+!             std::string name(s2c->GetAnnotation(idx));
+!             property->SetMaterialName(name.c_str());
+!             useMaterial = true;
+!           }
+          }
+        }
+  
+***************
+*** 2187,2196 ****
+          // Use the color for the field data value
+          int ncomps = mapperColors->GetNumberOfComponents();
+          uint8_t* mapperColorsPtr = mapperColors->GetPointer(0);
+!         mapperColorsPtr = mapperColorsPtr + mapper->GetFieldDataTupleId() * ncomps;
+          double diffuseColor[3] = { mapperColorsPtr[0] * property->GetDiffuse() / 255.0,
+            mapperColorsPtr[1] * property->GetDiffuse() / 255.0,
+!           mapperColorsPtr[2] * property->GetDiffuse() / 255.0f };
+          property->SetDiffuseColor(diffuseColor);
+        }
+      }
+--- 2291,2300 ----
+          // Use the color for the field data value
+          int ncomps = mapperColors->GetNumberOfComponents();
+          uint8_t* mapperColorsPtr = mapperColors->GetPointer(0);
+!         mapperColorsPtr = mapperColorsPtr + (mapper->GetFieldDataTupleId() * ncomps);
+          double diffuseColor[3] = { mapperColorsPtr[0] * property->GetDiffuse() / 255.0,
+            mapperColorsPtr[1] * property->GetDiffuse() / 255.0,
+!           mapperColorsPtr[2] * property->GetDiffuse() / 255.0 };
+          property->SetDiffuseColor(diffuseColor);
+        }
+      }
+***************
+*** 2214,2230 ****
+      if (mapperColorCoords && mapperColorTextureMap)
+      {
+        // color on point interpolated values (subsequently colormapped via 1D LUT)
+!       int numPointValueTextureCoords = mapperColorCoords->GetNumberOfTuples();
+!       pointValueTextureCoords.resize(numPointValueTextureCoords);
+!       float* tc = mapperColorCoords->GetPointer(0);
+  
+!       for (int i = 0; i < numPointValueTextureCoords; i++)
+        {
+!         pointValueTextureCoords[i] = *tc;
+!         tc += 2;
+        }
+  
+!       albedoTextureMap = mapperColorTextureMap;
+      }
+    }
+  
+--- 2318,2356 ----
+      if (mapperColorCoords && mapperColorTextureMap)
+      {
+        // color on point interpolated values (subsequently colormapped via 1D LUT)
+!       const int numOfTuples = mapperColorCoords->GetNumberOfTuples();
+!       const int ncomps = mapperColorCoords->GetNumberOfComponents();
+  
+!       const int numTexCoords = ncomps < 2 ? (numOfTuples / 2) : numOfTuples;
+!       cellValueTextureCoords.resize(numTexCoords);
+! 
+!       for (int i = 0, j = 0; i < numOfTuples && j < numTexCoords; i++, j++)
+        {
+!         vec2 tcoord;
+! 
+!         if (ncomps >= 2)
+!         {
+!           tcoord = vec2{ static_cast<float>(mapperColorCoords->GetTuple(i)[0]),
+!             static_cast<float>(mapperColorCoords->GetTuple(i)[1]) };
+!         }
+!         else if (ncomps == 1)
+!         {
+!           tcoord = vec2{ static_cast<float>(mapperColorCoords->GetTuple(i)[0]),
+!             static_cast<float>(mapperColorCoords->GetTuple(++i)[0]) };
+!         }
+!         else
+!         {
+!           tcoord = vec2{ static_cast<float>(*mapperColorCoords->GetTuple(i)),
+!             static_cast<float>(*mapperColorCoords->GetTuple(++i)) };
+!         }
+! 
+!         cellValueTextureCoords[j] = tcoord;
+! 
+        }
+  
+!       tmpAlbedoTex = vtkSmartPointer<vtkTexture>::New();
+!       tmpAlbedoTex->SetInputData(mapperColorTextureMap);
+!       tmpAlbedoTex->SetUseSRGBColorSpace(false);
+      }
+    }
+  
+***************
+*** 2329,2337 ****
+      if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_SPHERE)
+      {
+        auto anariSampler = this->Internal->VTKToAnariSampler(
+!         "albedoTex", "attribute0", anariSamplerInTransform, albedoTextureMap, sRGB);
+        anariSurface = this->Internal->RenderAsSpheres(anariSampler, property, poly, vertices,
+!         conn.vertex_index, pointSize, scaleArray, scaleFunction, textureCoords,
+          pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+      }
+  
+--- 2455,2463 ----
+      if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_SPHERE)
+      {
+        auto anariSampler = this->Internal->VTKToAnariSampler(
+!         "albedoTex", "attribute0", anariSamplerInTransform, tmpAlbedoTex);
+        anariSurface = this->Internal->RenderAsSpheres(anariSampler, property, poly, vertices,
+!         conn.vertex_index, pointSize, scaleArray, scaleFunction, cellValueTextureCoords,
+          pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+      }
+  
+***************
+*** 2342,2355 ****
+    {
+      anari::Surface anariSurface = nullptr;
+  
+!     if (property->GetRepresentation() == VTK_POINTS)
+      {
+        if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_SPHERE)
+        {
+          auto anariSampler = this->Internal->VTKToAnariSampler(
+!           "albedoTex", "attribute0", anariSamplerInTransform, albedoTextureMap, sRGB);
+          anariSurface = this->Internal->RenderAsSpheres(anariSampler, property, poly, vertices,
+!           conn.line_index, pointSize, scaleArray, scaleFunction, textureCoords,
+            pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+        }
+      }
+--- 2468,2481 ----
+    {
+      anari::Surface anariSurface = nullptr;
+  
+!     if (connRepresentation == VTK_POINTS)
+      {
+        if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_SPHERE)
+        {
+          auto anariSampler = this->Internal->VTKToAnariSampler(
+!           "albedoTex", "attribute0", anariSamplerInTransform, tmpAlbedoTex);
+          anariSurface = this->Internal->RenderAsSpheres(anariSampler, property, poly, vertices,
+!           conn.line_index, pointSize, scaleArray, scaleFunction, cellValueTextureCoords,
+            pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+        }
+      }
+***************
+*** 2358,2374 ****
+        if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_CYLINDER)
+        {
+          auto anariSampler = this->Internal->VTKToAnariSampler(
+!           "albedoTex", "attribute0", anariSamplerInTransform, albedoTextureMap, sRGB);
+          anariSurface = this->Internal->RenderAsCylinders(anariSampler, property, poly, vertices,
+!           conn.line_index, lineWidth, scaleArray, scaleFunction, textureCoords,
+            pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+        }
+        else if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_CURVE)
+        {
+          auto anariSampler = this->Internal->VTKToAnariSampler(
+!           "albedoTex", "attribute0", anariSamplerInTransform, albedoTextureMap, sRGB);
+          anariSurface = this->Internal->RenderAsCurves(anariSampler, property, poly, vertices,
+!           conn.line_index, lineWidth, scaleArray, scaleFunction, textureCoords,
+            pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+        }
+      }
+--- 2484,2500 ----
+        if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_CYLINDER)
+        {
+          auto anariSampler = this->Internal->VTKToAnariSampler(
+!           "albedoTex", "attribute0", anariSamplerInTransform, tmpAlbedoTex);
+          anariSurface = this->Internal->RenderAsCylinders(anariSampler, property, poly, vertices,
+!           conn.line_index, lineWidth, scaleArray, scaleFunction, cellValueTextureCoords,
+            pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+        }
+        else if (anariDeviceExtensions.ANARI_KHR_GEOMETRY_CURVE)
+        {
+          auto anariSampler = this->Internal->VTKToAnariSampler(
+!           "albedoTex", "attribute0", anariSamplerInTransform, tmpAlbedoTex);
+          anariSurface = this->Internal->RenderAsCurves(anariSampler, property, poly, vertices,
+!           conn.line_index, lineWidth, scaleArray, scaleFunction, cellValueTextureCoords,
+            pointValueTextureCoords, pointColors, attributeArrays, cellFlag);
+        }
+      }
+***************
+*** 2382,2399 ****
+    if (!conn.triangle_index.empty())
+    {
+      auto anariSampler = this->Internal->VTKToAnariSampler(
+!       "albedoTex", "attribute0", anariSamplerInTransform, albedoTextureMap, sRGB);
+      this->Internal->RenderSurfaces(anariSampler, actor, poly, vertices, conn.triangle_index, true,
+!       pointSize, lineWidth, scaleArray, scaleFunction, textureCoords, pointValueTextureCoords,
+        pointColors, attributeArrays, conn2, cellFlag);
+    }
+  
+    if (!conn.strip_index.empty())
+    {
+      auto anariSampler = this->Internal->VTKToAnariSampler(
+!       "albedoTex", "attribute0", anariSamplerInTransform, albedoTextureMap, sRGB);
+      this->Internal->RenderSurfaces(anariSampler, actor, poly, vertices, conn.strip_index, false,
+!       pointSize, lineWidth, scaleArray, scaleFunction, textureCoords, pointValueTextureCoords,
+        pointColors, attributeArrays, conn2, cellFlag);
+    }
+  }
+--- 2508,2525 ----
+    if (!conn.triangle_index.empty())
+    {
+      auto anariSampler = this->Internal->VTKToAnariSampler(
+!       "albedoTex", "attribute0", anariSamplerInTransform, tmpAlbedoTex);
+      this->Internal->RenderSurfaces(anariSampler, actor, poly, vertices, conn.triangle_index, true,
+!       pointSize, lineWidth, scaleArray, scaleFunction, cellValueTextureCoords, pointValueTextureCoords,
+        pointColors, attributeArrays, conn2, cellFlag);
+    }
+  
+    if (!conn.strip_index.empty())
+    {
+      auto anariSampler = this->Internal->VTKToAnariSampler(
+!       "albedoTex", "attribute0", anariSamplerInTransform, tmpAlbedoTex);
+      this->Internal->RenderSurfaces(anariSampler, actor, poly, vertices, conn.strip_index, false,
+!       pointSize, lineWidth, scaleArray, scaleFunction, cellValueTextureCoords, pointValueTextureCoords,
+        pointColors, attributeArrays, conn2, cellFlag);
+    }
+  }
+***************
+*** 2540,2546 ****
+    }
+    else
+    {
+!     this->Internal->ActorName = &"vtk_actor_"[this->RendererNode->ReservePropId()];
+    }
+  }
+  
+--- 2666,2672 ----
+    }
+    else
+    {
+!     this->Internal->ActorName = "vtk_actor_" + std::to_string(this->RendererNode->ReservePropId());
+    }
+  }
+
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk 9.5 ANARI patch ${current_patch}/${count_patches} for vtkAnariPolyDataMapperNode.cxx failed."
+        return 1
+    fi
+    
+    # 5) vtkAnariSceneGraph update
+    ((current_patch++))
+    patch -p0 << \EOF 
+*** Rendering/ANARI/vtkAnariSceneGraph.cxx.orig	2025-06-23 14:12:36.000000000 -0500
+--- Rendering/ANARI/vtkAnariSceneGraph.cxx	    2026-02-20 10:45:43.271451336 -0600
+***************
+*** 227,242 ****
+  {
+    const uvec2 frameSize = { static_cast<uint32_t>(this->Size[0]),
+      static_cast<uint32_t>(this->Size[1]) };
+!   if ((uint32_t)this->Internal->ImageX == frameSize[0] &&
+!     (uint32_t)this->Internal->ImageY == frameSize[1])
+    {
+      return;
+    }
+  
+    this->Internal->ImageX = frameSize[0];
+    this->Internal->ImageY = frameSize[1];
+! 
+!   const size_t totalSize = this->Size[0] * this->Size[1];
+    this->Internal->ColorBuffer.resize(totalSize * sizeof(float));
+    this->Internal->DepthBuffer.resize(totalSize);
+  
+--- 227,244 ----
+  {
+    const uvec2 frameSize = { static_cast<uint32_t>(this->Size[0]),
+      static_cast<uint32_t>(this->Size[1]) };
+!   const size_t totalSize = this->Size[0] * this->Size[1];
+!   if ((uint32_t)this->Internal->ImageY == frameSize[1] && !this->Internal->ColorBuffer.empty() &&
+!     !this->Internal->DepthBuffer.empty() &&
+!     this->Internal->ColorBuffer.size() == totalSize * sizeof(float) &&
+!     this->Internal->DepthBuffer.size() == totalSize)
+    {
+      return;
+    }
+  
+    this->Internal->ImageX = frameSize[0];
+    this->Internal->ImageY = frameSize[1];
+!   
+    this->Internal->ColorBuffer.resize(totalSize * sizeof(float));
+    this->Internal->DepthBuffer.resize(totalSize);
+  
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "vtk 9.5 ANARI patch $current_patch/$count_patches for vtkAnariSceneGraph.cxx failed."
+        return 1
+    fi
+}
+
 function apply_vtk95_vktanari_patches
 {
     count_patches=2
@@ -437,11 +2143,20 @@ function apply_vtk_patch
             return 1
         fi
         
-        # MR will be submitted to kitware for these updates
-        # Will need to remove after next VTK update
+        # MR submitted to kitware for these updates
+        # Remove when upgrading to 9.6.0 or later
         apply_vtk95_vktanari_patches
         if [[ $? != 0 ]] ; then
             return 1
+        fi
+
+        # MR merged for this patch in VTK "master" branch, but we need to 
+        # apply it to 9.5 branch. 
+        # see: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12759
+        # Remove when upgrading to 9.6.0 or later
+        apply_vtk95_texture_anari_patches
+        if [[ $? != 0 ]] ; then
+            return 1    
         fi
     fi
 


### PR DESCRIPTION
### Description
Resolves #20831. 

* Backport of VTK MR 12759 to improve texture support and back-end switching stability.
* Updated release notes  under `Dev Changes` section.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?
1. Create a Pseudocolor or Volume Plot
2. Enable ANARI Rendering
3. Switch between Anari back-ends for rendering 

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
