### PR TITLE
update quick recipe for importing visit

### DIFF
--- a/src/doc/python_scripting/quickrecipes.rst
+++ b/src/doc/python_scripting/quickrecipes.rst
@@ -53,83 +53,32 @@ Some common use cases are using VisIt_ as part of a larger Python workflow or wh
 You should always try to use VisIt_'s Python interpreter directly, since importing VisIt's Python module may not always work.
 
 When importing the VisIt_ module into the system Python, at a minimum the major version numbers must match and ideally the major and minor version numbers would match.
+As of VisIt_ 3.5.0, the python import process uses a frontend module `visit_launcher` to locate and launch VisIt_.
 In general, there are three things you must do to import the VisIt_ module into the system Python.
 
-1. Tell the Python interpreter where the standard C++ library used to compile VisIt_ is located.
-   This needs to be done before any modules other than `ctypes` are imported.
-2. Tell the Python interpreter where the VisIt_ module is located.
-3. Specify the version of VisIt_ you are using if you have multiple versions of VisIt_ installed in the same directory.
+1. Tell the Python interpreter where the `visit_launcher` module is located.
+2. Set launch options
+3. Launch and `import visit`
 
-Not all of the steps are necessary.
-For example, if VisIt_ was compiled with the default system compiler then you do not need to perform the first step.
-It is important that the steps are done in the order specified above.
+In this example VisIt_ is imported into the system Python and used to save an image from one of our sample datasets. ::
 
-In this example VisIt_ is imported into the system Python and used to save an image from one of our sample datasets.
-The paths specified for the location of the standard C++ library and the VisIt_ module will need to be changed as appropriate for your system. ::
+    #
+    # setup visit module launcher
+    #
+    import sys
+    sys.path.append("/usr/gapps/visit/current/linux-x86_64/lib/site-packages/")
+    import visit_launcher
+    visit_launcher.AddArgument("-v 3.5")
+    visit_launcher.LaunchNowin(vdir="/usr/gapps/visit/")
+    #
+    # use launched visit
+    #
+    import visit
+    visit.OpenDatabase("/usr/gapps/visit/data/noise.silo")
+    visit.AddPlot("Pseudocolor", "hardyglobal")
+    visit.DrawPlots()
+    visit.SaveWindow()
 
-    python3
-    Python 3.7.2 (default, Feb 26 2019, 08:59:10)
-    [GCC 4.9.3] on linux
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> import ctypes
-    >>> ctypes.cdll.LoadLibrary('/usr/tce/packages/gcc/gcc-7.3.0/lib64/libstdc++.so.6')
-    <CDLL '/usr/tce/packages/gcc/gcc-7.3.0/lib64/libstdc++.so.6', handle 6d3e30 at 0x2aaaac14b7f0>
-    >>> import sys
-    >>> sys.path.append("/usr/gapps/visit/3.3.3/linux-x86_64/lib/site-packages/")
-    >>> import visit
-    >>> visit.AddArgument("-v")
-    >>> visit.AddArgument("3.3.3")
-    >>> visit.LaunchNowin()
-    Running: viewer3.3.3 -nowin -forceversion 3.3.3 -noint -host 127.0.0.1 -port 5601
-    True
-    >>> import visit
-    >>> visit.OpenDatabase("/usr/gapps/visit/data/noise.silo")
-    Running: mdserver3.3.3 -forceversion 3.3.3 -host 127.0.0.1 -port 5601
-    Running: engine_ser3.3.3 -forceversion 3.3.3 -dir /usr/gapps/visit -idle-timeout 480 -host 127.0.0.1 -port 5601
-    1
-    >>> visit.AddPlot("Pseudocolor", "hardyglobal")
-    1
-    >>> visit.DrawPlots()
-    1
-    >>> visit.SaveWindow()
-    VisIt: Message - Rendering window 1...
-    VisIt: Message - Saving window 1...
-    VisIt: Message - Saved visit0000.png
-    'visit0000.png'
-    >>> quit()
-
-Sometimes telling Python where the standard C++ library used to compile VisIt_ is located does not work and instead you can tell it where VisIt_'s Python library is located. ::
-
-    python3
-    Python 3.9.12 (main, Apr 15 2022, 09:20:22)
-    [GCC 10.3.1 20210422 (Red Hat 10.3.1-1)] on linux
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> import ctypes
-    >>> ctypes.CDLL('/usr/gapps/visit/3.3.3/linux-x86_64-toss4/lib/libpython3.7m.so')
-    <CDLL '/usr/gapps/visit/3.3.3/linux-x86_64-toss4/lib/libpython3.7m.so', handle 508b30 at 0x155546edf4f0>
-    >>> import sys
-    >>> sys.path.append("/usr/gapps/visit/3.3.3/linux-x86_64-toss4/lib/site-packages")
-    >>> import visit
-    >>> visit.AddArgument("-v")
-    >>> visit.AddArgument("3.3.3")
-    >>> visit.LaunchNowin()
-    Running: viewer3.3.3 -nowin -forceversion 3.3.3 -noint -host 127.0.0.1 -port 5600
-    True
-    >>> import visit
-    >>> visit.OpenDatabase("/usr/gapps/visit/data/noise.silo")
-    Running: mdserver3.3.3 -forceversion 3.3.3 -host 127.0.0.1 -port 5600
-    Running: engine_ser3.3.3 -forceversion 3.3.3 -dir /usr/gapps/visit -idle-timeout 480 -host 127.0.0.1 -port 5600
-    1
-    >>> visit.AddPlot("Pseudocolor", "hardyglobal")
-    1
-    >>> visit.DrawPlots()
-    1
-    >>> visit.SaveWindow()
-    VisIt: Message - Rendering window 1...
-    VisIt: Message - Saving window 1...
-    VisIt: Message - Saved visit0000.png
-    'visit0000.png'
-    >>> quit()
 
 Handling Command line arguments
 -------------------------------

--- a/src/visitpy/visit_utils/src/common.py
+++ b/src/visitpy/visit_utils/src/common.py
@@ -28,11 +28,10 @@ except:
     __visit_imported = False
 
 
-#LC Python crashes when PySide2 is imported
-#try:
-#    import PySide2.QtCore
-#    __pyside_imported = True
-#except:
+try:
+    import PySide2.QtCore
+    __pyside_imported = True
+except:
 __pyside_imported = False
 
 

--- a/src/visitpy/visit_utils/src/common.py
+++ b/src/visitpy/visit_utils/src/common.py
@@ -32,7 +32,7 @@ try:
     import PySide2.QtCore
     __pyside_imported = True
 except:
-__pyside_imported = False
+    __pyside_imported = False
 
 
 #

--- a/src/visitpy/visit_utils/src/common.py
+++ b/src/visitpy/visit_utils/src/common.py
@@ -28,11 +28,12 @@ except:
     __visit_imported = False
 
 
-try:
-    import PySide2.QtCore
-    __pyside_imported = True
-except:
-    __pyside_imported = False
+#LC Python crashes when PySide2 is imported
+#try:
+#    import PySide2.QtCore
+#    __pyside_imported = True
+#except:
+__pyside_imported = False
 
 
 #


### PR DESCRIPTION

### Description

Resolves #20842 

For the quick recipe update, many things changed:

One example: The lc gcc does not have a stdlibc++ as part of its install.
I made the choice to simplify as much as possible. 
I also added the `vdir` arg b/c users may not have `visit` in their `PATH`





<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->
