### PR TITLE
A couple of test suite fixes.

### DIFF
--- a/src/tools/dev/scripts/cron_script_run_test_suite.sh
+++ b/src/tools/dev/scripts/cron_script_run_test_suite.sh
@@ -2,6 +2,14 @@
 #
 # Cron driver script to run visit's test suite
 #
+# WARNING WARNING WARNING WARNING WARNING WARNING
+#
+#   If you change this file you will need to manually copy it to the
+#   directory where the crontab runs this script. Currently that is
+#   /usr/WS1/visit/test_trunk/nightly_cron on the RZ. You should also
+#   make sure the permissions are 775.
+#
+# WARNING WARNING WARNING WARNING WARNING WARNING
 
 # Change directories to the working directory.
 cd /usr/WS1/visit/test_trunk/nightly_cron

--- a/src/tools/dev/scripts/nightly_crontab
+++ b/src/tools/dev/scripts/nightly_crontab
@@ -5,7 +5,7 @@ MAILTO=cyrush@llnl.gov
 
 #
 # run at 8:00 PM, every day
-00 20 * * * /usr/WS1/visit/test_trunk/visit/src/tools/dev/scripts/cron_script_run_test_suite.sh >> /usr/WS1/visit/test_trunk/nightly_logs/cron_script_`date +\%Y-\%m-\%d-\%H-\%M`_log  2>&1
+00 20 * * * /usr/WS1/visit/test_trunk/nightly_cron/cron_script_run_test_suite.sh >> /usr/WS1/visit/test_trunk/nightly_logs/cron_script_`date +\%Y-\%m-\%d-\%H-\%M`_log  2>&1
 # run at 6:00 AM, every day
 0 7 * * * /usr/WS1/visit/test_trunk/visit/src/tools/dev/scripts/cron_script_change_perms.sh >> /usr/WS1/visit/test_trunk/nightly_logs/change_perms_`date +\%Y-\%m-\%d-\%H-\%M`_log  2>&1
 

--- a/src/tools/dev/scripts/regressiontest_postit
+++ b/src/tools/dev/scripts/regressiontest_postit
@@ -81,18 +81,25 @@ if test "$post" = "true" ; then
     if test "$hasFailed" = ""; then
         echo "Updating lastpass_$testHost at `date`."
         gitHead=`git log -1 | grep "^commit" | cut -d' ' -f2`
-        # First do a "git checkout" on lastpass to restore it in case
-        # it was modified and not committed. Then do a "git pull" to
-        # update develop in case there have been an commits since the
-        # test suite run started. Then update lastpass and push to
-        # GitHub.
+        gitBranch="task/visit/`date +%Y_%m_%d`_update_lastpass"
+        # First do a git checkout of develop, do a git pull to update
+        # it, then create a branch to update lastpass, update lastpass,
+        # merge the branch into develop, push develop to the remote and
+        # finally delete the branch used to update lastpass.
+        git checkout develop
+        git pull
+        git checkout -b $gitBranch
         git checkout src/tools/dev/scripts/lastpass_$testHost
         rm -f src/tools/dev/scripts/lastpass_$testHost
         git pull
         echo "$gitHead" > src/tools/dev/scripts/lastpass_$testHost
         git add src/tools/dev/scripts/lastpass_$testHost
         git commit -m "Update the last test suite pass on $testHost."
-        git push
+        git fetch origin
+        git checkout develop
+        git merge $gitBranch
+        git push origin develop
+        git branch -D $gitBranch
     fi
 
     # Copy the results to the dashboard checkout on quartz. 


### PR DESCRIPTION
### Description

I fixed a couple of issues I noticed with the test suite.

1) The crontab runs the script `cron_script_run_test_suite.sh` directly out of the visit clone used to run the test suite. The issue is that the visit clone doesn't have to exist since the regression test script will do the clone if it is missing. I modified the crontab to run the script from `/usr/WS1/visit/test_trunk/nightly_cron`. This means that if the script is changed it will need to be manually copied to the directory. I added a warning at the top of `cron_script_run_test_suite.sh` that it needs to be manually copied to that directory if it is modified.

2) The update of `lastpass_rzwhippet` happens directly on develop. This no longer works so I modified `regressiontest_postit` to modify it on a branch and merge that into develop.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I didn't test the crontab change. It will be tested when it is updated. The change is pretty simple and the consequence of it not being correct is miniscule.

I created a small test script with the commands to update lastpass from `regressiontest_postit` and used it to update the visit repo at GitHub.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
