### PR TITLE
Fix dbcomment annotation macro test

### DIFF
--- a/src/test/tests/rendering/annot_macros.py
+++ b/src/test/tests/rendering/annot_macros.py
@@ -16,6 +16,11 @@
 #    Removed 'fulldbname' test from allmacros, as it fails when run in any
 #    location other than the nightly regression location.
 #
+#    Mark C. Miller, Fri Mar 20 16:20:47 PDT 2026
+#    Moved testing of dbcomment macro to its own function to avoid using
+#    Silo data to test. The reason is Silo's dbcomment includes information
+#    about current HDF5/PDB driver and Silo library version information.
+#
 # ----------------------------------------------------------------------------
 import os
 
@@ -34,7 +39,7 @@ def allmacros():
     # "zunits" and "varunits" because the input database has no values
     # specified for these.
     #
-    macroNames = ("time", "cycle", "index", "numstates", "dbcomment",
+    macroNames = ("time", "cycle", "index", "numstates",
         "vardim", "numvar", "topodim", "spatialdim", "varname",
         "meshname", "filename", "xlabel", "ylabel", "zlabel")
 
@@ -54,6 +59,30 @@ def allmacros():
     text2d.Delete()
     text3d.Delete()
     textts.Delete()
+
+def dbcmacro():
+    """dbcomment macro"""
+
+    OpenDatabase(data_path("ProteinDataBank_test_data/1D1H.pdb"))
+    AddPlot("Molecule", "backbone")
+    DrawPlots()
+    text2d = create_text2d_annot()
+    text3d = CreateAnnotationObject("Text3D")
+    text3d.heightMode = text3d.Relative
+    text3d.relativeHeight = 0.03
+    text3d.position=(2.0, 1.0, 7.0)
+    textts = CreateAnnotationObject("TimeSlider")
+    textts.height = 0.15
+    textts.position = (0.05, 0.1)
+    text2d.text = "dbcomment $dbcomment"
+    text3d.text = "dbcomment $dbcomment"
+    textts.text = "dbcomment $dbcomment"
+    TestAutoName()
+    text2d.Delete()
+    text3d.Delete()
+    textts.Delete()
+    DeleteAllPlots()
+    CloseDatabase(data_path("ProteinDataBank_test_data/1D1H.pdb"))
 
 def multimacro():
     """Multiple macros in same annotation"""
@@ -218,6 +247,7 @@ def main():
     tafile()
     tsprintf()
     finalize()
+    dbcmacro()
 
 main()
 

--- a/test/baseline/rendering/annot_macros/annot_macros_allmacros_3.png
+++ b/test/baseline/rendering/annot_macros/annot_macros_allmacros_3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13357f86d21eff60d81a429a200d1869d9b0983af5e5b15fc430957e143b02c5
-size 5513

--- a/test/baseline/rendering/annot_macros/annot_macros_dbcmacro_0.png
+++ b/test/baseline/rendering/annot_macros/annot_macros_dbcmacro_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d7e8f915305977207017e15b8a6eb934a0600cf1da25316576fdfd4d3422fb2
+size 29158


### PR DESCRIPTION
### Description

This should fix failing test suite case for annotation macros.

The change that caused the failure is that I added logic to `avtSiloFileFormat.C` database plugin to populate the database comment it creates with information about the pdb/hdf5 and silo version numbers used to create the file as well as those being used in VisIt to read the file.

The `$dbcomment` annotation macro renders that text into the viewer image. So, that test output changed as a result. But, it changed in a way that merely rebaselining did not make sense because the hdf5 and silo library version information can change with time.

So, I removed `$dbcomment` annotation macro test from the main body of the `annot_macros.py` test and created a wholly separate case for just that test using some ProtienDatabase data (which is another database that sets the database comment).

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [x] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have confirmed new and existing unit tests pass locally with my changes.~~
- [x] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
