### PR TITLE
macos layout change blank window fix

### DIFF
--- a/src/gui/SplashScreen.C
+++ b/src/gui/SplashScreen.C
@@ -284,6 +284,9 @@
 //    Cyrus Harrison, Thu Mar  5 14:58:16 PST 2026
 //    Changed the date on the splash screen to March 2026.
 //
+//    Cyrus Harrison, Mon Mar 30 17:03:12 PDT 2026
+//    Changed the date on the splash screen to April 2026.
+//
 // ****************************************************************************
 
 SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
@@ -390,7 +393,7 @@ SplashScreen::SplashScreen(bool cyclePictures) : QFrame(0, Qt::SplashScreen)
            << tr("October")
            << tr("November")
            << tr("December");
-    int currentMonth = 3;
+    int currentMonth = 4;
     lLayout->addWidget(new QLabel(versionText, this));
     lLayout->addWidget(new QLabel(months[currentMonth-1] + " 2026", this));
 

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -77,6 +77,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug with the Line tool where it would hide behind 2D plots during interaction.</li>
   <li>Ensure Line tool is disabled for Curve plots, because it shouldn't be enabled in this situation.</li>
   <li>Fixed a bug where the line cue in Lineout mode would be drawn far from the mouse location when running on a laptop monitor.</li>
+  <li>Fixed a bug with layout changes causing existing viewer windows to be drawn blank until they were resized.</li>
 </ul>
 
 <a name="CLI_changes"></a>

--- a/src/viewer/core/ViewerWindowManager.C
+++ b/src/viewer/core/ViewerWindowManager.C
@@ -4529,6 +4529,11 @@ ViewerWindowManager::UpdateColorTable(const std::string &ctName)
 //
 //    Mark C. Miller, Fri Mar 17 15:14:30 PDT 2023
 //    Add APPLE-specific logic to address blank viewer windows (#18090)
+//
+//    Cyrus Harrison, Mon Mar 30 16:58:43 PDT 2026
+//    Add APPLE-specific `raise` call to force redraw of existing windows
+//    and avoids blankn windows after a window layout change.
+//
 // ****************************************************************************
 
 void
@@ -4593,6 +4598,9 @@ ViewerWindowManager::SetWindowLayout(const int windowLayout)
         GetActiveWindow()->DeIconify();
         GetActiveWindow()->SetSize(width, height);
         GetActiveWindow()->SetLocation(x, y);
+#if defined(__APPLE__) // on apple we need raise to force redraw
+        GetActiveWindow()->Raise();
+#endif
     }
     else
     {
@@ -4624,6 +4632,9 @@ ViewerWindowManager::SetWindowLayout(const int windowLayout)
                     height = windowLimits[layoutIndex][nWindowsProcessed].height;
                     windows[iWindow]->SetSize(width, height);
                     windows[iWindow]->SetLocation(x, y);
+#if defined(__APPLE__) // on apple we need raise to force redraw
+                    windows[iWindow]->Raise();
+#endif
                 }
                 else
                 {


### PR DESCRIPTION
### Description

Even after Mark's fixes for blank window on start up, I noticed that when I change views, existing windows would often become blank until I manually resize them.

Here are some examples:

<img width="2371" height="1066" alt="Screenshot 2026-03-30 at 5 11 08 PM" src="https://github.com/user-attachments/assets/88b23756-db5e-406a-9c8d-7c8cb9bf2065" />
<img width="1712" height="1021" alt="Screenshot 2026-03-30 at 5 11 15 PM" src="https://github.com/user-attachments/assets/f71153ee-2938-4d7f-9c3a-07e81e795e16" />



I tested a few things and found a solution that I added for macOS only.

When the window layout is changed, calling the `raise` command on the viewer windows solved it. 

Also, I tested disabling Mark's macOS logic to make sure the first window is bumped on start up to avoid being drawn blank. I found I didn't need this logic, but I left it in out of an abundance of caution. It has solved the startup issue for a while.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on my macOS laptop.

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [x] I have updated the release notes.~~
~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have added debugging support to my changes.~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
~~- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
~~- [ ] I have added new baselines for any new tests to the repo.~~
~~- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
