### PR TITLE
Fix bv_qt.sh such that qttools and qtsvg use MesaGL when needed.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -543,15 +543,7 @@ function build_qt_base
         qt_flags="${qt_flags} -debug"
     fi
 
-    qt_cmake_flags=""
-    if [[ "$DO_MESAGL" == "yes" ]] ; then
-        # '--' separates the qt-configure-style flags from the cmake flags
-        qt_cmake_flags=" -- -DOPENGL_INCLUDE_DIR:PATH=${MESAGL_INCLUDE_DIR}"
-        qt_cmake_flags="${qt_cmake_flags} -DOPENGL_gl_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
-        qt_cmake_flags="${qt_cmake_flags} -DOPENGL_opengl_LIBRARY:STRING="
-        qt_cmake_flags="${qt_cmake_flags} -DOPENGL_glu_LIBRARY:STRING=${MESAGL_GLU_LIB}"
-        qt_cmake_flags="${qt_cmake_flags} -DOpenGL_GL_PREFERENCE:STRING=LEGACY"
-    fi
+    qt_cmake_flags="$(qt_base_mesagl_cmake_flags)"
     info "Configuring Qt base: . . . "
     set -x
     (echo "o"; echo "yes") | env PATH="${CMAKE_INSTALL}:$PATH" \
@@ -593,6 +585,33 @@ function build_qt_base
     return 0
 }
 
+function qt_mesagl_cmake_flags
+{
+    local qt_module_cmake_flags=""
+    if [[ "$DO_MESAGL" == "yes" ]] ; then
+        qt_module_cmake_flags=" -- -DOPENGL_INCLUDE_DIR:PATH=${MESAGL_INCLUDE_DIR}"
+        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_gl_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
+        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_opengl_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
+        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_glx_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
+        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_glu_LIBRARY:STRING=${MESAGL_GLU_LIB}"
+        qt_module_cmake_flags="${qt_module_cmake_flags} -DOpenGL_GL_PREFERENCE:STRING=LEGACY"
+    fi
+    echo "${qt_module_cmake_flags}"
+}
+
+function qt_base_mesagl_cmake_flags
+{
+    local qt_cmake_flags=""
+    if [[ "$DO_MESAGL" == "yes" ]] ; then
+        qt_cmake_flags=" -- -DOPENGL_INCLUDE_DIR:PATH=${MESAGL_INCLUDE_DIR}"
+        qt_cmake_flags="${qt_cmake_flags} -DOPENGL_gl_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
+        qt_cmake_flags="${qt_cmake_flags} -DOPENGL_opengl_LIBRARY:STRING="
+        qt_cmake_flags="${qt_cmake_flags} -DOPENGL_glu_LIBRARY:STRING=${MESAGL_GLU_LIB}"
+        qt_cmake_flags="${qt_cmake_flags} -DOpenGL_GL_PREFERENCE:STRING=LEGACY"
+    fi
+    echo "${qt_cmake_flags}"
+}
+
 
 function build_qt_tools
 {
@@ -625,9 +644,12 @@ function build_qt_tools
 
     cd ${QT_TOOLS_BUILD_DIR}
 
+    qt_module_cmake_flags="$(qt_mesagl_cmake_flags)"
+
     info "Configuring Qt tools . . . "
     env CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
-        ${QT_INSTALL_DIR}/bin/qt-configure-module  ../${QT_TOOLS_SOURCE_DIR}
+        ${QT_INSTALL_DIR}/bin/qt-configure-module  ../${QT_TOOLS_SOURCE_DIR} \
+        ${qt_module_cmake_flags}
 
     info "Building Qt6 tools . . . "
     ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
@@ -669,9 +691,12 @@ function build_qt_svg
 
     cd ${QT_SVG_BUILD_DIR}
 
+    qt_module_cmake_flags="$(qt_mesagl_cmake_flags)"
+
     info "Configuring Qt svg . . . "
     env CC="${C_COMPILER}" CXX="${CXX_COMPILER}"  \
-        ${QT_INSTALL_DIR}/bin/qt-configure-module  ../${QT_SVG_SOURCE_DIR}
+        ${QT_INSTALL_DIR}/bin/qt-configure-module  ../${QT_SVG_SOURCE_DIR} \
+        ${qt_module_cmake_flags}
 
     info "Building Qt6 svg . . . "
     ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -543,7 +543,7 @@ function build_qt_base
         qt_flags="${qt_flags} -debug"
     fi
 
-    qt_cmake_flags="$(qt_base_mesagl_cmake_flags)"
+    qt_cmake_flags="$(qt_mesagl_cmake_flags)"
     info "Configuring Qt base: . . . "
     set -x
     (echo "o"; echo "yes") | env PATH="${CMAKE_INSTALL}:$PATH" \
@@ -586,20 +586,6 @@ function build_qt_base
 }
 
 function qt_mesagl_cmake_flags
-{
-    local qt_module_cmake_flags=""
-    if [[ "$DO_MESAGL" == "yes" ]] ; then
-        qt_module_cmake_flags=" -- -DOPENGL_INCLUDE_DIR:PATH=${MESAGL_INCLUDE_DIR}"
-        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_gl_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
-        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_opengl_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
-        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_glx_LIBRARY:STRING=${MESAGL_OPENGL_LIB}"
-        qt_module_cmake_flags="${qt_module_cmake_flags} -DOPENGL_glu_LIBRARY:STRING=${MESAGL_GLU_LIB}"
-        qt_module_cmake_flags="${qt_module_cmake_flags} -DOpenGL_GL_PREFERENCE:STRING=LEGACY"
-    fi
-    echo "${qt_module_cmake_flags}"
-}
-
-function qt_base_mesagl_cmake_flags
 {
     local qt_cmake_flags=""
     if [[ "$DO_MESAGL" == "yes" ]] ; then


### PR DESCRIPTION
### Description
I discoverd while building in a docker container with no gl libs installed, that Qt's tools and svg didn't built correctly (didn't know until qwt failed to build).  The problem was a dependence on GL, but since there was no system GL and the Mesa flags weren't passed, the qt tools and qt svg failed 'silently' (there were entries in the log file, but build_visit didn't stop processing).

This fixes that problem by creating a helper function to set mesa flags (when building with mesa) and pass the flags to configure for qtbase, qttools and qtsvg

### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other
Build issue

### How Has This Been Tested?

Ran the update build_visit in the aforementioned container, with success for all components of Qt and Qwt.
VisIt successfully compiled, installed and ran the standard python test script.

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

