### PR TITLE
fix lldb launch from xterm on arm64

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -1483,7 +1483,11 @@ class LLDBDebugger(Debugger):
         super(LLDBDebugger, self).__init__(launcher)
 
     def Executable(self):
-        return ["lldb"]
+        native_arm64 = subprocess.check_output(["sysctl", "-n", "hw.optional.arm64"]).decode().strip()
+        if native_arm64 == "1":
+            return ["arch", "-arm64", "lldb"]
+        else:
+            return ["lldb"]
 
     def CreateCommand(self, args):
         #lldb_args = ["process","launch","--tty","--"]


### PR DESCRIPTION
### Description

Fixes an issue launching `lldb` from `xterm` on Apple Mx macs.
The XQuartz stuff appears to all be `x86_64` based.
When `lldb` is launched from it, it is set up to debug `x86_64` code and so fails to operate on VisIt code.
The solution is to detect underlying architecture and inject `arch -arm64` ahead of the `lldb` launch command.

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).
