### PR TITLE
Disable MSAA until a crash-on-startup can be appropriately fixed.

### DIFF
--- a/src/avt/VisWindow/Colleagues/VisWinRendering.C
+++ b/src/avt/VisWindow/Colleagues/VisWinRendering.C
@@ -2725,17 +2725,24 @@ VisWinRendering::SetMSAASamples(int numSamples)
 //   Kathleen Biagas, Thu Oct 16, 2025.
 //   Check of olgWin is valid, prevent possible crash.
 //
+//   Kathleen Biagas, Fri Apr 17, 2026
+//   Due to a crash when this is called at startup and before the full
+//   gl context is created, disable MSAA completely until the crash can
+//   be fixed in an appropriate manner.
+//
 // ****************************************************************************
 
 bool
 VisWinRendering::MSAAAvailable()
 {
+#if 0
 #ifdef GL_MAX_SAMPLES
     vtkOpenGLRenderWindow* oglWin = vtkOpenGLRenderWindow::SafeDownCast(GetRenderWindow());
     int msamples = 0;
     if(oglWin)
         oglWin->GetState()->vtkglGetIntegerv(GL_MAX_SAMPLES, &msamples);
     return (msamples > 1);
+#endif
 #endif
     return false;
 }

--- a/src/resources/help/en_US/relnotes3.5.0.html
+++ b/src/resources/help/en_US/relnotes3.5.0.html
@@ -43,7 +43,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Added '-python-log-file' command line option to control the name of the file used to log python methods (default='visitlog.py').</li>
   <li>Add individual stress components to the PVLD plugin metadata.</li>
   <li>Refactored how to import visit into a stand alone python module. This is now done via the 'visit_launcher' module, avoiding module namespace issues.</li>
-  <li>Antialiasing is no longer an on/off option, there are two modes: MSAA (when available) and FXAA. The default is still no antialiasing.</li>
+  <li>Antialiasing is no longer an on/off option, there are two modes: MSAA (when available) and FXAA. The default is still no antialiasing. (Due to a crash discovered during the final hours of 3.5.0 release creation, MSAA is disabled for now.)</li>
   <li>Added environment variable logging to VisIt's debug vlog files.</li>
   <li>Fix bug in PVLD reader that caused some files to not open.</li>
   <li>Updated Python to 3.13.9, support for Python 2 was removed.</li>


### PR DESCRIPTION
### Description
Disables the vtkglIntgerv call that causes the crash, and has MSAAAvailable always return false until a vetted fix for the crash can be implemented.


<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
