### PR TITLE
Add a patch to vtk to fix a crash contouring VTK_CONVEX_POINT_SET cells.

### DIFF
--- a/src/resources/help/en_US/relnotes3.5.1.html
+++ b/src/resources/help/en_US/relnotes3.5.1.html
@@ -22,7 +22,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Bugs_fixed"></a>
 <p><b><font size="4">Bugs fixed in version 3.5.1</font></b></p>
 <ul>
-  <li>Bugs Fixed 1</li>
+  <li>Fixed a bug where slicing or contouring an unstructured mesh with VTK_CONVEX_POINT_SET cells caused a crash.</li>
   <li>Bugs Fixed 2</li>
 </ul>
 

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -2155,6 +2155,36 @@ EOF
     fi
 }
 
+function apply_vtk95_vtk_convex_point_set_patch
+{
+    # patch vtkConvexPointSet to fix a contouring bug.
+    patch -p0 << \EOF
+--- Common/DataModel/vtkConvexPointSet.cxx.orig	2026-05-19 14:58:47.244708000 -0700
++++ Common/DataModel/vtkConvexPointSet.cxx	2026-05-19 15:01:39.993741000 -0700
+@@ -59,7 +59,13 @@
+   if (numPts < 1)
+     return;
+
+-  this->Triangulate(0, this->TetraIds, this->TetraPoints);
++  this->TriangulateLocalIds(0, this->TetraIds);
++
++  this->TetraPoints->SetNumberOfPoints(this->TetraIds->GetNumberOfIds());
++  for (int i = 0; i < this->TetraIds->GetNumberOfIds(); i++)
++  {
++    this->TetraPoints->SetPoint(i, this->Points->GetPoint(this->TetraIds->GetId(i)));
++  }
+ }
+
+ //------------------------------------------------------------------------------
+EOF
+
+    if [[ $? != 0 ]] ; then
+      warn "vtk patch for vtkConvexPointSet.cxx failed."
+      return 1
+    fi
+    return 0;
+}
+
 function apply_vtk_patch
 {
     if [[ ${VTK_VERSION} == 9.5.0 ]] ; then
@@ -2193,6 +2223,12 @@ function apply_vtk_patch
         apply_vtk95_texture_anari_patches
         if [[ $? != 0 ]] ; then
             return 1    
+        fi
+
+        # should submit a MR to kitware
+        apply_vtk95_vtk_convex_point_set_patch
+        if [[ $? != 0 ]] ; then
+           return 1
         fi
     fi
 


### PR DESCRIPTION
### Description

Resolves #20947

This fixes a crash slicing or contouring un unstructured mesh with VTK_CONVEX_POINT_SET cells. The fix is applying a patch to vtkConvexPointSet class in VTK.

The `Contour` method required that the point ids it had stored were local to the cell being contoured. Instead they were the global ids for the full unstructured mesh. The patch changes the point ids to be local to the cell.

### Type of change

* [X] Bug fix~~

### How Has This Been Tested?

I tested it on the data provided by Greg Burton that caused VisIt 3.5.0 to crash and it worked fine after the fix was applied. I also checked the VTK build and the patch was indeed applied.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
