### PR TITLE
Support IndexSelect on unstructured meshes

### DIFF
--- a/src/operators/IndexSelect/avtIndexSelectFilter.C
+++ b/src/operators/IndexSelect/avtIndexSelectFilter.C
@@ -518,8 +518,9 @@ avtIndexSelectFilter::ExecuteData(avtDataRepresentation *in_dr)
         }
         PrepareFilters(ind, amri, curvilinearFilter, rectilinearFilter, 
                        pointsFilter);
-    
+
         vtkDataSet *rv = NULL;
+        bool rvOwned = false;
         int dstype = ds->GetDataObjectType();
         if (dstype == VTK_STRUCTURED_GRID)
         {
@@ -540,13 +541,107 @@ avtIndexSelectFilter::ExecuteData(avtDataRepresentation *in_dr)
             pointsFilter->Update();
             rv = pointsFilter->GetOutput();
         }
+        else if (atts.GetDim() == IndexSelectAttributes::OneD &&
+                 (dstype == VTK_POLY_DATA || dstype == VTK_UNSTRUCTURED_GRID))
+        {
+            vtkUnstructuredGrid *out_ug = vtkUnstructuredGrid::New();
+            vtkPoints *out_pts = vtkPoints::New();
+            out_ug->SetPoints(out_pts);
+            out_pts->Delete();
+
+            vtkCellData *out_cd = out_ug->GetCellData();
+            vtkCellData *in_cd = ds->GetCellData();
+            out_cd->CopyAllocate(in_cd);
+
+            vtkPointData *out_pd = out_ug->GetPointData();
+            vtkPointData *in_pd = ds->GetPointData();
+            out_pd->CopyAllocate(in_pd);
+
+            int ncells = ds->GetNumberOfCells();
+            int npoints = ds->GetNumberOfPoints();
+            vector<vtkIdType> ptMap(npoints, -1);
+            vector<vtkIdType> outCellPts;
+            out_ug->Allocate(ncells);
+
+            int xmin = atts.GetXMin();
+            int xmax = atts.GetXMax();
+            xmax = (xmax < 0 ? ncells : xmax);
+            int xincr = atts.GetXIncr();
+            if (xincr <= 0)
+                xincr = 1;
+            int out_cell = 0;
+            for (int i = 0; i < ncells; ++i)
+            {
+                if (i < xmin || i >= xmax)
+                    continue;
+                if (((i - xmin) % xincr) != 0)
+                    continue;
+
+                vtkCell *cell = ds->GetCell(i);
+                vtkIdList *list = cell->GetPointIds();
+                int ncellpts = list->GetNumberOfIds();
+                outCellPts.resize(ncellpts);
+                for (int j = 0; j < ncellpts; ++j)
+                {
+                    vtkIdType oldPtId = list->GetId(j);
+                    vtkIdType newPtId = ptMap[oldPtId];
+                    if (newPtId < 0)
+                    {
+                        double pt[3];
+                        ds->GetPoint(oldPtId, pt);
+                        newPtId = out_pts->InsertNextPoint(pt);
+                        out_pd->CopyData(in_pd, oldPtId, newPtId);
+                        ptMap[oldPtId] = newPtId;
+                    }
+                    outCellPts[j] = newPtId;
+                }
+                out_ug->InsertNextCell(ds->GetCellType(i), ncellpts,
+                                       &outCellPts[0]);
+                out_cd->CopyData(in_cd, i, out_cell++);
+            }
+
+            if (dstype == VTK_POLY_DATA)
+            {
+                vtkPolyData *out_pd = vtkPolyData::New();
+                out_pd->SetPoints(out_ug->GetPoints());
+                out_pd->GetPointData()->ShallowCopy(out_ug->GetPointData());
+                out_pd->GetCellData()->ShallowCopy(out_ug->GetCellData());
+                out_pd->Allocate(out_ug->GetNumberOfCells());
+                for (int i = 0; i < out_ug->GetNumberOfCells(); ++i)
+                {
+                    int celltype = out_ug->GetCellType(i);
+                    vtkIdType npts;
+                    const vtkIdType *pts;
+                    out_ug->GetCellPoints(i, npts, pts);
+                    out_pd->InsertNextCell(celltype, npts, pts);
+                }
+                out_ug->Delete();
+                rv = out_pd;
+            }
+            else
+            {
+                rv = out_ug;
+            }
+            rvOwned = true;
+        }
         else
         {
             if (!haveIssuedWarning)
             {
-                avtCallback::IssueWarning("The index select operator was "
+                if (dstype == VTK_UNSTRUCTURED_GRID || dstype == VTK_POLY_DATA)
+                {
+                    avtCallback::IssueWarning("The Index Select operator was "
+                            "applied in 2D or 3D mode to an unstructured or "
+                            "polydata mesh, which supports only 1D index "
+                            "selection.  Switch the operator to 1D mode to use "
+                            "it on this mesh.  It is not being applied.");
+                }
+                else
+                {
+                    avtCallback::IssueWarning("The index select operator was "
                             "applied to a non-structured mesh.  It is not "
                             "being applied.");
+                }
                 VisitMutexLock("avtIndexSelectFilter::ThreadSafeExecuteData");
                 haveIssuedWarning = true; 
                 VisitMutexUnlock("avtIndexSelectFilter::ThreadSafeExecuteData");
@@ -561,11 +656,15 @@ avtIndexSelectFilter::ExecuteData(avtDataRepresentation *in_dr)
 
         if (rv->GetNumberOfPoints() <= 0 || rv->GetNumberOfCells() <= 0)
         {
+            if (rvOwned)
+                rv->Delete();
             return NULL;
         }
 
         out_ds = (vtkDataSet *) rv->NewInstance();
         out_ds->ShallowCopy(rv);
+        if (rvOwned)
+            rv->Delete();
     }
     else
     {
@@ -2029,4 +2128,3 @@ avtIndexSelectFilter::LogicalSpaces::MatchesMaxAt(int idx, int _max)
 {
     return idx < 3 && idx >= 0 && maxs[idx] == _max;
 }
-

--- a/src/test/tests/operators/indexselect.py
+++ b/src/test/tests/operators/indexselect.py
@@ -617,4 +617,87 @@ Test("ops_indexselect39")
 DeleteAllPlots()
 
 
+# ----------------------------------------------------------------------------
+#  Test IndexSelect on an unstructured line mesh, treating the cells as a
+#  1D logical index space (issue #18422).
+#
+#  This is a value-based test (no baseline image). It writes a small line
+#  mesh, applies IndexSelect in 1D mode, and verifies the resulting zone and
+#  node counts. It exercises the VTK_UNSTRUCTURED_GRID / VTK_POLY_DATA path
+#  added for #18422, including point remapping so unused points are dropped.
+#
+#  Programmer: Shistata Subedi
+#  Date:       June 2026
+# ----------------------------------------------------------------------------
+TestSection("IndexSelect on unstructured line mesh (#18422)")
+
+import os
+
+DeleteAllPlots()
+
+# Write a small unstructured line mesh: 11 points, 10 line cells in a row.
+ug_dir = out_path("current", "operators")
+if not os.path.isdir(ug_dir):
+    os.makedirs(ug_dir)
+ug_vtk = os.path.join(ug_dir, "indexselect_lines.vtk")
+ug_pts = "\n".join("%d 0 0" % i for i in range(11))
+ug_cells = "\n".join("2 %d %d" % (i, i + 1) for i in range(10))
+ug_cellids = "\n".join(str(i) for i in range(10))
+with open(ug_vtk, "w") as ug_f:
+    ug_f.write("# vtk DataFile Version 3.0\n")
+    ug_f.write("Ten line cells for IndexSelect test\n")
+    ug_f.write("ASCII\n")
+    ug_f.write("DATASET UNSTRUCTURED_GRID\n")
+    ug_f.write("POINTS 11 float\n" + ug_pts + "\n")
+    ug_f.write("CELLS 10 30\n" + ug_cells + "\n")
+    ug_f.write("CELL_TYPES 10\n" + "\n".join(["3"] * 10) + "\n")
+    ug_f.write("CELL_DATA 10\n")
+    ug_f.write("SCALARS cell_id int 1\nLOOKUP_TABLE default\n" + ug_cellids + "\n")
+
+OpenDatabase(ug_vtk)
+AddPlot("Pseudocolor", "cell_id")
+DrawPlots()
+
+# Baseline counts for the full line mesh.
+Query("NumZones")
+TestValueEQ("indexselect_ugrid_base_zones", GetQueryOutputValue(), 10)
+Query("NumNodes")
+TestValueEQ("indexselect_ugrid_base_nodes", GetQueryOutputValue(), 11)
+
+# Contiguous 1D selection of cells [xMin, xMax): cells 0..3 -> 4 cells, 5 nodes.
+isel1d = IndexSelectAttributes()
+isel1d.dim = 0  # 0 -> 1D
+isel1d.xMin = 0
+isel1d.xMax = 4
+isel1d.xIncr = 1
+AddOperator("IndexSelect")
+SetOperatorOptions(isel1d)
+DrawPlots()
+
+Query("NumZones")
+TestValueEQ("indexselect_ugrid_contig_zones", GetQueryOutputValue(), 4)
+Query("NumNodes")
+TestValueEQ("indexselect_ugrid_contig_nodes", GetQueryOutputValue(), 5)
+
+RemoveLastOperator()
+
+# Strided 1D selection over all cells (xMax = -1): every 2nd cell -> 0,2,4,6,8.
+# 5 cells, and point remapping keeps only the 10 referenced nodes (not all 11).
+isel1ds = IndexSelectAttributes()
+isel1ds.dim = 0
+isel1ds.xMin = 0
+isel1ds.xMax = -1
+isel1ds.xIncr = 2
+AddOperator("IndexSelect")
+SetOperatorOptions(isel1ds)
+DrawPlots()
+
+Query("NumZones")
+TestValueEQ("indexselect_ugrid_stride_zones", GetQueryOutputValue(), 5)
+Query("NumNodes")
+TestValueEQ("indexselect_ugrid_stride_nodes", GetQueryOutputValue(), 10)
+
+DeleteAllPlots()
+
+
 Exit()


### PR DESCRIPTION
### Description

Resolves #18422

This adds 1D Index Select support for unstructured and polydata meshes by treating cells as a 1D logical index space.

The issue discussion notes that an unstructured mesh can be viewed as a 1D logical index space, and that Index Select should support selecting fewer line cells using start/stop/stride controls. This patch applies `xMin`, `xMax`, and `xIncr` over cell indices for `VTK_UNSTRUCTURED_GRID` and `VTK_POLY_DATA` inputs when Index Select is in 1D mode.

<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [x] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Tested on Linux using a local VisIt 3.4.0 build.
I created a small unstructured VTK dataset with 10 line cells and applied Index Select in 1D mode with:

xMin = 0
xMax = 4
xIncr = 1

Before the fix, VisIt warned that Index Select was applied to a non-structured mesh and was not being applied:

BASE_ZONES=10.0
INDEX_SELECTED_ZONES=10.0

After the fix, the same test returned:

BASE_ZONES=10.0
INDEX_SELECTED_ZONES=4.0

I rebuilt the relevant IndexSelect operator targets successfully:

make -j16 EIndexSelectOperator_ser IIndexSelectOperator SIndexSelectOperator VIndexSelectOperator



### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [x] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
