### PR TITLE
Fix bug 20540 (zone pick failure on highly zoomed plot). (#21005)

### DIFF
--- a/src/resources/help/en_US/relnotes3.5.1.html
+++ b/src/resources/help/en_US/relnotes3.5.1.html
@@ -23,7 +23,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Bugs fixed in version 3.5.1</font></b></p>
 <ul>
   <li>Fixed a bug where slicing or contouring an unstructured mesh with VTK_CONVEX_POINT_SET cells caused a crash.</li>
-  <li>Bugs Fixed 2</li>
+  <li>Fixed a bug with Zone-Pick on an extremely zoomed-in plot containing extremely long thin hexes.</li>
 </ul>
 
 <a name="Enhancements"></a>

--- a/src/visit_vtk/lightweight/vtkVisItUtility.C
+++ b/src/visit_vtk/lightweight/vtkVisItUtility.C
@@ -29,6 +29,7 @@
 #include <vtkRectilinearGrid.h>
 #include <vtkShortArray.h>
 #include <vtkStructuredGrid.h>
+#include <vtkVisItCellLocator.h>
 #include <vtkVisItPointLocator.h>
 #include <vtkWedge.h>
 
@@ -518,6 +519,11 @@ vtkVisItUtility::ComputeStructuredCoordinates(vtkRectilinearGrid *rgrid,
 //    Kathleen Bonnell, Wed Jul  7 15:02:03 PDT 2004
 //    Delete objects before early return, to prevent memory leaks.
 //
+//    Kathleen Bonnell, Wed Jun 3, 2026
+//    Add last-ditch attempt to find cell using vtkVisItCellLocator after other
+//    attempts have failed. Fixes bug with extremely zoomed in plot containing
+//    extremely long thin hexes.
+//
 // ****************************************************************************
 
 int
@@ -634,6 +640,40 @@ vtkVisItUtility::FindCell(vtkDataSet *ds, double x[3])
         cellIds->Delete();
         closestPoints->Delete();
         locator->Delete();
+
+        //
+        // When this method is called from avtZonePickQuery or avtNodePickQuery,
+        // it is usually because an intersection was found but for various
+        // reasons the first reported cellId is discarded.  It is expected a
+        // valid cellId should be found here. There has been user data with
+        // very long thin hexes with tiny spatial extents which confounds
+        // the vtkCell::EvaluatePosition method used above, so this next
+        // piece of logic is a last-ditch effort to find the intersected cell.
+        //
+        if (found == -1)
+        {
+            vtkVisItCellLocator *cellLocator = vtkVisItCellLocator::New();
+            cellLocator->SetDataSet(ds);
+            cellLocator->SetIgnoreGhosts(true);
+            cellLocator->BuildLocator();
+
+            vtkIdType closestCell = -1;
+            int closestSubId = -1;
+            double closestDist2 = FLT_MAX;
+            double closestPt[3] = {0., 0., 0.};
+            cellLocator->FindClosestPoint(x, closestPt, closestCell,
+                                          closestSubId, closestDist2);
+
+            if (closestCell >= 0)
+            {
+                const double locatorTol = std::max(tol, 1e-8*diagLen);
+                if (closestDist2 <= locatorTol*locatorTol)
+                    found = static_cast<int>(closestCell);
+            }
+
+            cellLocator->Delete();
+        }
+
         return found;
     }
 }


### PR DESCRIPTION
### Description

Resolves #20540.

Very long thin, tiny-extents hexahedrons in the data triggered numeric instability in some logic designed to help find the correct zone id associated with the intersection point of the pick.
A last-ditch fallback section of logic was added in case of failure of the normal route.


### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~ [ ] Other~~

### How Has This Been Tested?

Tested zone pick on data from the ticket, under described conditions with success.
Tested at other zoom levels and locations with success as well.
Full regression suite passed in serial and parallel on rzwhippet.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
