### PR TITLE
Replace all literal includes with line numbers with text tags.

### DIFF
--- a/src/doc/data_into_visit/BOVFormat.rst
+++ b/src/doc/data_into_visit/BOVFormat.rst
@@ -23,7 +23,9 @@ This is the origin of your grid.
 Here is an example of specifying the origin of your grid.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 8-8
+   :language: none
+   :start-at: BRICK_ORIGIN
+   :end-at: BRICK_ORIGIN
 
 BRICK_SIZE
 ~~~~~~~~~~
@@ -33,7 +35,9 @@ This is the size of your grid.
 Here is an example of specifying the size of your grid.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 9-9
+   :language: none
+   :start-at: BRICK_SIZE
+   :end-at: BRICK_SIZE
 
 The `i` component varies the fastest, then `j`, then `k`. 
 This means that if `BRICK_SIZE` is `2. 2. 2.`, the first float in the data file corresponds to `[0,0,0]`, the second to `[1,0,0]`, the third to `[0,1,0]`, the fourth to `[1,1,0]`, the fifth to `[0,0,1]`, and so on.
@@ -59,7 +63,9 @@ Valid values are `ZONAL` and `NODAL`.
 Here is an example of specifying the centering of your variable.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 7-7
+   :language: none
+   :start-at: CENTERING
+   :end-at: CENTERING
 
 DATA_BRICKLETS
 ~~~~~~~~~~~~~~
@@ -95,7 +101,9 @@ Data from Intel processors is `LITTLE`, while most other processors are `BIG`.
 Here is an example of specifying the Endian representation of your variable.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 6-6
+   :language: none
+   :start-at: DATA_ENDIAN
+   :end-at: DATA_ENDIAN
 
 DATA_FILE
 ~~~~~~~~~
@@ -105,7 +113,9 @@ This is the name of the file with the binary data.
 Here is an example of specifying the name of the data file.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 2-2
+   :language: none
+   :start-at: DATA_FILE
+   :end-at: DATA_FILE
 
 DATA_FORMAT
 ~~~~~~~~~~~
@@ -116,7 +126,9 @@ Valid values are `BYTE`, `SHORT`, `INT`, `FLOAT` and `DOUBLE`.
 Here is an example of specifying the type of your variable.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 4-4
+   :language: none
+   :start-at: DATA_FORMAT
+   :end-at: DATA_FORMAT
 
 DATA_SIZE
 ~~~~~~~~~
@@ -126,7 +138,9 @@ These are the dimensions of your variable.
 Here is an example of specifying the dimensions of your variable.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 3-3
+   :language: none
+   :start-at: DATA_SIZE
+   :end-at: DATA_SIZE
 
 DIVIDE_BRICK
 ~~~~~~~~~~~~
@@ -147,7 +161,9 @@ This is the time associated with the variable.
 Here is an example of specifying the time.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 1-1
+   :language: none
+   :start-at: TIME
+   :end-at: TIME
 
 VARIABLE
 ~~~~~~~~
@@ -157,7 +173,9 @@ This is the name of your variable.
 Here is an example of specifying the name of your variable.
 
 .. literalinclude:: data_examples/density.bov
-   :lines: 5-5
+   :language: none
+   :start-at: VARIABLE
+   :end-at: VARIABLE
 
 An example of a BOV file
 ------------------------

--- a/src/doc/data_into_visit/BlueprintFormat.rst
+++ b/src/doc/data_into_visit/BlueprintFormat.rst
@@ -11,7 +11,9 @@ The `Node` supports hierarchical construction.
 Here is a simple example of using Conduit in Python.
 
 .. literalinclude:: data_examples/node_example.py
-      :lines: 4-12
+      :language: python
+      :start-after: begin simple example sphinx literal include tag
+      :end-before: end simple example sphinx literal include tag
 
 Here is the output.
 
@@ -24,7 +26,9 @@ Blueprint can be used to check if a Conduit Node conforms to the Blueprint speci
 Here is a simple example writing a Blueprint uniform mesh in Python.
 
 .. literalinclude:: data_examples/blueprint_example.py
-      :lines: 4-45
+      :language: python
+      :start-after: begin blueprint example sphinx leteral include tag
+      :end-before: end blueprint example sphinx leteral include tag
 
 Here is the output.
 

--- a/src/doc/data_into_visit/BlueprintFormat.rst
+++ b/src/doc/data_into_visit/BlueprintFormat.rst
@@ -27,8 +27,8 @@ Here is a simple example writing a Blueprint uniform mesh in Python.
 
 .. literalinclude:: data_examples/blueprint_example.py
       :language: python
-      :start-after: begin blueprint example sphinx leteral include tag
-      :end-before: end blueprint example sphinx leteral include tag
+      :start-after: begin blueprint example sphinx literal include tag
+      :end-before: end blueprint example sphinx literal include tag
 
 Here is the output.
 

--- a/src/doc/data_into_visit/PlainTextFormat.rst
+++ b/src/doc/data_into_visit/PlainTextFormat.rst
@@ -26,7 +26,9 @@ In this example, the values on each row are separated by commas.
 Here are the first 10 lines of an example of a file representing curves.
 
 .. literalinclude:: data_examples/curves.csv
-   :lines: 1-10
+   :language: none
+   :start-at: angle,sine,cosine
+   :end-at: 0,0.642788,0.766044
 
 Here is the Python script that created the file.
 
@@ -60,7 +62,9 @@ Here are the first 10 lines of an example of a file representing curves where th
 In this example, the values on each row are separated by commas.
 
 .. literalinclude:: data_examples/curves_nox.csv
-   :lines: 1-10
+   :language: none
+   :start-at: inverse,sqrt,quadratic
+   :end-at: 11.1111,28.2843,0.64
 
 Here is the Python script that created the file.
 
@@ -90,7 +94,9 @@ In this example, the values on each row are separated by spaces.
 Here are the first 10 lines of an example of a file representing 3D points.
 
 .. literalinclude:: data_examples/points.txt
-   :lines: 1-10
+   :language: none
+   :start-at: x y z velx vely velz temp
+   :end-at: -0.665597 0.45823 0.808081 0.808081 0.928962 1.04691 0.419192
 
 Here is the Python script that created the file.
 

--- a/src/doc/data_into_visit/PlainTextFormat.rst
+++ b/src/doc/data_into_visit/PlainTextFormat.rst
@@ -28,7 +28,7 @@ Here are the first 10 lines of an example of a file representing curves.
 .. literalinclude:: data_examples/curves.csv
    :language: none
    :start-at: angle,sine,cosine
-   :end-at: 0,0.642788,0.766044
+   :end-at: 40,0.642788,0.766044
 
 Here is the Python script that created the file.
 

--- a/src/doc/data_into_visit/VTKFormat.rst
+++ b/src/doc/data_into_visit/VTKFormat.rst
@@ -520,7 +520,7 @@ The following lines represent the time associated with this file.
 .. literalinclude:: data_examples/extra_metadata.vtk
    :language: none
    :start-at: TIME 1 1 double
-   :end-at: VisItExpressions 1 2 string
+   :end-before: VisItExpressions 1 2 string
 
 The following lines represent the expressions associated with this file.
 

--- a/src/doc/data_into_visit/VTKFormat.rst
+++ b/src/doc/data_into_visit/VTKFormat.rst
@@ -352,7 +352,9 @@ If the value is a `2`, it is a Z-R mesh.
 Here is an example of specifying the mesh coordinate type.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 6-7
+   :language: none
+   :start-at: MeshCoordType 1 1 int
+   :end-before: MeshName 1 1 string
 
 MeshName
 ~~~~~~~~
@@ -362,7 +364,9 @@ The mesh name is represented as a string.
 Here is an example of specifying the mesh name.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 8-9
+   :language: none
+   :start-at: MeshName 1 1 string
+   :end-before: CYCLE 1 1 int
 
 CYCLE
 ~~~~~
@@ -372,7 +376,9 @@ The cycle is specified as a single integer value.
 Here is an example of specifying the cycle.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 10-11
+   :language: none
+   :start-at: CYCLE 1 1 int
+   :end-before: TIME 1 1 double
 
 TIME
 ~~~~
@@ -382,7 +388,9 @@ The time is specified as a single double precision value.
 Here is an example of specifying the time.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 12-13
+   :language: none
+   :start-at: TIME 1 1 double
+   :end-before: VisItExpressions 1 2 string
 
 VisItExpressions
 ~~~~~~~~~~~~~~~~
@@ -395,7 +403,9 @@ The expression type consists of one of `curve`, `scalar`, `vector`, `tensor`, `a
 Here is an example of specifying the expressions.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 14-16
+   :language: none
+   :start-at: VisItExpressions 1 2 string
+   :end-at: speed;scalar;sqrt(u*u+v*v)
 
 avtGhostZones
 ~~~~~~~~~~~~~
@@ -408,7 +418,9 @@ The ghost zone metadata is stored as CELL_DATA FIELD data.
 Here is an example of specifying ghost zones.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 33-37
+   :language: none
+   :start-at: FIELD FieldData 1
+   :end-at: 1 1 1 1
 
 .. _data_into_visit_vtk_example:
 
@@ -418,46 +430,62 @@ An example VTK file
 A basic VTK file is shown here.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 1-21
+   :language: none
+   :start-at: # vtk DataFile Version 3.0
+   :end-at: 1 2 3 1 2 3 1 2 3 1 2 3
 
 The line below contains the version and identifier.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: -1
+   :language: none
+   :start-at: # vtk DataFile Version 3.0
+   :end-at: # vtk DataFile Version 3.0
 
 The line below contains the title.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 2-2
+   :language: none
+   :start-at: vtk output
+   :end-at: vtk output
 
 The line below contains the datatype, which in this case is ASCII.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 3-3
+   :language: none
+   :start-at: ASCII
+   :end-at: ASCII
 
 The line below identifies the type of the mesh, which in this case is a rectilinear grid.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 4-4
+   :language: none
+   :start-at: DATASET RECTILINEAR_GRID
+   :end-at: DATASET RECTILINEAR_GRID
 
 The following lines provide the coordinate information for the mesh.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 5-11
+   :language: none
+   :start-at: DIMENSIONS 3 2 2
+   :end-before: CELL_DATA 2
 
 The information provides the dimensions of the coordinate arrays of the mesh along with the coordinates in each of the three directions.
 
 The following lines represent one scalar field defined on the cells.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 13-16
+   :language: none
+   :start-at: CELL_DATA 2
+   :end-before: POINT_DATA 12
 
 The information tells us that there are 2 values for the cell data, that it is a scalar, that the name of the variable is `density`, that it should be read in as float values, that we should use the default lookup table, and that the values consist of `1 2`.
 
 The following lines represent one scalar field defined at the points.
 
 .. literalinclude:: data_examples/rectilineargrid.vtk
-   :lines: 18-21
+   :language: none
+   :start-at: POINT_DATA 12
+   :end-at: 1 2 3 1 2 3 1 2 3 1 2 3
 
 The information tells us that there are 12 values for the point data, that it is a scalar, that the name of the variable is `u`, that it should be read in as float values, that we should use the default lookup table, and that the values consist of `1 2 3 1 2 3 1 2 3 1 2 3`.
 
@@ -469,32 +497,44 @@ An example of a VTK file with extra metadata
 A VTK file with extra metadata is shown here.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 1-45
+   :language: none
+   :start-at: # vtk DataFile Version 3.0
+   :end-at: LOOKUP_TABLE default
 
 The following lines represent the mesh name associated with this file.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 8-9
+   :language: none
+   :start-at: MeshName 1 1 string
+   :end-before: CYCLE 1 1 int
 
 The following lines represent cycle associated with this file.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 10-11
+   :language: none
+   :start-at: CYCLE 1 1 int
+   :end-before: TIME 1 1 double
 
 The following lines represent the time associated with this file.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 12-13
+   :language: none
+   :start-at: TIME 1 1 double
+   :end-at: VisItExpressions 1 2 string
 
 The following lines represent the expressions associated with this file.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 14-16
+   :language: none
+   :start-at: VisItExpressions 1 2 string
+   :end-at: speed;scalar;sqrt(u*u+v*v)
 
 The following lines represent the ghost zones associated with this file.
 
 .. literalinclude:: data_examples/extra_metadata.vtk
-   :lines: 33-37
+   :language: none
+   :start-at: FIELD FieldData 1
+   :end-at: 1 1 1 1
 
 .. _data_into_visit_vtk_struct_points:
 

--- a/src/doc/data_into_visit/XdmfFormat.rst
+++ b/src/doc/data_into_visit/XdmfFormat.rst
@@ -238,7 +238,9 @@ It is defined by a ``Polyvertex`` topology.
 Here is the code that writes a 3D point mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1666-1709
+      :language: c
+      :start-after: begin create_point3d sphinx literal include tag
+      :end-before: end create_point3d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 
@@ -254,7 +256,9 @@ It is defined by a ``2DCoRectMesh`` or ``3DCoRectMesh`` topology.
 Here is the code that writes a 3D regular mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1516-1563
+      :language: c
+      :start-after: begin create_corect3d sphinx literal include tag
+      :end-before: end create_corect3d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 
@@ -263,7 +267,9 @@ Here is the resultant Xdmf file.
 Here is the code that writes a 2D regular mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1467-1514
+      :language: c
+      :start-after: begin create_corect2d sphinx literal include tag
+      :end-before: end create_corect2d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 
@@ -279,7 +285,9 @@ It is defined by a ``2DRectMesh`` or ``3DRectMesh`` topology.
 Here is the code that writes a 3D rectilinear mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1614-1664
+      :language: c
+      :start-after: begin create_rect3d sphinx literal include tag
+      :end-before: end create_rect3d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 
@@ -288,7 +296,9 @@ Here is the resultant Xdmf file.
 Here is the code that writes a 2D rectilinear mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1565-1612
+      :language: c
+      :start-after: begin create_rect2d sphinx literal include tag
+      :end-before: end create_rect2d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 
@@ -304,7 +314,9 @@ It is defined by a ``2DSMesh`` or ``3DSMesh`` topology.
 Here is the code that writes a 3D curvilinear mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1338-1392
+      :language: c
+      :start-after: begin create_curv3d sphinx literal include tag
+      :end-before: end create_curv3d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 
@@ -313,7 +325,9 @@ Here is the resultant Xdmf file.
 Here is the code that writes a 2D curvilinear mesh.
 
 .. literalinclude:: data_examples/xdmf.C
-      :lines: 1292-1336
+      :language: c
+      :start-after: begin create_curv2d sphinx literal include tag
+      :end-before: end create_curv2d sphinx literal include tag
 
 Here is the resultant Xdmf file.
 

--- a/src/doc/data_into_visit/data_examples/blueprint_example.py
+++ b/src/doc/data_into_visit/data_examples/blueprint_example.py
@@ -1,6 +1,7 @@
 import sys
 sys.path.append("/usr/gapps/conduit/software/ascent/0.7.1/toss_3_x86_64_ib/openmp/gnu/conduit-install/lib/python3.7/site-packages")
 
+# begin blueprint example sphinx leteral include tag
 import conduit
 import conduit.relay.io
 import conduit.blueprint.mesh
@@ -43,3 +44,4 @@ if not conduit.blueprint.mesh.verify(mesh, verify_info):
 print(mesh)
 
 conduit.relay.io.blueprint.write_mesh(mesh, "blueprint_example", "json")
+# end blueprint example sphinx leteral include tag

--- a/src/doc/data_into_visit/data_examples/blueprint_example.py
+++ b/src/doc/data_into_visit/data_examples/blueprint_example.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("/usr/gapps/conduit/software/ascent/0.7.1/toss_3_x86_64_ib/openmp/gnu/conduit-install/lib/python3.7/site-packages")
 
-# begin blueprint example sphinx leteral include tag
+# begin blueprint example sphinx literal include tag
 import conduit
 import conduit.relay.io
 import conduit.blueprint.mesh
@@ -44,4 +44,4 @@ if not conduit.blueprint.mesh.verify(mesh, verify_info):
 print(mesh)
 
 conduit.relay.io.blueprint.write_mesh(mesh, "blueprint_example", "json")
-# end blueprint example sphinx leteral include tag
+# end blueprint example sphinx literal include tag

--- a/src/doc/data_into_visit/data_examples/extra_metadata.vtk
+++ b/src/doc/data_into_visit/data_examples/extra_metadata.vtk
@@ -34,7 +34,7 @@ FIELD FieldData 1
 avtGhostZones 1 12 unsigned_char
 1 0 0 1
 1 0 0 1
-1 0 0 1
+1 1 1 1
 
 POINT_DATA 20
 SCALARS u float 1

--- a/src/doc/data_into_visit/data_examples/node_example.py
+++ b/src/doc/data_into_visit/data_examples/node_example.py
@@ -1,6 +1,7 @@
 import sys
 sys.path.append("/usr/gapps/conduit/software/ascent/0.7.1/toss_3_x86_64_ib/openmp/gnu/conduit-install/lib/python3.7/site-packages")
 
+# begin simple example sphinx literal include tag
 import conduit
 
 n = conduit.Node()
@@ -10,3 +11,4 @@ n["a"]["b"]["e"] = 64.0
 print(n)
 
 print("total bytes: %d" % n.total_strided_bytes())
+# end simple example sphinx literal include tag

--- a/src/doc/data_into_visit/data_examples/xdmf.C
+++ b/src/doc/data_into_visit/data_examples/xdmf.C
@@ -1289,6 +1289,7 @@ create_multi_grid3d()
     fclose(xmf);
 }
 
+// begin create_curv2d sphinx literal include tag
 void
 create_curv2d()
 {
@@ -1334,7 +1335,9 @@ create_curv2d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_curv2d sphinx literal include tag
 
+// begin create_curv3d sphinx literal include tag
 void
 create_curv3d()
 {
@@ -1390,6 +1393,7 @@ create_curv3d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_curv3d sphinx literal include tag
 
 void
 create_xml_data()
@@ -1464,6 +1468,7 @@ create_xml_data()
     fclose(xmf);
 }
 
+// begin create_corect2d sphinx literal include tag
 void
 create_corect2d()
 {
@@ -1512,7 +1517,9 @@ create_corect2d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_corect2d sphinx literal include tag
 
+// begin create_corect3d sphinx literal include tag
 void
 create_corect3d()
 {
@@ -1561,7 +1568,9 @@ create_corect3d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_corect3d sphinx literal include tag
 
+// begin create_rect2d sphinx literal include tag
 void
 create_rect2d()
 {
@@ -1610,7 +1619,9 @@ create_rect2d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_rect2d sphinx literal include tag
 
+// begin create_rect3d sphinx literal include tag
 void
 create_rect3d()
 {
@@ -1662,7 +1673,9 @@ create_rect3d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_rect3d sphinx literal include tag
 
+// begin create_point3d sphinx literal include tag
 void
 create_point3d()
 {
@@ -1707,6 +1720,7 @@ create_point3d()
     fprintf(xmf, "</Xdmf>\n");
     fclose(xmf);
 }
+// end create_point3d sphinx literal include tag
 
 void
 create_multi_point3d()

--- a/src/doc/tutorials/Scripting.rst
+++ b/src/doc/tutorials/Scripting.rst
@@ -93,7 +93,8 @@ Pseudocolor plot
 
 .. literalinclude:: tutorial_examples/scripting/listing_1_setting_attributes.py
    :language: python
-   :lines: 10-
+   :start-at: DeleteAllPlots()
+   :end-at: SetPlotOptions(p)
 
 Animating an isosurface
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,7 +104,8 @@ display of a range of isovalues from "example.silo".
 
 .. literalinclude:: tutorial_examples/scripting/listing_2_animating_an_isosurface.py
    :language: python
-   :lines: 10-
+   :start-at: DeleteAllPlots()
+   :end-at: # SaveWindow()
 
 Using all of VisIt_'s building blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -121,7 +123,8 @@ that case delete all the plots and execute the script again.
 
 .. literalinclude:: tutorial_examples/scripting/listing_3_using_visits_building_blocks.py
    :language: python
-   :lines: 10-
+   :start-at: # Clear any previous plots
+   :end-before: # end of script sphinx literal include tag
 
 
 Creating a movie of animated streamline paths
@@ -137,7 +140,8 @@ This example extends the "Using all of VisIt_'s Building Blocks" example by
 
 .. literalinclude:: tutorial_examples/scripting/listing_4_creating_a_movie_of_animated_streamline_paths.py
    :language: python
-   :lines: 10-
+   :start-at: # import visit_utils, we will use it to help encode our movie
+   :end-at: encoding.encode(input_pattern,output_movie,fdup=4)
 
 Rendering each timestep of a dataset to a movie
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,7 +154,8 @@ This example assumes the "aneurysm.visit" is already opened.
 
 .. literalinclude:: tutorial_examples/scripting/listing_5_rendering_a_dataset_to_a_movie.py
    :language: python
-   :lines: 10-
+   :start-at: # import visit_utils, we will use it to help encode our movie
+   :end-at: encoding.encode(input_pattern,output_movie,fdup=4)
 
 
 Animating the camera
@@ -158,14 +163,16 @@ Animating the camera
 
 .. literalinclude:: tutorial_examples/scripting/listing_6_animating_the_camera.py
    :language: python
-   :lines: 10-
+   :start-at: def fly():
+   :end-before: # end of script sphinx literal include tag
 
 Automating data analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: tutorial_examples/scripting/listing_7_automating_data_analysis.py
    :language: python
-   :lines: 10-
+   :start-at: def TakeMassPerSlice():
+   :end-before: # end of script sphinx literal include tag
 
 
 Extracting a per-material aggregate value at each timestep
@@ -173,7 +180,8 @@ Extracting a per-material aggregate value at each timestep
 
 .. literalinclude:: tutorial_examples/scripting/listing_8_extracting_aggregate_values.py
    :language: python
-   :lines: 10-
+   :start-at: from visit_utils import *
+   :end-at: sys.exit(0)
 
 
 .. _Recording_GUI_actions_to_Python_scripts:

--- a/src/doc/tutorials/tutorial_examples/scripting/listing_3_using_visits_building_blocks.py
+++ b/src/doc/tutorials/tutorial_examples/scripting/listing_3_using_visits_building_blocks.py
@@ -49,3 +49,4 @@ patts.endPointRadiusBBox = 0.01
 SetPlotOptions(patts)
 
 DrawPlots()
+# end of script sphinx literal include tag

--- a/src/doc/tutorials/tutorial_examples/scripting/listing_6_animating_the_camera.py
+++ b/src/doc/tutorials/tutorial_examples/scripting/listing_6_animating_the_camera.py
@@ -106,3 +106,4 @@ def fly():
         # SaveWindow()
  
 fly()
+# end of script sphinx literal include tag

--- a/src/doc/tutorials/tutorial_examples/scripting/listing_7_automating_data_analysis.py
+++ b/src/doc/tutorials/tutorial_examples/scripting/listing_7_automating_data_analysis.py
@@ -32,3 +32,4 @@ DeleteAllPlots()
 OpenDatabase("mass_per_slice.ultra")
 AddPlot("Curve", "mass_per_slice")
 DrawPlots()
+# end of script sphinx literal include tag

--- a/src/doc/tutorials/tutorial_examples/scripting/listing_8_extracting_aggregate_values.py
+++ b/src/doc/tutorials/tutorial_examples/scripting/listing_8_extracting_aggregate_values.py
@@ -2,19 +2,14 @@
 # file: VisIt Scripting Tutorial Listing 8
 ###########################################
 #
-# 1) Run visit from the CLI as described below.
-#
-
-
-
-####################
 # Example that demonstrates looping over a dataset
 # to extract an aggregate value at each timestep.
 #
-#  visit -nowin -cli -s listing_8_extracting_aggregate_values.py wave.visit pressure wave_pressure_out
-####################
- 
-import sys
+# 1) Run visit from the CLI as shown below.
+#
+#    visit -nowin -cli -s listing_8_extracting_aggregate_values.py wave.visit pressure wave_pressure_out
+#
+
 from visit_utils import *
  
 def setup_plot(dbname,varname, materials = None):


### PR DESCRIPTION
### Description

Resolves #20600

I replaced all the literal includes that specified specific lines with text tags using a combination of ``start-at``, ``start-after``, ``end-at`` and ``end-before`` keywords.

### Type of change

* [X] Documentation update~~

### How Has This Been Tested?

I proofread the affected portions of the documentation in the output of the sphinx documentation CI test.

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
