### PR TITLE
Fix zlib patch in TPL cmake builds.

### DIFF
--- a/scripts/TPBuildsCMake/patches/zlib-1.3.1-patched-files.zip
+++ b/scripts/TPBuildsCMake/patches/zlib-1.3.1-patched-files.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca579ed322c113eb946bc273ab8f4f557896a9b2503947938aea5364f47d8ed2
-size 2553

--- a/scripts/TPBuildsCMake/patches/zlib-1.3.1-patched-files/zlib-1.3.1-CMakeLists.txt.patch
+++ b/scripts/TPBuildsCMake/patches/zlib-1.3.1-patched-files/zlib-1.3.1-CMakeLists.txt.patch
@@ -1,0 +1,47 @@
+--- CMakeLists.txt     	2026-06-23 09:05:01.252640000 -0700
++++ CMakeLists.txt	2026-06-23 08:57:11.256781000 -0700
+@@ -151,8 +151,8 @@
+ 
+ add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+ target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+-add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-target_include_directories(zlibstatic PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
++#add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
++#target_include_directories(zlibstatic PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+ set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
+ set_target_properties(zlib PROPERTIES SOVERSION 1)
+ 
+@@ -175,11 +175,12 @@
+    endif()
+ elseif(BUILD_SHARED_LIBS AND WIN32)
+     # Creates zlib1.dll when building shared library version
+-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
++    #set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+ endif()
+ 
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
+-    install(TARGETS zlib zlibstatic
++    #install(TARGETS zlib zlibstatic
++    install(TARGETS zlib
+         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+         LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+@@ -187,12 +188,12 @@
+ if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
+ endif()
+-if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
+-    install(FILES zlib.3 DESTINATION "${INSTALL_MAN_DIR}/man3")
+-endif()
+-if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
+-    install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+-endif()
++#if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
++#    install(FILES zlib.3 DESTINATION "${INSTALL_MAN_DIR}/man3")
++#endif()
++#if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
++#    install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
++#endif()
+ 
+ #============================================================================
+ # Example binaries

--- a/scripts/TPBuildsCMake/patches/zlib-patch.cmake
+++ b/scripts/TPBuildsCMake/patches/zlib-patch.cmake
@@ -2,11 +2,12 @@
 # Project developers.  See the top-level LICENSE file for dates and other
 # details.  No copyright assignment is required to contribute to VisIt.
 
-
-if(EXISTS ${PATCH_DIR}/zlib-${ZLIB_VERSION}-patched-files.zip)
-    file(ARCHIVE_EXTRACT
-         INPUT ${PATCH_DIR}/zlib-${ZLIB_VERSION}-patched-files.zip
-         VERBOSE)
+set(pd ${PATCH_DIR}/zlib-${ZLIB_VERSION}-patch-files)
+if(EXISTS ${pd})
+    file(GLOB patchfiles ${pd}/*.patch)
+    foreach(patch_file ${patchfiles})
+        execute_process(COMMAND ${PATCH_CMD} -u --verbose -p0 -i ${patch_file})
+    endforeach()
 else()
     message(STATUS "No patches exist for zlib version: ${ZLIB_VERSION}")
 endif()

--- a/scripts/TPBuildsCMake/zlib.cmake
+++ b/scripts/TPBuildsCMake/zlib.cmake
@@ -40,5 +40,7 @@ ExternalProject_Add(ZLIB
     INSTALL_DIR      ${visit_zlib_root}
     CMAKE_CACHE_ARGS ${ZLIB_CMAKE_OPTIONS}
     ${LOGGING_OPTIONS}
-    PATCH_COMMAND    ${CMAKE_COMMAND} -DZLIB_VERSION:STRING=${ZLIB_VERSION} -DPATCH_DIR:PATH=${visit_tp_patches} -P ${visit_tp_patches}/zlib-patch.cmake )
+    PATCH_COMMAND    ${CMAKE_COMMAND} -DZLIB_VERSION:STRING=${ZLIB_VERSION}
+                                      -DPATCH_DIR:PATH=${visit_tp_patches}
+                                      -P ${visit_tp_patches}/zlib-patch.cmake )
 


### PR DESCRIPTION
### Description

Workflow for the cmake TPL builds on Windows failed with an error on how zlib is patched.
Modified the zlib build to use a standard patch file instead of a modified file stored in .zip.

### Type of change

* [X] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

Will modify the workflow schedule to run again tonight.

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

