### PR TITLE
Modify help window to display some content in external browser.

### DIFF
--- a/src/gui/QvisHelpWindow.C
+++ b/src/gui/QvisHelpWindow.C
@@ -68,6 +68,9 @@
 //   Alister Maguire, Wed Nov  6 08:11:16 PST 2019
 //   Added manualPath for accessing the sphinx manual.
 //
+//   Kathleen Biagas, Wed June 24, 2026
+//   Initialize startOptsPath.
+//
 // ****************************************************************************
 
 QvisHelpWindow::QvisHelpWindow(const QString &captionString) :
@@ -79,6 +82,12 @@ QvisHelpWindow::QvisHelpWindow(const QString &captionString) :
     // Create a path to locate the manual from the helpPath.
     manualPath = QString("manual") + QString(VISIT_SLASH_STRING) +
         QString("index.html");
+
+    startOptsPath = QString("manual") +
+                  QString(VISIT_SLASH_STRING) +
+                  QString("getting_started") +
+                  QString(VISIT_SLASH_STRING) +
+                  QString("Startup_Options.html");
 
     firstShow = true;
     activeTab = 0;
@@ -372,6 +381,11 @@ QvisHelpWindow::ReleaseNotesFile() const
 //   Kathleen Biagas, Tue Mar 18, 2025
 //   Removed ultrawrapper document.
 //
+//   Kathleen Biagas, Wed June 24, 2026
+//   Changed 'argsPage' data from 'args.html' to 'startOptsPath'. The new
+//   data points to a page in our local manual.
+//   Removed faqPage.
+//
 // ****************************************************************************
 
 void
@@ -395,14 +409,8 @@ QvisHelpWindow::LoadHelp(const QString &fileName)
     QTreeWidgetItem *argsPage = new QTreeWidgetItem(
         helpContents, 0);
     argsPage->setText(0, tr("Command line arguments"));
-    argsPage->setData(0, Qt::UserRole, QVariant("args.html"));
+    argsPage->setData(0, Qt::UserRole, QVariant(startOptsPath));
     argsPage->setIcon(0, helpIcon);
-
-    QTreeWidgetItem *faqPage = new QTreeWidgetItem(
-        helpContents, 0);
-    faqPage->setText(0, tr("Frequently asked questions"));
-    faqPage->setData(0, Qt::UserRole, QVariant("faq.html"));
-    faqPage->setIcon(0, helpIcon);
 
     QTreeWidgetItem *copyrightPage = new QTreeWidgetItem(
         helpContents, 0);
@@ -517,6 +525,9 @@ QvisHelpWindow::BuildContents(QTreeWidgetItem *parentItem,
 //   Kathleen Biagas, Tue Mar 18, 2025
 //   Removed ultrawrapper document.
 //
+//   Kathleen Biagas, Wed June 24, 2026
+//   Removed faq.
+//
 // ****************************************************************************
 
 void
@@ -525,8 +536,6 @@ QvisHelpWindow::BuildIndex()
     // Add a few more items to the index.
     AddToIndex(tr("Copyright"), "copyright.html");
     AddToIndex(tr("Command line arguments"), "args.html");
-    AddToIndex(tr("Frequently asked questions"), "faq.html");
-    AddToIndex(tr("FAQ"), "faq.html");
     AddToIndex(tr("VisIt"), "home.html");
     AddToIndex(tr("Release notes"), ReleaseNotesFile());
     AddToIndex(tr("VisIt Manuals"), manualPath);
@@ -1001,6 +1010,11 @@ QvisHelpWindow::activateBookmarkTab()
 //   Brad Whitlock, Thu Jun 19 16:27:10 PDT 2008
 //   Qt 4.
 //
+//   Kathleen Biagas, Wed June 24, 2026
+//   For manual and command line args, add displayTitle and a call to
+//   displayPage that sets externalBrowser to true so that content is opened
+//   in external browser for better viewing.
+//
 // ****************************************************************************
 
 void
@@ -1009,11 +1023,24 @@ QvisHelpWindow::openHelp(QTreeWidgetItem *item)
     if(item)
     {
         QString document(item->data(0, Qt::UserRole).toString());
-
         if(!document.isEmpty())
-            displayPage(document);
+        {
+            QString itemText(item->text(0));
+            if((itemText == QString("VisIt Manuals")) ||
+               (itemText == QString("Command line arguments")))
+            {
+                displayTitle(item->text(0), QString("opens in external browser"));
+                displayPage(document, true);
+            }
+            else
+            {
+                displayPage(document);
+            }
+        }
         else
+        {
             displayTitle(item->text(0));
+        }
     }
 }
 
@@ -1050,7 +1077,8 @@ static int DepthOfModelIndex(QModelIndex mi)
 void
 QvisHelpWindow::openHelp(const QString& entry)
 {
-    if(!isCreated) {
+    if(!isCreated)
+    {
         CreateEntireWindow();
     }
 
@@ -1241,6 +1269,18 @@ QvisHelpWindow::displayTitle(const QString &title)
     helpFile = "none";
 }
 
+void
+QvisHelpWindow::displayTitle(const QString &title, const QString &title2)
+{
+    QString html = QString("<html><body background=\"#ffffff\"><center><b><h2>") +
+                   title +
+                   QString("</h2></b><h3>") +
+                   title2 +
+                   QString("<h3></center></body></html>");
+    helpBrowser->setText(html);
+    helpFile = "none";
+}
+
 // ****************************************************************************
 // Method: QvisHelpWindow::displayCopyright
 //
@@ -1391,7 +1431,7 @@ QvisHelpWindow::displayHome()
 //
 // Arguments:
 //   page   : The name of the page to display.
-//   reload : Whether or not to force the page to reload.
+//   externalBrowser : Whether or not to force the page to load in external browser.
 //
 // Returns:   This method return true if the page is displayed; false otherwise.
 //
@@ -1408,19 +1448,25 @@ QvisHelpWindow::displayHome()
 //   Kathleen Bonnell, Thu Apr  8 17:20:52 PST 2010
 //   Convert file to url so it will work on windows.
 //
+//   Kathleen Biagas, Wed June 24, 2026
+//   Removed no-longer-used 'reload' arg. Added 'externalBrowswer' arg.
+//
 // ****************************************************************************
 
 bool
-QvisHelpWindow::displayPage(const QString &page, bool reload)
+QvisHelpWindow::displayPage(const QString &page, bool externalBrowser)
 {
     bool retval = false;
 
-    if(page != helpFile || reload)
+    if(page != helpFile)
     {
         QString file(CompleteFileName(page));
         if(QFile(file).exists())
         {
-            helpBrowser->setSource(QUrl::fromLocalFile(file));
+            if(externalBrowser)
+                QDesktopServices::openUrl(file);
+            else
+                helpBrowser->setSource(QUrl::fromLocalFile(file));
             helpFile = page;
             retval = true;
         }

--- a/src/gui/QvisHelpWindow.C
+++ b/src/gui/QvisHelpWindow.C
@@ -1464,7 +1464,7 @@ QvisHelpWindow::displayPage(const QString &page, bool externalBrowser)
         if(QFile(file).exists())
         {
             if(externalBrowser)
-                QDesktopServices::openUrl(file);
+                QDesktopServices::openUrl(QUrl::fromLocalFile(file));
             else
                 helpBrowser->setSource(QUrl::fromLocalFile(file));
             helpFile = page;

--- a/src/gui/QvisHelpWindow.h
+++ b/src/gui/QvisHelpWindow.h
@@ -58,6 +58,11 @@ class QWidget;
 //   Alister Maguire, Wed Nov  6 08:11:16 PST 2019
 //   Added manualPath.
 //
+//   Kathleen Biagas, Wed June 24, 2026
+//   Replaced 'reload' with 'externalBrowser' argument to displayPage as the
+//   reload arg not being used. Added a second displayTitle method and new
+//   startOptsPath ivar.
+//
 // ****************************************************************************
 
 class GUI_API QvisHelpWindow : public QvisDelayedWindow
@@ -89,8 +94,9 @@ private slots:
     void topicCollapsed(QTreeWidgetItem *);
     void displayNoHelp();
     void displayTitle(const QString &title);
+    void displayTitle(const QString &title, const QString &title2);
     void displayHome();
-    bool displayPage(const QString &page, bool reload = false);
+    bool displayPage(const QString &page, bool externalBrowser = false);
     void increaseFontSize();
     void decreaseFontSize();
     void displayIndexTopic();
@@ -139,6 +145,7 @@ private:
     QString      helpFile;
     QString      helpPath;
     QString      manualPath;
+    QString      startOptsPath;
     bool         firstShow;
     int          activeTab;
     IndexMap     index;

--- a/src/resources/help/en_US/home.html
+++ b/src/resources/help/en_US/home.html
@@ -5,14 +5,15 @@
 <meta name="GENERATOR" content="Microsoft FrontPage 5.0">
 <meta name="ProgId" content="FrontPage.Editor.Document">
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-<title>VisIt home page</title>
+<title><a href="https://visit.llnl.gov">VisIt home page</a></title>
 </head>
 
 <body>
 
-<p align="center"><b><font size="6">VisIt home page</font></b></p>
+<p align="center"><b><font size="6">VisIt help home page</font></b></p>
 <p>Welcome to VisIt's main help page.
-VisIt is a distributed, parallel, visualization tool for visualizing data defined on two- and three-dimensional structured and unstructured meshes. VisIt's 
+VisIt is a distributed, parallel, visualization tool for visualizing data defined
+on two- and three-dimensional structured and unstructured meshes. VisIt's 
 distributed architecture allows it to leverage both the compute power of a large 
 parallel computer and the graphics acceleration hardware of a local workstation. 
 Another benefit of the distributed architecture is that VisIt can visualize the 
@@ -28,7 +29,7 @@ programming languages.</p>
   <tr vAlign="top">
     <td width="20%" bgColor="#ccccff">Has rich feature set for scalar, vector, 
     and tensor&nbsp; field visualization</td>
-    <td width="40%" bgColor="#ccccff">VisIt’s visualization capabilities are 
+    <td width="40%" bgColor="#ccccff">VisItâ€™s visualization capabilities are 
     primarily grouped into two categories:
     <ul>
       <li><b>Plots </b>are 
@@ -59,7 +60,7 @@ programming languages.</p>
     <td width="20%" bgColor="#ccccff">VisIt is also a powerful analysis tool. It 
     provides support for derived fields, which allow new fields to be calculated 
     using existing fields. For example, if a dataset contains a velocity field, 
-    it is possible to define a new field that is the velocity magnitude. VisIt’s 
+    it is possible to define a new field that is the velocity magnitude. VisItâ€™s 
     quantitative analysis tools include:<ul>
       <li>Line-out, which 
       allows you to create curves from higher dimensional datasets by 
@@ -79,7 +80,7 @@ programming languages.</p>
   <tr vAlign="top">
     <td width="20%" bgColor="#ccccff">Powerful, full-featured graphical user 
     interface (GUI)</td>
-    <td width="20%" bgColor="#ccccff">VisIt’s graphical user interface allows 
+    <td width="20%" bgColor="#ccccff">VisItâ€™s graphical user interface allows 
     novice users to quickly get started visualizing their data, as well as 
     allowing power users access to advanced features. VisIt automatically 
     creates time-based animations from data sets that contain multiple time 
@@ -93,14 +94,14 @@ programming languages.</p>
     <td bgColor="#ccccff">Parallel and distributed architecture for visualizing 
     terascale data sets</td>
     <td bgColor="#ccccff">VisIt employs a distributed and parallel architecture 
-    in order to handle extremely large data sets interactively. VisIt’s 
+    in order to handle extremely large data sets interactively. VisItâ€™s 
     rendering and data processing capabilities are split into viewer and engine 
     components that may be distributed across multiple machines:<ul>
-      <li>Viewer—Responsible for rendering and is typically run on a local 
+      <li>Viewerâ€”Responsible for rendering and is typically run on a local 
       desktop or visualization server so that it can leverage the extremely 
       powerful graphics cards that have been developed in the last few years.
       </li>
-      <li>Engine—Responsible for the bulk of the data processing and 
+      <li>Engineâ€”Responsible for the bulk of the data processing and 
       input/output (I/O) and is typically run on a remote machine where the data 
       is located. This eliminates the need move the data and makes high-end 
       compute and I/O resources available to it. The engine can be run serially 
@@ -123,7 +124,7 @@ programming languages.</p>
   <tr vAlign="top">
     <td bgColor="#ccccff">Extensible with dynamically loaded plug-ins</td>
     <td bgColor="#ccccff">VisIt achieves extensibility through the use of 
-    dynamically loaded plugins. All of VisIt’s plots, operators, and database 
+    dynamically loaded plugins. All of VisItâ€™s plots, operators, and database 
     readers are implemented as plugins and are loaded at run-time from the 
     plugin directory. New plugins can be added simply by installing them in this 
     directory. VisIt comes with a graphical plugin creation tool, which greatly 
@@ -137,10 +138,9 @@ programming languages.</p>
   </tr>
   <tr vAlign="top">
     <td bgColor="#ccccff">Multi-platform support</td>
-    <td bgColor="#ccccff">VisIt operates on UNIX (Irix, Tru64, AIX, Linux, 
-    Solaris), Windows, and MacOS X platforms. Software for these platforms can 
-    be downloaded at 
-    ftp://ftp.llnl.gov/pub/visit.</td>
+    <td bgColor="#ccccff">VisIt operates on UNIX/Linux, Windows and macOS as
+    well as a variety of LCF OSs (e.g. toss4, sles, crayos).
+    </td>
   </tr>
   <tr vAlign="top">
     <td bgColor="#ccccff">Open-source code</td>
@@ -151,7 +151,7 @@ programming languages.</p>
     <td bgColor="#ccccff">Customer support</td>
     <td bgColor="#ccccff">
     <ul>
-    <li>Contact the VisIt project via <i>https://visit-help.llnl.gov</i>.</li>
+    <li>Contact the VisIt project for <a href="https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/getting_help/index.html">help.</a>
     <li>LLNL users can dial extension 4-2VIS during normal working hours (8am-5pm PST)
         to reach the VisIt help desk.
     </li>

--- a/src/resources/help/en_US/relnotes3.5.1.html
+++ b/src/resources/help/en_US/relnotes3.5.1.html
@@ -32,6 +32,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>CGNS reader was enhanced to handle SIDS-style time-varying data.</li>
   <li>The visit-install scripts now accepts '-f' argument allowing specification of the distribution filename in lieu of using the 'version' and 'platform' positional arguments.</li>
   <li>IndexSelect operator was enhanced to support non-regularized grids. It can now be used in 1D mode on ucd meshes of any cell type and curves. Setting a non-unity stride can be useful, for example, in cutting down clutter in point meshes with millions of points.</li>
+  <li>The 'Help' window has been updated to display 'VisIt Manuals' and 'Command line arguments' content in an external browser.</li>
 </ul>
 
 <a name="Dev_changes"></a>


### PR DESCRIPTION
### Description

Resolves part of #20930

* removed FAQ
* use QDesktopServices::openUrl to open user's default browser using local copy of html for Manuals and Command Line Options.

### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other

### How Has This Been Tested?

I tested on Windows and Linux, user's default browser opened successfully.
@markcmiller86 tested on Mac


### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

