### PR TITLE
Fix problem opening session file from command line when corresponding gui file doesn't exist.

### DIFF
--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <algorithm>
 #include <map>
+#include <filesystem> // for determining full-path location of sessionfile
 
 #include <visit-config.h> // To get the version number
 #include <QColor>
@@ -5115,6 +5116,12 @@ QvisGUIApplication::RestoreSessionWithDifferentSources()
 //   David Camp, Tue Aug  4 11:04:14 PDT 2015
 //   Added new ablitiy to load session files from a remote host.
 //
+//   Kathleen Biagas, Mon Jun 29 17:11:10 PDT 2026
+//   Use std::filesystem to determint full path location of session file.
+//   If it doesn't already contain full path, test cwd, then VisIt user dir
+//   and stop processing if it cannot be found.
+//   Only attempt to process .gui file if it exists.
+//
 // ****************************************************************************
 
 void
@@ -5130,40 +5137,66 @@ QvisGUIApplication::RestoreSessionFile(const QString &s,
         restoringSession = true;
         std::string filename(s.toStdString());
 
-        // Make the gui read in its part of the config.
-        std::string guifilename(filename);
-        guifilename += ".gui";
-        DataNode *node;
-        if(host.empty() || host == "localhost")
+        // get full-path to session file, if it doesn't already contain
+        // will first check cwd, then VisIt user dir.
+
+        std::filesystem::path fsp(s.toStdString());
+        if(fsp.has_parent_path())
         {
-            node = ReadConfigFile(guifilename.c_str());
+            // make sure it is absolute before passing it along
+            filename = std::filesystem::absolute(fsp).lexically_normal().string();
         }
         else
         {
-            std::istringstream sessionGUI;
-            std::string sessionGUIStr;
-
-            fileServer->RestoreSessionFile(host, guifilename, sessionGUIStr);
-            sessionGUI.str( sessionGUIStr );
-            node = ReadConfigFile(sessionGUI);
-        }
-
-        // If the file could not be opened then try and prepend the
-        // VisIt directory to it.
-#ifndef _WIN32
-        if(node == 0)
-        {
-            if(guifilename[0] != VISIT_SLASH_CHAR)
+            // no parent path, check cwd
+            if(std::filesystem::exists(fsp))
             {
-                filename = GetUserVisItDirectory() + filename;
-                guifilename = GetUserVisItDirectory() + guifilename;
-                debug1 << "The desired session file " << s.toStdString()
-                       << ".gui could not be opened. VisIt will try and open "
-                       << guifilename.c_str() << endl;
-                node = ReadConfigFile(guifilename.c_str());
+                std::filesystem::path tmp(std::filesystem::current_path());
+                tmp /= fsp;
+                filename = tmp.string();
+            }
+            else
+            {
+                // not in cwd, check VisIt user directory.
+                std::filesystem::path vud(GetUserVisItDirectory());
+                vud /= fsp;
+                if(std::filesystem::exists(vud))
+                {
+                    cerr << "  session file exists in vud" << endl;
+                    filename = vud.string();
+                }
+                else
+                {
+                    QString msg = tr("Could not find session file (%1). Please provide full path if is it not in current working directory or your VisIt user directory.").arg(s.toStdString().c_str());
+                    Error(msg);
+                    restoringSession = false;
+                    return;
+                }
             }
         }
-#endif
+
+        // Make the gui read in its part of the config.
+        std::string guifilename(filename);
+        guifilename += ".gui";
+
+
+        DataNode *node = nullptr;
+        if(std::filesystem::exists(guifilename))
+        {
+            if(host.empty() || host == "localhost")
+            {
+                node = ReadConfigFile(guifilename.c_str());
+            }
+            else
+            {
+                std::istringstream sessionGUI;
+                std::string sessionGUIStr;
+
+                fileServer->RestoreSessionFile(host, guifilename, sessionGUIStr);
+                sessionGUI.str( sessionGUIStr );
+                node = ReadConfigFile(sessionGUI);
+            }
+        }
 
         ProcessSessionNode(node, filename, sources, host);
 

--- a/src/gui/QvisGUIApplication.C
+++ b/src/gui/QvisGUIApplication.C
@@ -5117,7 +5117,7 @@ QvisGUIApplication::RestoreSessionWithDifferentSources()
 //   Added new ablitiy to load session files from a remote host.
 //
 //   Kathleen Biagas, Mon Jun 29 17:11:10 PDT 2026
-//   Use std::filesystem to determint full path location of session file.
+//   Use std::filesystem to determine full path location of session file.
 //   If it doesn't already contain full path, test cwd, then VisIt user dir
 //   and stop processing if it cannot be found.
 //   Only attempt to process .gui file if it exists.
@@ -5162,12 +5162,11 @@ QvisGUIApplication::RestoreSessionFile(const QString &s,
                 vud /= fsp;
                 if(std::filesystem::exists(vud))
                 {
-                    cerr << "  session file exists in vud" << endl;
                     filename = vud.string();
                 }
                 else
                 {
-                    QString msg = tr("Could not find session file (%1). Please provide full path if is it not in current working directory or your VisIt user directory.").arg(s.toStdString().c_str());
+                    QString msg = tr("Could not find session file (%1). Please provide full path if it is not in current working directory or your VisIt user directory.").arg(s.toStdString().c_str());
                     Error(msg);
                     restoringSession = false;
                     return;

--- a/src/resources/help/en_US/relnotes3.5.1.html
+++ b/src/resources/help/en_US/relnotes3.5.1.html
@@ -24,6 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug where slicing or contouring an unstructured mesh with VTK_CONVEX_POINT_SET cells caused a crash.</li>
   <li>Fixed a bug with Zone-Pick on an extremely zoomed-in plot containing extremely long thin hexes.</li>
+  <li>VisIt will now open a session file passed on the command line with '-sessionfile' even if the corresponding .gui component file does not exist.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION

Resolves #2160.

I added logic to QvisGUIApplication to supply full-path to the session file using std::filesystem helpers.
This will save extra logic elsewhere in VisIt trying to resolve the location of the session file.

1) if passed session file has a parent_path, then normalize it to an absolute path
2) if no parent path, see if it exists in cwd, and if so create a full-path-to-cwd/sessionfile.
3) if not in cwd, check in VisIt user directory, if it exists there, create full-path-to-visit-users-dir/sessionfile.
4) if location cannot be determined, generate an error message and stop processing.

After determining location of session file, tests if '.gui' version exists, and processes the .gui file if present.
Always pass full-path-to-sessionfile to viewer unless location couldn't be determined.

I tested this on rzwhippet with:
file in cwd using `-sessionfile myfile.session`
file in ~/.visit using `-sessionfile myfile.session`
file elsewhere using `-sessionfile ../../myfile.session`
file elsewhere using `-sessionfile ~/myfile.session`
file elsewhere using `-sessionfile /full/path/to/myfile.session`
file that doesn't exist using `-sessionfile nofile.session`

NEEDS TESTING ON ~~WINDOWS AND~~ MAC

Update July 13, 2026: I tested on Windows sucessfully using similar tests to above except `~/`

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
-~~ [ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

