### PR TITLE
Handle OBJ Writer Plot Extents

### DIFF
--- a/src/avt/FileWriter/avtDatasetFileWriter.C
+++ b/src/avt/FileWriter/avtDatasetFileWriter.C
@@ -399,7 +399,13 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
                                    const char *label,
                                    bool writeMTL,
                                    bool MTLHasTex,
-                                   std::string texFilename)
+                                   std::string texFilename,
+                                   bool useMin,
+                                   double minValue,
+                                   bool useMax,
+                                   double maxValue,
+                                   bool useBelowMinColor,
+                                   bool useAboveMaxColor)
 {
     vtkDataSet *activeDS = ds;
 
@@ -408,6 +414,9 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
 
     double range[2];
     activeDS->GetScalarRange(range);
+    const double minRange = useMin ? minValue : range[0];
+    const double maxRange = useMax ? maxValue : range[1];
+    const double gap = (maxRange > minRange ? maxRange - minRange : 1.);
 
     //
     // The OBJ file is going to expect the dataset as having node-centered
@@ -442,32 +451,34 @@ avtDatasetFileWriter::WriteOBJFile(vtkDataSet *ds,
     if (scalars != NULL)
     {
         //
-        // Get some information for normalizing the variable.
-        //
-        double gap = (range[1] != range[0] ? range[1] - range[0] : 1.);
-
-        //
         // Create the actual texture coordinate.
         //
         vtkDataArray *tcoords = scalars->NewInstance();
         tcoords->SetNumberOfComponents(2);
         tcoords->SetNumberOfTuples(scalars->GetNumberOfTuples());
 
-        // What is going on here?
-        // We want to add a pixel to either end of the color table.
-        // This is to prevent unwanted behavior with the max and min texture coordinates
-        // wrapping around. If we're going to add pixels, we must adjust the texture
-        // coords. We add two pixels and scale appropriately.
-        const double ncolors = 256.0; // this must match the GetColors() function
-        const double fudge_factor = 1.0 / ncolors;
-        const double new_divisor = 1.0 + fudge_factor * 2.0;
+        // The texture contains duplicate end pixels plus dedicated below/above
+        // colors, so we reserve two pixels at each end.
+        const double ncolors = 256.0;
+        const double totalcolors = ncolors + 4.0;
+        const double minCoord = 2.0 / totalcolors;
+        const double maxCoord = (ncolors + 1.0) / totalcolors;
+        const double belowCoord = 1.0 / totalcolors;
+        const double aboveCoord = (ncolors + 2.0) / totalcolors;
 
         for (int i = 0 ; i < scalars->GetNumberOfTuples() ; i++)
         {
             double *p = scalars->GetTuple(i);
             double s[2];
-            // assuming we have ncolors colors and want to add a duplicate to either end
-            s[0] = (((*p - range[0]) / gap) + fudge_factor) / new_divisor;
+            if (*p < minRange)
+                s[0] = useBelowMinColor ? belowCoord : minCoord;
+            else if (*p > maxRange)
+                s[0] = useAboveMaxColor ? aboveCoord : maxCoord;
+            else if (maxRange <= minRange)
+                s[0] = minCoord;
+            else
+                s[0] = (2.0 + ((*p - minRange) / gap) * (ncolors - 1.0)) /
+                       totalcolors;
             s[1] = 0.;
             tcoords->SetTuple(i, s);
         }

--- a/src/avt/FileWriter/avtDatasetFileWriter.h
+++ b/src/avt/FileWriter/avtDatasetFileWriter.h
@@ -92,7 +92,13 @@ class AVTFILEWRITER_API avtDatasetFileWriter : public avtTerminatingDatasetSink
                                     const char *, 
                                     bool writeMTL = false,
                                     bool MTLHasTex = false,
-                                    std::string texFilename = "");
+                                    std::string texFilename = "",
+                                    bool useMin = false,
+                                    double minValue = 0.,
+                                    bool useMax = false,
+                                    double maxValue = 1.,
+                                    bool useBelowMinColor = false,
+                                    bool useAboveMaxColor = false);
 
   protected:
     static const char *extensions[];
@@ -130,5 +136,4 @@ class AVTFILEWRITER_API avtDatasetFileWriter : public avtTerminatingDatasetSink
 
 
 #endif
-
 

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -12,8 +12,7 @@
 static const char *OptionType_strings[] = {
 "Bool", "Int", "Float",
 "Double", "String", "Enum",
-"MultiLineString",
-"Color"};
+"MultiLineString", "Color"};
 
 std::string
 DBOptionsAttributes::OptionType_ToString(DBOptionsAttributes::OptionType t)
@@ -1560,16 +1559,20 @@ DBOptionsAttributes::SetEnumStrings(const std::string &name,
     enumStringsSizes[eIndex] = values.size();
 }
 
+// ****************************************************************************
+//  Method: DBOptionsAttributes::SetColor
+//
+//  Purpose:
+//      Sets a color value.
+//
+// ****************************************************************************
+
 void
 DBOptionsAttributes::SetColor(const std::string &name,
                               const ColorAttribute &defaultValue)
 {
     int bIndex = FindIndex(name);
-    unsigned char rgba[4];
-    const unsigned char *src = defaultValue.GetColor();
-    for(int i = 0; i < 4; ++i)
-        rgba[i] = src[i];
-
+    const unsigned char *rgba = defaultValue.GetColor();
     if (bIndex < 0)
     {
         names.push_back(name);
@@ -1584,6 +1587,14 @@ DBOptionsAttributes::SetColor(const std::string &name,
             optColors[start + i] = (int)rgba[i];
     }
 }
+
+// ****************************************************************************
+//  Method: DBOptionsAttributes::GetColor
+//
+//  Purpose:
+//      Gets a color value.
+//
+// ****************************************************************************
 
 ColorAttribute
 DBOptionsAttributes::GetColor(const std::string &name) const
@@ -1777,11 +1788,11 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
                 SetEnum(name, obj.GetEnum(name));
                 SetEnumStrings(name, obj.GetEnumStrings(name));
                 break;
-            case Color:
-                SetColor(name, obj.GetColor(name));
-                break;
             case MultiLineString:
                 SetMultiLineString(name, obj.GetMultiLineString(name));
+                break;
+            case Color:
+                SetColor(name, obj.GetColor(name));
                 break;
             }
         }
@@ -1794,3 +1805,4 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
 
     return retval;
 }
+

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -1569,22 +1569,22 @@ DBOptionsAttributes::SetEnumStrings(const std::string &name,
 
 void
 DBOptionsAttributes::SetColor(const std::string &name,
-                              const ColorAttribute &defaultValue)
+                              int red, int green, int blue, int alpha)
 {
     int bIndex = FindIndex(name);
-    const unsigned char *rgba = defaultValue.GetColor();
+    int rgba[4] = {red, green, blue, alpha};
     if (bIndex < 0)
     {
         names.push_back(name);
         types.push_back(Color);
         for(int i = 0; i < 4; ++i)
-            optColors.push_back((int)rgba[i]);
+            optColors.push_back(rgba[i]);
     }
     else
     {
         int start = bIndex * 4;
         for(int i = 0; i < 4; ++i)
-            optColors[start + i] = (int)rgba[i];
+            optColors[start + i] = rgba[i];
     }
 }
 
@@ -1596,18 +1596,19 @@ DBOptionsAttributes::SetColor(const std::string &name,
 //
 // ****************************************************************************
 
-ColorAttribute
-DBOptionsAttributes::GetColor(const std::string &name) const
+void
+DBOptionsAttributes::GetColor(const std::string &name, int &red, int &green,
+                              int &blue, int &alpha) const
 {
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
 
     int start = bIndex * 4;
-    return ColorAttribute(optColors[start],
-                          optColors[start + 1],
-                          optColors[start + 2],
-                          optColors[start + 3]);
+    red = optColors[start];
+    green = optColors[start + 1];
+    blue = optColors[start + 2];
+    alpha = optColors[start + 3];
 }
 
 // ****************************************************************************
@@ -1792,7 +1793,11 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
                 SetMultiLineString(name, obj.GetMultiLineString(name));
                 break;
             case Color:
-                SetColor(name, obj.GetColor(name));
+                {
+                    int red, green, blue, alpha;
+                    obj.GetColor(name, red, green, blue, alpha);
+                    SetColor(name, red, green, blue, alpha);
+                }
                 break;
             }
         }

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -5,6 +5,8 @@
 #include <DBOptionsAttributes.h>
 #include <DataNode.h>
 
+#include "ColorAttribute.h"
+
 //
 // Enum conversion methods for DBOptionsAttributes::OptionType
 //

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -5,8 +5,6 @@
 #include <DBOptionsAttributes.h>
 #include <DataNode.h>
 
-#include "ColorAttribute.h"
-
 //
 // Enum conversion methods for DBOptionsAttributes::OptionType
 //

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -1565,26 +1565,42 @@ DBOptionsAttributes::SetEnumStrings(const std::string &name,
 //  Purpose:
 //      Sets a color value.
 //
+//  Programmer: Justin Privitera
+//  Creation:   Mon Jul 20 16:40:22 PDT 2026
+//
 // ****************************************************************************
 
 void
 DBOptionsAttributes::SetColor(const std::string &name,
-                              int red, int green, int blue, int alpha)
+                              int red,
+                              int green,
+                              int blue,
+                              int alpha)
 {
-    int bIndex = FindIndex(name);
+    // optColors stores all colors flattened into one intVector, with 4 integers per option
+    // [r, g, b, a, r, g, b, a, ...]
+
+    const int bIndex = FindIndex(name);
     int rgba[4] = {red, green, blue, alpha};
     if (bIndex < 0)
     {
         names.push_back(name);
         types.push_back(Color);
-        for(int i = 0; i < 4; ++i)
+        for (int i = 0; i < 4; i ++)
+        {
             optColors.push_back(rgba[i]);
+        }
     }
     else
     {
-        int start = bIndex * 4;
-        for(int i = 0; i < 4; ++i)
+        // bIndex is the index of the color option within the color-option storage, 
+        // not within all options. So to find where that option’s RGBA data begins,
+        // we multiply by 4.
+        const int start = bIndex * 4;
+        for (int i = 0; i < 4; i ++)
+        {
             optColors[start + i] = rgba[i];
+        }
     }
 }
 
@@ -1594,17 +1610,26 @@ DBOptionsAttributes::SetColor(const std::string &name,
 //  Purpose:
 //      Gets a color value.
 //
+//  Programmer: Justin Privitera
+//  Creation:   Mon Jul 20 16:40:22 PDT 2026
+//
 // ****************************************************************************
 
 void
-DBOptionsAttributes::GetColor(const std::string &name, int &red, int &green,
-                              int &blue, int &alpha) const
+DBOptionsAttributes::GetColor(const std::string &name,
+                              int &red,
+                              int &green,
+                              int &blue,
+                              int &alpha) const
 {
-    int bIndex = FindIndex(name);
+    const int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
 
-    int start = bIndex * 4;
+    // bIndex is the index of the color option within the color-option storage, 
+    // not within all options. So to find where that option’s RGBA data begins,
+    // we multiply by 4.
+    const int start = bIndex * 4;
     red = optColors[start];
     green = optColors[start + 1];
     blue = optColors[start + 2];
@@ -1754,6 +1779,10 @@ DBOptionsAttributes::IsObsolete(const std::string &name) const
 //
 //  Programmer: Brad Whitlock
 //  Creation:   Fri Aug 14 18:04:39 PDT 2015
+// 
+//  Modifications:
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Handle the "color" case.
 //
 // ****************************************************************************
 

--- a/src/common/state/DBOptionsAttributes.C
+++ b/src/common/state/DBOptionsAttributes.C
@@ -12,20 +12,21 @@
 static const char *OptionType_strings[] = {
 "Bool", "Int", "Float",
 "Double", "String", "Enum",
-"MultiLineString"};
+"MultiLineString",
+"Color"};
 
 std::string
 DBOptionsAttributes::OptionType_ToString(DBOptionsAttributes::OptionType t)
 {
     int index = int(t);
-    if(index < 0 || index >= 7) index = 0;
+    if(index < 0 || index >= 8) index = 0;
     return OptionType_strings[index];
 }
 
 std::string
 DBOptionsAttributes::OptionType_ToString(int t)
 {
-    int index = (t < 0 || t >= 7) ? 0 : t;
+    int index = (t < 0 || t >= 8) ? 0 : t;
     return OptionType_strings[index];
 }
 
@@ -33,7 +34,7 @@ bool
 DBOptionsAttributes::OptionType_FromString(const std::string &s, DBOptionsAttributes::OptionType &val)
 {
     val = DBOptionsAttributes::Bool;
-    for(int i = 0; i < 7; ++i)
+    for(int i = 0; i < 8; ++i)
     {
         if(s == OptionType_strings[i])
         {
@@ -90,6 +91,7 @@ void DBOptionsAttributes::Copy(const DBOptionsAttributes &obj)
     optInts = obj.optInts;
     optStrings = obj.optStrings;
     optEnums = obj.optEnums;
+    optColors = obj.optColors;
     optMultiLineStrings = obj.optMultiLineStrings;
     enumStrings = obj.enumStrings;
     enumStringsSizes = obj.enumStringsSizes;
@@ -260,6 +262,7 @@ DBOptionsAttributes::operator == (const DBOptionsAttributes &obj) const
             (optInts == obj.optInts) &&
             (optStrings == obj.optStrings) &&
             (optEnums == obj.optEnums) &&
+            (optColors == obj.optColors) &&
             (optMultiLineStrings == obj.optMultiLineStrings) &&
             (enumStrings == obj.enumStrings) &&
             (enumStringsSizes == obj.enumStringsSizes) &&
@@ -416,6 +419,7 @@ DBOptionsAttributes::SelectAll()
     Select(ID_optInts,             (void *)&optInts);
     Select(ID_optStrings,          (void *)&optStrings);
     Select(ID_optEnums,            (void *)&optEnums);
+    Select(ID_optColors,           (void *)&optColors);
     Select(ID_optMultiLineStrings, (void *)&optMultiLineStrings);
     Select(ID_enumStrings,         (void *)&enumStrings);
     Select(ID_enumStringsSizes,    (void *)&enumStringsSizes);
@@ -501,6 +505,12 @@ DBOptionsAttributes::CreateNode(DataNode *parentNode, bool completeSave, bool fo
         node->AddNode(new DataNode("optEnums", optEnums));
     }
 
+    if(completeSave || !FieldsEqual(ID_optColors, &defaultObject))
+    {
+        addToParent = true;
+        node->AddNode(new DataNode("optColors", optColors));
+    }
+
     if(completeSave || !FieldsEqual(ID_optMultiLineStrings, &defaultObject))
     {
         addToParent = true;
@@ -583,6 +593,8 @@ DBOptionsAttributes::SetFromNode(DataNode *parentNode)
         SetOptStrings(node->AsStringVector());
     if((node = searchNode->GetNode("optEnums")) != 0)
         SetOptEnums(node->AsIntVector());
+    if((node = searchNode->GetNode("optColors")) != 0)
+        SetOptColors(node->AsIntVector());
     if((node = searchNode->GetNode("optMultiLineStrings")) != 0)
         SetOptMultiLineStrings(node->AsStringVector());
     if((node = searchNode->GetNode("enumStrings")) != 0)
@@ -653,6 +665,13 @@ DBOptionsAttributes::SetOptEnums(const intVector &optEnums_)
 {
     optEnums = optEnums_;
     Select(ID_optEnums, (void *)&optEnums);
+}
+
+void
+DBOptionsAttributes::SetOptColors(const intVector &optColors_)
+{
+    optColors = optColors_;
+    Select(ID_optColors, (void *)&optColors);
 }
 
 void
@@ -790,6 +809,18 @@ DBOptionsAttributes::GetOptEnums()
     return optEnums;
 }
 
+const intVector &
+DBOptionsAttributes::GetOptColors() const
+{
+    return optColors;
+}
+
+intVector &
+DBOptionsAttributes::GetOptColors()
+{
+    return optColors;
+}
+
 const stringVector &
 DBOptionsAttributes::GetOptMultiLineStrings() const
 {
@@ -903,6 +934,12 @@ DBOptionsAttributes::SelectOptEnums()
 }
 
 void
+DBOptionsAttributes::SelectOptColors()
+{
+    Select(ID_optColors, (void *)&optColors);
+}
+
+void
 DBOptionsAttributes::SelectOptMultiLineStrings()
 {
     Select(ID_optMultiLineStrings, (void *)&optMultiLineStrings);
@@ -964,6 +1001,7 @@ DBOptionsAttributes::GetFieldName(int index) const
     case ID_optInts:             return "optInts";
     case ID_optStrings:          return "optStrings";
     case ID_optEnums:            return "optEnums";
+    case ID_optColors:           return "optColors";
     case ID_optMultiLineStrings: return "optMultiLineStrings";
     case ID_enumStrings:         return "enumStrings";
     case ID_enumStringsSizes:    return "enumStringsSizes";
@@ -1001,6 +1039,7 @@ DBOptionsAttributes::GetFieldType(int index) const
     case ID_optInts:             return FieldType_intVector;
     case ID_optStrings:          return FieldType_stringVector;
     case ID_optEnums:            return FieldType_intVector;
+    case ID_optColors:           return FieldType_intVector;
     case ID_optMultiLineStrings: return FieldType_stringVector;
     case ID_enumStrings:         return FieldType_stringVector;
     case ID_enumStringsSizes:    return FieldType_intVector;
@@ -1038,6 +1077,7 @@ DBOptionsAttributes::GetFieldTypeName(int index) const
     case ID_optInts:             return "intVector";
     case ID_optStrings:          return "stringVector";
     case ID_optEnums:            return "intVector";
+    case ID_optColors:           return "intVector";
     case ID_optMultiLineStrings: return "stringVector";
     case ID_enumStrings:         return "stringVector";
     case ID_enumStringsSizes:    return "intVector";
@@ -1107,6 +1147,11 @@ DBOptionsAttributes::FieldsEqual(int index_, const AttributeGroup *rhs) const
     case ID_optEnums:
         {  // new scope
         retval = (optEnums == obj.optEnums);
+        }
+        break;
+    case ID_optColors:
+        {  // new scope
+        retval = (optColors == obj.optColors);
         }
         break;
     case ID_optMultiLineStrings:
@@ -1515,6 +1560,45 @@ DBOptionsAttributes::SetEnumStrings(const std::string &name,
     enumStringsSizes[eIndex] = values.size();
 }
 
+void
+DBOptionsAttributes::SetColor(const std::string &name,
+                              const ColorAttribute &defaultValue)
+{
+    int bIndex = FindIndex(name);
+    unsigned char rgba[4];
+    const unsigned char *src = defaultValue.GetColor();
+    for(int i = 0; i < 4; ++i)
+        rgba[i] = src[i];
+
+    if (bIndex < 0)
+    {
+        names.push_back(name);
+        types.push_back(Color);
+        for(int i = 0; i < 4; ++i)
+            optColors.push_back((int)rgba[i]);
+    }
+    else
+    {
+        int start = bIndex * 4;
+        for(int i = 0; i < 4; ++i)
+            optColors[start + i] = (int)rgba[i];
+    }
+}
+
+ColorAttribute
+DBOptionsAttributes::GetColor(const std::string &name) const
+{
+    int bIndex = FindIndex(name);
+    if (bIndex < 0)
+        EXCEPTION0(BadDeclareFormatString);
+
+    int start = bIndex * 4;
+    return ColorAttribute(optColors[start],
+                          optColors[start + 1],
+                          optColors[start + 2],
+                          optColors[start + 3]);
+}
+
 // ****************************************************************************
 //  Method: DBOptionsAttributes::GetMultiLineString
 //
@@ -1693,6 +1777,9 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
                 SetEnum(name, obj.GetEnum(name));
                 SetEnumStrings(name, obj.GetEnumStrings(name));
                 break;
+            case Color:
+                SetColor(name, obj.GetColor(name));
+                break;
             case MultiLineString:
                 SetMultiLineString(name, obj.GetMultiLineString(name));
                 break;
@@ -1707,4 +1794,3 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
 
     return retval;
 }
-

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -426,6 +426,65 @@ DBOptionsAttributes::SetEnumStrings(const std::string &name,
 }
 
 Target: xml2atts
+Function: SetColor
+Declaration: void SetColor(const std::string &name, const ColorAttribute &defaultValue);
+Definition:
+// ****************************************************************************
+//  Method: DBOptionsAttributes::SetColor
+//
+//  Purpose:
+//      Sets a color value.
+//
+// ****************************************************************************
+
+void
+DBOptionsAttributes::SetColor(const std::string &name,
+                              const ColorAttribute &defaultValue)
+{
+    int bIndex = FindIndex(name);
+    const unsigned char *rgba = defaultValue.GetColor();
+    if (bIndex < 0)
+    {
+        names.push_back(name);
+        types.push_back(Color);
+        for(int i = 0; i < 4; ++i)
+            optColors.push_back((int)rgba[i]);
+    }
+    else
+    {
+        int start = bIndex * 4;
+        for(int i = 0; i < 4; ++i)
+            optColors[start + i] = (int)rgba[i];
+    }
+}
+
+Target: xml2atts
+Function: GetColor
+Declaration: ColorAttribute GetColor(const std::string &name) const;
+Definition:
+// ****************************************************************************
+//  Method: DBOptionsAttributes::GetColor
+//
+//  Purpose:
+//      Gets a color value.
+//
+// ****************************************************************************
+
+ColorAttribute
+DBOptionsAttributes::GetColor(const std::string &name) const
+{
+    int bIndex = FindIndex(name);
+    if (bIndex < 0)
+        EXCEPTION0(BadDeclareFormatString);
+
+    int start = bIndex * 4;
+    return ColorAttribute(optColors[start],
+                          optColors[start + 1],
+                          optColors[start + 2],
+                          optColors[start + 3]);
+}
+
+Target: xml2atts
 Function: GetMultiLineString
 Declaration: const std::string &GetMultiLineString(const std::string &name) const;
 Definition:
@@ -642,6 +701,9 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
             case MultiLineString:
                 SetMultiLineString(name, obj.GetMultiLineString(name));
                 break;
+            case Color:
+                SetColor(name, obj.GetColor(name));
+                break;
             }
         }
     }
@@ -653,4 +715,3 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
 
     return retval;
 }
-

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -435,26 +435,42 @@ Definition:
 //  Purpose:
 //      Sets a color value.
 //
+//  Programmer: Justin Privitera
+//  Creation:   Mon Jul 20 16:40:22 PDT 2026
+//
 // ****************************************************************************
 
 void
 DBOptionsAttributes::SetColor(const std::string &name,
-                              int red, int green, int blue, int alpha)
+                              int red,
+                              int green,
+                              int blue,
+                              int alpha)
 {
-    int bIndex = FindIndex(name);
+    // optColors stores all colors flattened into one intVector, with 4 integers per option
+    // [r, g, b, a, r, g, b, a, ...]
+
+    const int bIndex = FindIndex(name);
     int rgba[4] = {red, green, blue, alpha};
     if (bIndex < 0)
     {
         names.push_back(name);
         types.push_back(Color);
-        for(int i = 0; i < 4; ++i)
+        for (int i = 0; i < 4; i ++)
+        {
             optColors.push_back(rgba[i]);
+        }
     }
     else
     {
-        int start = bIndex * 4;
-        for(int i = 0; i < 4; ++i)
+        // bIndex is the index of the color option within the color-option storage, 
+        // not within all options. So to find where that option’s RGBA data begins,
+        // we multiply by 4.
+        const int start = bIndex * 4;
+        for (int i = 0; i < 4; i ++)
+        {
             optColors[start + i] = rgba[i];
+        }
     }
 }
 
@@ -468,17 +484,26 @@ Definition:
 //  Purpose:
 //      Gets a color value.
 //
+//  Programmer: Justin Privitera
+//  Creation:   Mon Jul 20 16:40:22 PDT 2026
+//
 // ****************************************************************************
 
 void
-DBOptionsAttributes::GetColor(const std::string &name, int &red, int &green,
-                              int &blue, int &alpha) const
+DBOptionsAttributes::GetColor(const std::string &name,
+                              int &red,
+                              int &green,
+                              int &blue,
+                              int &alpha) const
 {
-    int bIndex = FindIndex(name);
+    const int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
 
-    int start = bIndex * 4;
+    // bIndex is the index of the color option within the color-option storage, 
+    // not within all options. So to find where that option’s RGBA data begins,
+    // we multiply by 4.
+    const int start = bIndex * 4;
     red = optColors[start];
     green = optColors[start + 1];
     blue = optColors[start + 2];
@@ -664,6 +689,10 @@ Definition:
 //
 //  Programmer: Brad Whitlock
 //  Creation:   Fri Aug 14 18:04:39 PDT 2015
+// 
+//  Modifications:
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Handle the "color" case.
 //
 // ****************************************************************************
 

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -1,4 +1,10 @@
 Target: xml2atts
+Code: DBOptionsAttributes.h
+Prefix:
+class ColorAttribute;
+Postfix:
+
+Target: xml2atts
 Function: FindIndex
 Declaration: int FindIndex(const std::string &name) const;
 Definition:

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -5,6 +5,12 @@ class ColorAttribute;
 Postfix:
 
 Target: xml2atts
+Code: DBOptionsAttributes.C
+Prefix:
+#include "ColorAttribute.h"
+Postfix:
+
+Target: xml2atts
 Function: FindIndex
 Declaration: int FindIndex(const std::string &name) const;
 Definition:

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -427,7 +427,7 @@ DBOptionsAttributes::SetEnumStrings(const std::string &name,
 
 Target: xml2atts
 Function: SetColor
-Declaration: void SetColor(const std::string &name, const ColorAttribute &defaultValue);
+Declaration: void SetColor(const std::string &name, int red, int green, int blue, int alpha = 255);
 Definition:
 // ****************************************************************************
 //  Method: DBOptionsAttributes::SetColor
@@ -439,28 +439,28 @@ Definition:
 
 void
 DBOptionsAttributes::SetColor(const std::string &name,
-                              const ColorAttribute &defaultValue)
+                              int red, int green, int blue, int alpha)
 {
     int bIndex = FindIndex(name);
-    const unsigned char *rgba = defaultValue.GetColor();
+    int rgba[4] = {red, green, blue, alpha};
     if (bIndex < 0)
     {
         names.push_back(name);
         types.push_back(Color);
         for(int i = 0; i < 4; ++i)
-            optColors.push_back((int)rgba[i]);
+            optColors.push_back(rgba[i]);
     }
     else
     {
         int start = bIndex * 4;
         for(int i = 0; i < 4; ++i)
-            optColors[start + i] = (int)rgba[i];
+            optColors[start + i] = rgba[i];
     }
 }
 
 Target: xml2atts
 Function: GetColor
-Declaration: ColorAttribute GetColor(const std::string &name) const;
+Declaration: void GetColor(const std::string &name, int &red, int &green, int &blue, int &alpha) const;
 Definition:
 // ****************************************************************************
 //  Method: DBOptionsAttributes::GetColor
@@ -470,18 +470,19 @@ Definition:
 //
 // ****************************************************************************
 
-ColorAttribute
-DBOptionsAttributes::GetColor(const std::string &name) const
+void
+DBOptionsAttributes::GetColor(const std::string &name, int &red, int &green,
+                              int &blue, int &alpha) const
 {
     int bIndex = FindIndex(name);
     if (bIndex < 0)
         EXCEPTION0(BadDeclareFormatString);
 
     int start = bIndex * 4;
-    return ColorAttribute(optColors[start],
-                          optColors[start + 1],
-                          optColors[start + 2],
-                          optColors[start + 3]);
+    red = optColors[start];
+    green = optColors[start + 1];
+    blue = optColors[start + 2];
+    alpha = optColors[start + 3];
 }
 
 Target: xml2atts
@@ -702,7 +703,11 @@ DBOptionsAttributes::Merge(const DBOptionsAttributes &obj)
                 SetMultiLineString(name, obj.GetMultiLineString(name));
                 break;
             case Color:
-                SetColor(name, obj.GetColor(name));
+                {
+                    int red, green, blue, alpha;
+                    obj.GetColor(name, red, green, blue, alpha);
+                    SetColor(name, red, green, blue, alpha);
+                }
                 break;
             }
         }

--- a/src/common/state/DBOptionsAttributes.code
+++ b/src/common/state/DBOptionsAttributes.code
@@ -1,16 +1,4 @@
 Target: xml2atts
-Code: DBOptionsAttributes.h
-Prefix:
-class ColorAttribute;
-Postfix:
-
-Target: xml2atts
-Code: DBOptionsAttributes.C
-Prefix:
-#include "ColorAttribute.h"
-Postfix:
-
-Target: xml2atts
 Function: FindIndex
 Declaration: int FindIndex(const std::string &name) const;
 Definition:

--- a/src/common/state/DBOptionsAttributes.h
+++ b/src/common/state/DBOptionsAttributes.h
@@ -8,8 +8,7 @@
 #include <string>
 #include <AttributeSubject.h>
 
-class ColorAttribute;
-
+#include <ColorAttribute.h>
 
 // ****************************************************************************
 // Class: DBOptionsAttributes

--- a/src/common/state/DBOptionsAttributes.h
+++ b/src/common/state/DBOptionsAttributes.h
@@ -7,8 +7,8 @@
 #include <state_exports.h>
 #include <string>
 #include <AttributeSubject.h>
-#include <ColorAttribute.h>
 
+#include <ColorAttribute.h>
 
 // ****************************************************************************
 // Class: DBOptionsAttributes

--- a/src/common/state/DBOptionsAttributes.h
+++ b/src/common/state/DBOptionsAttributes.h
@@ -7,6 +7,7 @@
 #include <state_exports.h>
 #include <string>
 #include <AttributeSubject.h>
+#include <ColorAttribute.h>
 
 
 // ****************************************************************************
@@ -35,7 +36,8 @@ public:
         Double,
         String,
         Enum,
-        MultiLineString
+        MultiLineString,
+        Color
     };
 
     // These constructors are for objects of this class
@@ -71,6 +73,7 @@ public:
     void SelectOptInts();
     void SelectOptStrings();
     void SelectOptEnums();
+    void SelectOptColors();
     void SelectOptMultiLineStrings();
     void SelectEnumStrings();
     void SelectEnumStringsSizes();
@@ -86,6 +89,7 @@ public:
     void SetOptInts(const intVector &optInts_);
     void SetOptStrings(const stringVector &optStrings_);
     void SetOptEnums(const intVector &optEnums_);
+    void SetOptColors(const intVector &optColors_);
     void SetOptMultiLineStrings(const stringVector &optMultiLineStrings_);
     void SetEnumStrings(const stringVector &enumStrings_);
     void SetEnumStringsSizes(const intVector &enumStringsSizes_);
@@ -109,6 +113,8 @@ public:
           stringVector &GetOptStrings();
     const intVector    &GetOptEnums() const;
           intVector    &GetOptEnums();
+    const intVector    &GetOptColors() const;
+          intVector    &GetOptColors();
     const stringVector &GetOptMultiLineStrings() const;
           stringVector &GetOptMultiLineStrings();
     const stringVector &GetEnumStrings() const;
@@ -152,6 +158,8 @@ public:
     void SetEnum(const std::string &name, int defaultValue);
     int GetEnum(const std::string &name) const;
     void SetEnumStrings(const std::string &name, const std::vector<std::string> &values);
+    void SetColor(const std::string &name, const ColorAttribute &defaultValue);
+    ColorAttribute GetColor(const std::string &name) const;
     const std::string &GetMultiLineString(const std::string &name) const;
     void SetMultiLineString(const std::string &name, const std::string &defaultValue);
     int GetNumberOfOptions(void) const;
@@ -172,6 +180,7 @@ public:
         ID_optInts,
         ID_optStrings,
         ID_optEnums,
+        ID_optColors,
         ID_optMultiLineStrings,
         ID_enumStrings,
         ID_enumStringsSizes,
@@ -189,6 +198,7 @@ private:
     intVector    optInts;
     stringVector optStrings;
     intVector    optEnums;
+    intVector    optColors;
     stringVector optMultiLineStrings;
     stringVector enumStrings;
     intVector    enumStringsSizes;
@@ -199,6 +209,6 @@ private:
     static const char *TypeMapFormatString;
     static const private_tmfs_t TmfsStruct;
 };
-#define DBOPTIONSATTRIBUTES_TMFS "i*s*i*d*d*i*s*i*s*s*i*s*s"
+#define DBOPTIONSATTRIBUTES_TMFS "i*s*i*d*d*i*s*i*i*s*s*i*s*s"
 
 #endif

--- a/src/common/state/DBOptionsAttributes.h
+++ b/src/common/state/DBOptionsAttributes.h
@@ -8,7 +8,8 @@
 #include <string>
 #include <AttributeSubject.h>
 
-#include <ColorAttribute.h>
+class ColorAttribute;
+
 
 // ****************************************************************************
 // Class: DBOptionsAttributes

--- a/src/common/state/DBOptionsAttributes.h
+++ b/src/common/state/DBOptionsAttributes.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <AttributeSubject.h>
 
-#include <ColorAttribute.h>
 
 // ****************************************************************************
 // Class: DBOptionsAttributes
@@ -158,8 +157,8 @@ public:
     void SetEnum(const std::string &name, int defaultValue);
     int GetEnum(const std::string &name) const;
     void SetEnumStrings(const std::string &name, const std::vector<std::string> &values);
-    void SetColor(const std::string &name, const ColorAttribute &defaultValue);
-    ColorAttribute GetColor(const std::string &name) const;
+    void SetColor(const std::string &name, int red, int green, int blue, int alpha = 255);
+    void GetColor(const std::string &name, int &red, int &green, int &blue, int &alpha) const;
     const std::string &GetMultiLineString(const std::string &name) const;
     void SetMultiLineString(const std::string &name, const std::string &defaultValue);
     int GetNumberOfOptions(void) const;

--- a/src/common/state/DBOptionsAttributes.xml
+++ b/src/common/state/DBOptionsAttributes.xml
@@ -8,6 +8,7 @@
       String
       Enum
       MultiLineString
+      Color
     </Enum>
     <Field name="types" label="Format String" type="intVector">
     </Field>
@@ -24,6 +25,8 @@
     <Field name="optStrings" label="String options" type="stringVector" internal="true">
     </Field>
     <Field name="optEnums" label="Enumerated type options" type="intVector" internal="true">
+    </Field>
+    <Field name="optColors" label="Color options" type="intVector" internal="true">
     </Field>
     <Field name="optMultiLineStrings" label="Multi Line String Options" type="stringVector" internal="true">
     </Field>
@@ -63,6 +66,10 @@
     </Function>
     <Function name="SetEnumStrings" user="true" member="true">
     </Function>
+    <Function name="SetColor" user="true" member="true">
+    </Function>
+    <Function name="GetColor" user="true" member="true">
+    </Function>
     <Function name="GetMultiLineString" user="true" member="true">
     </Function>
     <Function name="SetMultiLineString" user="true" member="true">
@@ -81,4 +88,7 @@
     </Function>
     <Function name="Merge" user="true" member="true">
     </Function>
+    <Include file="header" quoted="false">
+      ColorAttribute.h
+    </Include>
   </Attribute>

--- a/src/common/state/DBOptionsAttributes.xml
+++ b/src/common/state/DBOptionsAttributes.xml
@@ -88,4 +88,7 @@
     </Function>
     <Function name="Merge" user="true" member="true">
     </Function>
+    <Include file="header" quoted="false">
+      ColorAttribute.h
+    </Include>
   </Attribute>

--- a/src/common/state/DBOptionsAttributes.xml
+++ b/src/common/state/DBOptionsAttributes.xml
@@ -88,7 +88,4 @@
     </Function>
     <Function name="Merge" user="true" member="true">
     </Function>
-    <Include file="header" quoted="false">
-      ColorAttribute.h
-    </Include>
   </Attribute>

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
@@ -9,6 +9,8 @@
 #include <avtWavefrontOBJOptions.h>
 
 #include <DBOptionsAttributes.h>
+#include <ColorAttribute.h>
+#include <avtColorTables.h>
 
 #include <string>
 
@@ -57,7 +59,16 @@ GetWavefrontOBJWriteOptions(void)
 {
     DBOptionsAttributes *rv = new DBOptionsAttributes;
     rv->SetBool("Output colors", false);
-    rv->SetString("Color table", "hot");
+    rv->SetString("Color table",
+                  avtColorTables::Instance()->GetDefaultContinuousColorTable());
     rv->SetBool("Invert color table", false);
+    rv->SetBool("Use min", false);
+    rv->SetDouble("Min", 0.);
+    rv->SetBool("Use max", false);
+    rv->SetDouble("Max", 1.);
+    rv->SetBool("Use below min color", false);
+    rv->SetColor("Below min color", ColorAttribute());
+    rv->SetBool("Use above max color", false);
+    rv->SetColor("Above max color", ColorAttribute());
     return rv;
 }

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
@@ -9,7 +9,6 @@
 #include <avtWavefrontOBJOptions.h>
 
 #include <DBOptionsAttributes.h>
-#include <avtColorTables.h>
 
 #include <string>
 
@@ -58,16 +57,15 @@ GetWavefrontOBJWriteOptions(void)
 {
     DBOptionsAttributes *rv = new DBOptionsAttributes;
     rv->SetBool("Output colors", false);
-    rv->SetString("Color table",
-                  avtColorTables::Instance()->GetDefaultContinuousColorTable());
+    rv->SetString("Color table", "hot");
     rv->SetBool("Invert color table", false);
-    rv->SetBool("Use min", false);
-    rv->SetDouble("Min", 0.);
-    rv->SetBool("Use max", false);
-    rv->SetDouble("Max", 1.);
-    rv->SetBool("Use below min color", false);
-    rv->SetColor("Below min color", 0, 0, 0, 255);
-    rv->SetBool("Use above max color", false);
-    rv->SetColor("Above max color", 0, 0, 0, 255);
+    rv->SetBool("Use minimum", false);
+    rv->SetDouble("Minimum", 0.);
+    rv->SetBool("Use maximum", false);
+    rv->SetDouble("Maximum", 1.);
+    rv->SetBool("Use color for values < min", false);
+    rv->SetColor("Color for values < min", 0, 0, 0, 255);
+    rv->SetBool("Use color for values > max", false);
+    rv->SetColor("Color for values > max", 0, 0, 0, 255);
     return rv;
 }

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
@@ -50,6 +50,9 @@ GetWavefrontOBJReadOptions(void)
 //    Justin Privitera, Tue Nov 28 17:31:40 PST 2023
 //    Added "Invert color table" option.
 //
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Added new options for controlling limits.
+//
 // ****************************************************************************
 
 DBOptionsAttributes *

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJOptions.C
@@ -9,7 +9,6 @@
 #include <avtWavefrontOBJOptions.h>
 
 #include <DBOptionsAttributes.h>
-#include <ColorAttribute.h>
 #include <avtColorTables.h>
 
 #include <string>
@@ -67,8 +66,8 @@ GetWavefrontOBJWriteOptions(void)
     rv->SetBool("Use max", false);
     rv->SetDouble("Max", 1.);
     rv->SetBool("Use below min color", false);
-    rv->SetColor("Below min color", ColorAttribute());
+    rv->SetColor("Below min color", 0, 0, 0, 255);
     rv->SetBool("Use above max color", false);
-    rv->SetColor("Above max color", ColorAttribute());
+    rv->SetColor("Above max color", 0, 0, 0, 255);
     return rv;
 }

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -39,6 +39,27 @@
 using     std::string;
 using     std::vector;
 
+namespace
+{
+
+void
+CopyColor(unsigned char *dest, const unsigned char *src)
+{
+    dest[0] = src[0];
+    dest[1] = src[1];
+    dest[2] = src[2];
+}
+
+void
+CopyColor(unsigned char *dest, const ColorAttribute &src)
+{
+    dest[0] = (unsigned char)src.Red();
+    dest[1] = (unsigned char)src.Green();
+    dest[2] = (unsigned char)src.Blue();
+}
+
+}
+
 
 // ****************************************************************************
 //  Method: avtWavefrontOBJWriter constructor
@@ -59,7 +80,17 @@ avtWavefrontOBJWriter::avtWavefrontOBJWriter(const DBOptionsAttributes *atts)
 {
     doColor = atts->GetBool("Output colors");
     colorTable = atts->GetString("Color table");
+    if (colorTable.empty())
+        colorTable = avtColorTables::Instance()->GetDefaultContinuousColorTable();
     invertCT = atts->GetBool("Invert color table");
+    useMin = atts->GetBool("Use min");
+    minValue = atts->GetDouble("Min");
+    useMax = atts->GetBool("Use max");
+    maxValue = atts->GetDouble("Max");
+    useBelowMinColor = atts->GetBool("Use below min color");
+    belowMinColor = atts->GetColor("Below min color");
+    useAboveMaxColor = atts->GetBool("Use above max color");
+    aboveMaxColor = atts->GetColor("Above max color");
 }
 
 // ****************************************************************************
@@ -142,14 +173,24 @@ avtWavefrontOBJWriter::WriteChunk(vtkDataSet *ds, int chunk)
                                            nullptr, // label
                                            true, // YES writeMTL
                                            true, // YES MTLHasTex
-                                           textureFilename); // name of texture file
+                                           textureFilename, // name of texture file
+                                           useMin,
+                                           minValue,
+                                           useMax,
+                                           maxValue,
+                                           useBelowMinColor,
+                                           useAboveMaxColor);
 
         vtkImageData *image = GetColorTable();
-        vtkImageWriter *writer = vtkPNGWriter::New();
-        writer->SetFileName(textureFilename.c_str());
-        writer->SetInputData(image);
-        writer->Write();
-        writer->Delete();
+        if (image != NULL)
+        {
+            vtkImageWriter *writer = vtkPNGWriter::New();
+            writer->SetFileName(textureFilename.c_str());
+            writer->SetInputData(image);
+            writer->Write();
+            writer->Delete();
+            image->Delete();
+        }
     }
     else
     {
@@ -245,90 +286,56 @@ avtWavefrontOBJWriter::GetColorTable()
 
     if (! table)
     {
-        return nullptr;
+        colorTable = avtColorTables::Instance()->GetDefaultContinuousColorTable();
+        table = colorTables->GetColorControlPoints(colorTable);
+        if (!table)
+            return NULL;
     }
     
 
     // We don't have color tables that have this many control points,
     // so this should be a good choice for the number of colors.
     const int ncolors = 256;
+    const int ntotalcolors = ncolors + 4;
     unsigned char rgb[ncolors * 3];
     
     table->GetColors(rgb, ncolors);
 
     vtkImageData *imageData = vtkImageData::New();
 
-    // We need two extra colors, so (ncolors - 1 + 2) -> (ncolors + 1)
-    // hence x: [0, ncolors + 1], y: [0, 0], z: [0, 0]
-    // These pixels will sit on the ends and act as padding so the texture coords
-    // don't lead to strange behavior with max and min values wrapping around
-    imageData->SetExtent(0, ncolors + 1, 0, 0, 0, 0);
+    // Add duplicate edge pixels plus dedicated above/below pixels to keep
+    // texture wrapping from corrupting the end colors.
+    imageData->SetExtent(0, ntotalcolors - 1, 0, 0, 0, 0);
     imageData->SetSpacing(1., 1., 1.);
     imageData->SetOrigin(0., 0., 0.);
     imageData->AllocateScalars(VTK_UNSIGNED_CHAR, 3);
     unsigned char *pixels = (unsigned char *)imageData->GetScalarPointer(0, 0, 0);
-    unsigned char *ipixel = pixels;
-
-    if (invertCT)
+    unsigned char orderedRGB[ncolors * 3];
+    for (int i = 0; i < ncolors; ++i)
     {
-        // the first extra pixel will get the same color as the first real pixel
-        int last_index = ncolors * 3 - 3;
-        *ipixel = rgb[last_index];
-        ipixel ++;
-        *ipixel = rgb[last_index + 1];
-        ipixel ++;
-        *ipixel = rgb[last_index + 2];
-        ipixel ++;
-
-        // iterate through the colors in reverse
-        for (int i = ncolors * 3 - 3; i >= 0; i -= 3)
-        {
-            *ipixel = rgb[i];
-            ipixel ++;
-            *ipixel = rgb[i + 1];
-            ipixel ++;
-            *ipixel = rgb[i + 2];
-            ipixel ++;
-        }
-
-        // the second (and last) extra pixel will get the same color as the last real pixel
-        *ipixel = rgb[0];
-        ipixel ++;
-        *ipixel = rgb[1];
-        ipixel ++;
-        *ipixel = rgb[2];
-        ipixel ++;
+        int srcIndex = invertCT ? (ncolors - 1 - i) : i;
+        CopyColor(orderedRGB + i * 3, rgb + srcIndex * 3);
     }
+
+    unsigned char lowerColor[3];
+    unsigned char upperColor[3];
+    if (useBelowMinColor)
+        CopyColor(lowerColor, belowMinColor);
     else
-    {
-        // the first extra pixel will get the same color as the first real pixel
-        *ipixel = rgb[0];
-        ipixel ++;
-        *ipixel = rgb[1];
-        ipixel ++;
-        *ipixel = rgb[2];
-        ipixel ++;
+        CopyColor(lowerColor, orderedRGB);
 
-        // iterate through the colors
-        for (int i = 0; i < ncolors * 3; i += 3)
-        {
-            *ipixel = rgb[i];
-            ipixel ++;
-            *ipixel = rgb[i + 1];
-            ipixel ++;
-            *ipixel = rgb[i + 2];
-            ipixel ++;
-        }
+    int last = (ncolors - 1) * 3;
+    if (useAboveMaxColor)
+        CopyColor(upperColor, aboveMaxColor);
+    else
+        CopyColor(upperColor, orderedRGB + last);
 
-        // the second (and last) extra pixel will get the same color as the last real pixel
-        int last_index = ncolors * 3 - 3;
-        *ipixel = rgb[last_index];
-        ipixel ++;
-        *ipixel = rgb[last_index + 1];
-        ipixel ++;
-        *ipixel = rgb[last_index + 2];
-        ipixel ++;
-    }
+    CopyColor(pixels, lowerColor);
+    CopyColor(pixels + 3, lowerColor);
+    for (int i = 0; i < ncolors; ++i)
+        CopyColor(pixels + (i + 2) * 3, orderedRGB + i * 3);
+    CopyColor(pixels + (ncolors + 2) * 3, upperColor);
+    CopyColor(pixels + (ncolors + 3) * 3, upperColor);
 
     return imageData;
 }

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -83,20 +83,20 @@ avtWavefrontOBJWriter::avtWavefrontOBJWriter(const DBOptionsAttributes *atts)
     if (colorTable.empty())
         colorTable = avtColorTables::Instance()->GetDefaultContinuousColorTable();
     invertCT = atts->GetBool("Invert color table");
-    useMin = atts->GetBool("Use min");
-    minValue = atts->GetDouble("Min");
-    useMax = atts->GetBool("Use max");
-    maxValue = atts->GetDouble("Max");
-    useBelowMinColor = atts->GetBool("Use below min color");
+    useMin = atts->GetBool("Use minimum");
+    minValue = atts->GetDouble("Minimum");
+    useMax = atts->GetBool("Use maximum");
+    maxValue = atts->GetDouble("Maximum");
+    useBelowMinColor = atts->GetBool("Use color for values < min");
     {
         int red, green, blue, alpha;
-        atts->GetColor("Below min color", red, green, blue, alpha);
+        atts->GetColor("Color for values < min", red, green, blue, alpha);
         belowMinColor = ColorAttribute(red, green, blue, alpha);
     }
-    useAboveMaxColor = atts->GetBool("Use above max color");
+    useAboveMaxColor = atts->GetBool("Use color for values > max");
     {
         int red, green, blue, alpha;
-        atts->GetColor("Above max color", red, green, blue, alpha);
+        atts->GetColor("Color for values > max", red, green, blue, alpha);
         aboveMaxColor = ColorAttribute(red, green, blue, alpha);
     }
 }

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -88,9 +88,17 @@ avtWavefrontOBJWriter::avtWavefrontOBJWriter(const DBOptionsAttributes *atts)
     useMax = atts->GetBool("Use max");
     maxValue = atts->GetDouble("Max");
     useBelowMinColor = atts->GetBool("Use below min color");
-    belowMinColor = atts->GetColor("Below min color");
+    {
+        int red, green, blue, alpha;
+        atts->GetColor("Below min color", red, green, blue, alpha);
+        belowMinColor = ColorAttribute(red, green, blue, alpha);
+    }
     useAboveMaxColor = atts->GetBool("Use above max color");
-    aboveMaxColor = atts->GetColor("Above max color");
+    {
+        int red, green, blue, alpha;
+        atts->GetColor("Above max color", red, green, blue, alpha);
+        aboveMaxColor = ColorAttribute(red, green, blue, alpha);
+    }
 }
 
 // ****************************************************************************

--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.h
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.h
@@ -11,6 +11,7 @@
 
 #include <avtDatabaseWriter.h>
 
+#include <ColorAttribute.h>
 #include <string>
 
 class DBOptionsAttributes;
@@ -65,6 +66,14 @@ avtWavefrontOBJWriter : public avtDatabaseWriter
     bool                       doColor;
     std::string                colorTable;
     bool                       invertCT;
+    bool                       useMin;
+    double                     minValue;
+    bool                       useMax;
+    double                     maxValue;
+    bool                       useBelowMinColor;
+    ColorAttribute             belowMinColor;
+    bool                       useAboveMaxColor;
+    ColorAttribute             aboveMaxColor;
 };
 
 

--- a/src/gui/QvisDBOptionsDialog.C
+++ b/src/gui/QvisDBOptionsDialog.C
@@ -59,6 +59,9 @@
 //    multiple lines are properly displayed. Also use a fixed-width font
 //    (Courier) and prevent tabs from being entered by setting
 //    tabChangesFocus to true.
+// 
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Handle color.
 //
 // ****************************************************************************
 
@@ -222,6 +225,9 @@ QvisDBOptionsDialog::~QvisDBOptionsDialog()
 //
 //    Chris Laganella, Tue Feb  8 18:24:35 EST 2022
 //    Add support for multi line string
+// 
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Handle color.
 // ****************************************************************************
 
 void

--- a/src/gui/QvisDBOptionsDialog.C
+++ b/src/gui/QvisDBOptionsDialog.C
@@ -4,6 +4,7 @@
 
 #include <QvisDBOptionsDialog.h>
 #include <QvisDBOptionsHelpWindow.h>
+#include <QvisColorButton.h>
 #include <QLayout>
 #include <QPushButton>
 #include <QComboBox>
@@ -134,6 +135,17 @@ QvisDBOptionsDialog::QvisDBOptionsDialog(DBOptionsAttributes *dbatts,
             comboboxes.append(cbo_box);
             }
             break;
+          case DBOptionsAttributes::Color:
+            { // new scope
+            ColorAttribute color = atts->GetColor(name);
+            QColor qcolor(color.Red(), color.Green(), color.Blue(), color.Alpha());
+            QvisColorButton *colorButton = new QvisColorButton(this);
+            colorButton->setButtonColor(qcolor);
+            grid->addWidget(new QLabel(tr(name.c_str()), this), i, 0);
+            grid->addWidget(colorButton, i, 1, Qt::AlignLeft);
+            colorbuttons.append(colorButton);
+            }
+            break;
           case DBOptionsAttributes::MultiLineString:
             { // new scope
             txt = atts->GetMultiLineString(name).c_str();
@@ -219,6 +231,7 @@ QvisDBOptionsDialog::okayClicked()
     int lineedit_index = 0;
     int checkbox_index = 0;
     int combobox_index = 0;
+    int colorbutton_index = 0;
     int multiLineEditIdx = 0;
     for (int i=0; i<size; i++)
     {
@@ -270,6 +283,17 @@ QvisDBOptionsDialog::okayClicked()
             int val = comboboxes[combobox_index++]->currentIndex();
             debug5 << mName << "Setting \"" << name.c_str() << "\" to " << val << endl;
             atts->SetEnum(name, val);
+          }
+            break;
+          case DBOptionsAttributes::Color:
+          {
+            QColor val = colorbuttons[colorbutton_index++]->buttonColor();
+            debug5 << mName << "Setting \"" << name.c_str() << "\" to "
+                   << val.red() << "," << val.green() << ","
+                   << val.blue() << "," << val.alpha() << endl;
+            atts->SetColor(name,
+                           ColorAttribute(val.red(), val.green(),
+                                          val.blue(), val.alpha()));
           }
             break;
           case DBOptionsAttributes::MultiLineString:

--- a/src/gui/QvisDBOptionsDialog.C
+++ b/src/gui/QvisDBOptionsDialog.C
@@ -137,8 +137,9 @@ QvisDBOptionsDialog::QvisDBOptionsDialog(DBOptionsAttributes *dbatts,
             break;
           case DBOptionsAttributes::Color:
             { // new scope
-            ColorAttribute color = atts->GetColor(name);
-            QColor qcolor(color.Red(), color.Green(), color.Blue(), color.Alpha());
+            int red, green, blue, alpha;
+            atts->GetColor(name, red, green, blue, alpha);
+            QColor qcolor(red, green, blue, alpha);
             QvisColorButton *colorButton = new QvisColorButton(this);
             colorButton->setButtonColor(qcolor);
             grid->addWidget(new QLabel(tr(name.c_str()), this), i, 0);
@@ -291,9 +292,8 @@ QvisDBOptionsDialog::okayClicked()
             debug5 << mName << "Setting \"" << name.c_str() << "\" to "
                    << val.red() << "," << val.green() << ","
                    << val.blue() << "," << val.alpha() << endl;
-            atts->SetColor(name,
-                           ColorAttribute(val.red(), val.green(),
-                                          val.blue(), val.alpha()));
+            atts->SetColor(name, val.red(), val.green(),
+                           val.blue(), val.alpha());
           }
             break;
           case DBOptionsAttributes::MultiLineString:

--- a/src/gui/QvisDBOptionsDialog.h
+++ b/src/gui/QvisDBOptionsDialog.h
@@ -37,6 +37,9 @@ class DBOptionsAttributes;
 //    Use QPlainTextEdit for MultiLineString instead of QTextEdit, so that
 //    multiple lines are properly displayed.
 //
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Added color buttons.
+//
 // ****************************************************************************
 
 class QvisDBOptionsDialog : public QDialog

--- a/src/gui/QvisDBOptionsDialog.h
+++ b/src/gui/QvisDBOptionsDialog.h
@@ -12,6 +12,7 @@ class QCheckBox;
 class QLineEdit;
 class QComboBox;
 class QPlainTextEdit;
+class QvisColorButton;
 class DBOptionsAttributes;
 
 // ****************************************************************************
@@ -54,6 +55,7 @@ private:
     QList<QCheckBox*>       checkboxes;
     QList<QLineEdit*>       lineedits;
     QList<QComboBox*>       comboboxes;
+    QList<QvisColorButton*> colorbuttons;
     QList<QPlainTextEdit*>  multiLineEdits;
 
     QPushButton         *okButton;

--- a/src/java/DBOptionsAttributes.java
+++ b/src/java/DBOptionsAttributes.java
@@ -25,7 +25,7 @@ import java.lang.Double;
 
 public class DBOptionsAttributes extends AttributeSubject
 {
-    private static int DBOptionsAttributes_numAdditionalAtts = 13;
+    private static int DBOptionsAttributes_numAdditionalAtts = 14;
 
     // Enum values
     public final static int OPTIONTYPE_BOOL = 0;
@@ -35,6 +35,7 @@ public class DBOptionsAttributes extends AttributeSubject
     public final static int OPTIONTYPE_STRING = 4;
     public final static int OPTIONTYPE_ENUM = 5;
     public final static int OPTIONTYPE_MULTILINESTRING = 6;
+    public final static int OPTIONTYPE_COLOR = 7;
 
 
     public DBOptionsAttributes()
@@ -49,6 +50,7 @@ public class DBOptionsAttributes extends AttributeSubject
         optInts = new Vector();
         optStrings = new Vector();
         optEnums = new Vector();
+        optColors = new Vector();
         optMultiLineStrings = new Vector();
         enumStrings = new Vector();
         enumStringsSizes = new Vector();
@@ -68,6 +70,7 @@ public class DBOptionsAttributes extends AttributeSubject
         optInts = new Vector();
         optStrings = new Vector();
         optEnums = new Vector();
+        optColors = new Vector();
         optMultiLineStrings = new Vector();
         enumStrings = new Vector();
         enumStringsSizes = new Vector();
@@ -126,6 +129,12 @@ public class DBOptionsAttributes extends AttributeSubject
         {
             Integer iv = (Integer)obj.optEnums.elementAt(i);
             optEnums.addElement(new Integer(iv.intValue()));
+        }
+        optColors = new Vector();
+        for(i = 0; i < obj.optColors.size(); ++i)
+        {
+            Integer iv = (Integer)obj.optColors.elementAt(i);
+            optColors.addElement(new Integer(iv.intValue()));
         }
         optMultiLineStrings = new Vector(obj.optMultiLineStrings.size());
         for(i = 0; i < obj.optMultiLineStrings.size(); ++i)
@@ -236,6 +245,15 @@ public class DBOptionsAttributes extends AttributeSubject
             Integer optEnums2 = (Integer)obj.optEnums.elementAt(i);
             optEnums_equal = optEnums1.equals(optEnums2);
         }
+        // Compare the elements in the optColors vector.
+        boolean optColors_equal = (obj.optColors.size() == optColors.size());
+        for(i = 0; (i < optColors.size()) && optColors_equal; ++i)
+        {
+            // Make references to Integer from Object.
+            Integer optColors1 = (Integer)optColors.elementAt(i);
+            Integer optColors2 = (Integer)obj.optColors.elementAt(i);
+            optColors_equal = optColors1.equals(optColors2);
+        }
         // Compare the elements in the optMultiLineStrings vector.
         boolean optMultiLineStrings_equal = (obj.optMultiLineStrings.size() == optMultiLineStrings.size());
         for(i = 0; (i < optMultiLineStrings.size()) && optMultiLineStrings_equal; ++i)
@@ -281,6 +299,7 @@ public class DBOptionsAttributes extends AttributeSubject
                 optInts_equal &&
                 optStrings_equal &&
                 optEnums_equal &&
+                optColors_equal &&
                 optMultiLineStrings_equal &&
                 enumStrings_equal &&
                 enumStringsSizes_equal &&
@@ -337,34 +356,40 @@ public class DBOptionsAttributes extends AttributeSubject
         Select(7);
     }
 
+    public void SetOptColors(Vector optColors_)
+    {
+        optColors = optColors_;
+        Select(8);
+    }
+
     public void SetOptMultiLineStrings(Vector optMultiLineStrings_)
     {
         optMultiLineStrings = optMultiLineStrings_;
-        Select(8);
+        Select(9);
     }
 
     public void SetEnumStrings(Vector enumStrings_)
     {
         enumStrings = enumStrings_;
-        Select(9);
+        Select(10);
     }
 
     public void SetEnumStringsSizes(Vector enumStringsSizes_)
     {
         enumStringsSizes = enumStringsSizes_;
-        Select(10);
+        Select(11);
     }
 
     public void SetObsoleteNames(Vector obsoleteNames_)
     {
         obsoleteNames = obsoleteNames_;
-        Select(11);
+        Select(12);
     }
 
     public void SetHelp(String help_)
     {
         help = help_;
-        Select(12);
+        Select(13);
     }
 
     // Property getting methods
@@ -376,6 +401,7 @@ public class DBOptionsAttributes extends AttributeSubject
     public Vector GetOptInts() { return optInts; }
     public Vector GetOptStrings() { return optStrings; }
     public Vector GetOptEnums() { return optEnums; }
+    public Vector GetOptColors() { return optColors; }
     public Vector GetOptMultiLineStrings() { return optMultiLineStrings; }
     public Vector GetEnumStrings() { return enumStrings; }
     public Vector GetEnumStringsSizes() { return enumStringsSizes; }
@@ -402,14 +428,16 @@ public class DBOptionsAttributes extends AttributeSubject
         if(WriteSelect(7, buf))
             buf.WriteIntVector(optEnums);
         if(WriteSelect(8, buf))
-            buf.WriteStringVector(optMultiLineStrings);
+            buf.WriteIntVector(optColors);
         if(WriteSelect(9, buf))
-            buf.WriteStringVector(enumStrings);
+            buf.WriteStringVector(optMultiLineStrings);
         if(WriteSelect(10, buf))
-            buf.WriteIntVector(enumStringsSizes);
+            buf.WriteStringVector(enumStrings);
         if(WriteSelect(11, buf))
-            buf.WriteStringVector(obsoleteNames);
+            buf.WriteIntVector(enumStringsSizes);
         if(WriteSelect(12, buf))
+            buf.WriteStringVector(obsoleteNames);
+        if(WriteSelect(13, buf))
             buf.WriteString(help);
     }
 
@@ -442,18 +470,21 @@ public class DBOptionsAttributes extends AttributeSubject
             SetOptEnums(buf.ReadIntVector());
             break;
         case 8:
-            SetOptMultiLineStrings(buf.ReadStringVector());
+            SetOptColors(buf.ReadIntVector());
             break;
         case 9:
-            SetEnumStrings(buf.ReadStringVector());
+            SetOptMultiLineStrings(buf.ReadStringVector());
             break;
         case 10:
-            SetEnumStringsSizes(buf.ReadIntVector());
+            SetEnumStrings(buf.ReadStringVector());
             break;
         case 11:
-            SetObsoleteNames(buf.ReadStringVector());
+            SetEnumStringsSizes(buf.ReadIntVector());
             break;
         case 12:
+            SetObsoleteNames(buf.ReadStringVector());
+            break;
+        case 13:
             SetHelp(buf.ReadString());
             break;
         }
@@ -470,6 +501,7 @@ public class DBOptionsAttributes extends AttributeSubject
         str = str + intVectorToString("optInts", optInts, indent) + "\n";
         str = str + stringVectorToString("optStrings", optStrings, indent) + "\n";
         str = str + intVectorToString("optEnums", optEnums, indent) + "\n";
+        str = str + intVectorToString("optColors", optColors, indent) + "\n";
         str = str + stringVectorToString("optMultiLineStrings", optMultiLineStrings, indent) + "\n";
         str = str + stringVectorToString("enumStrings", enumStrings, indent) + "\n";
         str = str + intVectorToString("enumStringsSizes", enumStringsSizes, indent) + "\n";
@@ -488,6 +520,7 @@ public class DBOptionsAttributes extends AttributeSubject
     private Vector optInts; // vector of Integer objects
     private Vector optStrings; // vector of String objects
     private Vector optEnums; // vector of Integer objects
+    private Vector optColors; // vector of Integer objects
     private Vector optMultiLineStrings; // vector of String objects
     private Vector enumStrings; // vector of String objects
     private Vector enumStringsSizes; // vector of Integer objects

--- a/src/tools/data/convert/convert.C
+++ b/src/tools/data/convert/convert.C
@@ -70,6 +70,9 @@ static void UsageAndExit(DatabasePluginManager *, const char *);
 //
 //    Kathleen Biagas, Tue Sep 13, 2022
 //    Support MultiLineString option type.
+// 
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Support Color option type.
 //
 // ****************************************************************************
 void

--- a/src/tools/data/convert/convert.C
+++ b/src/tools/data/convert/convert.C
@@ -108,10 +108,11 @@ FillOptionsFromCommandline(DBOptionsAttributes *opts)
           case DBOptionsAttributes::Color:
             if (PAR_Rank() == 0)
             {
-                ColorAttribute color = opts->GetColor(name);
+                int red, green, blue, alpha;
+                opts->GetColor(name, red, green, blue, alpha);
                 cerr << " (color as 'r g b [a]', default="
-                     << color.Red() << " " << color.Green() << " "
-                     << color.Blue() << " " << color.Alpha() << "):\n";
+                     << red << " " << green << " "
+                     << blue << " " << alpha << "):\n";
             }
             break;
           case DBOptionsAttributes::MultiLineString:
@@ -188,7 +189,7 @@ FillOptionsFromCommandline(DBOptionsAttributes *opts)
                 }
                 if (!(iss >> rgba[3]))
                     rgba[3] = 255;
-                opts->SetColor(name, ColorAttribute(rgba[0], rgba[1], rgba[2], rgba[3]));
+                opts->SetColor(name, rgba[0], rgba[1], rgba[2], rgba[3]);
                 if (PAR_Rank() == 0)
                     cerr << "Set to new value " << rgba[0] << " "
                          << rgba[1] << " " << rgba[2] << " "

--- a/src/tools/data/convert/convert.C
+++ b/src/tools/data/convert/convert.C
@@ -37,6 +37,7 @@
 
 #include <VisItException.h>
 #include <visitstream.h>
+#include <sstream>
 
 #include <string>
 #include <vector>
@@ -104,6 +105,15 @@ FillOptionsFromCommandline(DBOptionsAttributes *opts)
             if (PAR_Rank() == 0)
                 cerr << " (string, default='"<<opts->GetString(name)<<"'):\n";
             break;
+          case DBOptionsAttributes::Color:
+            if (PAR_Rank() == 0)
+            {
+                ColorAttribute color = opts->GetColor(name);
+                cerr << " (color as 'r g b [a]', default="
+                     << color.Red() << " " << color.Green() << " "
+                     << color.Blue() << " " << color.Alpha() << "):\n";
+            }
+            break;
           case DBOptionsAttributes::MultiLineString:
             if (PAR_Rank() == 0)
                 cerr << " (multi line string, default='"<<opts->GetMultiLineString(name)<<"'):\n";
@@ -164,6 +174,26 @@ FillOptionsFromCommandline(DBOptionsAttributes *opts)
             opts->SetString(name, buff);
             if (PAR_Rank() == 0)
                 cerr << "Set to new value "<<opts->GetString(name) << endl;
+            break;
+          case DBOptionsAttributes::Color:
+            {
+                std::istringstream iss(str);
+                int rgba[4] = {0, 0, 0, 255};
+                if (!(iss >> rgba[0] >> rgba[1] >> rgba[2]))
+                {
+                    if (PAR_Rank() == 0)
+                        cerr << "Invalid color input for '" << name
+                             << "'. Expected 'r g b [a]'" << endl;
+                    break;
+                }
+                if (!(iss >> rgba[3]))
+                    rgba[3] = 255;
+                opts->SetColor(name, ColorAttribute(rgba[0], rgba[1], rgba[2], rgba[3]));
+                if (PAR_Rank() == 0)
+                    cerr << "Set to new value " << rgba[0] << " "
+                         << rgba[1] << " " << rgba[2] << " "
+                         << rgba[3] << endl;
+            }
             break;
           case DBOptionsAttributes::MultiLineString:
             opts->SetMultiLineString(name, buff);
@@ -788,5 +818,3 @@ UsageAndExit(DatabasePluginManager *dbmgr, const char *argv0)
     PAR_Exit();
     exit(EXIT_FAILURE);
 }
-
-

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -1225,6 +1225,43 @@ FillDBOptionsFromDictionary(PyObject *obj, DBOptionsAttributes &opts)
                 return false;
             }
             break;
+          case DBOptionsAttributes::Color:
+            if (PyTuple_Check(value) || PyList_Check(value))
+            {
+                Py_ssize_t nvals = PySequence_Size(value);
+                if(nvals == 3 || nvals == 4)
+                {
+                    int rgba[4] = {0, 0, 0, 255};
+                    for(Py_ssize_t i = 0; i < nvals; ++i)
+                    {
+                        PyObject *item = PySequence_GetItem(value, i);
+                        if(item == NULL || !PyInt_Check(item))
+                        {
+                            Py_XDECREF(item);
+                            sprintf(msg, "Expected integer entries to set color '%s'", name.c_str());
+                            VisItErrorFunc(msg);
+                            return false;
+                        }
+                        rgba[i] = PyInt_AS_LONG(item);
+                        Py_DECREF(item);
+                    }
+                    opts.SetColor(name, ColorAttribute(rgba[0], rgba[1], rgba[2], rgba[3]));
+                }
+                else
+                {
+                    sprintf(msg, "Expected a 3- or 4-component sequence to set color '%s'",
+                            name.c_str());
+                    VisItErrorFunc(msg);
+                    return false;
+                }
+            }
+            else
+            {
+                sprintf(msg, "Expected a sequence to set color '%s'", name.c_str());
+                VisItErrorFunc(msg);
+                return false;
+            }
+            break;
           case DBOptionsAttributes::MultiLineString:
             if (PyString_Check(value))
             {
@@ -1378,6 +1415,18 @@ CreateDictionaryFromDBOptions(DBOptionsAttributes &opts)
             break;
           case DBOptionsAttributes::String:
             PyDict_SetItemString(dict,name,PyString_FromString(opts.GetString(name).c_str()));
+            break;
+          case DBOptionsAttributes::Color:
+            {
+                ColorAttribute color = opts.GetColor(name);
+                PyObject *tuple = Py_BuildValue("(iiii)",
+                                                color.Red(),
+                                                color.Green(),
+                                                color.Blue(),
+                                                color.Alpha());
+                PyDict_SetItemString(dict, name, tuple);
+                Py_DECREF(tuple);
+            }
             break;
           case DBOptionsAttributes::MultiLineString:
             PyDict_SetItemString(dict,name,PyString_FromString(opts.GetMultiLineString(name).c_str()));

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -1109,6 +1109,12 @@ void PickleInit()
 //    Chris Laganella, Mon Feb 14 14:37:24 EST 2022
 //    Support MultiLineString from DBOptionsAttributes
 //
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Now accepts color-valued DB options from Python as a 3- or 4-element
+//    integer sequence. It interprets them as (r, g, b) or (r, g, b, a), 
+//    defaults alpha to 255 if omitted, and stores the result into 
+//    DBOptionsAttributes.
+//
 // ****************************************************************************
 bool
 FillDBOptionsFromDictionary(PyObject *obj, DBOptionsAttributes &opts)
@@ -1387,6 +1393,10 @@ FillDBOptionsFromDictionary(PyObject *obj, DBOptionsAttributes &opts)
 //
 //    Kathleen Biagas, Tue Sept 13, 2022
 //    Support MultiLineString option type.
+// 
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Now exports color-valued DB options back to Python as a 4-tuple
+//    (r, g, b, a).
 //
 // ****************************************************************************
 PyObject *

--- a/src/visitpy/common/visitmodule.C
+++ b/src/visitpy/common/visitmodule.C
@@ -1245,7 +1245,7 @@ FillDBOptionsFromDictionary(PyObject *obj, DBOptionsAttributes &opts)
                         rgba[i] = PyInt_AS_LONG(item);
                         Py_DECREF(item);
                     }
-                    opts.SetColor(name, ColorAttribute(rgba[0], rgba[1], rgba[2], rgba[3]));
+                    opts.SetColor(name, rgba[0], rgba[1], rgba[2], rgba[3]);
                 }
                 else
                 {
@@ -1418,12 +1418,10 @@ CreateDictionaryFromDBOptions(DBOptionsAttributes &opts)
             break;
           case DBOptionsAttributes::Color:
             {
-                ColorAttribute color = opts.GetColor(name);
+                int red, green, blue, alpha;
+                opts.GetColor(name, red, green, blue, alpha);
                 PyObject *tuple = Py_BuildValue("(iiii)",
-                                                color.Red(),
-                                                color.Green(),
-                                                color.Blue(),
-                                                color.Alpha());
+                                                red, green, blue, alpha);
                 PyDict_SetItemString(dict, name, tuple);
                 Py_DECREF(tuple);
             }

--- a/src/visitpy/visitpy/PyDBOptionsAttributes.C
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes.C
@@ -106,6 +106,7 @@ DBOptionsAttributes_dir(PyObject *self, PyObject *args)
         if (i == 9) continue; // internal field
         if (i == 10) continue; // internal field
         if (i == 11) continue; // internal field
+        if (i == 12) continue; // internal field
         PyList_Append(dir_list, PyUnicode_FromString(atts.GetFieldName(i).c_str()));
     }
 

--- a/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
@@ -56,12 +56,10 @@ PyDBOptionsAttributes_CreateDictionaryFromDBOptions(const DBOptionsAttributes &o
             break;
           case DBOptionsAttributes::Color:
             {
-                ColorAttribute color = opts.GetColor(name);
+                int red, green, blue, alpha;
+                opts.GetColor(name, red, green, blue, alpha);
                 PyObject *tuple = Py_BuildValue("(iiii)",
-                                                color.Red(),
-                                                color.Green(),
-                                                color.Blue(),
-                                                color.Alpha());
+                                                red, green, blue, alpha);
                 PyDict_SetItemString(dict, name, tuple);
                 Py_DECREF(tuple);
             }

--- a/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
@@ -54,6 +54,18 @@ PyDBOptionsAttributes_CreateDictionaryFromDBOptions(const DBOptionsAttributes &o
           case DBOptionsAttributes::String:
             PyDict_SetItemString(dict,name,PyString_FromString(opts.GetString(name).c_str()));
             break;
+          case DBOptionsAttributes::Color:
+            {
+                ColorAttribute color = opts.GetColor(name);
+                PyObject *tuple = Py_BuildValue("(iiii)",
+                                                color.Red(),
+                                                color.Green(),
+                                                color.Blue(),
+                                                color.Alpha());
+                PyDict_SetItemString(dict, name, tuple);
+                Py_DECREF(tuple);
+            }
+            break;
           case DBOptionsAttributes::MultiLineString:
             PyDict_SetItemString(dict,name,PyString_FromString(opts.GetMultiLineString(name).c_str()));
             break;
@@ -108,4 +120,3 @@ PyDBOptionsAttributes_CreateDictionaryStringFromDBOptions(const DBOptionsAttribu
     Py_DECREF(py_opts_repr);
     return res;
 }
-

--- a/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
+++ b/src/visitpy/visitpy/PyDBOptionsAttributes_Helpers.C
@@ -24,6 +24,12 @@
 //    Kathleen Biagas, Tue Sep 13, 2022
 //    Support MultiLineString option type.
 //
+//    Justin Privitera, Mon Jul 20 16:40:22 PDT 2026
+//    Now handles the new DBOptionsAttributes::Color option type. For color
+//    options, instead of ignoring them or failing, it reads the RGBA
+//    components from DBOptionsAttributes and inserts a Python 4-tuple 
+//    (r, g, b, a) into the returned dictionary.
+//
 // ****************************************************************************
 
 PyObject *


### PR DESCRIPTION
### Description

Resolves #20779 <!-- If this PR is unrelated to a ticket, please erase this line -->

<!-- Please include a summary of the change and any other information and instructions to help reviewers understand the work -->


# DRAFT DRAFT DRAFT DRAFT DRAFT

 - Adds a color type to the DBOptions.
 - Adds new options to the WavefrontOBJ writer as shown below
<img width="284" height="350" alt="image" src="https://github.com/user-attachments/assets/9aa89e7f-e4ee-4341-98de-2abc0b1b8164" />

 - TODO adds tests

I decided not to plumb options from pseudocolor plots to the wavefrontOBJ writer because...

> The OBJ writer naturally receives exported data plus DBOptionsAttributes. It does not naturally receive plot attributes. Trying to “steal” values from the active pseudocolor plot means pushing plot-specific state through generic viewer/export code, which creates layering problems and ambiguous behavior.

> The main issues with stealing from the plot are:

> - the export path is not plot-attribute-driven;
> - viewer core should not depend on pseudocolor-specific attributes just to configure a writer;
> - it becomes unclear which plot should win if multiple plots are involved;
> - non-pseudocolor exports need fallback behavior anyway;
> - it ties OBJ export behavior to current GUI plot state in a fragile way.

> By putting the settings in export options instead:

> - the configuration lives exactly where the writer already expects it;
> - the behavior is explicit and reproducible;
> - GUI, CLI, Python, and other DB-options consumers all use the same mechanism;
> - we avoid extra coupling between viewer core and plot plugins.


<!-- Note that all the checklist items in various bulleted lists below end with ~~ characters.
     This is to facilitate striking them out when they do not apply.
     One just has to add ~~ characters just before the opening square bracket [ -->

### Type of change

<!-- Please check one of the boxes below -->

* [ ] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->
TODO add tests
TODO test this with powerpoint import

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [ ] I have commented my code where applicable.~~
- [ ] I have updated the release notes.~~
- [ ] I have made corresponding changes to the documentation.~~
- [ ] I have added debugging support to my changes.~~
- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- [ ] I have added new baselines for any new tests to the repo.~~
- [ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
