### PR TITLE
Make vtkVisItTubeFilter a subclass of vtkTubeFilter

### DIFF
--- a/src/operators/Tube/avtTubeFilter.C
+++ b/src/operators/Tube/avtTubeFilter.C
@@ -162,6 +162,9 @@ avtTubeFilter::Equivalent(const AttributeGroup *a)
 //    Eric Brugger, Tue Aug 19 09:45:37 PDT 2014
 //    Modified the class to work with avtDataRepresentation.
 //
+//    Kathleen Biagas, Tue July 21, 2026
+//    Fix potential leak with ugridAsPD.
+//
 // ****************************************************************************
 
 avtDataRepresentation *
@@ -193,7 +196,7 @@ avtTubeFilter::ExecuteData(avtDataRepresentation *in_dr)
     if (in_ds->GetDataObjectType() == VTK_UNSTRUCTURED_GRID)
     {
         vtkUnstructuredGrid *ugrid = (vtkUnstructuredGrid *) in_ds;
-        vtkPolyData *ugridAsPD = vtkPolyData::New();
+        ugridAsPD = vtkPolyData::New();
         ugridAsPD->SetPoints(ugrid->GetPoints());
         ugridAsPD->GetPointData()->ShallowCopy(ugrid->GetPointData());
         ugridAsPD->GetCellData()->ShallowCopy(ugrid->GetCellData());

--- a/src/visit_vtk/full/vtkVisItTubeFilter.C
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.C
@@ -1,52 +1,50 @@
-/*=========================================================================
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
 
-Program:   Visualization Toolkit
-Module:    $RCSfile: vtkVisItTubeFilter.cxx,v $
-
-Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
-All rights reserved.
-See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notice for more information.
-
-=========================================================================*/
 #include "vtkVisItTubeFilter.h"
-#include "vtkCellArray.h"
-#include "vtkCellArrayIterator.h"
-#include "vtkCellData.h"
-#include "vtkFloatArray.h"
-#include "vtkMath.h"
-#include "vtkInformation.h"
-#include "vtkInformationVector.h"
-#include "vtkObjectFactory.h"
-#include "vtkPointData.h"
-#include "vtkPolyData.h"
-#include "vtkPolyLine.h"
+#include <vtkCellArray.h>
+#include <vtkCellArrayIterator.h>
+#include <vtkCellData.h>
+#include <vtkFloatArray.h>
+#include <vtkMath.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkPolyLine.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace
+{
+
+struct IdPointsEqual
+{
+    IdPointsEqual(vtkPoints *points)
+        : Points(points)
+    {
+    }
+
+    bool operator()(vtkIdType id1, vtkIdType id2) const
+    {
+        double p1[3], p2[3];
+        this->Points->GetPoint(id1, p1);
+        this->Points->GetPoint(id2, p2);
+        return (p1[0] == p2[0] && p1[1] == p2[1] && p1[2] == p2[2]);
+    }
+
+    vtkPoints *Points;
+};
+
+}
 
 vtkStandardNewMacro(vtkVisItTubeFilter);
 
-// Construct object with radius 0.5, radius variation turned off, the number
-// of sides set to 3, and radius factor of 10.
 vtkVisItTubeFilter::vtkVisItTubeFilter()
 {
-    this->Radius = 0.5;
-    this->VaryRadius = VTK_VARY_RADIUS_OFF;
-    this->NumberOfSides = 3;
-    this->RadiusFactor = 10;
-
-    this->DefaultNormal[0] = this->DefaultNormal[1] = 0.0;
-    this->DefaultNormal[2] = 1.0;
-
-    this->UseDefaultNormal = false;
-    this->SidesShareVertices = true;
-    this->Capping = false;
-    this->OnRatio = 1;
-    this->Offset = 0;
-
-    this->GenerateTCoords = VTK_TCOORDS_OFF;
-    this->TextureLength = 1.0;
     this->ScalarsForRadius = nullptr;
 }
 
@@ -65,9 +63,11 @@ vtkVisItTubeFilter::~vtkVisItTubeFilter()
 //    Kathleen Biagas, Thu Aug 11, 2022
 //    Support VTK9, use vtkCellArrayIterator and const for pts.
 //
+//    Kathleen Biagas, Mon July 20, 2026
+//    Update with improvements/changes from vtk9.5 version of vtkTubeFilter.
+//
 
-int vtkVisItTubeFilter::RequestData(
-                                    vtkInformation *vtkNotUsed(request),
+int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
                                     vtkInformationVector **inputVector,
                                     vtkInformationVector *outputVector)
 {
@@ -77,9 +77,9 @@ int vtkVisItTubeFilter::RequestData(
 
     // get the input and ouptut
     vtkPolyData *input = vtkPolyData::SafeDownCast(
-                                                   inInfo->Get(vtkDataObject::DATA_OBJECT()));
+        inInfo->Get(vtkDataObject::DATA_OBJECT()));
     vtkPolyData *output = vtkPolyData::SafeDownCast(
-                                                    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+        outInfo->Get(vtkDataObject::DATA_OBJECT()));
 
     vtkPointData *pd=input->GetPointData();
     vtkPointData *outPD=output->GetPointData();
@@ -111,7 +111,7 @@ int vtkVisItTubeFilter::RequestData(
     const vtkIdType *pts=nullptr;
     vtkIdType offset=0;
     vtkFloatArray *newTCoords=nullptr;
-    int abort=0;
+    bool abort = false;
     vtkIdType inCellId;
     double oldRadius=1.0;
 
@@ -129,7 +129,19 @@ int vtkVisItTubeFilter::RequestData(
 
     // Create the geometry and topology
     numNewPts = numPts * this->NumberOfSides;
-    newPts = vtkPoints::New(inPts->GetDataType());
+    newPts = vtkPoints::New();
+    if (this->OutputPointsPrecision == vtkAlgorithm::DEFAULT_PRECISION)
+    {
+        newPts->SetDataType(inPts->GetDataType());
+    }
+    else if (this->OutputPointsPrecision == vtkAlgorithm::SINGLE_PRECISION)
+    {
+        newPts->SetDataType(VTK_FLOAT);
+    }
+    else if (this->OutputPointsPrecision == vtkAlgorithm::DOUBLE_PRECISION)
+    {
+        newPts->SetDataType(VTK_DOUBLE);
+    }
     newPts->Allocate(numNewPts);
     newNormals = vtkFloatArray::New();
     newNormals->SetName("TubeNormals");
@@ -141,7 +153,7 @@ int vtkVisItTubeFilter::RequestData(
 
     // Point data: copy scalars, vectors, tcoords. Normals may be computed here.
     outPD->CopyNormalsOff();
-    if ( (this->GenerateTCoords == VTK_TCOORDS_FROM_SCALARS && inScalars) ||
+    if ( (this->GenerateTCoords == VTK_TCOORDS_FROM_SCALARS && inScalars && !cellScalars) ||
          this->GenerateTCoords == VTK_TCOORDS_FROM_LENGTH ||
          this->GenerateTCoords == VTK_TCOORDS_FROM_NORMALIZED_LENGTH )
     {
@@ -216,13 +228,21 @@ int vtkVisItTubeFilter::RequestData(
     //
     this->Theta = 2.0*vtkMath::Pi() / this->NumberOfSides;
     vtkPolyLine *lineNormalGenerator = vtkPolyLine::New();
+    inCellId = input->GetNumberOfVerts();
+    int checkAbortInterval = std::min(numLines / 10 + 1, (vtkIdType)1000);
+    int progressCounter = 0;
     auto iter = vtk::TakeSmartPointer(inLines->NewIterator());
-    for (iter->GoToFirstCell(); !iter->IsDoneWithTraversal() && !abort; iter->GoToNextCell())
+    for (iter->GoToFirstCell(); !iter->IsDoneWithTraversal() && !abort;
+         iter->GoToNextCell(), inCellId++)
     {
-        inCellId = iter->GetCurrentCellId();
         iter->GetCurrentCell(npts, pts);
-        this->UpdateProgress((double)inCellId/numLines);
-        abort = this->GetAbortExecute();
+        this->UpdateProgress((double)progressCounter / numLines);
+        if (progressCounter % checkAbortInterval == 0 && this->CheckAbort())
+        {
+            abort = this->CheckAbort();
+            break;
+        }
+        progressCounter++;
 
         if (npts < 2)
         {
@@ -230,12 +250,21 @@ int vtkVisItTubeFilter::RequestData(
             continue; //skip tubing this polyline
         }
 
+        std::vector<vtkIdType> ptsCopy(pts, pts + npts);
+        vtkIdType *ptsPtr = ptsCopy.data();
+        npts = static_cast<vtkIdType>(
+            std::unique(ptsPtr, ptsPtr + npts, IdPointsEqual(inPts)) - ptsPtr);
+        if (npts < 2)
+        {
+            continue; // skip tubing this polyline
+        }
+
         // If necessary calculate normals, each polyline calculates its
         // normals independently, avoiding conflicts at shared vertices.
         if (generateNormals)
         {
             singlePolyline->Reset(); //avoid instantiation
-            singlePolyline->InsertNextCell(npts,pts);
+            singlePolyline->InsertNextCell(npts,ptsPtr);
             if ( !lineNormalGenerator->GenerateSlidingNormals(inPts,singlePolyline,
                                                               inNormals) )
             {
@@ -249,7 +278,7 @@ int vtkVisItTubeFilter::RequestData(
         // if the polyline is bad.
         //
         if ( !this->GeneratePoints(offset,inCellId,
-                                   npts,pts,inPts,newPts,pd,outPD,
+                                   npts,ptsPtr,inPts,newPts,pd,outPD,
                                    newNormals,
                                    inScalars, cellScalars,
                                    range,inVectors,
@@ -261,13 +290,13 @@ int vtkVisItTubeFilter::RequestData(
 
         // Generate the strips for this polyline (including caps)
         //
-        this->GenerateStrips(offset,npts,pts,inCellId,cd,outCD,newStrips);
+        this->GenerateStrips(offset,npts,ptsPtr,inCellId,cd,outCD,newStrips);
 
         // Generate the texture coordinates for this polyline
         //
         if ( newTCoords )
         {
-            this->GenerateTextureCoords(offset,npts,pts,inPts,
+            this->GenerateTextureCoords(offset,npts,ptsPtr,inPts,
                                         inScalars,cellScalars,
                                         newTCoords);
         }
@@ -460,6 +489,12 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
                 sFactor = this->RadiusFactor;
             }
         }
+        else if ( inVectors && this->VaryRadius == VTK_VARY_RADIUS_BY_VECTOR_NORM )
+        {
+            sFactor = 1.0 + ((this->RadiusFactor - 1.0) *
+                             vtkMath::Norm(inVectors->GetTuple(pts[j])) /
+                             maxSpeed);
+        }
         else if ( inScalars &&
                   this->VaryRadius == VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR )
         {
@@ -561,113 +596,6 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
     return 1;
 }
 
-//
-// Modifications:
-//    Kathleen Biagas, Thu Aug 11, 2022
-//    Support VTK9, change pts arg to const.
-//
-void vtkVisItTubeFilter::GenerateStrips(vtkIdType offset, vtkIdType npts,
-                                        const vtkIdType* vtkNotUsed(pts),
-                                        vtkIdType inCellId,
-                                        vtkCellData *cd, vtkCellData *outCD,
-                                        vtkCellArray *newStrips)
-{
-    vtkIdType i, outCellId;
-    int k;
-    int i1, i2, i3;
-
-    if (this->SidesShareVertices)
-    {
-        for (k=this->Offset; k<(this->NumberOfSides+this->Offset);
-             k+=this->OnRatio)
-        {
-            i1 = k % this->NumberOfSides;
-            i2 = (k+1) % this->NumberOfSides;
-            outCellId = newStrips->InsertNextCell(npts*2);
-            outCD->CopyData(cd,inCellId,outCellId);
-            for (i=0; i < npts; i++)
-            {
-                i3 = i*this->NumberOfSides;
-                newStrips->InsertCellPoint(offset+i2+i3);
-                newStrips->InsertCellPoint(offset+i1+i3);
-            }
-        } //for each side of the tube
-    }
-    else
-    {
-        for (k=this->Offset; k<(this->NumberOfSides+this->Offset);
-             k+=this->OnRatio)
-        {
-            i1 = 2*(k % this->NumberOfSides) + 1;
-            i2 = 2*((k+1) % this->NumberOfSides);
-            outCellId = newStrips->InsertNextCell(npts*2);
-            outCD->CopyData(cd,inCellId,outCellId);
-            for (i=0; i < npts; i++)
-            {
-                i3 = i*2*this->NumberOfSides;
-                newStrips->InsertCellPoint(offset+i2+i3);
-                newStrips->InsertCellPoint(offset+i1+i3);
-            }
-        } //for each side of the tube
-    }
-
-    // Take care of capping. The caps are n-sided polygons that can be
-    // easily triangle stripped.
-    if (this->Capping)
-    {
-        vtkIdType startIdx = offset + npts*this->NumberOfSides;
-        vtkIdType idx;
-
-        if ( ! this->SidesShareVertices )
-        {
-            startIdx = offset + 2*npts*this->NumberOfSides;
-        }
-
-        //The start cap
-        outCellId = newStrips->InsertNextCell(this->NumberOfSides);
-        outCD->CopyData(cd,inCellId,outCellId);
-        newStrips->InsertCellPoint(startIdx);
-        newStrips->InsertCellPoint(startIdx+1);
-        for (i1=this->NumberOfSides-1, i2=2, k=0; k<(this->NumberOfSides-2); k++)
-        {
-            if ( (k%2) )
-            {
-                idx = startIdx + i2;
-                newStrips->InsertCellPoint(idx);
-                i2++;
-            }
-            else
-            {
-                idx = startIdx + i1;
-                newStrips->InsertCellPoint(idx);
-                i1--;
-            }
-        }
-
-        //The end cap - reversed order to be consistent with normal
-        startIdx += this->NumberOfSides;
-        outCellId = newStrips->InsertNextCell(this->NumberOfSides);
-        outCD->CopyData(cd,inCellId,outCellId);
-        newStrips->InsertCellPoint(startIdx);
-        newStrips->InsertCellPoint(startIdx+this->NumberOfSides-1);
-        for (i1=this->NumberOfSides-2, i2=1, k=0; k<(this->NumberOfSides-2); k++)
-        {
-            if ( (k%2) )
-            {
-                idx = startIdx + i1;
-                newStrips->InsertCellPoint(idx);
-                i1--;
-            }
-            else
-            {
-                idx = startIdx + i2;
-                newStrips->InsertCellPoint(idx);
-                i2++;
-            }
-        }
-    }
-}
-
 //   Jeremy Meredith, Wed May 26 14:52:29 EDT 2010
 //   Allow cell scalars for tube radius.
 //   We don't support them for texture coordinates, but we need to
@@ -676,6 +604,9 @@ void vtkVisItTubeFilter::GenerateStrips(vtkIdType offset, vtkIdType npts,
 //
 //   Kathleen Biagas, Thu Aug 11, 2022
 //   Support VTK9, change pts arg to const.
+//
+//   Kathleen Biagas, Mon July 20, 2026
+//   Update with improvements/changes from vtk9.5 version of vtkTubeFilter.
 //
 void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
                                                vtkIdType npts, const vtkIdType *pts,
@@ -701,10 +632,15 @@ void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
     //The first texture coordinate is always 0.
     for ( k=0; k < numSides; k++)
     {
-        newTCoords->InsertTuple2(offset+k,0.0,0.0);
+        double tcy = static_cast<double>(k) / (numSides - 1);
+        newTCoords->InsertTuple2(offset+k,0.0,tcy);
     }
     if ( this->GenerateTCoords == VTK_TCOORDS_FROM_SCALARS )
     {
+        if (inScalars == nullptr)
+        {
+            return;
+        }
         s0 = inScalars->GetTuple1(pts[0]);
         for (i=1; i < npts; i++)
         {
@@ -712,7 +648,8 @@ void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
             tc = (s - s0) / this->TextureLength;
             for ( k=0; k < numSides; k++)
             {
-                newTCoords->InsertTuple2(offset+i*numSides+k,tc,0.0);
+                double tcy = static_cast<double>(k) / (numSides - 1);
+                newTCoords->InsertTuple2(offset+i*numSides+k,tc,tcy);
             }
         }
     }
@@ -727,7 +664,8 @@ void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
             tc = len / this->TextureLength;
             for ( k=0; k < numSides; k++)
             {
-                newTCoords->InsertTuple2(offset+i*numSides+k,tc,0.0);
+                double tcy = static_cast<double>(k) / (numSides - 1);
+                newTCoords->InsertTuple2(offset+i*numSides+k,tc,tcy);
             }
             xPrev[0]=x[0]; xPrev[1]=x[1]; xPrev[2]=x[2];
         }
@@ -751,7 +689,8 @@ void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
             tc = len / length;
             for ( k=0; k < numSides; k++)
             {
-                newTCoords->InsertTuple2(offset+i*2+k,tc,0.0);
+                double tcy = static_cast<double>(k) / (numSides - 1);
+                newTCoords->InsertTuple2(offset+i*numSides+k,tc,tcy);
             }
             xPrev[0]=x[0]; xPrev[1]=x[1]; xPrev[2]=x[2];
         }
@@ -777,90 +716,9 @@ void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
     }
 }
 
-// Compute the number of points in this tube
-vtkIdType vtkVisItTubeFilter::ComputeOffset(vtkIdType offset, vtkIdType npts)
-{
-    if ( this->SidesShareVertices )
-    {
-        offset += this->NumberOfSides * npts;
-    }
-    else
-    {
-        offset += 2 * this->NumberOfSides * npts; //points are duplicated
-    }
-
-    if ( this->Capping )
-    {
-        offset += 2*this->NumberOfSides; //cap points are duplicated
-    }
-
-    return offset;
-}
-
-// Description:
-// Return the method of varying tube radius descriptive character string.
-const char *vtkVisItTubeFilter::GetVaryRadiusAsString(void)
-{
-    if ( this->VaryRadius == VTK_VARY_RADIUS_OFF )
-    {
-        return "VaryRadiusOff";
-    }
-    else if ( this->VaryRadius == VTK_VARY_RADIUS_BY_SCALAR )
-    {
-        return "VaryRadiusByScalar";
-    }
-    else if ( this->VaryRadius == VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR )
-    {
-        return "VaryRadiusByAbsoluteScalar";
-    }
-    else
-    {
-        return "VaryRadiusByVector";
-    }
-}
-
-// Description:
-// Return the method of generating the texture coordinates.
-const char *vtkVisItTubeFilter::GetGenerateTCoordsAsString(void)
-{
-    if ( this->GenerateTCoords == VTK_TCOORDS_OFF )
-    {
-        return "GenerateTCoordsOff";
-    }
-    else if ( this->GenerateTCoords == VTK_TCOORDS_FROM_SCALARS )
-    {
-        return "GenerateTCoordsFromScalar";
-    }
-    else if ( this->GenerateTCoords == VTK_TCOORDS_FROM_LENGTH )
-    {
-        return "GenerateTCoordsFromLength";
-    }
-    else
-    {
-        return "GenerateTCoordsFromNormalizedLength";
-    }
-}
-
 void vtkVisItTubeFilter::PrintSelf(ostream& os, vtkIndent indent)
 {
     this->Superclass::PrintSelf(os,indent);
-
-    os << indent << "Radius: " << this->Radius << "\n";
-    os << indent << "Vary Radius: " << this->GetVaryRadiusAsString() << endl;
-    os << indent << "Radius Factor: " << this->RadiusFactor << "\n";
-    os << indent << "Number Of Sides: " << this->NumberOfSides << "\n";
-    os << indent << "On Ratio: " << this->OnRatio << "\n";
-    os << indent << "Offset: " << this->Offset << "\n";
-
-    os << indent << "Use Default Normal: "
-       << (this->UseDefaultNormal ? "On\n" : "Off\n");
-    os << indent << "Sides Share Vertices: "
-       << (this->SidesShareVertices ? "On\n" : "Off\n");
-    os << indent << "Default Normal: " << "( " << this->DefaultNormal[0] <<
-        ", " << this->DefaultNormal[1] << ", " << this->DefaultNormal[2] <<
-        " )\n";
-    os << indent << "Capping: " << (this->Capping ? "On\n" : "Off\n");
-    os << indent << "Generate TCoords: "
-       << this->GetGenerateTCoordsAsString() << endl;
-    os << indent << "Texture Length: " << this->TextureLength << endl;
+    os << indent << "Scalars For Radius: "
+       << (this->ScalarsForRadius ? this->ScalarsForRadius : "(none)") << endl;
 }

--- a/src/visit_vtk/full/vtkVisItTubeFilter.C
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.C
@@ -41,7 +41,7 @@ struct IdPointsEqual
 
 }
 
-vtkStandardNewMacro(vtkVisItTubeFilter);
+vtkStandardNewMacro(vtkVisItTubeFilter)
 
 vtkVisItTubeFilter::vtkVisItTubeFilter()
 {
@@ -148,7 +148,7 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
     newNormals->SetNumberOfComponents(3);
     newNormals->Allocate(3*numNewPts);
     newStrips = vtkCellArray::New();
-    newStrips->Allocate(newStrips->EstimateSize(1,numNewPts));
+    newStrips->AllocateEstimate(1,numNewPts);
     vtkCellArray *singlePolyline = vtkCellArray::New();
 
     // Point data: copy scalars, vectors, tcoords. Normals may be computed here.
@@ -229,14 +229,14 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
     this->Theta = 2.0*vtkMath::Pi() / this->NumberOfSides;
     vtkPolyLine *lineNormalGenerator = vtkPolyLine::New();
     inCellId = input->GetNumberOfVerts();
-    int checkAbortInterval = std::min(numLines / 10 + 1, (vtkIdType)1000);
+    int checkAbortInterval = std::min(static_cast<int>(numLines) / 10 + 1, 1000);
     int progressCounter = 0;
     auto iter = vtk::TakeSmartPointer(inLines->NewIterator());
     for (iter->GoToFirstCell(); !iter->IsDoneWithTraversal() && !abort;
          iter->GoToNextCell(), inCellId++)
     {
         iter->GetCurrentCell(npts, pts);
-        this->UpdateProgress((double)progressCounter / numLines);
+        this->UpdateProgress(static_cast<double>(progressCounter) / static_cast<double>(numLines));
         if (progressCounter % checkAbortInterval == 0 && this->CheckAbort())
         {
             abort = this->CheckAbort();
@@ -483,7 +483,7 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
         else if ( inVectors && this->VaryRadius == VTK_VARY_RADIUS_BY_VECTOR )
         {
             sFactor =
-                sqrt((double)maxSpeed/vtkMath::Norm(inVectors->GetTuple(pts[j])));
+                sqrt(maxSpeed/vtkMath::Norm(inVectors->GetTuple(pts[j])));
             if ( sFactor > this->RadiusFactor )
             {
                 sFactor = this->RadiusFactor;
@@ -515,8 +515,8 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
             {
                 for (i=0; i<3; i++)
                 {
-                    normal[i] = w[i]*cos((double)k*this->Theta) +
-                        nP[i]*sin((double)k*this->Theta);
+                    normal[i] = w[i]*cos(k*this->Theta) +
+                        nP[i]*sin(k*this->Theta);
                     s[i] = p[i] + this->Radius * sFactor * normal[i];
                 }
                 newPts->InsertPoint(ptId,s);
@@ -538,12 +538,12 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
                     // polygonal appearance, as if by flat-shading around the tube,
                     // while still allowing smooth (gouraud) shading along the
                     // tube as it bends.
-                    normal[i]  = w[i]*cos((double)(k+0.0)*this->Theta) +
-                        nP[i]*sin((double)(k+0.0)*this->Theta);
-                    n_right[i] = w[i]*cos((double)(k-0.5)*this->Theta) +
-                        nP[i]*sin((double)(k-0.5)*this->Theta);
-                    n_left[i]  = w[i]*cos((double)(k+0.5)*this->Theta) +
-                        nP[i]*sin((double)(k+0.5)*this->Theta);
+                    normal[i]  = w[i]*cos((k+0.0)*this->Theta) +
+                        nP[i]*sin((k+0.0)*this->Theta);
+                    n_right[i] = w[i]*cos((k-0.5)*this->Theta) +
+                        nP[i]*sin((k-0.5)*this->Theta);
+                    n_left[i]  = w[i]*cos((k+0.5)*this->Theta) +
+                        nP[i]*sin((k+0.5)*this->Theta);
                     s[i] = p[i] + this->Radius * sFactor * normal[i];
                 }
                 newPts->InsertPoint(ptId,s);
@@ -578,10 +578,10 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
             ptId++;
         }
         //the end cap
-        int endOffset = offset + (npts-1)*this->NumberOfSides;
+        int endOffset = static_cast<int>(offset) + (static_cast<int>(npts)-1)*this->NumberOfSides;
         if ( ! this->SidesShareVertices )
         {
-            endOffset = offset + 2*(npts-1)*this->NumberOfSides;
+            endOffset = static_cast<int>(offset) + 2*(static_cast<int>(npts)-1)*this->NumberOfSides;
         }
         for (k=0; k < numCapSides; k+=capIncr)
         {

--- a/src/visit_vtk/full/vtkVisItTubeFilter.C
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.C
@@ -87,6 +87,7 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
     vtkCellData *outCD=output->GetCellData();
     vtkCellArray *inLines;
     vtkDataArray *inNormals;
+// begin VisIt change (handle cell scalars)
     vtkDataArray *inScalars = pd->GetScalars(this->ScalarsForRadius);
 
     bool cellScalars = false;
@@ -96,6 +97,7 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
         inScalars = cd->GetScalars(this->ScalarsForRadius);
     }
     vtkDataArray *inVectors=pd->GetVectors();
+// end VisIt Change
 
     vtkPoints *inPts;
     vtkIdType numPts;
@@ -108,7 +110,7 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
     double range[2], maxSpeed=0;
     vtkCellArray *newStrips;
     vtkIdType npts=0;
-    const vtkIdType *pts=nullptr;
+    const vtkIdType* ptsOrig = nullptr;
     vtkIdType offset=0;
     vtkFloatArray *newTCoords=nullptr;
     bool abort = false;
@@ -153,7 +155,9 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
 
     // Point data: copy scalars, vectors, tcoords. Normals may be computed here.
     outPD->CopyNormalsOff();
+// begin VisIt change ( add cellScalars test)
     if ( (this->GenerateTCoords == VTK_TCOORDS_FROM_SCALARS && inScalars && !cellScalars) ||
+// end VisIt change
          this->GenerateTCoords == VTK_TCOORDS_FROM_LENGTH ||
          this->GenerateTCoords == VTK_TCOORDS_FROM_NORMALIZED_LENGTH )
     {
@@ -192,7 +196,9 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
     //
     if ( inScalars )
     {
+// begin VisIt change
         inScalars->GetRange(range,0);
+// end VisIt change
         if ((range[1] - range[0]) == 0.0)
         {
             if (this->VaryRadius == VTK_VARY_RADIUS_BY_SCALAR )
@@ -228,14 +234,12 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
     //
     this->Theta = 2.0*vtkMath::Pi() / this->NumberOfSides;
     vtkPolyLine *lineNormalGenerator = vtkPolyLine::New();
+    // the line cellIds start after the last vert cellId
     inCellId = input->GetNumberOfVerts();
     int checkAbortInterval = std::min(static_cast<int>(numLines) / 10 + 1, 1000);
     int progressCounter = 0;
-    auto iter = vtk::TakeSmartPointer(inLines->NewIterator());
-    for (iter->GoToFirstCell(); !iter->IsDoneWithTraversal() && !abort;
-         iter->GoToNextCell(), inCellId++)
+    for (inLines->InitTraversal(); inLines->GetNextCell(npts, ptsOrig) && !abort; inCellId++)
     {
-        iter->GetCurrentCell(npts, pts);
         this->UpdateProgress(static_cast<double>(progressCounter) / static_cast<double>(numLines));
         if (progressCounter % checkAbortInterval == 0 && this->CheckAbort())
         {
@@ -250,10 +254,11 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
             continue; //skip tubing this polyline
         }
 
-        std::vector<vtkIdType> ptsCopy(pts, pts + npts);
-        vtkIdType *ptsPtr = ptsCopy.data();
-        npts = static_cast<vtkIdType>(
-            std::unique(ptsPtr, ptsPtr + npts, IdPointsEqual(inPts)) - ptsPtr);
+        std::vector<vtkIdType> ptsCopy(ptsOrig, ptsOrig + npts);
+        vtkIdType* pts = ptsCopy.data();
+
+        // remove degenerate lines to avoid warnings
+        npts = static_cast<vtkIdType>(std::unique(pts, pts + npts, IdPointsEqual(inPts)) - pts);
         if (npts < 2)
         {
             continue; // skip tubing this polyline
@@ -264,25 +269,21 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
         if (generateNormals)
         {
             singlePolyline->Reset(); //avoid instantiation
-            singlePolyline->InsertNextCell(npts,ptsPtr);
-            if ( !lineNormalGenerator->GenerateSlidingNormals(inPts,singlePolyline,
-                                                              inNormals) )
-            {
-                vtkWarningMacro("Could not generate normals for line. "
-                                "Skipping to next.");
-                continue; //skip tubing this polyline
-            }
+            singlePolyline->InsertNextCell(npts, pts);
+            vtkPolyLine::GenerateSlidingNormals(inPts, singlePolyline, inNormals);
         }
 
         // Generate the points around the polyline. The tube is not stripped
         // if the polyline is bad.
         //
+// begin VisIt change (addition of inCellId, cellScalars)
         if ( !this->GeneratePoints(offset,inCellId,
-                                   npts,ptsPtr,inPts,newPts,pd,outPD,
+                                   npts,pts,inPts,newPts,pd,outPD,
                                    newNormals,
                                    inScalars, cellScalars,
                                    range,inVectors,
                                    maxSpeed,inNormals) )
+// end VisIt change
         {
             vtkWarningMacro(<< "Could not generate points!");
             continue; //skip tubing this polyline
@@ -290,14 +291,14 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
 
         // Generate the strips for this polyline (including caps)
         //
-        this->GenerateStrips(offset,npts,ptsPtr,inCellId,cd,outCD,newStrips);
+        this->GenerateStrips(offset,npts,pts,inCellId,cd,outCD,newStrips);
 
         // Generate the texture coordinates for this polyline
         //
         if ( newTCoords )
         {
-            this->GenerateTextureCoords(offset,npts,ptsPtr,inPts,
-                                        inScalars,cellScalars,
+            this->GenerateTextureCoords(offset,npts,pts,inPts,
+                                        inScalars,
                                         newTCoords);
         }
 
@@ -352,6 +353,7 @@ int vtkVisItTubeFilter::RequestData(vtkInformation *vtkNotUsed(request),
 //    Support VTK9, change pts arg to const.
 //
 
+// begin VisIt change (add inCellId, cellScalars)
 int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
                                        vtkIdType npts, const vtkIdType *pts,
                                        vtkPoints *inPts, vtkPoints *newPts,
@@ -361,12 +363,13 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
                                        double range[2],
                                        vtkDataArray *inVectors, double maxSpeed,
                                        vtkDataArray *inNormals)
+// end VisIt change
 {
     vtkIdType j;
     int i, k;
     double p[3];
     double pNext[3];
-    double sNext[3] = {0., 0., 0};
+    double sNext[3] = { 0.0, 0.0, 0.0 };
     double sPrev[3];
     double startCapNorm[3], endCapNorm[3];
     double n[3];
@@ -472,6 +475,7 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
         // Compute a scale factor based on scalars or vectors
         if ( inScalars && this->VaryRadius == VTK_VARY_RADIUS_BY_SCALAR )
         {
+// begin VisIt change (handle cellScalars)
             double value = (cellScalars ?
                             inScalars->GetComponent(inCellId,0) :
                             inScalars->GetComponent(pts[j],0));
@@ -479,11 +483,11 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
             sFactor = 1.0 + ((this->RadiusFactor - 1.0) *
                              (value - range[0])
                              / (range[1]-range[0]));
+// end VisIt change
         }
         else if ( inVectors && this->VaryRadius == VTK_VARY_RADIUS_BY_VECTOR )
         {
-            sFactor =
-                sqrt(maxSpeed/vtkMath::Norm(inVectors->GetTuple(pts[j])));
+            sFactor = sqrt(maxSpeed / vtkMath::Norm(inVectors->GetTuple(pts[j])));
             if ( sFactor > this->RadiusFactor )
             {
                 sFactor = this->RadiusFactor;
@@ -498,9 +502,11 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
         else if ( inScalars &&
                   this->VaryRadius == VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR )
         {
+// begin VisIt change (handle cell scalars)
             sFactor = (cellScalars ?
                        inScalars->GetComponent(inCellId,0) :
                        inScalars->GetComponent(pts[j],0));
+// end VisIt change
             if (sFactor < 0.0)
             {
                 vtkWarningMacro(<<"Scalar value less than zero, skipping line");
@@ -515,8 +521,7 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
             {
                 for (i=0; i<3; i++)
                 {
-                    normal[i] = w[i]*cos(k*this->Theta) +
-                        nP[i]*sin(k*this->Theta);
+                    normal[i] = w[i]*cos(k*this->Theta) + nP[i]*sin(k*this->Theta);
                     s[i] = p[i] + this->Radius * sFactor * normal[i];
                 }
                 newPts->InsertPoint(ptId,s);
@@ -594,126 +599,6 @@ int vtkVisItTubeFilter::GeneratePoints(vtkIdType offset, vtkIdType inCellId,
     }//if capping
 
     return 1;
-}
-
-//   Jeremy Meredith, Wed May 26 14:52:29 EDT 2010
-//   Allow cell scalars for tube radius.
-//   We don't support them for texture coordinates, but we need to
-//   know if inScalars is point- or cell-based so we know if we
-//   should ignore them.
-//
-//   Kathleen Biagas, Thu Aug 11, 2022
-//   Support VTK9, change pts arg to const.
-//
-//   Kathleen Biagas, Mon July 20, 2026
-//   Update with improvements/changes from vtk9.5 version of vtkTubeFilter.
-//
-void vtkVisItTubeFilter::GenerateTextureCoords(vtkIdType offset,
-                                               vtkIdType npts, const vtkIdType *pts,
-                                               vtkPoints *inPts,
-                                               vtkDataArray *inScalars_,
-                                               bool cellScalars,
-                                               vtkFloatArray *newTCoords)
-{
-    vtkIdType i;
-    int k;
-    double tc=0.0;
-
-    // We only handle point-centered scalars
-    vtkDataArray *inScalars = cellScalars ? nullptr : inScalars_;
-
-    int numSides = this->NumberOfSides;
-    if ( ! this->SidesShareVertices )
-    {
-        numSides = 2 * this->NumberOfSides;
-    }
-
-    double s0, s;
-    //The first texture coordinate is always 0.
-    for ( k=0; k < numSides; k++)
-    {
-        double tcy = static_cast<double>(k) / (numSides - 1);
-        newTCoords->InsertTuple2(offset+k,0.0,tcy);
-    }
-    if ( this->GenerateTCoords == VTK_TCOORDS_FROM_SCALARS )
-    {
-        if (inScalars == nullptr)
-        {
-            return;
-        }
-        s0 = inScalars->GetTuple1(pts[0]);
-        for (i=1; i < npts; i++)
-        {
-            s = inScalars->GetTuple1(pts[i]);
-            tc = (s - s0) / this->TextureLength;
-            for ( k=0; k < numSides; k++)
-            {
-                double tcy = static_cast<double>(k) / (numSides - 1);
-                newTCoords->InsertTuple2(offset+i*numSides+k,tc,tcy);
-            }
-        }
-    }
-    else if ( this->GenerateTCoords == VTK_TCOORDS_FROM_LENGTH )
-    {
-        double xPrev[3], x[3], len=0.0;
-        inPts->GetPoint(pts[0],xPrev);
-        for (i=1; i < npts; i++)
-        {
-            inPts->GetPoint(pts[i],x);
-            len += sqrt(vtkMath::Distance2BetweenPoints(x,xPrev));
-            tc = len / this->TextureLength;
-            for ( k=0; k < numSides; k++)
-            {
-                double tcy = static_cast<double>(k) / (numSides - 1);
-                newTCoords->InsertTuple2(offset+i*numSides+k,tc,tcy);
-            }
-            xPrev[0]=x[0]; xPrev[1]=x[1]; xPrev[2]=x[2];
-        }
-    }
-    else if ( this->GenerateTCoords == VTK_TCOORDS_FROM_NORMALIZED_LENGTH )
-    {
-        double xPrev[3], x[3], length=0.0, len=0.0;
-        inPts->GetPoint(pts[0],xPrev);
-        for (i=1; i < npts; i++)
-        {
-            inPts->GetPoint(pts[i],x);
-            length += sqrt(vtkMath::Distance2BetweenPoints(x,xPrev));
-            xPrev[0]=x[0]; xPrev[1]=x[1]; xPrev[2]=x[2];
-        }
-
-        inPts->GetPoint(pts[0],xPrev);
-        for (i=1; i < npts; i++)
-        {
-            inPts->GetPoint(pts[i],x);
-            len += sqrt(vtkMath::Distance2BetweenPoints(x,xPrev));
-            tc = len / length;
-            for ( k=0; k < numSides; k++)
-            {
-                double tcy = static_cast<double>(k) / (numSides - 1);
-                newTCoords->InsertTuple2(offset+i*numSides+k,tc,tcy);
-            }
-            xPrev[0]=x[0]; xPrev[1]=x[1]; xPrev[2]=x[2];
-        }
-    }
-
-    // Capping, set the endpoints as appropriate
-    if ( this->Capping )
-    {
-        int ik;
-        vtkIdType startIdx = offset + npts*numSides;
-
-        //start cap
-        for (ik=0; ik < this->NumberOfSides; ik++)
-        {
-            newTCoords->InsertTuple2(startIdx+ik,0.0,0.0);
-        }
-
-        //end cap
-        for (ik=0; ik < this->NumberOfSides; ik++)
-        {
-            newTCoords->InsertTuple2(startIdx+this->NumberOfSides+ik,tc,0.0);
-        }
-    }
 }
 
 void vtkVisItTubeFilter::PrintSelf(ostream& os, vtkIndent indent)

--- a/src/visit_vtk/full/vtkVisItTubeFilter.h
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.h
@@ -8,6 +8,11 @@
 #include <vtkTubeFilter.h>
 #include <visit_vtk_exports.h>
 
+//****************************************************************************
+// Purpose:  a Tube filter that expands vtkTubeFilter to allow scaling by
+//           cell scalars, and specification by name of the scalars to be
+//           used for scaling radius.
+//
 // Modifications:
 //   Jeremy Meredith, Wed May 26 14:52:29 EDT 2010
 //   Allow cell scalars for tube radius.

--- a/src/visit_vtk/full/vtkVisItTubeFilter.h
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.h
@@ -52,12 +52,6 @@ protected:
                      double range[2], vtkDataArray *inVectors, double maxNorm,
                      vtkDataArray *inNormals);
 
-  void GenerateTextureCoords(vtkIdType offset, vtkIdType npts,
-                             const vtkIdType *pts,
-                             vtkPoints *inPts,
-                             vtkDataArray *inScalars, bool cellScalars,
-                            vtkFloatArray *newTCoords);
-
 private:
   vtkVisItTubeFilter(const vtkVisItTubeFilter&) = delete;
   void operator=(const vtkVisItTubeFilter&) = delete;

--- a/src/visit_vtk/full/vtkVisItTubeFilter.h
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.h
@@ -1,215 +1,46 @@
-/*=========================================================================
-
-  Program:   Visualization Toolkit
-
-  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
-  All rights reserved.
-  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
-
-     This software is distributed WITHOUT ANY WARRANTY; without even
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-     PURPOSE.  See the above copyright notice for more information.
-
-=========================================================================*/
-// .NAME vtkVisItTubeFilter - filter that generates tubes around lines
-// .SECTION Description
-// vtkVisItTubeFilter is a filter that generates a tube around each input line. 
-// The tubes are made up of triangle strips and rotate around the tube with
-// the rotation of the line normals. (If no normals are present, they are
-// computed automatically.) The radius of the tube can be set to vary with 
-// scalar or vector value. If the radius varies with scalar value the radius
-// is linearly adjusted. If the radius varies with vector value, a mass
-// flux preserving variation is used. The number of sides for the tube also 
-// can be specified. You can also specify which of the sides are visible. This
-// is useful for generating interesting striping effects. Other options
-// include the ability to cap the tube and generate texture coordinates.
-// Texture coordinates can be used with an associated texture map to create
-// interesting effects such as marking the tube with stripes corresponding
-// to length or time.
-//
-// This filter is typically used to create thick or dramatic lines. Another
-// common use is to combine this filter with vtkStreamLine to generate
-// streamtubes.
-
-// .SECTION Caveats
-// The number of tube sides must be greater than 3. If you wish to use fewer
-// sides (i.e., a ribbon), use vtkRibbonFilter.
-//
-// The input line must not have duplicate points, or normals at points that
-// are parallel to the incoming/outgoing line segments. (Duplicate points
-// can be removed with vtkCleanPolyData.) If a line does not meet this
-// criteria, then that line is not tubed.
-
-// .SECTION See Also
-// vtkRibbonFilter vtkStreamLine
-
-// .SECTION Thanks
-// Michael Finch for absolute scalar radius
+// Copyright (c) Lawrence Livermore National Security, LLC and other VisIt
+// Project developers.  See the top-level LICENSE file for dates and other
+// details.  No copyright assignment is required to contribute to VisIt.
 
 #ifndef __vtkVisItTubeFilter_h
 #define __vtkVisItTubeFilter_h
 
-#include "vtkPolyDataAlgorithm.h"
+#include "vtkTubeFilter.h"
 #include <visit_vtk_exports.h>
-
-#define VTK_VARY_RADIUS_OFF 0
-#define VTK_VARY_RADIUS_BY_SCALAR 1
-#define VTK_VARY_RADIUS_BY_VECTOR 2
-#define VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR 3
-
-#define VTK_TCOORDS_OFF                    0
-#define VTK_TCOORDS_FROM_NORMALIZED_LENGTH 1
-#define VTK_TCOORDS_FROM_LENGTH            2
-#define VTK_TCOORDS_FROM_SCALARS           3
-
-class vtkCellArray;
-class vtkCellData;
-class vtkDataArray;
-class vtkFloatArray;
-class vtkPointData;
-class vtkPoints;
 
 // Modifications:
 //   Jeremy Meredith, Wed May 26 14:52:29 EDT 2010
 //   Allow cell scalars for tube radius.
 //
 //   Kathleen Biagas, Tue Aug  7 10:55:50 PDT 2012
-//   Added ScalarsForRadius var, so that a non-default scalar can be used 
+//   Added ScalarsForRadius var, so that a non-default scalar can be used
 //    to scale the radius.
-// 
+//
+//    Kathleen Biagas, Mon July 20, 2026
+//    Inherit from vtkTubeFilter. Add comments denoting VisIt additions.
 
-class VISIT_VTK_API vtkVisItTubeFilter : public vtkPolyDataAlgorithm
+class VISIT_VTK_API vtkVisItTubeFilter : public vtkTubeFilter
 {
 public:
-  vtkTypeMacro(vtkVisItTubeFilter,vtkPolyDataAlgorithm);
+  vtkTypeMacro(vtkVisItTubeFilter,vtkTubeFilter);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  // Description:
-  // Construct object with radius 0.5, radius variation turned off, the
-  // number of sides set to 3, and radius factor of 10.
   static vtkVisItTubeFilter *New();
 
-  // Description:
-  // Set the minimum tube radius (minimum because the tube radius may vary).
-  vtkSetClampMacro(Radius,double,0.0,VTK_DOUBLE_MAX);
-  vtkGetMacro(Radius,double);
-
-  // Description:
-  // Turn on/off the variation of tube radius with scalar value.
-  vtkSetClampMacro(VaryRadius,int,
-                   VTK_VARY_RADIUS_OFF,VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR);
-  vtkGetMacro(VaryRadius,int);
-  void SetVaryRadiusToVaryRadiusOff()
-    {this->SetVaryRadius(VTK_VARY_RADIUS_OFF);};
-  void SetVaryRadiusToVaryRadiusByScalar()
-    {this->SetVaryRadius(VTK_VARY_RADIUS_BY_SCALAR);};
-  void SetVaryRadiusToVaryRadiusByVector()
-    {this->SetVaryRadius(VTK_VARY_RADIUS_BY_VECTOR);};
-  void SetVaryRadiusToVaryRadiusByAbsoluteScalar()
-    {this->SetVaryRadius(VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR);};
-  const char *GetVaryRadiusAsString();
-
-  // Description:
-  // Set the number of sides for the tube. At a minimum, number of sides is 3.
-  vtkSetClampMacro(NumberOfSides,int,3,VTK_INT_MAX);
-  vtkGetMacro(NumberOfSides,int);
-
-  // Description:
-  // Set the maximum tube radius in terms of a multiple of the minimum radius.
-  vtkSetMacro(RadiusFactor,double);
-  vtkGetMacro(RadiusFactor,double);
-
-  // Description:
-  // Set the default normal to use if no normals are supplied, and the
-  // DefaultNormalOn is set.
-  vtkSetVector3Macro(DefaultNormal,double);
-  vtkGetVectorMacro(DefaultNormal,double,3);
-
-  // Description:
-  // Set a boolean to control whether to use default normals.
-  // DefaultNormalOn is set.
-  vtkSetMacro(UseDefaultNormal,bool);
-  vtkGetMacro(UseDefaultNormal,bool);
-  vtkBooleanMacro(UseDefaultNormal,bool);
-
-  // Description:
-  // Set a boolean to control whether tube sides should share vertices.
-  // This creates independent strips, with constant normals so the
-  // tube is always faceted in appearance.
-  vtkSetMacro(SidesShareVertices, bool);
-  vtkGetMacro(SidesShareVertices, bool);
-  vtkBooleanMacro(SidesShareVertices, bool);
-
-  // Description:
-  // Turn on/off whether to cap the ends with polygons.
-  vtkSetMacro(Capping,bool);
-  vtkGetMacro(Capping,bool);
-  vtkBooleanMacro(Capping,bool);
-
-  // Description:
-  // Control the striping of the tubes. If OnRatio is greater than 1,
-  // then every nth tube side is turned on, beginning with the Offset
-  // side.
-  vtkSetClampMacro(OnRatio,int,1,VTK_INT_MAX);
-  vtkGetMacro(OnRatio,int);
-
-  // Description:
-  // Control the striping of the tubes. The offset sets the
-  // first tube side that is visible. Offset is generally used with
-  // OnRatio to create nifty striping effects.
-  vtkSetClampMacro(Offset,int,0,VTK_INT_MAX);
-  vtkGetMacro(Offset,int);
-
-  // Description:
-  // Control whether and how texture coordinates are produced. This is
-  // useful for striping the tube with length textures, etc. If you
-  // use scalars to create the texture, the scalars are assumed to be
-  // monotonically increasing (or decreasing).
-  vtkSetClampMacro(GenerateTCoords,int,VTK_TCOORDS_OFF,
-                   VTK_TCOORDS_FROM_SCALARS);
-  vtkGetMacro(GenerateTCoords,int);
-  void SetGenerateTCoordsToOff()
-    {this->SetGenerateTCoords(VTK_TCOORDS_OFF);}
-  void SetGenerateTCoordsToNormalizedLength()
-    {this->SetGenerateTCoords(VTK_TCOORDS_FROM_NORMALIZED_LENGTH);}
-  void SetGenerateTCoordsToUseLength()
-    {this->SetGenerateTCoords(VTK_TCOORDS_FROM_LENGTH);}
-  void SetGenerateTCoordsToUseScalars()
-    {this->SetGenerateTCoords(VTK_TCOORDS_FROM_SCALARS);}
-  const char *GetGenerateTCoordsAsString();
-
-  // Description:
-  // Control the conversion of units during the texture coordinates
-  // calculation. The TextureLength indicates what length (whether 
-  // calculated from scalars or length) is mapped to the [0,1)
-  // texture space.
-  vtkSetClampMacro(TextureLength,double,0.000001,VTK_INT_MAX);
-  vtkGetMacro(TextureLength,double);
-
+  // begin VisIt addition
   vtkSetStringMacro(ScalarsForRadius);
   vtkGetStringMacro(ScalarsForRadius);
+  // end VisIt addition
 
 protected:
   vtkVisItTubeFilter();
-  ~vtkVisItTubeFilter();
+  ~vtkVisItTubeFilter() override;
 
-  // Usual data generation method
   int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
-  double Radius; //minimum radius of tube
-  int VaryRadius; //controls radius variation
-  int NumberOfSides; //number of sides to create tube
-  double RadiusFactor; //maxium allowablew radius
-  double DefaultNormal[3];
-  bool UseDefaultNormal;
-  bool SidesShareVertices;
-  bool Capping; //control whether tubes are capped
-  int OnRatio; //control the generation of the sides of the tube
-  int Offset;  //control the generation of the sides
-  int GenerateTCoords; //control texture coordinate generation
-  double TextureLength; //this length is mapped to [0,1) texture space
-
-  char *ScalarsForRadius; 
+  // begin VisIt addition
+  char *ScalarsForRadius;
+  // end VisIt addition
 
   // Helper methods
   int GeneratePoints(vtkIdType offset, vtkIdType inCellId,
@@ -220,18 +51,12 @@ protected:
                      vtkDataArray *inScalars, bool cellScalars,
                      double range[2], vtkDataArray *inVectors, double maxNorm,
                      vtkDataArray *inNormals);
-  void GenerateStrips(vtkIdType offset, vtkIdType npts, const vtkIdType *pts,
-                      vtkIdType inCellId, vtkCellData *cd, vtkCellData *outCD,
-                      vtkCellArray *newStrips);
+
   void GenerateTextureCoords(vtkIdType offset, vtkIdType npts,
                              const vtkIdType *pts,
                              vtkPoints *inPts,
                              vtkDataArray *inScalars, bool cellScalars,
                             vtkFloatArray *newTCoords);
-  vtkIdType ComputeOffset(vtkIdType offset,vtkIdType npts);
-  
-  // Helper data members
-  double Theta;
 
 private:
   vtkVisItTubeFilter(const vtkVisItTubeFilter&) = delete;

--- a/src/visit_vtk/full/vtkVisItTubeFilter.h
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.h
@@ -22,7 +22,7 @@
 class VISIT_VTK_API vtkVisItTubeFilter : public vtkTubeFilter
 {
 public:
-  vtkTypeMacro(vtkVisItTubeFilter,vtkTubeFilter);
+  vtkTypeMacro(vtkVisItTubeFilter,vtkTubeFilter)
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   static vtkVisItTubeFilter *New();

--- a/src/visit_vtk/full/vtkVisItTubeFilter.h
+++ b/src/visit_vtk/full/vtkVisItTubeFilter.h
@@ -5,7 +5,7 @@
 #ifndef __vtkVisItTubeFilter_h
 #define __vtkVisItTubeFilter_h
 
-#include "vtkTubeFilter.h"
+#include <vtkTubeFilter.h>
 #include <visit_vtk_exports.h>
 
 // Modifications:
@@ -14,10 +14,10 @@
 //
 //   Kathleen Biagas, Tue Aug  7 10:55:50 PDT 2012
 //   Added ScalarsForRadius var, so that a non-default scalar can be used
-//    to scale the radius.
+//   to scale the radius.
 //
-//    Kathleen Biagas, Mon July 20, 2026
-//    Inherit from vtkTubeFilter. Add comments denoting VisIt additions.
+//   Kathleen Biagas, Mon July 20, 2026
+//   Inherit from vtkTubeFilter. Add comments denoting VisIt additions.
 
 class VISIT_VTK_API vtkVisItTubeFilter : public vtkTubeFilter
 {


### PR DESCRIPTION
### Description

Reduces code duplication, gains new functionality from vtk.
Methods that needed to remain for VisIt's usage picked up some changes/improvement from the vtk 9.5 version.
Removed warnings (linux - gcc, windows -msvc).
Annotated VisIt specific changes for ease of future-updating against vtk version.

### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other
Code cleanup

### How Has This Been Tested?

Ran tests that utilize Tube operator with success:
tests/operators/ic_geometry.py 
tests/operators/ic_streamlines.py
tests/operators/persistent_particles.py
tests/operators/tube.py
tests/plots/pseudocolor.py 


### Checklist:

- [X] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

