### PR TITLE
Remove old cmake policy settings. (#21054)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,25 +163,18 @@
 #    Allow test data dir to be specified by VISIT_DATA_DIR var, which will
 #    only be used if 'data' dir does not exist peer to 'src'.
 #
+#    Kathleen Biagas, Mon July 13, 2026
+#    Removed cmake policy settings that are no longer needed. Should allow
+#    VisIt to be built with CMake 4.0 and newer. Update minimum CMake
+#    version to 3.26, due to requirements introduced by previous work.
+#
 #****************************************************************************
 
-cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
 
-if(COMMAND cmake_policy)
-    cmake_policy(SET CMP0033 OLD)
-    if(WIN32)
-        # don't automatically link with qtmain
-        cmake_policy(SET CMP0020 OLD)
-        if(POLICY CMP0091) # introduced in cmake 3.15
-            # Tell CMake to always use /MD, even for debug builds.
-            # Done because prebuilt TP libraries are built with /MD and
-            # if debug build of VisIt uses /MDd there are runtime issues.
-            cmake_policy(SET CMP0091 NEW) # MSVC_RUNTIME_LIBRARY
-            set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-        endif()
-    endif()
+if(WIN32)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 endif()
-
 
 #
 # Try to capture the initial set of cmake command line args passed by

--- a/src/resources/help/en_US/relnotes3.5.1.html
+++ b/src/resources/help/en_US/relnotes3.5.1.html
@@ -24,6 +24,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>Fixed a bug where slicing or contouring an unstructured mesh with VTK_CONVEX_POINT_SET cells caused a crash.</li>
   <li>Fixed a bug with Zone-Pick on an extremely zoomed-in plot containing extremely long thin hexes.</li>
+  <li>Fixed a bug preventing VisIt from being built with CMake 4.0.</li>
   <li>VisIt will now open a session file passed on the command line with '-sessionfile' even if the corresponding .gui component file does not exist.</li>
 </ul>
 


### PR DESCRIPTION
They are no longer necessary and their removal should allow VisIt to build with CMake 4.0.

Resolves #20304

Also updated minimum version of CMake to 3.26 due to requirements introduced in previous work.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

I built CMake 4.4.0 on Windows and Linux, then tested the build of VisIt with CMake 4.4.0, with the current version of CMake used by build_visit (3.31.8) and with the current VisIt minimum version (3.26), all with success.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

