### PR TITLE
When calling prepare_build_dir the sha-type-string should be capitalized

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_adios.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios.sh
@@ -142,7 +142,7 @@ function build_adios
     #
     # Prepare build dir
     #
-    prepare_build_dir $ADIOS_BUILD_DIR $ADIOS_FILE sha256 $ADIOS_SHA256_CHECKSUM
+    prepare_build_dir $ADIOS_BUILD_DIR $ADIOS_FILE SHA256 $ADIOS_SHA256_CHECKSUM
     untarred_ADIOS=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -131,7 +131,7 @@ function build_adios2
     #
     # Prepare build dir
     #
-    prepare_build_dir $ADIOS2_BUILD_DIR $ADIOS2_FILE sha256 $ADIOS2_SHA256_CHECKSUM
+    prepare_build_dir $ADIOS2_BUILD_DIR $ADIOS2_FILE SHA256 $ADIOS2_SHA256_CHECKSUM
     untarred_ADIOS2=$?
     if [[ $untarred_ADIOS2 == -1 ]] ; then
         warn "Unable to prepare ADIOS2 Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_advio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_advio.sh
@@ -271,7 +271,7 @@ function build_advio
     #
     # Prepare build dir
     #
-    prepare_build_dir $ADVIO_BUILD_DIR $ADVIO_FILE sha256 $ADVIO_SHA256_CHECKSUM
+    prepare_build_dir $ADVIO_BUILD_DIR $ADVIO_FILE SHA256 $ADVIO_SHA256_CHECKSUM
     untarred_ADVIO=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_anari.sh
+++ b/src/tools/dev/scripts/bv_support/bv_anari.sh
@@ -123,7 +123,7 @@ function build_anari
     fi
 
     # Extract sources
-    prepare_build_dir $ANARI_SRC_DIR $ANARI_FILE sha256 $ANARI_SHA256_CHECKSUM
+    prepare_build_dir $ANARI_SRC_DIR $ANARI_FILE SHA256 $ANARI_SHA256_CHECKSUM
     untarred_anari=$?
     # -1 on failure, 0 for success without untar
     #  1 for success with untar, 2 for failure with checksum

--- a/src/tools/dev/scripts/bv_support/bv_blosc2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_blosc2.sh
@@ -62,7 +62,7 @@ function build_blosc2
     #
     # Prepare build dir
     #
-    prepare_build_dir $BLOSC2_BUILD_DIR $BLOSC2_FILE sha256 $BLOSC2_SHA256_CHECKSUM
+    prepare_build_dir $BLOSC2_BUILD_DIR $BLOSC2_FILE SHA256 $BLOSC2_SHA256_CHECKSUM
     untarred_blosc2=$?
     if [[ $untarred_blosc2 == -1 ]] ; then
         warn "Unable to prepare Blosc2 build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_boost.sh
+++ b/src/tools/dev/scripts/bv_support/bv_boost.sh
@@ -151,7 +151,7 @@ function build_boost
     #
     # Prepare build dir
     #
-    prepare_build_dir $BOOST_BUILD_DIR $BOOST_FILE sha256 $BOOST_SHA256_CHECKSUM
+    prepare_build_dir $BOOST_BUILD_DIR $BOOST_FILE SHA256 $BOOST_SHA256_CHECKSUM
     untarred_boost=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_boxlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_boxlib.sh
@@ -247,7 +247,7 @@ function build_boxlib
     #
     # Prepare build dir
     #
-    prepare_build_dir $BOXLIB_BUILD_DIR $BOXLIB_FILE sha256 $BOXLIB_SHA256_CHECKSUM
+    prepare_build_dir $BOXLIB_BUILD_DIR $BOXLIB_FILE SHA256 $BOXLIB_SHA256_CHECKSUM
     untarred_boxlib=$?
     if [[ $untarred_boxlib == -1 ]] ; then
         warn "Unable to prepare Boxlib Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_cfitsio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cfitsio.sh
@@ -84,7 +84,7 @@ function build_cfitsio
     #
     # Prepare build dir
     #
-    prepare_build_dir $CFITSIO_BUILD_DIR $CFITSIO_FILE sha256 $CFITSIO_SHA256_CHECKSUM
+    prepare_build_dir $CFITSIO_BUILD_DIR $CFITSIO_FILE SHA256 $CFITSIO_SHA256_CHECKSUM
     untarred_cfitsio=$?
     if [[ $untarred_cfitsio == -1 ]] ; then
         warn "Unable to prepare CFITSIO Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -197,7 +197,7 @@ function build_cgns
     #
     # Prepare build dir
     #
-    prepare_build_dir $CGNS_BUILD_DIR $CGNS_FILE sha256 $CGNS_SHA256_CHECKSUM
+    prepare_build_dir $CGNS_BUILD_DIR $CGNS_FILE SHA256 $CGNS_SHA256_CHECKSUM
     untarred_cgns=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_cmake.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cmake.sh
@@ -146,7 +146,7 @@ function build_cmake
     #
     # Prepare cmake build directory
     #
-    prepare_build_dir $CMAKE_BUILD_DIR $CMAKE_FILE sha256 $CMAKE_SHA256_CHECKSUM
+    prepare_build_dir $CMAKE_BUILD_DIR $CMAKE_FILE SHA256 $CMAKE_SHA256_CHECKSUM
     untarred_cmake=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_conduit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_conduit.sh
@@ -130,7 +130,7 @@ function build_conduit
     #
     # Prepare build dir
     #
-    prepare_build_dir $CONDUIT_BUILD_DIR $CONDUIT_FILE sha256 $CONDUIT_SHA256_CHECKSUM
+    prepare_build_dir $CONDUIT_BUILD_DIR $CONDUIT_FILE SHA256 $CONDUIT_SHA256_CHECKSUM
     untarred_conduit=$?
     if [[ $untarred_conduit == -1 ]] ; then
         warn "Unable to prepare Conduit build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_damaris.sh
+++ b/src/tools/dev/scripts/bv_support/bv_damaris.sh
@@ -122,7 +122,7 @@ function build_damaris
     #
     # Prepare build dir for Damaris
     #
-    prepare_build_dir $DAMARIS_BUILD_DIR $DAMARIS_FILE sha256 $DAMARIS_SHA256_CHECKSUM
+    prepare_build_dir $DAMARIS_BUILD_DIR $DAMARIS_FILE SHA256 $DAMARIS_SHA256_CHECKSUM
     untarred_damaris=$?
     if [[ $untarred_damaris == -1 ]] ; then
         warn "Unable to prepare Damaris build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_fms.sh
+++ b/src/tools/dev/scripts/bv_support/bv_fms.sh
@@ -82,7 +82,7 @@ function build_fms
     #
     # Prepare build dir
     #
-    prepare_build_dir $FMS_BUILD_DIR $FMS_FILE sha256 $FMS_SHA256_CHECKSUM
+    prepare_build_dir $FMS_BUILD_DIR $FMS_FILE SHA256 $FMS_SHA256_CHECKSUM
     untarred_fms=$?
     if [[ $untarred_fms == -1 ]] ; then
         warn "Unable to prepare FMS build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_gdal.sh
+++ b/src/tools/dev/scripts/bv_support/bv_gdal.sh
@@ -167,7 +167,7 @@ function build_gdal
     #
     # Prepare build dir
     #
-    prepare_build_dir $GDAL_BUILD_DIR $GDAL_FILE sha256 $GDAL_SHA256_CHECKSUM
+    prepare_build_dir $GDAL_BUILD_DIR $GDAL_FILE SHA256 $GDAL_SHA256_CHECKSUM
     untarred_gdal=$?
     if [[ $untarred_gdal == -1 ]] ; then
         warn "Unable to prepare GDAL Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_glu.sh
+++ b/src/tools/dev/scripts/bv_support/bv_glu.sh
@@ -153,7 +153,7 @@ function build_glu
     #
     # prepare build dir
     #
-    prepare_build_dir $GLU_BUILD_DIR $GLU_FILE sha256 $GLU_SHA256_CHECKSUM
+    prepare_build_dir $GLU_BUILD_DIR $GLU_FILE SHA256 $GLU_SHA256_CHECKSUM
     untarred_glu=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_h5part.sh
+++ b/src/tools/dev/scripts/bv_support/bv_h5part.sh
@@ -567,7 +567,7 @@ function build_h5part
     #
     # Prepare build dir
     #
-    prepare_build_dir $H5PART_BUILD_DIR $H5PART_FILE sha256 $H5PART_SHA256_CHECKSUM
+    prepare_build_dir $H5PART_BUILD_DIR $H5PART_FILE SHA256 $H5PART_SHA256_CHECKSUM
     untarred_h5part=$?
     if [[ $untarred_h5part == -1 ]] ; then
         warn "Unable to prepare H5Part Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -108,7 +108,7 @@ function build_hdf5
     #
     # Prepare build dir
     #
-    prepare_build_dir $HDF5_BUILD_DIR $HDF5_FILE sha256 $HDF5_SHA256_CHECKSUM
+    prepare_build_dir $HDF5_BUILD_DIR $HDF5_FILE SHA256 $HDF5_SHA256_CHECKSUM
     untarred_hdf5=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_icet.sh
+++ b/src/tools/dev/scripts/bv_support/bv_icet.sh
@@ -117,7 +117,7 @@ function build_icet
     #
     CMAKE_BIN="${CMAKE_COMMAND}"
 
-    prepare_build_dir $ICET_BUILD_DIR $ICET_FILE sha256 $ICET_SHA256_CHECKSUM
+    prepare_build_dir $ICET_BUILD_DIR $ICET_FILE SHA256 $ICET_SHA256_CHECKSUM
     untarred_icet=$?
     if [[ $untarred_icet == -1 ]] ; then
         warn "Unable to prepare IceT build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_llvm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_llvm.sh
@@ -109,7 +109,7 @@ function build_llvm
     #
     # prepare build dir
     #
-    prepare_build_dir $BV_LLVM_BUILD_DIR $BV_LLVM_FILE sha256 $BV_LLVM_SHA256_CHECKSUM
+    prepare_build_dir $BV_LLVM_BUILD_DIR $BV_LLVM_FILE SHA256 $BV_LLVM_SHA256_CHECKSUM
     untarred_llvm=$?
     if [[ $untarred_llvm == -1 ]] ; then
         warn "Unable to prepare LLVM build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -359,7 +359,7 @@ function build_mesagl
     #
     # prepare build dir
     #
-    prepare_build_dir $MESAGL_BUILD_DIR $MESAGL_FILE sha256 $MESAGL_SHA256_CHECKSUM
+    prepare_build_dir $MESAGL_BUILD_DIR $MESAGL_FILE SHA256 $MESAGL_SHA256_CHECKSUM
     untarred_mesagl=$?
     if [[ $untarred_mesagl == -1 ]] ; then
         warn "Unable to prepare MesaGL build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -143,7 +143,7 @@ function build_mfem
     #
     # Prepare build dir
     #
-    prepare_build_dir $MFEM_BUILD_DIR $MFEM_FILE sha256 $MFEM_SHA256_CHECKSUM
+    prepare_build_dir $MFEM_BUILD_DIR $MFEM_FILE SHA256 $MFEM_SHA256_CHECKSUM
     untarred_mfem=$?
     if [[ $untarred_mfem == -1 ]] ; then
         warn "Unable to prepare mfem build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -341,7 +341,7 @@ function build_mili
     #
     # Prepare build dir
     #
-    prepare_build_dir $MILI_BUILD_DIR $MILI_FILE sha256 $MILI_SHA256_CHECKSUM
+    prepare_build_dir $MILI_BUILD_DIR $MILI_FILE SHA256 $MILI_SHA256_CHECKSUM
     untarred_mili=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_moab.sh
+++ b/src/tools/dev/scripts/bv_support/bv_moab.sh
@@ -76,7 +76,7 @@ function build_moab
     #
     # Prepare build dir
     #
-    prepare_build_dir $MOAB_BUILD_DIR $MOAB_FILE sha256 $MOAB_SHA256_CHECKSUM
+    prepare_build_dir $MOAB_BUILD_DIR $MOAB_FILE SHA256 $MOAB_SHA256_CHECKSUM
     untarred_moab=$?
     if [[ $untarred_moab == -1 ]] ; then
         warn "Unable to prepare moab build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_mpich.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mpich.sh
@@ -151,7 +151,7 @@ function build_mpich
     #
     # Prepare build dir
     #
-    prepare_build_dir $MPICH_BUILD_DIR $MPICH_FILE sha256 $MPICH_SHA256_CHECKSUM
+    prepare_build_dir $MPICH_BUILD_DIR $MPICH_FILE SHA256 $MPICH_SHA256_CHECKSUM
     untarred_mpich=$?
     if [[ $untarred_mpich == -1 ]] ; then
         warn "Unable to prepare MPICH build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
+++ b/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
@@ -212,7 +212,7 @@ function build_nektarpp
     #
     # Prepare build dir
     #
-    prepare_build_dir $NEKTAR_PLUS_PLUS_BUILD_DIR $NEKTAR_PLUS_PLUS_FILE sha256 $NEKTAR_PLUS_PLUS_SHA256_CHECKSUM
+    prepare_build_dir $NEKTAR_PLUS_PLUS_BUILD_DIR $NEKTAR_PLUS_PLUS_FILE SHA256 $NEKTAR_PLUS_PLUS_SHA256_CHECKSUM
     untarred_nektar_plus_plus=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_netcdf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_netcdf.sh
@@ -174,7 +174,7 @@ function build_netcdf
 {
     # Prepare build dir
     #
-    prepare_build_dir $NETCDF_BUILD_DIR $NETCDF_FILE sha256 $NETCDF_SHA256_CHECKSUM
+    prepare_build_dir $NETCDF_BUILD_DIR $NETCDF_FILE SHA256 $NETCDF_SHA256_CHECKSUM
     untarred_netcdf=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -87,7 +87,7 @@ function build_ninja
     #
     # Prepare build dir
     #
-    prepare_build_dir $NINJA_BUILD_DIR $NINJA_FILE sha256 $NINJA_SHA256_CHECKSUM
+    prepare_build_dir $NINJA_BUILD_DIR $NINJA_FILE SHA256 $NINJA_SHA256_CHECKSUM
     untarred_ninja=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_openexr.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openexr.sh
@@ -96,7 +96,7 @@ function build_imath
     #
     # Prepare build dir
     #
-    prepare_build_dir $IMATH_BUILD_DIR $IMATH_FILE sha256 $IMATH_SHA256_CHECKSUM
+    prepare_build_dir $IMATH_BUILD_DIR $IMATH_FILE SHA256 $IMATH_SHA256_CHECKSUM
     untarred_imath=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -231,7 +231,7 @@ function build_openexr
     #
     # Prepare build dir
     #
-    prepare_build_dir $OPENEXR_BUILD_DIR $OPENEXR_FILE sha256 $OPENEXR_SHA256_CHECKSUM
+    prepare_build_dir $OPENEXR_BUILD_DIR $OPENEXR_FILE SHA256 $OPENEXR_SHA256_CHECKSUM
     untarred_openexr=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -359,7 +359,7 @@ function build_osmesa
     #
     # prepare build dir
     #
-    prepare_build_dir $OSMESA_BUILD_DIR $OSMESA_FILE sha256 $OSMESA_SHA256_CHECKSUM
+    prepare_build_dir $OSMESA_BUILD_DIR $OSMESA_FILE SHA256 $OSMESA_SHA256_CHECKSUM
     untarred_osmesa=$?
     if [[ $untarred_osmesa == -1 ]] ; then
         warn "Unable to prepare Mesa build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -225,7 +225,7 @@ function build_ospray
     #
     # Uncompress the source file
     #
-    prepare_build_dir $OSPRAY_SRC_DIR $OSPRAY_FILE sha256 $OSPRAY_SHA256_CHECKSUM
+    prepare_build_dir $OSPRAY_SRC_DIR $OSPRAY_FILE SHA256 $OSPRAY_SHA256_CHECKSUM
     untarred_ospray=$?
     if [[ $untarred_ospray == -1 ]] ; then
         warn "Unable to uncompress OSPRay source file. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_pidx.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pidx.sh
@@ -157,7 +157,7 @@ function build_pidx
     #
     # Prepare build dir
     #
-    prepare_build_dir $PIDX_BUILD_DIR $PIDX_FILE sha256 $PIDX_SHA256_CHECKSUM
+    prepare_build_dir $PIDX_BUILD_DIR $PIDX_FILE SHA256 $PIDX_SHA256_CHECKSUM
     untarred_pidx=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -667,7 +667,7 @@ function apply_python_patch
 
 function build_python
 {
-    prepare_build_dir $PYTHON_BUILD_DIR $PYTHON_FILE sha256 $PYTHON_SHA256_CHECKSUM
+    prepare_build_dir $PYTHON_BUILD_DIR $PYTHON_FILE SHA256 $PYTHON_SHA256_CHECKSUM
     untarred_python=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -417,7 +417,7 @@ EOF
 function build_qt_base
 {
     echo "Build Qt 6 base module"
-    prepare_build_dir $QT_BASE_SOURCE_DIR $QT_BASE_FILE sha256 $QTBASE_SHA256_CHECKSUM
+    prepare_build_dir $QT_BASE_SOURCE_DIR $QT_BASE_FILE SHA256 $QTBASE_SHA256_CHECKSUM
 
     untarred_qt=$?
     # 0, already exists, 1 untarred src, 2 error

--- a/src/tools/dev/scripts/bv_support/bv_qwt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qwt.sh
@@ -276,7 +276,7 @@ function build_qwt
     #
     # Prepare build dir
     #
-    prepare_build_dir $QWT_BUILD_DIR $QWT_FILE sha256 $QWT_SHA256_CHECKSUM
+    prepare_build_dir $QWT_BUILD_DIR $QWT_FILE SHA256 $QWT_SHA256_CHECKSUM
     untarred_qwt=$?
     if [[ $untarred_qwt == -1 ]] ; then
         warn "Unable to prepare Qwt build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -444,7 +444,7 @@ function build_silo
     #
     # Prepare build dir
     #
-    prepare_build_dir $SILO_BUILD_DIR $SILO_FILE sha256 $SILO_SHA256_CHECKSUM
+    prepare_build_dir $SILO_BUILD_DIR $SILO_FILE SHA256 $SILO_SHA256_CHECKSUM
     untarred_silo=$?
     if [[ $untarred_silo == -1 ]] ; then
         warn "Unable to prepare Silo build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_stripack.sh
+++ b/src/tools/dev/scripts/bv_support/bv_stripack.sh
@@ -101,7 +101,7 @@ function build_stripack
     #
     # Prepare build dir
     #
-    prepare_build_dir $STRIPACK_BUILD_DIR $STRIPACK_FILE sha256 $STRIPACK_SHA256_CHECKSUM
+    prepare_build_dir $STRIPACK_BUILD_DIR $STRIPACK_FILE SHA256 $STRIPACK_SHA256_CHECKSUM
     untarred_stripack=$?
     if [[ $untarred_stripack == -1 ]] ; then
         warn "Unable to prepare stripack Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -252,7 +252,7 @@ function build_uintah
     #
     # Prepare build dir
     #
-    prepare_build_dir $UINTAH_BUILD_DIR $UINTAH_FILE sha256 $UINTAH_SHA256_CHECKSUM
+    prepare_build_dir $UINTAH_BUILD_DIR $UINTAH_FILE SHA256 $UINTAH_SHA256_CHECKSUM
     untarred_uintah=$?
     if [[ $untarred_uintah == -1 ]] ; then
         warn "Unable to prepare UINTAH Build Directory. Giving Up"

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -2249,7 +2249,7 @@ function build_vtk
     #
     # Prepare the build dir using src file.
     #
-    prepare_build_dir $VTK_BUILD_DIR $VTK_FILE sha256 $VTK_SHA256_CHECKSUM
+    prepare_build_dir $VTK_BUILD_DIR $VTK_FILE SHA256 $VTK_SHA256_CHECKSUM
     untarred_vtk=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_vtkm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtkm.sh
@@ -143,7 +143,7 @@ function build_vtkm
     #
     # Prepare build dir
     #
-    prepare_build_dir $VTKM_BUILD_DIR $VTKM_FILE sha256 $VTKM_SHA256_CHECKSUM
+    prepare_build_dir $VTKM_BUILD_DIR $VTKM_FILE SHA256 $VTKM_SHA256_CHECKSUM
     untarred_vtkm=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -195,7 +195,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XORG_MACROS_BUILD_DIR $XORG_MACROS_FILE sha256 $XORG_MACROS_SHA256_CHECKSUM
+    prepare_build_dir $XORG_MACROS_BUILD_DIR $XORG_MACROS_FILE SHA256 $XORG_MACROS_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -220,7 +220,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_M4_BUILD_DIR $XCB_M4_FILE sha256 $XCB_M4_SHA256_CHECKSUM
+    prepare_build_dir $XCB_M4_BUILD_DIR $XCB_M4_FILE SHA256 $XCB_M4_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -239,7 +239,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_UTIL_BUILD_DIR $XCB_UTIL_FILE sha256 $XCB_UTIL_SHA256_CHECKSUM
+    prepare_build_dir $XCB_UTIL_BUILD_DIR $XCB_UTIL_FILE SHA256 $XCB_UTIL_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -273,7 +273,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_IMAGE_BUILD_DIR $XCB_IMAGE_FILE sha256 $XCB_IMAGE_SHA256_CHECKSUM
+    prepare_build_dir $XCB_IMAGE_BUILD_DIR $XCB_IMAGE_FILE SHA256 $XCB_IMAGE_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -302,7 +302,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_KEYSYMS_BUILD_DIR $XCB_KEYSYMS_FILE sha256 $XCB_KEYSYMS_SHA256_CHECKSUM
+    prepare_build_dir $XCB_KEYSYMS_BUILD_DIR $XCB_KEYSYMS_FILE SHA256 $XCB_KEYSYMS_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -331,7 +331,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_WM_BUILD_DIR $XCB_WM_FILE sha256 $XCB_WM_SHA256_CHECKSUM
+    prepare_build_dir $XCB_WM_BUILD_DIR $XCB_WM_FILE SHA256 $XCB_WM_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -360,7 +360,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XCB_RENDERUTIL_BUILD_DIR $XCB_RENDERUTIL_FILE sha256 $XCB_RENDERUTIL_SHA256_CHECKSUM
+    prepare_build_dir $XCB_RENDERUTIL_BUILD_DIR $XCB_RENDERUTIL_FILE SHA256 $XCB_RENDERUTIL_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_xdmf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xdmf.sh
@@ -350,7 +350,7 @@ function build_xdmf
     #
     # Prepare build dir
     #
-    prepare_build_dir $XDMF_BUILD_DIR $XDMF_FILE sha256 $XDMF_SHA256_CHECKSUM
+    prepare_build_dir $XDMF_BUILD_DIR $XDMF_FILE SHA256 $XDMF_SHA256_CHECKSUM
     untarred_xdmf=$?
     if [[ $untarred_xdmf == -1 ]] ; then
         warn "Unable to prepare Xdmf Build Directory. Giving up"

--- a/src/tools/dev/scripts/bv_support/bv_xercesc.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xercesc.sh
@@ -71,7 +71,7 @@ function build_xercesc
     #
     # Prepare build dir
     #
-    prepare_build_dir $XERCESC_BUILD_DIR $XERCESC_FILE sha256 $XERCESC_SHA256_CHECKSUM
+    prepare_build_dir $XERCESC_BUILD_DIR $XERCESC_FILE SHA256 $XERCESC_SHA256_CHECKSUM
     untarred_xc=$?
     if [[ $untarred_xc == -1 ]] ; then
         warn "Unable to prepare Xerces-C build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -79,7 +79,7 @@ function build_xkbcommon
     #
     # Prepare build dir
     #
-    prepare_build_dir $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE sha256 $XKBCOMMON_SHA256_CHECKSUM
+    prepare_build_dir $XKBCOMMON_BUILD_DIR $XKBCOMMON_FILE SHA256 $XKBCOMMON_SHA256_CHECKSUM
     untarred_xkbcommon=$?
     # 0, already exists, 1 untarred src, 2 error
 

--- a/src/tools/dev/scripts/bv_support/bv_xsd.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xsd.sh
@@ -76,7 +76,7 @@ function build_xsd
     #
     # Prepare build dir
     #
-    prepare_build_dir $XSD_BUILD_DIR $XSD_FILE sha256 $XSD_SHA256_CHECKSUM
+    prepare_build_dir $XSD_BUILD_DIR $XSD_FILE SHA256 $XSD_SHA256_CHECKSUM
     untarred_xsd=$?
     if [[ $untarred_xsd == -1 ]] ; then
         warn "Unable to prepare XSD build directory. Giving Up!"

--- a/src/tools/dev/scripts/bv_support/bv_zlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_zlib.sh
@@ -85,7 +85,7 @@ function build_zlib
     #
     # Prepare build dir
     #
-    prepare_build_dir $ZLIB_BUILD_DIR $ZLIB_FILE sha256 $ZLIB_SHA256_CHECKSUM
+    prepare_build_dir $ZLIB_BUILD_DIR $ZLIB_FILE SHA256 $ZLIB_SHA256_CHECKSUM
     untarred_zlib=$?
     if [[ $untarred_zlib == -1 ]] ; then
         warn "Unable to prepare ZLIB build directory. Giving Up!"


### PR DESCRIPTION
My recent merge adding checksum args to `prepare_build_dir` calls in build_visit modules used lower-cased sha-type string but it should have been capitalized.

Discovered when running build_visit in a directory where the tarballs had already been downloaded, the checksum test was bypassed because of an invalid type: `sha256` vs `SHA256`.

I opted not to change the logic to also test lowercase version, but to change the arguments in the individual modules.

I have verified the checksum test is now occurring when tarballs already present.