### PR TITLE
Add `--cleanup` option to `build_visit`.

### DIFF
--- a/src/doc/building_visit/Basic_Usage.rst
+++ b/src/doc/building_visit/Basic_Usage.rst
@@ -77,7 +77,7 @@ Having ``build_visit`` cleanup after itself
 By default, ``build_visit`` does not remove untarred source or build directories.
 You can change that behavior with the ``--cleanup`` option.
 When turned on, ``build_visit`` will remove untarred source and build directories for every library that successfully completes the build and install stages.
-Unsuccessful build or install of a library will preven that library's cleanup so that debugging the failure is easier.
+Unsuccessful build or install of a library will prevent that library's cleanup so that debugging the failure is easier.
 .. code:: bash
 
   ./build_visit3_5_0 --cleanup

--- a/src/doc/building_visit/Basic_Usage.rst
+++ b/src/doc/building_visit/Basic_Usage.rst
@@ -71,11 +71,22 @@ The following example uses the VisIt_ source code corresponding to the official 
 
   ./build_visit3_5_0 --optional --tarball visit3.5.0.tar.gz
 
+Having VisIt cleanup after itself
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, ``build_visit`` does not remove untarred source or build directories.
+You can change that behavior with the ``--cleanup`` option.
+When turned on, ``build_visit`` will remove untarred source and build directories for every library that successfully completes the build and install stages.
+Unsuccessful build or install of a library will preven that library's cleanup so that debugging the failure is easier.
+.. code:: bash
+
+  ./build_visit3_5_0 --cleanup
+
 If ``build_visit`` is interrupted
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If ``build_visit`` is interrupted while it is executing, it is suggested that you remove the directories associated with the last package it was in the process of building.
-``build_visit`` always leaves directories intact when it runs to aid with troubleshooting failures.
+``build_visit`` always leaves directories intact when it runs to aid with troubleshooting failures, unless the ``--cleanup`` option is used.
 Likewise, ``build_visit`` doesn't remove existing directories before starting to build a package.
 This can sometimes problems when ``build_visit`` is interrupted and you restart the build again.
 

--- a/src/doc/building_visit/Basic_Usage.rst
+++ b/src/doc/building_visit/Basic_Usage.rst
@@ -71,8 +71,8 @@ The following example uses the VisIt_ source code corresponding to the official 
 
   ./build_visit3_5_0 --optional --tarball visit3.5.0.tar.gz
 
-Having VisIt cleanup after itself
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Having ``build_visit`` cleanup after itself
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, ``build_visit`` does not remove untarred source or build directories.
 You can change that behavior with the ``--cleanup`` option.

--- a/src/resources/help/en_US/relnotes3.6.0.html
+++ b/src/resources/help/en_US/relnotes3.6.0.html
@@ -103,7 +103,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Changes for VisIt developers in version 3.6</font></b></p>
 <ul>
   <li>Enhanced <code>multi_test.C</code> data generator to handle both single and double precision.</li>
-  <li>Developer Change 2</li>
+  <li>build_visit now has a `--cleanup` option. When turned on it triggers deletion of src and build dirs for each library if build and install are successful.</li>
 </ul>
 
 <p>Click the following link to view the release notes for the previous version

--- a/src/tools/dev/scripts/bv_support/bv_adios.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios.sh
@@ -266,10 +266,9 @@ function build_adios
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/ADIOS"
-        chgrp -R ${GROUP} "$VISITDIR/ADIOS"
-    fi
+    cleanup_build_dirs $ADIOS_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/adios"
 
     cd "$START_DIR"
     info "Done with ADIOS"

--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -275,14 +275,13 @@ function build_adios2
             return 1
         fi
 
-        if [[ "$DO_GROUP" == "yes" ]] ; then
-            chmod -R ug+w,a+rX "$VISITDIR/adios2"
-            chgrp -R ${GROUP} "$VISITDIR/adios2"
-        fi
-
         cd "$START_DIR"
     done
 
+    # the build dirs are located inside the src, so only need to delete src
+    cleanup_build_dirs $ADIOS2_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/adios2"
     cd "$START_DIR"
     info "Done with ADIOS2"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_advio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_advio.sh
@@ -349,10 +349,9 @@ function build_advio
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/AdvIO"
-        chgrp -R ${GROUP} "$VISITDIR/AdvIO"
-    fi
+    cleanup_build_dirs $ADVIO_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/AdvIO"
 
     cd "$START_DIR"
     info "Done with AdvIO"

--- a/src/tools/dev/scripts/bv_support/bv_anari.sh
+++ b/src/tools/dev/scripts/bv_support/bv_anari.sh
@@ -204,11 +204,9 @@ function build_anari
     info "Installing ANARI . . . "
     ${CMAKE_COMMAND} --install . || error "ANARI did not install correctly."
 
-    chmod -R ug+w,a+rX ${VISITDIR}/${ANARI_INSTALL_DIR}
+    cleanup_build_dirs $ANARI_BUILD_DIR $ANARI_SRC_DIR
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chgrp -R ${GROUP} "$VISITDIR/${ANARI_INSTALL_DIR}"
-    fi
+    change_install_dir_perms ${VISITDIR}/${ANARI_INSTALL_DIR}
 
     cd "$START_DIR"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_blosc2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_blosc2.sh
@@ -112,10 +112,9 @@ function build_blosc2
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/blosc2"
-        chgrp -R ${GROUP} "$VISITDIR/blosc2"
-    fi
+    cleanup_build_dirs $BLOSC2_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/blosc2"
 
     cd "$START_DIR"
     info "Done with Blosc2"

--- a/src/tools/dev/scripts/bv_support/bv_boost.sh
+++ b/src/tools/dev/scripts/bv_support/bv_boost.sh
@@ -316,10 +316,10 @@ function build_boost
         fi
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/boost"
-        chgrp -R ${GROUP} "$VISITDIR/boost"
-    fi
+    cleanup_build_dirs $BOOST_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/boost"
+
     cd "$START_DIR"
     info "Done with BOOST"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_boxlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_boxlib.sh
@@ -23,6 +23,7 @@ function bv_boxlib_info
     export BOXLIB_VERSION=${BOXLIB_VERSION:-"1.3.5"}
     export BOXLIB_FILE=${BOXLIB_FILE:-"ccse-${BOXLIB_VERSION}.tar.gz"}
     export BOXLIB_COMPATIBILITY_VERSION=${BOXLIB_COMPATIBILITY_VERSION:-"1.3.5"}
+    export BOXLIB_SRC_DIR=${BOXLIB_SRC_DIR:-"ccse-${BOXLIB_VERSION}"}
     export BOXLIB_BUILD_DIR=${BOXLIB_BUILD_DIR:-"ccse-${BOXLIB_VERSION}/Src/C_BaseLib"}
     export BOXLIB_SHA256_CHECKSUM="2dd2496d27dc84d9171be06b44e3968fa481867d936174e7d49a547da5f6f755"
 }
@@ -348,10 +349,10 @@ function build_boxlib
     cp *.H "$VISITDIR/boxlib/$BOXLIB_VERSION/$VISITARCH/include" || \
         error "Boxlib install failed. Giving up!"
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/boxlib"
-        chgrp -R ${GROUP} "$VISITDIR/boxlib"
-    fi
+
+    cleanup_build_dirs $BOXLIB_BUILD_DIR $BOXLIB_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/boxlib"
 
     cd "$START_DIR"
     info "Done with BoxLib"

--- a/src/tools/dev/scripts/bv_support/bv_cfitsio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cfitsio.sh
@@ -162,10 +162,10 @@ function build_cfitsio
     info "Installing CFITSIO . . ."
     ${CMAKE_COMMAND} --install . || error "CFITSIO did not install correctly. Giving up."
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/cfitsio"
-        chgrp -R ${GROUP} "$VISITDIR/cfitsio"
-    fi
+    cleanup_build_dirs $CFITSIO_BUILD_SUBDIR $CFITSIO_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/cfitsio"
+
     cd "$START_DIR"
     info "Done with CFITSIO"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_cgns.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cgns.sh
@@ -307,10 +307,10 @@ function build_cgns
 
     ${CMAKE_COMMAND} --install . || error "CGNS did not install correctly. Giving up."
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/cgns"
-        chgrp -R ${GROUP} "$VISITDIR/cgns"
-    fi
+    cleanup_build_dirs $CGNS_BUILD_SUBDIR $CGNS_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/cgns"
+
     cd "$START_DIR"
     info "Done with CGNS"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_cmake.sh
+++ b/src/tools/dev/scripts/bv_support/bv_cmake.sh
@@ -192,14 +192,20 @@ function build_cmake
         warn "Cannot build cmake, giving up."
         return 1
     fi
+    info "Successfully built CMake"
 
     info "Installing CMake . . ."
     $MAKE install
-    info "Successfully built CMake"
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/cmake"
-        chgrp -R ${GROUP} "$VISITDIR/cmake"
+
+    if [[ $? != 0 ]] ; then
+        warn "Install for CMake failed."
+        return 1
     fi
+
+    cleanup_build_dirs $CMAKE_BUILD_DIR
+
+    change_install_dir_perms $VISITDIR/cmake
+
     cd "$START_DIR"
     info "Done with CMake"
 }

--- a/src/tools/dev/scripts/bv_support/bv_conduit.sh
+++ b/src/tools/dev/scripts/bv_support/bv_conduit.sh
@@ -309,10 +309,10 @@ function build_conduit
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/conduit"
-        chgrp -R ${GROUP} "$VISITDIR/conduit"
-    fi
+    cleanup_build_dirs $CONDUIT_BUILD_DIR $CONDUIT_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/conduit"
+
     cd "$START_DIR"
     info "Done with Conduit"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_damaris.sh
+++ b/src/tools/dev/scripts/bv_support/bv_damaris.sh
@@ -180,6 +180,12 @@ function build_damaris
         return 1
     fi
 
+    cleanup_build_dirs $DAMARIS_BUILD_DIR
+
+    change_install_dir_perms $VISITDIR/damaris
+
+    cd $START_DIR
+
     return 0
 }
 

--- a/src/tools/dev/scripts/bv_support/bv_fms.sh
+++ b/src/tools/dev/scripts/bv_support/bv_fms.sh
@@ -152,11 +152,15 @@ function build_fms
     #
     info "Installing FMS"
     ${CMAKE_COMMAND} --install .
-
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/fms"
-        chgrp -R ${GROUP} "$VISITDIR/fms"
+    if [[ $? != 0 ]] ; then
+        warn "FMS install failed.  Giving up"
+        return 1
     fi
+
+    cleanup_build_dirs $FMS_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/fms"
+
     cd "$START_DIR"    
     info "Done with FMS"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_gdal.sh
+++ b/src/tools/dev/scripts/bv_support/bv_gdal.sh
@@ -265,10 +265,10 @@ function build_gdal
                           $INSTALLNAMEPATH/libgdal.${SO_EXT}
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/gdal"
-        chgrp -R ${GROUP} "$VISITDIR/gdal"
-    fi
+    cleanup_build_dirs $GDAL_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/gdal"
+
     cd "$START_DIR"
     info "Done with GDAL"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_glu.sh
+++ b/src/tools/dev/scripts/bv_support/bv_glu.sh
@@ -217,10 +217,10 @@ function build_glu
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/glu"
-        chgrp -R ${GROUP} "$VISITDIR/glu"
-    fi
+    cleanup_build_dirs $GLU_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/glu"
+
     cd "$START_DIR"
     info "Done with GLU"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_h5part.sh
+++ b/src/tools/dev/scripts/bv_support/bv_h5part.sh
@@ -676,10 +676,10 @@ function build_h5part
         info "Creating dynamic libraries for H5Part . . ."
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/h5part"
-        chgrp -R ${GROUP} "$VISITDIR/h5part"
-    fi
+    cleanup_build_dirs $H5PART_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/h5part"
+
     cd "$START_DIR"
     info "Done with H5Part"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_hdf5.sh
+++ b/src/tools/dev/scripts/bv_support/bv_hdf5.sh
@@ -233,10 +233,10 @@ function build_hdf5
     #    echo "endif()" >> $targetsfile
     #fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/hdf5"
-        chgrp -R ${GROUP} "$VISITDIR/hdf5"
-    fi
+    cleanup_build_dirs $HDF5_BUILD_DIR $HDF5_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/hdf5"
+
     popd > /dev/null
     info "Done with HDF5"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_icet.sh
+++ b/src/tools/dev/scripts/bv_support/bv_icet.sh
@@ -193,10 +193,9 @@ function build_icet
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/icet"
-        chgrp -R ${GROUP} "$VISITDIR/icet"
-    fi
+    cleanup_build_dirs $ICET_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/icet"
 
     cd "$START_DIR"
     echo "Done with IceT"

--- a/src/tools/dev/scripts/bv_support/bv_llvm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_llvm.sh
@@ -265,10 +265,11 @@ function build_llvm
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/llvm"
-        chgrp -R ${GROUP} "$VISITDIR/llvm"
-    fi
+    cleanup_build_dirs $BV_LLVM_BUILD_DIR $BV_LLVM_SRC_DIR
+    cleanup_build_dirs clang
+
+    change_install_dir_perms "$VISITDIR/llvm"
+
     cd "$START_DIR"
     info "Done with LLVM"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_main.sh
+++ b/src/tools/dev/scripts/bv_support/bv_main.sh
@@ -557,6 +557,7 @@ function initialize_build_visit()
     export DO_CONTEXT_CHECK="yes"
     export VISIT_INSTALL_NETWORK=""
     DOWNLOAD_ONLY="no"
+    CLEANUP="no"
     LIST_TPS="no"
 
 
@@ -1148,6 +1149,7 @@ function run_build_visit()
             --java) DO_JAVA="yes";;
             --list-tpls) LIST_TPLS="yes";;
             --makeflags) next_arg="makeflags";;
+            --cleanup) CLEANUP="yes";;
             --no-hostconf) DO_HOSTCONF="no";;
             --no-boost) DO_BOOST="no";;
             --no-qt-silent) DO_QT_SILENT="no";;

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -468,10 +468,10 @@ function build_mesagl
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/mesagl"
-        chgrp -R ${GROUP} "$VISITDIR/mesagl"
-    fi
+    cleanup_build_dirs $MESAGL_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/mesagl"
+
     cd "$START_DIR"
     info "Done with MesaGL"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_meson.sh
+++ b/src/tools/dev/scripts/bv_support/bv_meson.sh
@@ -129,10 +129,10 @@ function build_meson
 
     chmod 700 $MESON_CMD
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/meson"
-        chgrp -R ${GROUP} "$VISITDIR/meson"
-    fi
+    cleanup_build_dirs $MESON_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/meson"
+
     cd "$START_DIR"
     info "Done with meson"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_mfem.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mfem.sh
@@ -243,11 +243,15 @@ function build_mfem
     #
     info "Installing mfem"
     ${CMAKE_COMMAND} --install .
-
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/mfem"
-        chgrp -R ${GROUP} "$VISITDIR/mfem"
+    if [[ $? != 0 ]] ; then
+        warn "mfem instsll failed.  Giving up"
+        return 1
     fi
+
+    cleanup_build_dirs $MFEM_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/mfem"
+
     cd "$START_DIR"
     info "Done with mfem"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_mili.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mili.sh
@@ -448,10 +448,10 @@ EOF
         cp lib_opt/libmili.a "$VISITDIR/mili/$MILI_VERSION/$VISITARCH/lib"
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/mili"
-        chgrp -R ${GROUP} "$VISITDIR/mili"
-    fi
+    cleanup_build_dirs $MILI_BUILD_DIR
+
+    change_install_dir_perms  "$VISITDIR/mili"
+
     cd "$START_DIR"
     info "Done with Mili"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_moab.sh
+++ b/src/tools/dev/scripts/bv_support/bv_moab.sh
@@ -145,11 +145,14 @@ function build_moab
     #
     info "Installing moab"
     $MAKE install
-
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/moab"
-        chgrp -R ${GROUP} "$VISITDIR/moab"
+    if [[ $? != 0 ]] ; then
+        warn "moab install failed.  Giving up"
+        return 1
     fi
+
+    cleanup_build_dirs $MOAB_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/moab"
 
     cd "$START_DIR"
     info "Done with moab"

--- a/src/tools/dev/scripts/bv_support/bv_mpich.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mpich.sh
@@ -255,10 +255,10 @@ function build_mpich
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/mpich"
-        chgrp -R ${GROUP} "$VISITDIR/mpich"
-    fi
+    cleanup_build_dirs $MPICH_BUILD_DIR
+
+    change_install_dir_perms  "$VISITDIR/mpich"
+
     cd "$START_DIR"
     info "Done with MPICH"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
+++ b/src/tools/dev/scripts/bv_support/bv_nektarpp.sh
@@ -368,10 +368,10 @@ function build_nektarpp
 
     #    mv ${nektar_plus_plus_inst_path}/lib64/* ${nektar_plus_plus_inst_path}/lib
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/nektar++"
-        chgrp -R ${GROUP} "$VISITDIR/nektar++"
-    fi
+    cleanup_build_dirs $NEKTAR_PLUS_PLUS_BUILD_DIR $NEKTAR_PLUS_PLUS_SRC_DIR
+
+    change_install_dir_perms  "$VISITDIR/nektar++"
+
     cd "$START_DIR"
     info "Done with Nektar++"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_netcdf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_netcdf.sh
@@ -299,10 +299,10 @@ function build_netcdf
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/netcdf"
-        chgrp -R ${GROUP} "$VISITDIR/netcdf"
-    fi
+    cleanup_build_dirs $NETCDF_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/netcdf"
+
     cd "$START_DIR"
     info "Done with NetCDF"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_ninja.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ninja.sh
@@ -126,10 +126,10 @@ function build_ninja
     info "Installing Ninja . . . (~2 minutes)"
     ${CMAKE_COMMAND} --install . || error "Ninja did not install correctly."
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/ninja"
-        chgrp -R ${GROUP} "$VISITDIR/ninja"
-    fi
+    cleanup_build_dirs $NINJA_BUILD_DIR
+
+    change_install_dir_perms  "$VISITDIR/ninja"
+
     cd "$START_DIR"
     info "Done with ninja"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_openexr.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openexr.sh
@@ -167,10 +167,11 @@ function build_imath
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/openexr"
-        chgrp -R ${GROUP} "$VISITDIR/openexr"
-    fi
+
+    cleanup_build_dirs $IMATH_BUILD_DIR $IMATH_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/openexr"
+
     cd "$START_DIR"
     info "Done with Imath"
     return 0
@@ -273,7 +274,7 @@ function build_openexr
     #
     # Configure OpenEXR
     #
-    cd $OPENEXR_BUILD_DIR || error "Can't cd to Imath build dir."
+    cd $OPENEXR_BUILD_DIR || error "Can't cd to OpenEXR build dir."
 
     #
     # Remove the CMakeCache.txt files ... existing files sometimes prevent
@@ -334,10 +335,10 @@ function build_openexr
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/openexr"
-        chgrp -R ${GROUP} "$VISITDIR/openexr"
-    fi
+    cleanup_build_dirs $OPENEXR_BUILD_DIR $OPENEXR_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/openexr"
+
     cd "$START_DIR"
     info "Done with OpenEXR"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -467,10 +467,10 @@ function build_osmesa
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/osmesa"
-        chgrp -R ${GROUP} "$VISITDIR/osmesa"
-    fi
+    cleanup_build_dirs $OSMESA_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/osmesa"
+
     cd "$START_DIR"
     info "Done with OSMesa"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_ospray.sh
+++ b/src/tools/dev/scripts/bv_support/bv_ospray.sh
@@ -162,64 +162,6 @@ function bv_ospray_is_installed
     return 0
 }
 
-function build_ospray_in_source
-{
-    # set compiler if the user hasn't explicitly set CC and CXX
-    if [ -z $CC ]; then
-        echo "***NOTE: using compiler $C_COMPILER/$CXX_COMPILER!"
-        export CC=$C_COMPILER
-        export CXX=$CXX_COMPILER
-    fi
-
-    #### Build OSPRay ####
-    mkdir -p build
-    cd build
-
-    # Clean out build directory to be sure we are doing a fresh build
-    rm -rf *
-
-    # set release and RPM settings
-    info "Configure OSPRay . . . "
-    CMAKE_INSTALL=${CMAKE_INSTALL:-"$VISITDIR/cmake/${CMAKE_VERSION}/$VISITARCH/bin"}
-
-    CMAKE_VARS=""
-    CMAKE_VARS=${CMAKE_VARS}" -D CMAKE_INSTALL_PREFIX=${OSPRAY_INSTALL_DIR} "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_BUILD_ISA=ALL "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_MODULE_VISIT=ON "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_MODULE_MPI=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_MODULE_MPI_APPS=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_APPS_EXAMPLEVIEWER=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_APPS_BENCHMARK=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_SG_CHOMBO=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_SG_OPENIMAGEIO=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_SG_VTK=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_ZIP_MODE=OFF "
-    CMAKE_VARS=${CMAKE_VARS}" -D embree_DIR=${EMBREE_INSTALL_DIR} "
-    CMAKE_VARS=${CMAKE_VARS}" -D ISPC_EXECUTABLE=${ISPC_INSTALL_DIR}/ispc "
-    if [[ "${TBB_INSTALL_DIR}" == "" ]]; then
-        bv_ospray_check_openmp
-        if [[ $? == 0 ]]; then
-            CMAKE_VARS=${CMAKE_VARS}" -D OSPRAY_TASKING_SYSTEM=OpenMP "
-        else
-            error "OSPRay cannot find neither TBB nor OpenMP."
-        fi
-    else
-        CMAKE_VARS=${CMAKE_VARS}" -D TBB_ROOT=${TBB_INSTALL_DIR} "
-    fi
-    ${CMAKE_INSTALL}/cmake ${CMAKE_VARS} \
-        .. || error "OSPRay did not configure correctly.  Giving up."
-
-    #
-    # Now build OSPRay
-    #
-    info "Building OSPRay (~10 minute)"
-    env DYLD_LIBRARY_PATH=`pwd`/bin ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || \
-        error "OSPRay did not build correctly.  Giving up."
-
-    info "Installing OSPRay . . . "
-    ${CMAKE_COMMAND} --install . || error "OSPRay did not install correctly."
-}
-
 function build_ospray
 {
     #
@@ -352,10 +294,10 @@ function build_ospray
 
     # No need to install as the cmake build does that.
 
-    if [[ "$DO_GROUP" == "yes" ]]; then
-        chmod -R ug+w,a+rX "$VISITDIR/ospray"
-        chgrp -R ${GROUP} "$VISITDIR/ospray"
-    fi
+    cleanup_build_dirs $OSPRAY_BUILD_DIR $OSPRAY_SRC_DIR
+    cleanup_build_dirs $OSPRAY_LIBS_DIR
+
+    change_install_dir_perms "$VISITDIR/ospray"
 
     cd "$START_DIR"
     info "Done with OSPRay"

--- a/src/tools/dev/scripts/bv_support/bv_pidx.sh
+++ b/src/tools/dev/scripts/bv_support/bv_pidx.sh
@@ -303,10 +303,10 @@ function build_pidx
 
 #    mv ${pidx_inst_path}/lib64/* ${pidx_inst_path}/lib
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/pidx"
-        chgrp -R ${GROUP} "$VISITDIR/pidx"
-    fi
+    cleanup_build_dirs $PIDX_BUILD_DIR $PIDX_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/pidx"
+
     cd "$START_DIR"
     info "Done with pidx"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_python.sh
+++ b/src/tools/dev/scripts/bv_support/bv_python.sh
@@ -75,15 +75,14 @@ function install_py_module
     fi
     popd > /dev/null
 
+    cleanup_build_dirs $MOD_DIR
+
     return 0
 }
 
 function fix_py_permissions
 {
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/python"
-        chgrp -R ${GROUP} "$VISITDIR/python"
-    fi
+    change_install_dir_perms "$VISITDIR/python"
     return 0
 }
 
@@ -763,6 +762,8 @@ function build_python
         return 1
     fi
 
+    cleanup_build_dirs $PYTHON_BUILD_DIR
+
     cd "$START_DIR"
     info "Done with Python"
 
@@ -1000,6 +1001,7 @@ function build_pillow
     # Simply re-execute the python perms command.
     fix_py_permissions
 
+    cleanup_build_dirs $PY_PILLOW_BUILD_DIR
     info "Done with Pillow."
     return 0
 }

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -562,7 +562,7 @@ function build_qt_base
     # Build Qt. Config options above make sure we only build the libs & tools.
     #
     info "Building Qt6 base . . . "
-    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || error "QtBase did not build correctly."
 
     if [[ $? != 0 ]] ; then
         warn "Qt base build failed.  Giving up"
@@ -570,14 +570,14 @@ function build_qt_base
     fi
 
     info "Installing Qt  base . . . "
-    ${CMAKE_COMMAND} --install .
+    ${CMAKE_COMMAND} --install . || error "QtBase did not install correctly."
+
+    cleanup_build_dirs $QT_BASE_BUILD_DIR $QT_BASE_SOURCE_DIR
 
     # Qt screws up permissions in some cases.  Try to fix that.
     chmod -R a+rX ${VISITDIR}/qt/${QT_VERSION}
-   if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/qt"
-        chgrp -R ${GROUP} "$VISITDIR/qt"
-    fi
+
+    change_install_dir_perms "$VISITDIR/qt"
 
     cd "$START_DIR"
     info "Done with Qt base "
@@ -638,10 +638,14 @@ function build_qt_tools
         ${qt_module_cmake_flags}
 
     info "Building Qt6 tools . . . "
-    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || error "QtTools did not build correctly."
 
     info "Installing Qt tools . . . "
-    ${CMAKE_COMMAND} --install .
+    ${CMAKE_COMMAND} --install . || error "QtTools did not install correctly."
+
+    cleanup_build_dirs $QT_TOOLS_BUILD_DIR $QT_TOOLS_SOURCE_DIR
+
+    change_install_dir_perms "$VISITDIR/qt"
 
     return 0;
 }
@@ -685,10 +689,14 @@ function build_qt_svg
         ${qt_module_cmake_flags}
 
     info "Building Qt6 svg . . . "
-    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS
+    ${CMAKE_COMMAND} --build . $MAKE_OPT_FLAGS || error "QtSVG did not build correctly."
 
     info "Installing Qt svg . . . "
-    ${CMAKE_COMMAND} --install .
+    ${CMAKE_COMMAND} --install .  || error "QtSVG did not install correctly."
+
+    cleanup_build_dirs $QT_SVG_BUILD_DIR $QT_SVG_SOURCE_DIR
+
+    change_install_dir_perms "$VISITDIR/qt"
 
     return 0;
 }

--- a/src/tools/dev/scripts/bv_support/bv_qwt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qwt.sh
@@ -352,10 +352,10 @@ function build_qwt
         fi
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/qwt"
-        chgrp -R ${GROUP} "$VISITDIR/qwt"
-    fi
+    cleanup_build_dirs $QWT_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/qwt"
+
     cd "$START_DIR"
     info "Done with Qwt"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -42,6 +42,7 @@ function bv_silo_info
     export SILO_VERSION=${SILO_VERSION:-"4.12.0"}
     export SILO_FILE=${SILO_FILE:-"Silo-${SILO_VERSION}.tar.xz"}
     export SILO_COMPATIBILITY_VERSION=${SILO_COMPATIBILITY_VERSION:-"4.12.0"}
+    export SILO_SRC_DIR=${SILO_SRC_DIR:-"Silo-${SILO_VERSION}"}
     export SILO_BUILD_DIR=${SILO_BUILD_DIR:-"Silo-${SILO_VERSION}-build"}
     export SILO_SHA256_CHECKSUM="bde1685e4547d5dd7416bd6215b41f837efef0e4934d938ba776957afbebdff0"
 }
@@ -51,6 +52,7 @@ function bv_silo_print
     printf "%s%s\n" "SILO_FILE=" "${SILO_FILE}"
     printf "%s%s\n" "SILO_VERSION=" "${SILO_VERSION}"
     printf "%s%s\n" "SILO_COMPATIBILITY_VERSION=" "${SILO_COMPATIBILITY_VERSION}"
+    printf "%s%s\n" "SILO_SRC_DIR=" "${SILO_SRC_DIR}"
     printf "%s%s\n" "SILO_BUILD_DIR=" "${SILO_BUILD_DIR}"
 }
 
@@ -77,7 +79,7 @@ function bv_silo_host_profile
 function bv_silo_ensure
 {
     if [[ "$DO_SILO" == "yes" ]] ; then
-        ensure_built_or_ready "silo" $SILO_VERSION $SILO_BUILD_DIR $SILO_FILE $SILO_URL
+        ensure_built_or_ready "silo" $SILO_VERSION $SILO_SRC_DIR $SILO_FILE $SILO_URL
         if [[ $? != 0 ]] ; then
             ANY_ERRORS="yes"
             DO_SILO="no"
@@ -444,7 +446,7 @@ function build_silo
     #
     # Prepare build dir
     #
-    prepare_build_dir $SILO_BUILD_DIR $SILO_FILE SHA256 $SILO_SHA256_CHECKSUM
+    prepare_build_dir $SILO_SRC_DIR $SILO_FILE SHA256 $SILO_SHA256_CHECKSUM
     untarred_silo=$?
     if [[ $untarred_silo == -1 ]] ; then
         warn "Unable to prepare Silo build directory. Giving Up!"
@@ -540,7 +542,7 @@ function build_silo
     #
 
     rm -f bv_run_cmake.sh
-    echo "\"${CMAKE_BIN}\"" ${cmake_opts} ../Silo-${SILO_VERSION} > bv_run_cmake.sh
+    echo "\"${CMAKE_BIN}\"" ${cmake_opts} ../${SILO_SRC_DIR} > bv_run_cmake.sh
     cat bv_run_cmake.sh
     issue_command bash bv_run_cmake.sh
 
@@ -569,10 +571,10 @@ function build_silo
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/silo"
-        chgrp -R ${GROUP} "$VISITDIR/silo"
-    fi
+    cleanup_build_dirs $SILO_BUILD_DIR $SILO_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/silo"
+
     cd "$START_DIR"
     info "Done with Silo"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_stripack.sh
+++ b/src/tools/dev/scripts/bv_support/bv_stripack.sh
@@ -117,10 +117,10 @@ function build_stripack
    
     info "Installing stripack. . ."
     cp libstripack.so $STRIPACK_INSTALL_DIR
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$STRIPACK_INSTALL_DIR/libstripack.so"
-        chgrp -R ${GROUP} "$STRIPACK_INSTALL_DIR/libstripack.so"
-    fi
+
+    cleanup_build_dirs $STRIPACK_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/sripack"
 
     cd "$START_DIR"
     echo "Done with stripack"

--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -273,6 +273,7 @@ function build_uintah
     #
     info "Configuring UINTAH . . ."
 
+    UINTAH_SRC_DIR="${UINTAH_BUILD_DIR}"
     UINTAH_BUILD_DIR="${UINTAH_BUILD_DIR}/optimized"
     if [[ ! -d $UINTAH_BUILD_DIR ]] ; then
         echo "Making build directory $UINTAH_BUILD_DIR"
@@ -395,10 +396,11 @@ function build_uintah
         done
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/uintah"
-        chgrp -R ${GROUP} "$VISITDIR/uintah"
-    fi
+    # build dir is a subdir for SRC, so only need to delete SRC
+    cleanup_build_dirs $UINTAH_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/uintah"
+
     cd "$START_DIR"
     info "Done with UINTAH"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_vtk.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtk.sh
@@ -2560,15 +2560,15 @@ function build_vtk
     info "Installing VTK . . . "
     ${CMAKE_COMMAND} --install . || error "VTK did not install correctly."
 
+    cleanup_build_dirs $VTK_BUILD_DIR $VTK_SRC_DIR
+
     # Filter out an include that references the user's VTK build directory
     configdir="${vtk_inst_path}/lib/cmake/vtk-${VTK_SHORT_VERSION}"
     cat ${configdir}/VTKConfig.cmake | grep -v "vtkTestingMacros" > ${configdir}/VTKConfig.cmake.new
     mv ${configdir}/VTKConfig.cmake.new ${configdir}/VTKConfig.cmake
 
-    chmod -R ug+w,a+rX ${VISITDIR}/${VTK_INSTALL_DIR}
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chgrp -R ${GROUP} "$VISITDIR/${VTK_INSTALL_DIR}"
-    fi
+    change_install_dir_perms ${VISITDIR}/${VTK_INSTALL_DIR}
+
     cd "$START_DIR"
     info "Done with VTK"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_vtkm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_vtkm.sh
@@ -233,10 +233,10 @@ function build_vtkm
     info "Installing VTKm . . . (~2 minutes)"
     ${CMAKE_COMMAND} --install . || error "VTKm did not install correctly."
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/vtkm"
-        chgrp -R ${GROUP} "$VISITDIR/vtkm"
-    fi
+    cleanup_build_dirs $VTKM_BUILD_DIR $VTKM_SRC_DIR
+
+    change_install_dir_perms "$VISITDIR/vtkm"
+
     cd "$START_DIR"
     info "Done with vtkm"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -383,10 +383,17 @@ function build_xcb
     make install
     cd ..
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/xcb"
-        chgrp -R ${GROUP} "$VISITDIR/xcb"
-    fi
+
+    cleanup_build_dirs $XCB_IMAGE_BUILD_DIR
+    cleanup_build_dirs $XCB_KEYSYMS_BUILD_DIR
+    cleanup_build_dirs $XCB_M4_BUILD_DIR
+    cleanup_build_dirs $XCB_RENDERUTIL_BUILD_DIR
+    cleanup_build_dirs $XCB_UTIL_BUILD_DIR
+    cleanup_build_dirs $XCB_WM_BUILD_DIR
+    cleanup_build_dirs $XORG_MACROS_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/xcb"
+
     cd "$START_DIR"
     info "Done with xcb"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_xdmf.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xdmf.sh
@@ -488,11 +488,9 @@ function build_xdmf
         install_name_tool -id $LIBDIR/libXdmf.dylib $LIBDIR/libXdmf.dylib
     fi
 
+    cleanup_build_dirs $XDMF_BUILD_DIR Xdmf
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/Xdmf"
-        chgrp -R ${GROUP} "$VISITDIR/Xdmf"
-    fi
+    change_install_dir_perms "$VISITDIR/Xdmf"
 
     cd "$START_DIR"
     info "Done with Xdmf"

--- a/src/tools/dev/scripts/bv_support/bv_xercesc.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xercesc.sh
@@ -116,10 +116,10 @@ function build_xercesc
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/xerces-c"
-        chgrp -R ${GROUP} "$VISITDIR/xerces-c"
-    fi
+    cleanup_build_dirs $XERCESC_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/xerces-c"
+
     cd "$START_DIR"
     return 0
 }

--- a/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xkbcommon.sh
@@ -138,10 +138,11 @@ function build_xkbcommon
     cp build/meson-private/xkbcommon-x11.pc ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig
     cp build/meson-private/xkbregistry.pc ${XKBCOMMON_INSTALL_DIR}/lib/pkgconfig
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/xkbcommon"
-        chgrp -R ${GROUP} "$VISITDIR/xkbcommon"
-    fi
+
+    cleanup_build_dirs $XKBCOMMON_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/xkbcommon"
+
     cd "$START_DIR"
     info "Done with xkbcommon"
     return 0

--- a/src/tools/dev/scripts/bv_support/bv_xsd.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xsd.sh
@@ -90,10 +90,10 @@ function build_xsd
     mkdir -p $VISITDIR/xsd/$XSD_VERSION/$VISITARCH/include
     cp -r libxsd/xsd $VISITDIR/xsd/$XSD_VERSION/$VISITARCH/include/
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/xsd"
-        chgrp -R ${GROUP} "$VISITDIR/xsd"
-    fi
+    cleanup_build_dirs $XSD_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/xsd"
+
     cd "$START_DIR"
     return 0
 }

--- a/src/tools/dev/scripts/bv_support/bv_zlib.sh
+++ b/src/tools/dev/scripts/bv_support/bv_zlib.sh
@@ -137,10 +137,10 @@ function build_zlib
         return 1
     fi
 
-    if [[ "$DO_GROUP" == "yes" ]] ; then
-        chmod -R ug+w,a+rX "$VISITDIR/zlib"
-        chgrp -R ${GROUP} "$VISITDIR/zlib"
-    fi
+    cleanup_build_dirs $ZLIB_BUILD_DIR
+
+    change_install_dir_perms "$VISITDIR/zlib"
+
     cd "$START_DIR"
     info "Done with ZLIB"
     return 0

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -918,6 +918,60 @@ function prepare_build_dir
     return $untarred_src
 }
 
+# *************************************************************************** #
+# Function: cleanup_build_dirs                                                #
+#                                                                             #
+# Purpose: Helper that deletes a build directory                              #
+#                                                                             #
+# Returns:                                                                    #
+#           0 for success with deletion                                       #
+#           1 for failure with deletion                                       #
+#                                                                             #
+# Programmer: Kathleen Biagas                                                 #
+# Date: Wed Jul 15, 2026                                                      #
+#                                                                             #
+# Modifications:                                                              #
+#                                                                             #
+# *************************************************************************** #
+function cleanup_build_dirs
+{
+    if [[ "$CLEANUP" == "no" ]] ; then
+        info "Not performing cleanup of build dirs"
+        return 0
+    fi
+
+    cd "$START_DIR"
+
+    info "deleting $1"
+    rm -rf $1
+
+    if [[ $? != 0 ]] ; then
+        warn "Unable to delete $1."
+        return 1
+    fi
+
+    if [[ $# == 2 ]]; then
+        info "deleting $2"
+        rm -rf $2
+
+        if [[ $? != 0 ]] ; then
+            warn "Unable to delete $2."
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+function change_install_dir_perms
+{
+    chmod -R ug+w,a+rX "$1"
+    if [[ "$DO_GROUP" == "yes" ]] ; then
+        chgrp -R ${GROUP} "$1"
+    fi
+}
+
+
 # *************************************************************************** 
 # check_3rdparty
 # --------------------------------------------------------------------------- 
@@ -1763,6 +1817,7 @@ function usage
     printf "\n"
 
     printf "%-20s %s [%s]\n" "--bv-debug"   "Enable debugging for this script" "no"
+    printf "%-20s %s [%s]\n" "--cleanup" "Cleanup (delete) src and build dirs upon successful compile and install." "no"
     printf "%-20s %s [%s]\n" "--download-only" "Only download the specified packages" "no"
     printf "%-20s %s [%s]\n" "--engine-only" "Only build the compute engine." "$DO_ENGINE_ONLY"
     printf "%-20s %s [%s]\n" "-h, --help" "Display this help message." "no"


### PR DESCRIPTION
### Description

Have modules use new `cleanup_build_dirs` function. This is a no-op if `--cleanup` wasn't used.

Also added `change_install_dir_perms` function for consistency. Modified all modules to use the function.

Resolves #1480

Removed unused function from bv_ospray.

Added blurb to basic usage docs.

### Type of change

* ~~[ ] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* [X] Other
build_visit

### How Has This Been Tested?

Ran build-visit with everything turned on and `--cleanup` added to command line.
After completion, all source and build dirs were removed.

### Checklist:

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
