### PR TITLE
Fix ANARI volume rendering broken by global ANARI surface pass

### DIFF
--- a/src/plots/Volume/avtVolumeFilter.C
+++ b/src/plots/Volume/avtVolumeFilter.C
@@ -635,13 +635,18 @@ avtVolumeFilter::GetRenderVariables( int &primIndex,
 //    Alister Maguire, Wed Oct  7 16:30:23 PDT 2020
 //    Removed the calls to SetDistance as they are no longer needed.
 //
+//    Kevin Griffin, Tue Jul 28 05:29:03 PM CDT 2026
+//    Route ANARI to RenderImageVTK() to execute the ANARI volume rendering 
+//    without any conflicting global render pass.
+//
 // ****************************************************************************
 
 avtImage_p
 avtVolumeFilter::RenderImage(avtImage_p opaque_image,
                              const WindowAttributes &window)
 {
-    if (atts.GetRendererType() == VolumeAttributes::Parallel)
+    if (atts.GetRendererType() == VolumeAttributes::Parallel ||
+        atts.GetRendererType() == VolumeAttributes::ANARI)
     {
         return RenderImageVTK(opaque_image, window);
     }

--- a/src/plots/Volume/avtVolumePlot.C
+++ b/src/plots/Volume/avtVolumePlot.C
@@ -184,6 +184,9 @@ avtVolumePlot::ManagesOwnTransparency(void)
 //    Hank Childs, Mon Sep 11 14:50:28 PDT 2006
 //    Add support for the integration ray function.
 //
+//    Kevin Griffin, Tue Jul 28 05:29:03 PM CDT 2026
+//    Add VolumeAttributes::ANARI to the return condition.
+//
 // ****************************************************************************
 
 bool
@@ -192,7 +195,8 @@ avtVolumePlot::PlotIsImageBased(void)
     return (atts.GetRendererType() == VolumeAttributes::Composite ||
             atts.GetRendererType() == VolumeAttributes::Integration ||
             atts.GetRendererType() == VolumeAttributes::SLIVR ||
-            atts.GetRendererType() == VolumeAttributes::Parallel);
+            atts.GetRendererType() == VolumeAttributes::Parallel ||
+            atts.GetRendererType() == VolumeAttributes::ANARI);
 }
 
 

--- a/src/resources/help/en_US/relnotes3.5.1.html
+++ b/src/resources/help/en_US/relnotes3.5.1.html
@@ -27,6 +27,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>Fixed a bug preventing VisIt from being built with CMake 4.0.</li>
   <li>VisIt will now open a session file passed on the command line with '-sessionfile' even if the corresponding .gui component file does not exist.</li>
   <li>Fixed a bug with the Viewer window not clearing deleted plots when ANARI rendering is enabled. </li>
+  <li>Fixed ANARI volume rendering broken by global ANARI surface pass.</li>
 </ul>
 
 <a name="Enhancements"></a>


### PR DESCRIPTION
### Description

Resolves #20871.

When the user enabled ANARI for surface rendering via the Advanced Rendering dialog, the global `vtkAnariPass` installed on the main render window would traverse the scene graph and process the volume plot's `vtkUserDefinedMapperBridge` actor (which inherits `vtkDataSetMapper`) through VisIt's poly-data ANARI node. That node never invoked the bridge's `Render()` method, so `vtkAnariVolumeMapper::Render()` was never called and the volume did not render.

Fix by making ANARI volume rendering image-based, routing it through `avtVisItVTKRenderFilter` (the same off-screen path used by the Parallel renderer). The filter renders to an isolated off-screen `vtkRenderWindow` with no conflicting render pass, so the global surface ANARI pass cannot interfere.

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

1. Create a volume plot, select and enable Anari.
2. In Options Menu->Rendering, Advanced Tab, enable Anari.
3. Volume rendering still good

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
