### PR TITLE
Fix build_visit `--print-files` missing some library files

### DIFF
--- a/src/resources/help/en_US/relnotes3.6.0.html
+++ b/src/resources/help/en_US/relnotes3.6.0.html
@@ -95,8 +95,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <a name="Build_features"></a>
 <p><b><font size="4">Changes to build_visit in version 3.6</font></b></p>
 <ul>
-  <li>Build Feature 1</li>
-  <li>Build Feature 2</li>
+  <li>The `--print-files` and `--print-files-html` options were fixed so that no libraries are missing from the printed lists.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_llvm.sh
+++ b/src/tools/dev/scripts/bv_support/bv_llvm.sh
@@ -30,9 +30,9 @@ function bv_llvm_info
     export BV_LLVM_BUILD_DIR=${BV_LLVM_BUILD_DIR:-"llvm-${BV_LLVM_VERSION}.src"}
     export BV_LLVM_SHA256_CHECKSUM="b6d6c324f9c71494c0ccaf3dac1f16236d970002b42bb24a6c9e1634f7d0f4e2"
 
-    export BV_CLANG_FILE="cfe-${BV_LLVM_VERSION}.src.tar.xz"
-    export BV_CLANG_BUILD_DIR="cfe-${BV_LLVM_VERSION}.src"
-    export BV_CLANG_SHA256_CHECKSUM="7c243f1485bddfdfedada3cd402ff4792ea82362ff91fbdac2dae67c6026b667"
+    export BV_LLVM_CLANG_FILE="cfe-${BV_LLVM_VERSION}.src.tar.xz"
+    export BV_LLVM_CLANG_BUILD_DIR="cfe-${BV_LLVM_VERSION}.src"
+    export BV_LLVM_CLANG_SHA256_CHECKSUM="7c243f1485bddfdfedada3cd402ff4792ea82362ff91fbdac2dae67c6026b667"
 }
 
 function bv_llvm_print
@@ -89,7 +89,7 @@ function bv_llvm_ensure
     if [[ "$DO_DBIO_ONLY" != "yes" ]]; then
         if [[ "$DO_LLVM" == "yes" ]] ; then
             if [[ "$DOWNLOAD_ONLY" == "yes" ]] ; then
-                download_file ${BV_CLANG_FILE} ${BV_CLANG_URL}
+                download_file ${BV_LLVM_CLANG_FILE} ${BV_LLVM_CLANG_URL}
             fi
             ensure_built_or_ready "llvm"   $BV_LLVM_VERSION   $BV_LLVM_BUILD_DIR   $BV_LLVM_FILE $BV_LLVM_URL
             if [[ $? != 0 ]] ; then
@@ -117,10 +117,10 @@ function build_llvm
     fi
 
     # download clang
-    if ! test -f ${BV_CLANG_FILE} ; then
-        download_file ${BV_CLANG_FILE} ${BV_CLANG_URL}
+    if ! test -f ${BV_LLVM_CLANG_FILE} ; then
+        download_file ${BV_LLVM_CLANG_FILE} ${BV_LLVM_CLANG_URL}
         if [[ $? != 0 ]] ; then
-            warn "Could not download ${BV_CLANG_FILE}"
+            warn "Could not download ${BV_LLVM_CLANG_FILE}"
             return 1
         fi
     fi
@@ -128,13 +128,13 @@ function build_llvm
     # extract clang
     if ! test -d clang ; then
         info "Extracting clang ..."
-        uncompress_untar ${BV_CLANG_FILE}
+        uncompress_untar ${BV_LLVM_CLANG_FILE}
         if test $? -ne 0 ; then
-            warn "Could not extract ${BV_CLANG_FILE}"
+            warn "Could not extract ${BV_LLVM_CLANG_FILE}"
             return 1
         fi
         # llvm build system expects the directory to be named clang
-        mv ${BV_CLANG_BUILD_DIR} clang
+        mv ${BV_LLVM_CLANG_BUILD_DIR} clang
     fi
 
     #

--- a/src/tools/dev/scripts/bv_support/bv_openexr.sh
+++ b/src/tools/dev/scripts/bv_support/bv_openexr.sh
@@ -26,11 +26,11 @@ function bv_openexr_info
     export OPENEXR_BUILD_DIR=${OPENEXR_BUILD_DIR:-"openexr-${OPENEXR_VERSION}"}
     export OPENEXR_SHA256_CHECKSUM="73a6d83edcc68333afb95e133f6e12012073815a854bc41abc1a01c1db5f124c"
 
-    export IMATH_VERSION=${IMATH_VERSION:-"3.1.12"}
-    export IMATH_FILE=${IMATH_FILE:-"Imath-${IMATH_VERSION}.tar.gz"}
-    export IMATH_COMPATIBILITY_VERSION=${IMATH_COMPATIBILITY_VERSION:-"3.1"}
-    export IMATH_BUILD_DIR=${IMATH_BUILD_DIR:-"Imath-${IMATH_VERSION}"}
-    export IMATH_SHA256_CHECKSUM="cb8ca9ca77ac4338ebbee911fc90c886011ac5b00088630bacf8ef6c6e522f0a"
+    export OPENEXR_IMATH_VERSION=${OPENEXR_IMATH_VERSION:-"3.1.12"}
+    export OPENEXR_IMATH_FILE=${OPENEXR_IMATH_FILE:-"Imath-${OPENEXR_IMATH_VERSION}.tar.gz"}
+    export OPENEXR_IMATH_COMPATIBILITY_VERSION=${OPENEXR_IMATH_COMPATIBILITY_VERSION:-"3.1"}
+    export OPENEXR_IMATH_BUILD_DIR=${OPENEXR_IMATH_BUILD_DIR:-"Imath-${OPENEXR_IMATH_VERSION}"}
+    export OPENEXR_IMATH_SHA256_CHECKSUM="cb8ca9ca77ac4338ebbee911fc90c886011ac5b00088630bacf8ef6c6e522f0a"
 }
 
 function bv_openexr_print
@@ -40,10 +40,10 @@ function bv_openexr_print
     printf "%s%s\n" "OPENEXR_COMPATIBILITY_VERSION=" "${OPENEXR_COMPATIBILITY_VERSION}"
     printf "%s%s\n" "OPENEXR_BUILD_DIR=" "${OPENEXR_BUILD_DIR}"
 
-    printf "%s%s\n" "IMATH_FILE=" "${IMATH_FILE}"
-    printf "%s%s\n" "IMATH_VERSION=" "${IMATH_VERSION}"
-    printf "%s%s\n" "IMATH_COMPATIBILITY_VERSION=" "${IMATH_COMPATIBILITY_VERSION}"
-    printf "%s%s\n" "IMATH_BUILD_DIR=" "${IMATH_BUILD_DIR}"
+    printf "%s%s\n" "OPENEXR_IMATH_FILE=" "${OPENEXR_IMATH_FILE}"
+    printf "%s%s\n" "OPENEXR_IMATH_VERSION=" "${OPENEXR_IMATH_VERSION}"
+    printf "%s%s\n" "OPENEXR_IMATH_COMPATIBILITY_VERSION=" "${OPENEXR_IMATH_COMPATIBILITY_VERSION}"
+    printf "%s%s\n" "OPENEXR_IMATH_BUILD_DIR=" "${OPENEXR_IMATH_BUILD_DIR}"
 }
 
 function bv_openexr_host_profile
@@ -75,11 +75,11 @@ function bv_openexr_ensure
             DO_OPENEXR="no"
             error "Unable to build OpenEXR.  ${OPENEXR_FILE} not found."
         fi
-        ensure_built_or_ready "openexr" $IMATH_VERSION $IMATH_BUILD_DIR $IMATH_FILE
+        ensure_built_or_ready "openexr" $OPENEXR_IMATH_VERSION $OPENEXR_IMATH_BUILD_DIR $OPENEXR_IMATH_FILE
         if [[ $? != 0 ]] ; then
             ANY_ERRORS="yes"
             DO_OPENEXR="no"
-            error "Unable to build OpenEXR.  ${IMATH_FILE} not found."
+            error "Unable to build OpenEXR.  ${OPENEXR_IMATH_FILE} not found."
         fi
     fi
 }
@@ -96,7 +96,7 @@ function build_imath
     #
     # Prepare build dir
     #
-    prepare_build_dir $IMATH_BUILD_DIR $IMATH_FILE SHA256 $IMATH_SHA256_CHECKSUM
+    prepare_build_dir $OPENEXR_IMATH_BUILD_DIR $OPENEXR_IMATH_FILE SHA256 $OPENEXR_IMATH_SHA256_CHECKSUM
     untarred_imath=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -106,25 +106,25 @@ function build_imath
     fi
 
     # Make a build directory for an out-of-source build. Change the
-    # IMATH_BUILD_DIR variable to represent the out-of-source build directory.
-    IMATH_SRC_DIR=$IMATH_BUILD_DIR
-    IMATH_BUILD_DIR="${IMATH_SRC_DIR}-build"
-    if [[ ! -d $IMATH_BUILD_DIR ]] ; then
-        echo "Making build directory $IMATH_BUILD_DIR"
-        mkdir $IMATH_BUILD_DIR
+    # OPENEXR_IMATH_BUILD_DIR variable to represent the out-of-source build directory.
+    OPENEXR_IMATH_SRC_DIR=$OPENEXR_IMATH_BUILD_DIR
+    OPENEXR_IMATH_BUILD_DIR="${OPENEXR_IMATH_SRC_DIR}-build"
+    if [[ ! -d $OPENEXR_IMATH_BUILD_DIR ]] ; then
+        echo "Making build directory $OPENEXR_IMATH_BUILD_DIR"
+        mkdir $OPENEXR_IMATH_BUILD_DIR
     fi
 
    
     #
     # Configure Imath
     #
-    cd $IMATH_BUILD_DIR || error "Can't cd to Imath build dir."
+    cd $OPENEXR_IMATH_BUILD_DIR || error "Can't cd to Imath build dir."
 
     #
     # Remove the CMakeCache.txt files ... existing files sometimes prevent
     # fields from getting overwritten properly.
     #
-    rm -Rf ${IMATH_BUILD_DIR}/CMakeCache.txt 
+    rm -Rf ${OPENEXR_IMATH_BUILD_DIR}/CMakeCache.txt
 
     imathopts=""
     imathopts="${imathopts} -DCMAKE_BUILD_TYPE:STRING=${VISIT_BUILD_MODE}"
@@ -145,7 +145,7 @@ function build_imath
     if test -e bv_run_cmake.sh ; then
         rm -f bv_run_cmake.sh
     fi
-    echo "\"${CMAKE_INSTALL}/cmake\"" ${imathopts} ../${IMATH_SRC_DIR} > bv_run_cmake.sh
+    echo "\"${CMAKE_INSTALL}/cmake\"" ${imathopts} ../${OPENEXR_IMATH_SRC_DIR} > bv_run_cmake.sh
     cat bv_run_cmake.sh
     issue_command bash bv_run_cmake.sh || error "Imath configuration failed."
 
@@ -168,7 +168,7 @@ function build_imath
     fi
 
 
-    cleanup_build_dirs $IMATH_BUILD_DIR $IMATH_SRC_DIR
+    cleanup_build_dirs $OPENEXR_IMATH_BUILD_DIR $OPENEXR_IMATH_SRC_DIR
 
     change_install_dir_perms "$VISITDIR/openexr"
 

--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -417,7 +417,7 @@ EOF
 function build_qt_base
 {
     echo "Build Qt 6 base module"
-    prepare_build_dir $QT_BASE_SOURCE_DIR $QT_BASE_FILE SHA256 $QTBASE_SHA256_CHECKSUM
+    prepare_build_dir $QT_BASE_SOURCE_DIR $QT_BASE_FILE SHA256 $QT_BASE_SHA256_CHECKSUM
 
     untarred_qt=$?
     # 0, already exists, 1 untarred src, 2 error
@@ -603,22 +603,14 @@ function build_qt_tools
 {
     cd "$START_DIR"
     echo "Build Qt 6 tools module"
+    prepare_build_dir $QT_TOOLS_SOURCE_DIR $QT_TOOLS_FILE SHA256 $QT_TOOLS_SHA256_CHECKSUM
 
-    if ! test -f ${QT_TOOLS_FILE} ; then
-        download_file ${QT_TOOLS_FILE} ${QT_URL}
-        if [[ $? != 0 ]] ; then
-            warn "Could not download ${QT_TOOLS_FILE}"
-            return 1
-        fi
-    fi
+    untarred_qt=$?
+    # 0, already exists, 1 untarred src, 2 error
 
-    if ! test -d ${QT_TOOLS_SOURCE_DIR} ; then
-        info "Extracting qt tools ..."
-        uncompress_untar ${QT_TOOLS_FILE}
-        if test $? -ne 0 ; then
-            warn "Could not extract ${QT_TOOLS_FILE}"
-            return 1
-        fi
+    if [[ $untarred_qt == -1 ]] ; then
+        warn "Unable to prepare Qt 6 tools directory. Giving Up!"
+        return 1
     fi
 
     # Make a build directory for an out-of-source build.
@@ -654,22 +646,14 @@ function build_qt_svg
 {
     cd "$START_DIR"
     echo "Build Qt 6 svg module"
+    prepare_build_dir $QT_SVG_SOURCE_DIR $QT_SVG_FILE SHA256 $QT_SVG_SHA256_CHECKSUM
 
-    if ! test -f ${QT_SVG_FILE} ; then
-        download_file ${QT_SVG_FILE} ${QT_URL}
-        if [[ $? != 0 ]] ; then
-            warn "Could not download ${QT_SVG_FILE}"
-            return 1
-        fi
-    fi
+    untarred_qt=$?
+    # 0, already exists, 1 untarred src, 2 error
 
-    if ! test -d ${QT_SVG_SOURCE_DIR} ; then
-        info "Extracting qt svg ..."
-        uncompress_untar ${QT_SVG_FILE}
-        if test $? -ne 0 ; then
-            warn "Could not extract ${QT_SVG_FILE}"
-            return 1
-        fi
+    if [[ $untarred_qt == -1 ]] ; then
+        warn "Unable to prepare Qt 6 svg directory. Giving Up!"
+        return 1
     fi
 
     # Make a build directory for an out-of-source build.

--- a/src/tools/dev/scripts/bv_support/bv_xcb.sh
+++ b/src/tools/dev/scripts/bv_support/bv_xcb.sh
@@ -52,10 +52,10 @@ function bv_xcb_info
     export XCB_WM_FILE=${XCB_WM_FILE:-"libxcb-wm-xcb-util-wm-${XCB_WM_VERSION}.tar.gz"}
     export XCB_WM_BUILD_DIR=${XCB_WM_BUILD_DIR:-"libxcb-wm-xcb-util-wm-${XCB_WM_VERSION}"}
     export XCB_WM_SHA256_CHECKSUM="c1b792306874c36b535413a33edc71a0ac46e78adcf6ddb1a34090a07393d717"
-    export XORG_MACROS_VERSION=${XORG_MACROS_VERSION:-"1.20.2"}
-    export XORG_MACROS_FILE=${XORG_MACROS_FILE:-"macros-util-macros-${XORG_MACROS_VERSION}.tar.gz"}
-    export XORG_MACROS_BUILD_DIR=${XORG_MACROS_BUILD_DIR:-"macros-util-macros-${XORG_MACROS_VERSION}"}
-    export XORG_MACROS_SHA256_CHECKSUM="beac7e00e5996bd0c9d9bd8cf62704583b22dbe8613bd768626b95fcac955744"
+    export XCB_XORG_MACROS_VERSION=${XCB_XORG_MACROS_VERSION:-"1.20.2"}
+    export XCB_XORG_MACROS_FILE=${XCB_XORG_MACROS_FILE:-"macros-util-macros-${XCB_XORG_MACROS_VERSION}.tar.gz"}
+    export XCB_XORG_MACROS_BUILD_DIR=${XCB_XORG_MACROS_BUILD_DIR:-"macros-util-macros-${XCB_XORG_MACROS_VERSION}"}
+    export XCB_XORG_MACROS_SHA256_CHECKSUM="beac7e00e5996bd0c9d9bd8cf62704583b22dbe8613bd768626b95fcac955744"
 }
 
 function bv_xcb_print
@@ -79,9 +79,9 @@ function bv_xcb_print
     printf "%s%s\n" "XCB_WM_FILE=" "${XCB_WM_FILE}"
     printf "%s%s\n" "XCB_WM_VERSION=" "${XCB_WM_VERSION}"
     printf "%s%s\n" "XCB_WM_BUILD_DIR=" "${XCB_WM_BUILD_DIR}"
-    printf "%s%s\n" "XORG_MACROS_FILE=" "${XORG_MACROS_FILE}"
-    printf "%s%s\n" "XORG_MACROS_VERSION=" "${XORG_MACROS_VERSION}"
-    printf "%s%s\n" "XORG_MACROS_BUILD_DIR=" "${XORG_MACROS_BUILD_DIR}"
+    printf "%s%s\n" "XCB_XORG_MACROS_FILE=" "${XCB_XORG_MACROS_FILE}"
+    printf "%s%s\n" "XCB_XORG_MACROS_VERSION=" "${XCB_XORG_MACROS_VERSION}"
+    printf "%s%s\n" "XCB_XORG_MACROS_BUILD_DIR=" "${XCB_XORG_MACROS_BUILD_DIR}"
 }
 
 function bv_xcb_print_usage
@@ -149,8 +149,8 @@ function bv_xcb_ensure
 
         # if XCB_IMAGE_FILE was downloaded, assume we need the utils as well
         if [[ -e ${XCB_IMAGE_FILE} ]] ; then
-            if [[ ! -e ${XORG_MACROS_FILE} ]] ; then
-                download_file $XORG_MACROS_FILE
+            if [[ ! -e ${XCB_XORG_MACROS_FILE} ]] ; then
+                download_file $XCB_XORG_MACROS_FILE
             fi
             if [[ ! -e ${XCB_M4_FILE} ]] ; then
                 download_file $XCB_M4_FILE
@@ -195,7 +195,7 @@ function build_xcb
     #
     # Prepare build dir
     #
-    prepare_build_dir $XORG_MACROS_BUILD_DIR $XORG_MACROS_FILE SHA256 $XORG_MACROS_SHA256_CHECKSUM
+    prepare_build_dir $XCB_XORG_MACROS_BUILD_DIR $XCB_XORG_MACROS_FILE SHA256 $XCB_XORG_MACROS_SHA256_CHECKSUM
     untarred_xcb=$?
     # 0, already exists, 1 untarred src, 2 error
 
@@ -208,7 +208,7 @@ function build_xcb
     # Configure and install
     #
     info "Configuring and installing xorg macros . . . (~1 minute)"
-    cd $XORG_MACROS_BUILD_DIR || error "Can't cd to xorg macros build dir."
+    cd $XCB_XORG_MACROS_BUILD_DIR || error "Can't cd to xorg macros build dir."
 
     ./autogen.sh
 
@@ -390,7 +390,7 @@ function build_xcb
     cleanup_build_dirs $XCB_RENDERUTIL_BUILD_DIR
     cleanup_build_dirs $XCB_UTIL_BUILD_DIR
     cleanup_build_dirs $XCB_WM_BUILD_DIR
-    cleanup_build_dirs $XORG_MACROS_BUILD_DIR
+    cleanup_build_dirs $XCB_XORG_MACROS_BUILD_DIR
 
     change_install_dir_perms "$VISITDIR/xcb"
 

--- a/src/tools/dev/scripts/bv_support/helper_funcs.sh
+++ b/src/tools/dev/scripts/bv_support/helper_funcs.sh
@@ -931,12 +931,13 @@ function prepare_build_dir
 # Date: Wed Jul 15, 2026                                                      #
 #                                                                             #
 # Modifications:                                                              #
-#                                                                             #
+#   Kathleen Biagas, Tue Aug 3, 2026                                          #
+#   Removed 'Not performing cleanup of build dirs' info message. Seemed a bit #
+#   excessive to be printed for every library.                                #
 # *************************************************************************** #
 function cleanup_build_dirs
 {
     if [[ "$CLEANUP" == "no" ]] ; then
-        info "Not performing cleanup of build dirs"
         return 0
     fi
 


### PR DESCRIPTION
### Description

Resolves #20913.

The logic used for the `--print-files` and `--print-files-html` option keys off a main module's library name.
For modules that build secondary libraries, the secondary libraries were skipped if their vars describing file, etc didn't also include the main library's name. I updated such modules.

I also fixed the QT module so that it's SVG and TOOLS libraries checksums were verified if the tarballs had already been downloaded.


### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ 
* 
### How Has This Been Tested?

In a directory where I had previously ran build_visit to build all libraries, I ran `build_visit --print-files` and verified the list of files against the tarballs in the directory. Similar for `--print-files-html`.

### Checklist:

- ~~[ ] I have commented my code where applicable.~~
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

