### PR TITLE
add missing visit-hdf5.h

### DIFF
--- a/src/databases/Blueprint/avtBlueprintTreeCache.C
+++ b/src/databases/Blueprint/avtBlueprintTreeCache.C
@@ -16,6 +16,8 @@
 #include <TimingsManager.h>
 #include <InvalidFilesException.h>
 #include "FileFunctions.h"
+#include <visit-hdf5.h>
+
 //-----------------------------------------------------------------------------
 // std lib includes
 //-----------------------------------------------------------------------------

--- a/src/databases/CarpetHDF5/avtCarpetHDF5FileFormat.h
+++ b/src/databases/CarpetHDF5/avtCarpetHDF5FileFormat.h
@@ -12,6 +12,8 @@
 #include <avtMTMDFileFormat.h>
 #include <avtSpatialBoxSelection.h>
 
+#include <visit-hdf5.h> // for H5Fclose() call here
+
 #include <hdf5.h>
 
 #include <string>


### PR DESCRIPTION
### Description

So, I wanted to be completely sure I had found all cases in our database plugins where some source file used either `H5Fopen()` or `H5Fclose()` and did not `#include visit-hdf5.h`.

I used the following terminal command on macOS...

```
find . -type f -exec sh -c "
grep -q '#include .hdf5\.h.' {} && \
grep -q 'H5Fopen\\\|H5Fclose' {} && \
! grep -q '#include .visit-hdf5.h.' {} \
" \; -print
```

And found two more cases.

### Type of change

<!-- Please check one of the boxes below -->

* [x] Bug fix~~
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- ~~[ ] I have commented my code where applicable.~~
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [x] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
