### PR TITLE
OBJ Reader Fix

### DIFF
--- a/src/databases/WavefrontOBJ/avtWavefrontOBJFileFormat.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJFileFormat.C
@@ -439,6 +439,8 @@ AddGroupings(avtDatabaseMetaData *md, vtkDataSet *ds, char const *meshname,
         ds->GetCellData()->GetAbstractArray("_vtkVisItOBJReader_AggregateGroupColors"));
     vtkStringArray *groupNamesTmp = vtkStringArray::SafeDownCast(
         ds->GetCellData()->GetAbstractArray("_vtkVisItOBJReader_AggregateGroupNames"));
+    if (!groupColors || !groupNamesTmp) return;
+
     vtkStringArray *groupNames = vtkStringArray::New();
     for (int n = 0; n < (int) groupNamesTmp->GetNumberOfTuples(); n++)
     {
@@ -447,8 +449,11 @@ AddGroupings(avtDatabaseMetaData *md, vtkDataSet *ds, char const *meshname,
         groupNames->InsertNextValue(str);
     }
 
-    if (!groupColors || !groupNames) return;
-    if (groupColors->GetNumberOfTuples() != groupNames->GetNumberOfTuples()) return;
+    if (groupColors->GetNumberOfTuples() != groupNames->GetNumberOfTuples())
+    {
+        groupNames->Delete();
+        return;
+    }
 
     vtkStringArray *colorNames = vtkStringArray::SafeDownCast(
         ds->GetCellData()->GetAbstractArray("_vtkVisItOBJReader_ColorNames"));
@@ -460,7 +465,7 @@ AddGroupings(avtDatabaseMetaData *md, vtkDataSet *ds, char const *meshname,
     for (std::set<std::string>::const_iterator cit = aggregatedGroupNames.begin();
         cit != aggregatedGroupNames.end(); cit++)
     {
-        char const *hchars = "0123456789ABCDEFabcdef#";
+        char const *hchars = "0123456789ABCDEFabcdef";
 
         /* specify material names in order of their existence in aggregatedGroupNames */
         matnames.push_back(*cit);
@@ -470,6 +475,7 @@ AddGroupings(avtDatabaseMetaData *md, vtkDataSet *ds, char const *meshname,
             debug5 << "Invalidating material object due to negative "
                    << "index for group name \"" << *cit << "\"" << endl;
             valid = false;
+            matcolors.push_back("");
             continue;
         }
 
@@ -477,19 +483,31 @@ AddGroupings(avtDatabaseMetaData *md, vtkDataSet *ds, char const *meshname,
            is of the form '#HHHHHH' where 'H' is a hex digit, then treat it as the
            rgb value itself */
         std::string groupColor = groupColors->GetValue(groupIndex);
-        if (groupColor[0] == '#' && groupColor.find_first_not_of(hchars) == std::string::npos)
+        if (groupColor.size() == 7 && groupColor[0] == '#' &&
+            groupColor.find_first_not_of(hchars, 1) == std::string::npos)
         {
             matcolors.push_back(groupColor);
             continue;
         }
 
+        if (!colorNames || !colorValues)
+        {
+            debug5 << "Invalidating material object due to missing color "
+                   << "lookup arrays" << endl;
+            valid = false;
+            matcolors.push_back("");
+            continue;
+        }
+
         /* Given the name of the color, lookit up in the colorNames array and get its index */
         int colorIndex = (int) colorNames->LookupValue(groupColors->GetValue(groupIndex));
-        if (colorIndex < 0)
+        if (colorIndex < 0 || colorIndex >= colorValues->GetNumberOfTuples() ||
+            colorValues->GetNumberOfComponents() < 3)
         {
-            debug5 << "Invalidating material object due to negative "
-                   << "index for color name \"" << groupColors->GetValue(groupIndex)<< "\"" << endl;
+            debug5 << "Invalidating material object due to invalid "
+                   << "RGB data for color name \"" << groupColors->GetValue(groupIndex)<< "\"" << endl;
             valid = false;
+            matcolors.push_back("");
             continue;
         }
 

--- a/src/databases/WavefrontOBJ/vtkVisItOBJReader.C
+++ b/src/databases/WavefrontOBJ/vtkVisItOBJReader.C
@@ -29,6 +29,7 @@
 #include "vtkStringArray.h"
 
 #include <cstring>
+#include <string>
 
 vtkStandardNewMacro(vtkVisItOBJReader);
 
@@ -113,6 +114,23 @@ int is_whitespace(char c)
     return 0;
 }
 
+static char *
+skip_whitespace(char *c)
+{
+  while (*c != '\0' && is_whitespace(*c))
+    c++;
+  return c;
+}
+
+static void
+strip_trailing_whitespace(char *c)
+{
+  char *end = c + strlen(c);
+  while (end > c && is_whitespace(*(end-1)))
+    end--;
+  *end = '\0';
+}
+
 // Parse an OBJ material file for material "names" and
 // coloration. Only the ambient color (Ka) is examined.
 static int
@@ -124,6 +142,7 @@ ParseMTLFile(char const *objFileName, char const *mtlFileName,
   float rgb[3];
   int everything_ok = 1;
   FILE *in;
+  std::string currentMaterial;
 
   if (mtlFileName[0] == '/') // abs path case
     {
@@ -139,18 +158,24 @@ ParseMTLFile(char const *objFileName, char const *mtlFileName,
   if (!in) return 0;
   while (everything_ok && fgets(line,MAX_LINE,in)!=NULL)
     {
-    if (strncmp(line,"newmtl ",7)==0)
+    char *lineStart = skip_whitespace(line);
+    if (strncmp(lineStart,"newmtl",6)==0 && is_whitespace(lineStart[6]))
       {
-      int len = (int) strlen(line);
-      line[len-1] = '\0'; // chop off newline char
-      colorNames->InsertNextValue(&line[7]);
+      char *materialName = skip_whitespace(lineStart+6);
+      strip_trailing_whitespace(materialName);
+      currentMaterial = materialName;
       }
-    else if (strncmp(line,"Ka ",3)==0)
+    else if (strncmp(lineStart,"Ka",2)==0 && is_whitespace(lineStart[2]))
       {
       // this is ambient color definition, expect three floats, separated by whitespace:
-      if (sscanf(line, "Ka %f %f %f", &rgb[0], &rgb[1], &rgb[2])==3)
+      if (sscanf(lineStart+2, "%f %f %f", &rgb[0], &rgb[1], &rgb[2])==3)
         {
-        rgbValues->InsertNextTypedTuple(rgb);
+        if (!currentMaterial.empty())
+          {
+          colorNames->InsertNextValue(currentMaterial.c_str());
+          rgbValues->InsertNextTypedTuple(rgb);
+          currentMaterial.clear();
+          }
         }
       else
         {

--- a/src/doc/python_scripting/quickrecipes.rst
+++ b/src/doc/python_scripting/quickrecipes.rst
@@ -883,3 +883,15 @@ CSV export is an option in the Conduit Blueprint Database Exporter.
     :start-after: # exportToBlueprintCSV {
     :end-before: # exportToBlueprintCSV }
 
+
+Exporting to OBJ
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is possible to export your mesh and variable with its coloring to WavefrontOBJ, yielding a mesh file (``.obj``), metadata file (``.mtl``), and a texture file (``.png``).
+The resulting export can be loaded into tools like PowerPoint, which supports 3D viewing.
+To load into PowerPoint, simply drag and drop the exported ``.obj`` file, and make sure the associated ``.mtl`` and ``.png`` files are in the same directory as the ``.obj`` file.
+
+.. literalinclude:: ../../test/tests/quickrecipes/export.py
+    :language: Python
+    :start-after: # exportToOBJ {
+    :end-before: # exportToOBJ }
+

--- a/src/doc/python_scripting/quickrecipes.rst
+++ b/src/doc/python_scripting/quickrecipes.rst
@@ -889,6 +889,7 @@ Exporting to OBJ
 It is possible to export your mesh and variable with its coloring to WavefrontOBJ, yielding a mesh file (``.obj``), metadata file (``.mtl``), and a texture file (``.png``).
 The resulting export can be loaded into tools like PowerPoint, which supports 3D viewing.
 To load into PowerPoint, simply drag and drop the exported ``.obj`` file, and make sure the associated ``.mtl`` and ``.png`` files are in the same directory as the ``.obj`` file.
+It is only possible to export a single variable at a time.
 
 .. literalinclude:: ../../test/tests/quickrecipes/export.py
     :language: Python

--- a/src/test/tests/quickrecipes/export.py
+++ b/src/test/tests/quickrecipes/export.py
@@ -85,11 +85,51 @@ def export_to_csv():
   TestValueEQ("qr_export_to_csv_cell",os.path.isfile(pjoin("my_csv_export.csv","vertex_data.csv")),True)
   DeleteAllPlots()
 
+def export_to_obj():
+  clean_data("my_obj_export.obj")
+  clean_data("my_obj_export.mtl")
+  clean_data("my_obj_export.png")
+  # exportToOBJ {
+  # Create a Pseudocolor plot and export multiple fields
+  AddPlot("Pseudocolor", "d")
+  # optional: setup operators to modify data before export
+  DrawPlots()
+  eatts = ExportDBAttributes()
+  eatts.db_type = "WavefrontOBJ"
+  eatts.variables = ("d")
+  eatts.filename = "my_obj_export"
+
+  # fetch Pseudocolor plot attributes to hand to OBJ export options
+  # (assumes your current active plot is a pseudocolor plot)
+  pc_atts = GetPlotOptions()
+
+  opts = GetExportOptions("WavefrontOBJ")
+  opts["Output colors"]              = 1 # turn colors on (1) or off (0)
+  opts["Color table"]                = pc_atts.colorTableName # choose a color table by name
+  opts["Number of colors"]           = 256 # choose a color table resolution
+  opts["Invert color table"]         = pc_atts.invertColorTable
+  opts["Use minimum"]                = pc_atts.minFlag
+  opts["Minimum"]                    = pc_atts.min
+  opts["Use color for values < min"] = pc_atts.useBelowMinColor
+  opts["Color for values < min"]     = pc_atts.belowMinColor
+  opts["Use maximum"]                = pc_atts.maxFlag
+  opts["Maximum"]                    = pc_atts.max
+  opts["Use color for values > max"] = pc_atts.useAboveMaxColor
+  opts["Color for values > max"]     = pc_atts.aboveMaxColor
+
+  ExportDatabase(eatts, opts)
+  # exportToOBJ }
+  TestValueEQ("qr_export_to_obj",os.path.isfile("my_obj_export.obj"),True)
+  TestValueEQ("qr_export_to_obj",os.path.isfile("my_obj_export.mtl"),True)
+  TestValueEQ("qr_export_to_obj",os.path.isfile("my_obj_export.png"),True)
+  DeleteAllPlots()
+
 
 OpenDatabase(silo_data_path("rect3d.silo"))
 export_to_vtk()
 export_to_silo()
 export_to_blueprint()
 export_to_csv()
+export_to_obj()
 
 Exit()

--- a/src/test/tests/quickrecipes/export.py
+++ b/src/test/tests/quickrecipes/export.py
@@ -120,8 +120,8 @@ def export_to_obj():
   ExportDatabase(eatts, opts)
   # exportToOBJ }
   TestValueEQ("qr_export_to_obj",os.path.isfile("my_obj_export.obj"),True)
-  TestValueEQ("qr_export_to_obj",os.path.isfile("my_obj_export.mtl"),True)
-  TestValueEQ("qr_export_to_obj",os.path.isfile("my_obj_export.png"),True)
+  TestValueEQ("qr_export_to_obj_mtl",os.path.isfile("my_obj_export.mtl"),True)
+  TestValueEQ("qr_export_to_obj_png",os.path.isfile("my_obj_export.png"),True)
   DeleteAllPlots()
 
 


### PR DESCRIPTION
  Changed:

  - src/databases/WavefrontOBJ/vtkVisItOBJReader.C:117: .mtl parsing now skips leading whitespace, trims trailing whitespace, and accepts indented newmtl / Ka lines.
  - src/databases/WavefrontOBJ/vtkVisItOBJReader.C:173: material names are only added when a matching RGB tuple is parsed, so the lookup arrays stay aligned.
  - src/databases/WavefrontOBJ/avtWavefrontOBJFileFormat.C:442: metadata creation now handles missing/mismatched group color arrays without leaking or crashing.
  - src/databases/WavefrontOBJ/avtWavefrontOBJFileFormat.C:493: material color lookup now checks for null arrays, bad indices, and short RGB tuples before calling
    GetTypedTuple.
