### PR TITLE
Fix dowloads of QtTools and QtSVG.

### DIFF
--- a/src/tools/dev/scripts/bv_support/bv_qt.sh
+++ b/src/tools/dev/scripts/bv_support/bv_qt.sh
@@ -87,13 +87,25 @@ function bv_qt_initialize_vars
 function bv_qt_ensure
 {
     if [[ "$DO_QT" == "yes" ]]; then
-        if [[ "$DOWNLOAD_ONLY" == "yes" ]] ; then
-            download_file ${QT_TOOLS_FILE} ${QT_URL}
-            download_file ${QT_SVG_FILE} ${QT_URL}
-        fi
         ensure_built_or_ready "qt"     $QT_VERSION    $QT_BASE_SOURCE_DIR    $QT_BASE_FILE    $QT_URL
+
+        # check if tools and svn have been installed/downloaded
+        INSTALL_DIR=$VISITDIR/qt/$QT_VERSION/$VISITARCH
+
+        PATTERN=(${INSTALL_DIR}/lib/*Tools*.*)
+        ensure_built_or_ready_component "qt" $QT_VERSION $QT_TOOLS_FILE $PATTERN
         if [[ $? != 0 ]] ; then
-            return 1
+            ANY_ERRORS="yes"
+            DO_QT="no"
+            error "Unable to build Qt Tools . ${QT_TOOLS_FILE} not found."
+        fi
+
+        PATTERN=(${INSTALL_DIR}/lib/*Svg*.*)
+        ensure_built_or_ready_component "qt" $QT_VERSION $QT_SVG_FILE $PATTERN
+        if [[ $? != 0 ]] ; then
+            ANY_ERRORS="yes"
+            DO_QT="no"
+            error "Unable to build Qt Svg. ${QT_SVG_FILE} not found."
         fi
     fi
     return 0


### PR DESCRIPTION
Use ensure_built_or_ready_component  during bv_qt_ensure. This downloads the tarball if not already present, both when building and when '--download-only' is used.


Resolves #21107

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

Ran build_visit with no qt tarballs present in the directory, and qtbase, qttools and qtsvg were downloaded and built.
Ran build_visit with --download-only, and no qt tarballs present in the directory, and qtbase, qttools and qtsvg were downloaded.

### Checklist:

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have confirmed new and existing unit tests pass locally with my changes.~~
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
