### PR TITLE
Fix windows compile error.

### DIFF
--- a/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
+++ b/src/databases/WavefrontOBJ/avtWavefrontOBJWriter.C
@@ -297,7 +297,7 @@ avtWavefrontOBJWriter::GetColorTable(const int ncolors)
         }
     }
 
-    unsigned char rgb[ncolors * 3];
+    unsigned char *rgb = new unsigned char[ncolors * 3];
     
     table->GetColors(rgb, ncolors);
 
@@ -388,6 +388,8 @@ avtWavefrontOBJWriter::GetColorTable(const int ncolors)
     // above max color
     set_pixel(above_color[0], above_color[1], above_color[2]);
     set_pixel(above_color[0], above_color[1], above_color[2]);
+
+    delete [] rgb;
 
     return imageData;
 }


### PR DESCRIPTION
### Description

Reference [dynamic arrays on WIndows](https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html#allocate-dynamic-arrays-on-the-heap-not-the-stack)

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix~~
* [ ] New feature~~
* [ ] Documentation update~~
* [ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

<!-- Please describe the tests you've added or any tests that already cover this change. Include relevant information, such as which operating system you tested on. -->

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.~~
- [X] I have updated the release notes.~~
- [X] I have made corresponding changes to the documentation.~~
- [X] I have added debugging support to my changes.~~
- [X] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.~~
- [X] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
