### PR TITLE
Modify handling of TP cmake-ified packages to be configuration agnostic.

### DIFF
--- a/src/CMake/FindANARI.cmake
+++ b/src/CMake/FindANARI.cmake
@@ -11,6 +11,9 @@
 #   Kathleen Biagas, Friday June 13, 2025
 #   Ensure libraries are installed on Windows, needs a different 'glob'.
 #
+#   Kathleen Biagas, Thur Aug 20, 2026
+#   Add call to generate_lib_setup_cmake.
+#
 #*****************************************************************************
 
 #[=======================================================================[.rst:
@@ -150,6 +153,7 @@ if(anari_FOUND)
                            NAMESPACE "anari::"
                            INCBASE "anari"
                            ITEMS ${target_list})
+    generate_lib_setup_cmake(NAME "ANARI")
     unset(target_list)
 endif()
 

--- a/src/CMake/FindHDF5.cmake
+++ b/src/CMake/FindHDF5.cmake
@@ -22,7 +22,7 @@
 #   alongside VisIt.
 #
 #   Kathleen Biagas, Mon Aug 17, 2026
-#   Use new visit_install_thirdparty_targets function to propery install
+#   Use new visit_install_thirdparty_targets function to properly install
 #   hdf5 targets without guessing configuration type.
 #
 #   Kathleen Biagas, Thur Aug 20, 2026

--- a/src/CMake/FindHDF5.cmake
+++ b/src/CMake/FindHDF5.cmake
@@ -25,6 +25,9 @@
 #   Use new visit_install_thirdparty_targets function to propery install
 #   hdf5 targets without guessing configuration type.
 #
+#   Kathleen Biagas, Thur Aug 20, 2026
+#   Add call to generate_lib_setup_cmake.
+#
 #****************************************************************************/
 
 # Uses the HDF5_DIR hint from the config-site .cmake file
@@ -63,8 +66,9 @@ if(TARGET hdf5-shared)
                            SIMPLE_INCLUDE true)
 
     # Add the needed CMake vars to the setup file.
-    set(fname ${VISIT_BINARY_DIR}/SetupHDF5.cmake)
+    get_lib_setup_cmake_input_file(fname "HDF5")
     file(APPEND ${fname} "\nset(HDF5_LIB ${HDF5_LIB})\n")
     file(APPEND ${fname} "\nset(HDF5_HL_LIB ${HDF5_HL_LIB})\n")
+    generate_lib_setup_cmake(NAME "HDF5")
 endif()
 

--- a/src/CMake/FindHDF5.cmake
+++ b/src/CMake/FindHDF5.cmake
@@ -21,6 +21,10 @@
 #   installation so that all the proper symlinks will be installed
 #   alongside VisIt.
 #
+#   Kathleen Biagas, Mon Aug 17, 2026
+#   Use new visit_install_thirdparty_targets function to propery install
+#   hdf5 targets without guessing configuration type.
+#
 #****************************************************************************/
 
 # Uses the HDF5_DIR hint from the config-site .cmake file
@@ -38,25 +42,15 @@ if(TARGET hdf5-shared)
     # For example: hdf5-shared vs hdf5-static.
     set(HDF5_LIB hdf5-shared)
     set(HAVE_HDF5 TRUE CACHE BOOL "Have HDF5 libraries")
-    if(WIN32)
-        get_target_property(hdf5_locr hdf5-shared IMPORTED_IMPLIB_RELEASE)
-    else()
-        get_target_property(hdf5_locr hdf5-shared IMPORTED_LOCATION_RELEASE)
-    endif()
-
-    THIRD_PARTY_INSTALL_LIBRARY(${hdf5_locr})
+    set(hdf5_targets hdf5-shared)
 
     if(TARGET hdf5_hl-shared)
         set(HDF5_HL_LIB hdf5_hl-shared)
         set(HAVE_HDF5_HL TRUE CACHE BOOL "Have HDF5 HL libraries")
-        if(WIN32)
-            get_target_property(hdf5_hl_locr hdf5_hl-shared IMPORTED_IMPLIB_RELEASE)
-        else()
-            get_target_property(hdf5_hl_locr hdf5_hl-shared IMPORTED_LOCATION_RELEASE)
-        endif()
-        THIRD_PARTY_INSTALL_LIBRARY(${hdf5_hl_locr})
+        list(APPEND hdf5_targets hdf5_hl-shared)
     endif()
 
+    visit_install_thirdparty_targets(NAME hdf5 TARGETS ${hdf5_targets})
     THIRD_PARTY_INSTALL_INCLUDE(hdf5 ${HDF5_INCLUDE_DIR})
 
     # for plugin vs install

--- a/src/CMake/FindSilo.cmake
+++ b/src/CMake/FindSilo.cmake
@@ -49,9 +49,12 @@
 #    installation so that all the proper symlinks will be installed
 #    alongside VisIt.
 #
-#   Kathleen Biagas, Mon Aug 17, 2026
-#   Use new visit_install_thirdparty_targets function to propery install
-#   silo targets without guessing configuration type.
+#    Kathleen Biagas, Mon Aug 17, 2026
+#    Use new visit_install_thirdparty_targets function to propery install
+#    silo targets without guessing configuration type.
+#
+#    Kathleen Biagas, Thur Aug 20, 2026
+#    Add call to generate_lib_setup_cmake.
 #
 #****************************************************************************/
 
@@ -103,8 +106,9 @@ if(TARGET silo)
                            SIMPLE_INCLUDE true)
 
     # need a few extras in the Setup file.
-    set(fname ${VISIT_BINARY_DIR}/SetupSILO.cmake)
+    get_lib_setup_cmake_input_file(fname "SILO")
     file(APPEND ${fname} "\nset(SILO_LIB ${SILO_LIB})\n")
     file(APPEND ${fname} "\nset(PDB_LIB  ${SILO_LIB})\n")
+    generate_lib_setup_cmake(NAME "SILO")
 endif()
 

--- a/src/CMake/FindSilo.cmake
+++ b/src/CMake/FindSilo.cmake
@@ -49,6 +49,10 @@
 #    installation so that all the proper symlinks will be installed
 #    alongside VisIt.
 #
+#   Kathleen Biagas, Mon Aug 17, 2026
+#   Use new visit_install_thirdparty_targets function to propery install
+#   silo targets without guessing configuration type.
+#
 #****************************************************************************/
 
 # Use the SILO_DIR hint from the config-site .cmake file
@@ -66,42 +70,22 @@ find_package(Silo PATHS ${SILO_DIR} NO_DEFAULT_PATH)
 if(TARGET silo)
     set(HAVE_SILO true)
     set(SILO_LIB silo)
+
+    set(silo_targets silo)
+
     if(WIN32)
-        get_target_property(silo_loc silo IMPORTED_IMPLIB_RELEASE)
-    else()
-        get_target_property(silo_loc silo IMPORTED_LOCATION_RELEASE)
+        if(TARGET silex)
+            list(APPEND silo_targets silex)
+        endif()
+        if(TARGET browser)
+            list(APPEND silo_targets browser)
+        endif()
     endif()
 
+    visit_install_thirdparty_targets(NAME silo TARGETS ${silo_targets})
     # include dirs aren't attached to the library in the export set
     target_include_directories(silo INTERFACE ${SILO_INCLUDE_DIR})
-    THIRD_PARTY_INSTALL_LIBRARY(${silo_loc})
     THIRD_PARTY_INSTALL_INCLUDE(silo ${SILO_INCLUDE_DIR})
-
-    if(WIN32 AND TARGET silex)
-        get_target_property(silex_loc silex IMPORTED_LOCATION_RELEASE)
-    
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy
-             ${silex_loc} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThirdParty)
-
-        install(FILES ${silex_loc}
-                DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
-                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                            GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                            WORLD_READ WORLD_EXECUTE)
-    endif()
-
-    if(WIN32 AND TARGET browser)
-        get_target_property(browser_loc browser IMPORTED_LOCATION_RELEASE)
-    
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy
-             ${browser_loc} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThirdParty)
-
-        install(FILES ${browser_loc}
-                DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
-                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                            GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                            WORLD_READ WORLD_EXECUTE)
-    endif()
 
     # We use Silo for PDB most of the time so set up additional PDB variables.
     message(STATUS "    Using PDB Lite built into Silo")

--- a/src/CMake/FindSilo.cmake
+++ b/src/CMake/FindSilo.cmake
@@ -50,7 +50,7 @@
 #    alongside VisIt.
 #
 #    Kathleen Biagas, Mon Aug 17, 2026
-#    Use new visit_install_thirdparty_targets function to propery install
+#    Use new visit_install_thirdparty_targets function to properly install
 #    silo targets without guessing configuration type.
 #
 #    Kathleen Biagas, Thur Aug 20, 2026

--- a/src/CMake/FindVTK9.cmake
+++ b/src/CMake/FindVTK9.cmake
@@ -27,6 +27,9 @@
 #  Kathleen Biagas, Mon Oct 20, 2025 
 #  Change ospray check to 'ospray_FOUND' instead of 'OSPRAY_FOUND'.
 #
+#  Kathleen Biagas, Thur Aug 20, 2026
+#  Add call to generate_lib_setup_cmake.
+#
 #*****************************************************************************
 
 # Use the VTK_DIR hint from the config-site .cmake file
@@ -166,6 +169,7 @@ else(VISIT_VTK_SKIP_INSTALL)
                            INCBASE "vtk-${vtk_majmin}" 
                            ITEMS ${vtktargs}
                            SIMPLE_INCLUDE true)
+    generate_lib_setup_cmake(NAME "VTK")
     unset(vtktargs)
 endif()
 

--- a/src/CMake/FindVTKm.cmake
+++ b/src/CMake/FindVTKm.cmake
@@ -37,7 +37,7 @@
 #   Replace vtkm_filter with vtkm::filter.
 #
 #   Kathleen Biagas, Mon Aug 17, 2026
-#   Use new visit_install_thirdparty_targets function to propery install
+#   Use new visit_install_thirdparty_targets function to properly install
 #   vtkm targets without guessing configuration type.
 #
 #   Kathleen Biagas, Thur Aug 20, 2026

--- a/src/CMake/FindVTKm.cmake
+++ b/src/CMake/FindVTKm.cmake
@@ -36,6 +36,10 @@
 #   Eric Brugger, Mon Jun 16 13:38:54 PDT 2025
 #   Replace vtkm_filter with vtkm::filter.
 #
+#   Kathleen Biagas, Mon Aug 17, 2026
+#   Use new visit_install_thirdparty_targets function to propery install
+#   vtkm targets without guessing configuration type.
+#
 #****************************************************************************/
 
 if (VISIT_VTKM_DIR)
@@ -59,42 +63,37 @@ if (VISIT_VTKM_DIR)
    if(VISIT_INSTALL_THIRD_PARTY AND NOT VISIT_VTKM_SKIP_INSTALL)
        set(vtkm_majmin ${VTKm_VERSION_MAJOR}.${VTKm_VERSION_MINOR})
 
-       # use the vtkm CMake properties to find locations and all interface
-       # link dependencies.
-       function(get_lib_loc_and_install _lib)
-           get_target_property(i_loc ${_lib} IMPORTED_LOCATION)
-           if (NOT i_loc)
-               get_target_property(i_loc ${_lib} IMPORTED_LOCATION_RELEASE)
-           endif()
-           if(i_loc)
-               THIRD_PARTY_INSTALL_LIBRARY(${i_loc})
-           endif()
-       endfunction()
-
+       # using a couple of main vtkm targets, find all of the link library
+       # targets for installation
+       list(APPEND vtkm_targets vtkm::filter vtkm::diy)
        get_target_property(VTKM_INT_LL vtkm::filter INTERFACE_LINK_LIBRARIES)
        # pluginVsInstall test for Slice on Windows revealed need for this module
        # and its link dependencies to be installed, too.
        get_target_property(VTKM_DIY_LL vtkm::diy INTERFACE_LINK_LIBRARIES)
        set(addl_ll)
        foreach(vtkmll ${VTKM_INT_LL} ${VTKM_DIY_LL})
-           get_lib_loc_and_install(${vtkmll})
+           # only process libraries that start with vtkm
+	   string(SUBSTRING ${vtkmll} 0 4 ll_dep_prefix)
+           if (TARGET ${vtkmll} AND "${ll_dep_prefix}" STREQUAL "vtkm")
+               list(APPEND vtkm_targets ${vtkmll})
+           endif()
+
            get_target_property(VTKM_LL_DEP ${vtkmll} INTERFACE_LINK_LIBRARIES)
            if(VTKM_LL_DEP)
                foreach(ll_dep ${VTKM_LL_DEP})
                    # only process libraries that start with vtkm
 	           string(SUBSTRING ${ll_dep} 0 4 ll_dep_prefix)
-                   if ("${ll_dep_prefix}" STREQUAL "vtkm")
-                       # don't process duplicates
-                       if (NOT ${ll_dep} IN_LIST VTKM_INT_LL AND
-                           NOT ${ll_dep} IN_LIST addl_ll)
-                           get_lib_loc_and_install(${ll_dep})
-                           list(APPEND addl_ll ${ll_dep})
-                       endif()
+                   if (TARGET ${ll_dep} AND "${ll_dep_prefix}" STREQUAL "vtkm")
+                       list(APPEND vtkm_targets ${ll_dep})
                    endif()
                endforeach()
            endif()
        endforeach()
+       list(REMOVE_DUPLICATES vtkm_targets)
        unset(addl_ll)
+
+       # install all library targets
+       visit_install_thirdparty_targets(NAME vtkm TARGETS ${vtkm_targets})
 
        if(NOT VISIT_HEADERS_SKIP_INSTALL)
            install(DIRECTORY ${VTKM_DIR}/include/vtkm-${vtkm_majmin}
@@ -107,7 +106,7 @@ if (VISIT_VTKM_DIR)
                                       WORLD_READ WORLD_EXECUTE)
        endif()
 
-        # write SetupVTKM.cmake 
+        # write SetupVTKM.cmake
         include(${VISIT_SOURCE_DIR}/CMake/WriteThirdPartySetup.cmake)
         set(target_list vtkm::filter)
         create_lib_setup_cmake(NAME "VTKM"

--- a/src/CMake/FindVTKm.cmake
+++ b/src/CMake/FindVTKm.cmake
@@ -40,6 +40,9 @@
 #   Use new visit_install_thirdparty_targets function to propery install
 #   vtkm targets without guessing configuration type.
 #
+#   Kathleen Biagas, Thur Aug 20, 2026
+#   Add call to generate_lib_setup_cmake.
+#
 #****************************************************************************/
 
 if (VISIT_VTKM_DIR)
@@ -116,9 +119,11 @@ if (VISIT_VTKM_DIR)
                                NESTED_INCLUDES true)
         unset(target_list)
 
-        file(APPEND ${VISIT_BINARY_DIR}/SetupVTKM.cmake "\nadd_library(vtkm::loguru INTERFACE IMPORTED)\n")
-        file(APPEND ${VISIT_BINARY_DIR}/SetupVTKM.cmake "set_target_properties(vtkm::loguru PROPERTIES INTERFACE_LINK_LIBRARIES \"Threads::Threads\")\n")
-        file(APPEND ${VISIT_BINARY_DIR}/SetupVTKM.cmake "\nadd_library(vtkm::diy_developer_flags INTERFACE IMPORTED)\n")
+        get_lib_setup_cmake_input_file(fname "VTKM")
+        file(APPEND ${fname} "\nadd_library(vtkm::loguru INTERFACE IMPORTED)\n")
+        file(APPEND ${fname} "set_target_properties(vtkm::loguru PROPERTIES INTERFACE_LINK_LIBRARIES \"Threads::Threads\")\n")
+        file(APPEND ${fname} "\nadd_library(vtkm::diy_developer_flags INTERFACE IMPORTED)\n")
+        generate_lib_setup_cmake(NAME "VTKM")
     endif()
 endif()
 

--- a/src/CMake/FindVisItPython.cmake
+++ b/src/CMake/FindVisItPython.cmake
@@ -112,6 +112,9 @@
 #   what we don't want instead of PATTERN to include what we do want, since
 #   the latter always seems to include everything, not just the PATTERNs.
 #
+#   Kathleen Biagas, Thur Aug 20, 2026
+#   Add call to generate_lib_setup_cmake.
+#
 #****************************************************************************/
 
 # - Find python libraries
@@ -186,9 +189,10 @@ if(Python3_FOUND)
                            ITEMS Python3::Python Python3::Interpreter
                            SIMPLE_INCLUDE true)
 
-    set(fname ${VISIT_BINARY_DIR}/SetupPYTHON.cmake)
+    get_lib_setup_cmake_input_file(fname "PYTHON")
     file(APPEND ${fname} "\nset(PYTHON_LIBRARY Python3::Python)\n")
     file(APPEND ${fname} "set(PYTHON_EXECUTABE Python3::Interpreter)\n\n")
+    generate_lib_setup_cmake(NAME "PYTHON")
 else()
     message("Python3 not found")
 endif()

--- a/src/CMake/FindVisItQt.cmake
+++ b/src/CMake/FindVisItQt.cmake
@@ -57,6 +57,9 @@
 #   Use new visit_install_thirdparty_targets function to propery install
 #   qt targets without guessing configuration type.
 #
+#   Kathleen Biagas, Thur Aug 20, 2026
+#   Add call to generate_lib_setup_cmake.
+#
 #*****************************************************************************
 
 #[====[
@@ -136,12 +139,13 @@ if(NOT VISIT_QT_SKIP_INSTALL)
 
     # need a few extras in the Setup file.
 
-    set(fname ${VISIT_BINARY_DIR}/SetupQT.cmake)
+    get_lib_setup_cmake_input_file(fname "QT")
     file(APPEND ${fname} "\nadd_library(WrapAtomic::WrapAtomic INTERFACE IMPORTED)\n")
     file(APPEND ${fname} "\nadd_library(WrapOpenGL::WrapOpenGL INTERFACE IMPORTED)\n")
     file(APPEND ${fname} "\nfunction(qt6_disable_unicode_defines target)\n")
     file(APPEND ${fname} "    set_target_properties(\${target} PROPERTIES QT_NO_UNICODE_DEFINES TRUE)\n")
     file(APPEND ${fname} "endfunction()\n")
+    generate_lib_setup_cmake(NAME "QT")
 
     if(APPLE)
         # Add Qt archives (lib*.a)

--- a/src/CMake/FindVisItQt.cmake
+++ b/src/CMake/FindVisItQt.cmake
@@ -53,6 +53,10 @@
 #   Now building/using a static version of openssl lib when build Qt on
 #   Windows, so no need to copy or install its libraries.
 #
+#   Kathleen Biagas, Mon Aug 17, 2026
+#   Use new visit_install_thirdparty_targets function to propery install
+#   qt targets without guessing configuration type.
+#
 #*****************************************************************************
 
 #[====[
@@ -100,70 +104,25 @@ if(NOT VISIT_QT_SKIP_INSTALL)
     install(DIRECTORY ${VISIT_QT_DIR}/mkspecs/
             DESTINATION ${VISIT_INSTALLED_VERSION_INCLUDE}/qt)
 
-
-    # moc
-    get_target_property(moc_location Qt${QT_MAJOR_VERSION}::moc LOCATION)
-    install(PROGRAMS ${moc_location}
-            DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
-            PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
-                        GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                                    WORLD_READ WORLD_EXECUTE)
-    unset(moc_location)
-
-    # automoc parser
-    get_target_property(automoc_location Qt${QT_MAJOR_VERSION}::cmake_automoc_parser LOCATION)
-    install(PROGRAMS ${automoc_location}
-            DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
-            PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
-                        GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                                    WORLD_READ WORLD_EXECUTE)
-    unset(automoc_location)
-
+    # moc and automoc parser
+    set(qt_targets Qt${QT_MAJOR_VERSION}::moc
+                   Qt${QT_MAJOR_VERSION}::cmake_automoc_parser)
 
     foreach(mod ${visit_qt_modules})
-        set(qt_lib Qt${QT_MAJOR_VERSION}::${mod})
-
-        if(APPLE)
-            if(EXISTS ${VISIT_QT_DIR}/lib/Qt${mod}.framework)
-                THIRD_PARTY_INSTALL_LIBRARY(${VISIT_QT_DIR}/lib/Qt${mod}.framework)
-            else()
-                get_target_property(qtlib_location ${qt_lib} LOCATION)
-            endif()
-        else()
-            if(WIN32)
-                get_target_property(qtlib_location ${qt_lib} IMPORTED_IMPLIB)
-            else()
-                get_target_property(qtlib_location ${qt_lib} IMPORTED_LOCATION)
-                # On Linux, the library names are Qtxxx.so.${QT_VERSION}
-                # We need to remove the version part so that
-                # THIRD_PARTY_INSTALL_LIBRARY will work correctly.
-                string(REPLACE ".${Qt${QT_MAJOR_VERSION}Core_VERSION}" ""
-                       qtlib_location ${qtlib_location})
-            endif()
-        endif()
-        if(qtlib_location)
-            THIRD_PARTY_INSTALL_LIBRARY(${qtlib_location})
-        endif()
-
-        unset(libname)
-        unset(qtlib_location)
-        unset(qt_lib)
+        list(APPEND qt_targets Qt${QT_MAJOR_VERSION}::${mod})
     endforeach()
+    visit_install_thirdparty_targets(NAME qt TARGETS ${qt_targets})
+
 
 
     # create SetupQT.cmake
-    set(qttargs)
-    foreach(mod ${visit_qt_modules})
-        list(APPEND qttargs Qt${QT_MAJOR_VERSION}::${mod})
-    endforeach()
-    list(APPEND qttargs Qt${QT_MAJOR_VERSION}::moc)
-    list(APPEND qttargs Qt${QT_MAJOR_VERSION}::cmake_automoc_parser)
     include(${VISIT_SOURCE_DIR}/CMake/WriteThirdPartySetup.cmake)
     create_lib_setup_cmake(NAME "QT"
                            NAMESPACE "Qt${QT_MAJOR_VERSION}::"
                            INCBASE "qt"
-                           ITEMS ${qttargs})
+                           ITEMS ${qt_targets})
 
+    unset(qt_targets)
     # QT also has a non-versioned namespace, so add these items, too.
     set(qttargs)
     foreach(mod ${visit_qt_modules})

--- a/src/CMake/FindVisItQt.cmake
+++ b/src/CMake/FindVisItQt.cmake
@@ -54,7 +54,7 @@
 #   Windows, so no need to copy or install its libraries.
 #
 #   Kathleen Biagas, Mon Aug 17, 2026
-#   Use new visit_install_thirdparty_targets function to propery install
+#   Use new visit_install_thirdparty_targets function to properly install
 #   qt targets without guessing configuration type.
 #
 #   Kathleen Biagas, Thur Aug 20, 2026

--- a/src/CMake/SetUpThirdParty.cmake
+++ b/src/CMake/SetUpThirdParty.cmake
@@ -59,6 +59,11 @@
 #   Fetch the 'stem' of the library so that file globbing will pick up all
 #   extensions including symlinks.
 #
+#   Kathleen Biagas, Mon Aug 17, 2026
+#   Add 'visit_install_thirdparty_targets', for installing imported third
+#   party target (from their cmake export sets) in a configuration-agnostic
+#   manner.
+#
 #****************************************************************************/
 
 # ==============================================
@@ -211,6 +216,7 @@ function(THIRD_PARTY_INSTALL_INCLUDE pkg incdir)
                 PATTERN "*.inc"
                 PATTERN "*.inl"
                 PATTERN ".svn" EXCLUDE
+                PATTERN ".git" EXCLUDE
             )
         endif()
 endfunction()
@@ -513,6 +519,129 @@ function(visit_import_third_party pkg)
     endif()
 endfunction()
 
+
+#[=======================================================================[
+  Function for installing thirdparty targets.
+  Used with third-party packages that provide their own CMake export sets
+  as they cannot be 'installed' in the normal fashion.
+  Uses $TARGET_XXX generator expressions so that the correct config
+  version of a library is installed (for packages that may supply multiple
+  configurations or a configuration that doesn't exactly match Visit's
+  current build configuration.)
+#]=======================================================================]
+
+function(visit_install_thirdparty_targets)
+    cmake_parse_arguments(vitt "" "NAME" "TARGETS" ${ARGN})
+
+    if(NOT DEFINED vitt_NAME)
+        message(FATAL_ERROR "Incomplete arguments to visit_install_thirdparty_targets. Required: NAME, TARGETS")
+    endif()
+    if(NOT DEFINED vitt_TARGETS)
+        message(FATAL_ERROR "Incomplete arguments to visit_install_thirdparty_targets. Required: NAME, TARGETS")
+    endif()
+
+    foreach(targetName ${vitt_TARGETS})
+        if(NOT TARGET ${targetName})
+            message(FATAL_ERROR "visit_install_thirdparty_targets, target does not exist: ${targetName}")
+        endif()
+
+        get_target_property(_targetType ${targetName} TYPE)
+        if(NOT _targetType)
+            message(FATAL_ERROR "visit_install_thirdparty_targets could not determine target type for: ${targetName}")
+        endif()
+
+        if(WIN32)
+            if(_targetType STREQUAL "SHARED_LIBRARY" OR
+               _targetType STREQUAL "EXECUTABLE")
+
+                # keep track of shared-library targets that will need
+                # dlls copied to build directory
+                if(_targetType STREQUAL "SHARED_LIBRARY")
+                    list(APPEND tfnames "$<TARGET_FILE:${targetName}>")
+                endif()
+
+                # this yields the same as target property
+                # IMPORTED_LOCATION_<CONFIG>
+                install(FILES "$<TARGET_FILE:${targetName}>"
+                        DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
+                        PERMISSIONS ${VISIT_TP_PERMS}
+                        OPTIONAL)
+            endif()
+
+            if(VISIT_INSTALL_THIRD_PARTY)
+                if(_targetType STREQUAL "SHARED_LIBRARY")
+                    # this yields the same as target property
+                    # IMPORTED_IMPLIB_<CONFIG>
+                    install(FILES "$<TARGET_LINKER_FILE:${targetName}>"
+                            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                            PERMISSIONS ${VISIT_TP_PERMS}
+                            OPTIONAL)
+                elseif(_targetType STREQUAL "STATIC_LIBRARY")
+                    # this yields the same as target property
+                    # IMPORTED_LOCATION_<CONFIG>
+                    install(FILES "$<TARGET_FILE:${targetName}>"
+                            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                            PERMISSIONS ${VISIT_TP_PERMS}
+                            OPTIONAL)
+                endif()
+            endif()
+        else()
+            if(APPLE)
+                get_target_property(_isFramework ${targetName} FRAMEWORK)
+                if(_isFramework)
+                    install(DIRECTORY "$<TARGET_BUNDLE_DIR:${targetName}>"
+                            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                            DIRECTORY_PERMISSIONS ${VISIT_TP_PERMS}
+                            FILE_PERMISSIONS ${VISIT_TP_PERMS}
+                            PATTERN "Qt*_debug" EXCLUDE)
+                    continue()
+                endif()
+            endif()
+
+            if(_targetType STREQUAL "SHARED_LIBRARY")
+                    # this yields the same as target property
+                    # IMPORTED_LOCATION_<CONFIG>
+                    install(FILES "$<TARGET_FILE:${targetName}>"
+                            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                            PERMISSIONS ${VISIT_TP_PERMS}
+                            OPTIONAL)
+                    # this yields the same as target property
+                    # IMPORTED_SONAME_<CONFIG>
+                    install(FILES "$<TARGET_SONAME_FILE:${targetName}>"
+                            DESTINATION ${VISIT_INSTALLED_VERSION_LIB}
+                            PERMISSIONS ${VISIT_TP_PERMS}
+                            OPTIONAL)
+            elseif(_targetType STREQUAL "STATIC_LIBRARY")
+                if(VISIT_INSTALL_THIRD_PARTY)
+                    # this yields the same as target property
+                    # IMPORTED_LOCATION_<CONFIG>
+                    install(FILES "$<TARGET_FILE:${targetName}>"
+                            DESTINATION ${VISIT_INSTALLED_VERSION_ARCHIVES}
+                            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
+                            OPTIONAL)
+                endif()
+            elseif(_targetType STREQUAL "EXECUTABLE")
+                install(PROGRAMS "$<TARGET_FILE:${targetName}>"
+                        DESTINATION ${VISIT_INSTALLED_VERSION_BIN}
+                        PERMISSIONS ${VISIT_TP_PERMS}
+                        OPTIONAL)
+            elseif(NOT _targetType STREQUAL "INTERFACE_LIBRARY")
+                message(FATAL_ERROR
+                    "visit_install_thirdparty_target does not support ${targetName} target type: ${_targetType}")
+            endif()
+        endif()
+    endforeach()
+
+
+    # copy available dlls to build directory
+    if(WIN32 AND tfnames)
+        add_custom_target(${vitt_NAME}_copy_dlls ALL
+                    COMMAND ${CMAKE_COMMAND} -E copy ${tfnames}
+                    "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThirdParty")
+        visit_add_to_util_builds(${vitt_NAME}_copy_dlls)
+        unset(tfnames)
+    endif()
+endfunction()
 
 # ==============================================
 # Installs a library's executables.

--- a/src/CMake/WriteThirdPartySetup.cmake
+++ b/src/CMake/WriteThirdPartySetup.cmake
@@ -15,18 +15,23 @@
 # 'FindDependencies.cmake' file.
 #
 # Modifications:
+#   Kathleen Biagas, Thu Aug 20, 2026
+#   Reworked logic so that an endless query of configuration-specific target
+#   properties does not need to performed.  Instead, use CMake generator
+#   expressions like $<TARGET_FILE_NAME>, written to a .cmake.in file that
+#   then gets 'generated' by CMake when the expression can be resolved.
+#   No longer write config-specific target properties to the Setup files.
+#   Update/add function header comments where needed.
 #
 #****************************************************************************
 
-macro(visit_tp_append_list)
-    cmake_parse_arguments(arg "" "NAME" "ITEMS" ${ARGN})
-    if(NOT DEFINED arg_NAME OR NOT DEFINED arg_ITEMS)
-        message(FATAL_ERROR "visit_tp_append_list called with invalid arguments. Must supply 'NAME' (name of list) and 'ITEMS' (list of items to be added to named list.)")
-    endif()
-    set(${arg_NAME} ${${arg_NAME}};${arg_ITEMS} CACHE STRING "" FORCE)
-endmacro()
 
-
+# Test whether a target property is explicitly set.
+#
+# Arguments:
+#   is_set      Output variable set to true or false.
+#   prop        Target property name to test.
+#   targetName  Target to inspect.
 macro(is_prop_set is_set prop targetName)
     if(TARGET ${targetName})
         get_property(${is_set} TARGET ${targetName} PROPERTY ${prop} SET)
@@ -36,6 +41,12 @@ macro(is_prop_set is_set prop targetName)
     endif()
 endmacro()
 
+# Write a target property entry to a generated set_target_properties() block.
+#
+# Arguments:
+#   fname       Setup file being written.
+#   ptype       Target property name to copy.
+#   targetName  Target to inspect.
 function(write_prop_if_set fname ptype targetName)
     is_prop_set(propIsSet ${ptype} ${targetName})
     if(propIsSet)
@@ -44,74 +55,145 @@ function(write_prop_if_set fname ptype targetName)
     endif()
 endfunction()
 
+# Decide whether a target needs a set_target_properties() block.
+#
+# Arguments:
+#   has_props   Output variable set to true when the target has properties or
+#               platform artifact locations that should be written.
+#   targetName  Target to inspect.
 macro(has_props_we_care_about has_props targetName)
 
-    list(APPEND props INTERFACE_INCLUDE_DIRECTORIES)
-    list(APPEND props IMPORTED_IMPLIB)
-    list(APPEND props IMPORTED_IMPLIB_RELEASE)
-    list(APPEND props IMPORTED_LOCATION)
-    list(APPEND props IMPORTED_LOCATION_RELEASE)
-    list(APPEND props INTERFACE_LINK_LIBRARIES)
-    list(APPEND props INTERFACE_COMPILE_OPTIONS)
-    list(APPEND props INTERFACE_COMPILE_DEFINITIONS)
-    list(APPEND props IMPORTED_SONAME)
-    list(APPEND props IMPORTED_SONAME_RELEASE)
+    set(props
+        INTERFACE_INCLUDE_DIRECTORIES
+        INTERFACE_LINK_LIBRARIES
+        INTERFACE_COMPILE_OPTIONS
+        INTERFACE_COMPILE_FEATURES
+        INTERFACE_COMPILE_DEFINITIONS)
     foreach(item ${props})
         is_prop_set(hasit ${item} ${targetName})
         if(${hasit})
             break()
         endif()
     endforeach()
+    get_target_property(ttype ${targetName} TYPE)
+    if(NOT ${ttype} STREQUAL "INTERFACE_LIBRARY")
+        set(hasit true)
+    endif()
     set(${has_props} ${hasit})
 endmacro()
 
-function(write_lib_location_type fname libType targetName prefix libdir)
-    is_prop_set(isLibSet ${libType} ${targetName})
-    if(isLibSet)
-        get_target_property(ilib ${targetName} ${libType})
-        cmake_path(GET ilib FILENAME ilib_name)
-        if(libdir STREQUAL "")
-            file(APPEND ${fname} "    ${libType} \"\${${prefix}}/${ilib_name}\"\n")
-        else()
-            file(APPEND ${fname} "    ${libType} \"\${${prefix}}/${libdir}/${ilib_name}\"\n")
-        endif()
+# Write one imported artifact location property.
+#
+# Arguments:
+#   fname            Setup file being written.
+#   libType          Imported property to write, such as IMPORTED_LOCATION.
+#   targetName       Target whose artifact name should be used.
+#   prefix           Setup-file prefix variable, such as VTK_PREFIX.
+#   libdir           Installed subdirectory below prefix; empty means prefix.
+#   targetFileGenex  TARGET_*_FILE_NAME generator expression selector.
+function(write_lib_location_type fname libType targetName prefix libdir targetFileGenex)
+    set(ilib_name "@VISIT_TP_GENEX_${targetFileGenex}:${targetName}@")
+    if(libdir STREQUAL "")
+        file(APPEND ${fname} "    ${libType} \"\${${prefix}}/${ilib_name}\"\n")
+    else()
+        file(APPEND ${fname} "    ${libType} \"\${${prefix}}/${libdir}/${ilib_name}\"\n")
     endif()
 endfunction()
 
+# Write a generic IMPORTED_SONAME property using target soname genex.
+#
+# Arguments:
+#   fname       Setup file being written.
+#   targetName  Shared-library target whose soname should be used.
+function(write_soname fname targetName)
+    file(APPEND ${fname} "    IMPORTED_SONAME \"@VISIT_TP_GENEX_TARGET_SONAME_FILE_NAME:${targetName}@\"\n")
+endfunction()
+
+# Test whether a target represents an Apple framework.
+#
+# Arguments:
+#   isFramework  Output variable set to true or false.
+#   targetName   Target to inspect.
+function(is_framework_target isFramework targetName)
+    set(framework false)
+    is_prop_set(propIsSet FRAMEWORK ${targetName})
+    if(propIsSet)
+        get_target_property(framework_prop ${targetName} FRAMEWORK)
+        if(framework_prop)
+            set(framework true)
+        endif()
+    endif()
+    set(${isFramework} ${framework} PARENT_SCOPE)
+endfunction()
+
+# Write IMPORTED_LOCATION for an installed Apple framework directory.
+#
+# Arguments:
+#   fname       Setup file being written.
+#   targetName  Framework target whose framework directory should be used.
+#   prefix      Setup-file prefix variable, such as QT_PREFIX.
+function(write_framework_location fname targetName prefix)
+    file(APPEND ${fname} "    IMPORTED_LOCATION \"\${${prefix}}/lib/@VISIT_TP_FRAMEWORK_DIR_NAME:${targetName}@\"\n")
+endfunction()
+
+# Write platform-specific imported artifact location properties.
+#
+# Arguments:
+#   fname       Setup file being written.
+#   targetName  Target whose installed artifact properties should be written.
+#   prefix      Setup-file prefix variable, such as VTK_PREFIX.
 function(write_lib_location fname targetName prefix)
     get_target_property(ttype ${targetName} TYPE)
 
     if(WIN32)
         if(${ttype} STREQUAL "SHARED_LIBRARY")
-            write_lib_location_type(${fname} IMPORTED_IMPLIB ${targetName} ${prefix} "lib")
-            write_lib_location_type(${fname} IMPORTED_IMPLIB_RELEASE ${targetName} ${prefix} "lib")
-            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "")
-            write_lib_location_type(${fname} IMPORTED_LOCATION_RELEASE ${targetName} ${prefix} "")
+            write_lib_location_type(${fname} IMPORTED_IMPLIB ${targetName} ${prefix} "lib" TARGET_LINKER_FILE_NAME)
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "" TARGET_FILE_NAME)
         elseif(${ttype} STREQUAL "STATIC_LIBRARY")
-            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "lib")
-            write_lib_location_type(${fname} IMPORTED_LOCATION_RELEASE ${targetName} ${prefix} "lib")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "lib" TARGET_FILE_NAME)
         elseif(${ttype} STREQUAL "EXECUTABLE")
-            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "")
-            write_lib_location_type(${fname} IMPORTED_LOCATION_RELEASE ${targetName} ${prefix} "")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "" TARGET_FILE_NAME)
         endif()
     elseif(LINUX)
         if(${ttype} STREQUAL "EXECUTABLE")
-            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "bin")
-            write_lib_location_type(${fname} IMPORTED_LOCATION_RELEASE ${targetName} ${prefix} "bin")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "bin" TARGET_FILE_NAME)
         elseif(${ttype} STREQUAL "SHARED_LIBRARY")
-            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "lib")
-            write_lib_location_type(${fname} IMPORTED_LOCATION_RELEASE ${targetName} ${prefix} "lib")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "lib" TARGET_FILE_NAME)
+            write_soname(${fname} ${targetName})
         elseif(${ttype} STREQUAL "STATIC_LIBRARY")
-            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "archives")
-            write_lib_location_type(${fname} IMPORTED_LOCATION_RELEASE ${targetName} ${prefix} "archives")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "archives" TARGET_FILE_NAME)
         endif()
-    else()
-        # install locations for mac are same as linux for visit tp, but
-        # I don't know about the 'IMPORTED_ZZZ', need someone with a Mac
-        # to provide samples from VTKm, Qt, VTK, anari
+    elseif(APPLE)
+        is_framework_target(isFramework ${targetName})
+        if(isFramework)
+            write_framework_location(${fname} ${targetName} ${prefix})
+            if(${ttype} STREQUAL "SHARED_LIBRARY")
+                write_soname(${fname} ${targetName})
+            endif()
+        elseif(${ttype} STREQUAL "EXECUTABLE")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "bin" TARGET_FILE_NAME)
+        elseif(${ttype} STREQUAL "SHARED_LIBRARY" OR ${ttype} STREQUAL "UNKNOWN_LIBRARY")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "lib" TARGET_FILE_NAME)
+            if(${ttype} STREQUAL "SHARED_LIBRARY")
+                write_soname(${fname} ${targetName})
+            endif()
+        elseif(${ttype} STREQUAL "STATIC_LIBRARY")
+            write_lib_location_type(${fname} IMPORTED_LOCATION ${targetName} ${prefix} "archives" TARGET_FILE_NAME)
+        endif()
     endif()
 endfunction()
 
+# Write the set_target_properties() block for one imported target.
+#
+# Arguments:
+#   fname              Setup file being written.
+#   targetName         Target whose properties should be written.
+#   namespace          Target namespace being exported.
+#   incBase            Installed include directory base below include/.
+#   prefix             Setup-file prefix variable, such as VTK_PREFIX.
+#   useSimpleInclude   If true, write include/${incBase} without inspecting
+#                      target include paths.
+#   hasNestedIncludes  If true, preserve nested include paths under incBase.
 function(write_target_props fname targetName namespace incBase prefix useSimpleInclude hasNestedIncludes)
 
      has_props_we_care_about(${targetName}_hasProps ${targetName})
@@ -181,6 +263,16 @@ function(write_target_props fname targetName namespace incBase prefix useSimpleI
 endfunction()
 
 
+# Write add_library()/add_executable() and properties for one target.
+#
+# Arguments:
+#   fname              Setup file being written.
+#   targetName         Target to recreate as an imported target.
+#   namespace          Target namespace being exported.
+#   incBase            Installed include directory base below include/.
+#   prefix             Setup-file prefix variable, such as VTK_PREFIX.
+#   useSimpleInclude   Passed through to write_target_props().
+#   hasNestedIncludes  Passed through to write_target_props().
 function(write_library_entry fname targetName namespace incBase prefix useSimpleInclude hasNestedIncludes)
 
     get_target_property(ttype ${targetName} TYPE)
@@ -191,28 +283,35 @@ function(write_library_entry fname targetName namespace incBase prefix useSimple
         file(APPEND ${fname} "add_library(${targetName} INTERFACE IMPORTED)\n")
     elseif(${ttype} STREQUAL "STATIC_LIBRARY")
         file(APPEND ${fname} "add_library(${targetName} STATIC IMPORTED)\n")
+    elseif(${ttype} STREQUAL "UNKNOWN_LIBRARY")
+        file(APPEND ${fname} "add_library(${targetName} UNKNOWN IMPORTED)\n")
     elseif(${ttype} STREQUAL "EXECUTABLE")
         file(APPEND ${fname} "add_executable(${targetName} IMPORTED)\n")
-    endif()
-
-    is_prop_set(propIsSet IMPORTED_CONFIGURATIONS ${targetName})
-    if(propIsSet)
-        get_target_property(conf ${targetName} IMPORTED_CONFIGURATIONS)
-        file(APPEND ${fname} "set_property(TARGET ${targetName} APPEND PROPERTY IMPORTED_CONFIGURATIONS \"${conf}\")\n")
     endif()
 
     write_target_props(${fname} ${targetName} ${namespace} ${incBase}
                        ${prefix} ${useSimpleInclude} ${hasNestedIncludes})
 endfunction()
 
-# assumes initial WRITE has already occurred
+# Write the standard VisIt copyright header.
+#
+# Arguments:
+#   fname  Setup file being written.
+#
+# Assumes the initial file(WRITE) has already occurred.
 function(write_copyright fname)
     file(APPEND ${fname} "# Copyright (c) Lawrence Livermore National Security, LLC and other VisIt\n")
     file(APPEND ${fname} "# Project developers.  See the top-level LICENSE file for dates and other\n")
     file(APPEND ${fname} "# details.  No copyright assignment is required to contribute to VisIt.\n\n")
 endfunction()
 
-# assumes initial WRITE has already occurred
+# Write the standard setup-file header and version variables.
+#
+# Arguments:
+#   fname  Setup file being written.
+#   kit    Third-party package name used in Setup<kit>.cmake and <kit>_PREFIX.
+#
+# Assumes the initial file(WRITE) has already occurred.
 function(write_standard_header fname kit)
     write_copyright(${fname})
 
@@ -229,6 +328,12 @@ function(write_standard_header fname kit)
     endif()
 endfunction()
 
+# Collect namespace targets and same-namespace transitive link dependencies.
+#
+# Arguments:
+#   NAME       Prefix for the cached output list variable (<NAME>_list).
+#   NAMESPACE  Namespace targets must start with to be collected.
+#   ITEMS      Initial targets or link entries to inspect.
 function(get_all_targets)
     cmake_parse_arguments(gat "" "NAME;NAMESPACE" "ITEMS" ${ARGN})
     if(NOT DEFINED gat_NAME)
@@ -242,49 +347,91 @@ function(get_all_targets)
     endif()
 
     # used for determining if a target belongs to the given namespace
-    string(LENGTH ${gat_NAMESPACE} size)
-    foreach(t ${gat_ITEMS})
-        if(NOT TARGET ${t})
+    set(_targets)
+    string(LENGTH "${gat_NAMESPACE}" size)
+    foreach(t IN LISTS gat_ITEMS)
+        if(NOT TARGET "${t}")
             continue()
         endif()
-        if(size GREATER_EQUAL 0)
-            string(SUBSTRING ${t} 0 ${size} starts_with_namespace)
-            if(starts_with_namespace STREQUAL ${gat_NAMESPACE})
-                visit_tp_append_list(NAME ${gat_NAME}_list ITEMS ${t})
-            endif()
-        else()
+        string(SUBSTRING "${t}" 0 ${size} starts_with_namespace)
+        if(starts_with_namespace STREQUAL ${gat_NAMESPACE})
+            list(APPEND _targets ${t})
         endif()
-        get_target_property(ill ${t} INTERFACE_LINK_LIBRARIES)
+        get_target_property(ill "${t}" INTERFACE_LINK_LIBRARIES)
         if(ill)
             foreach(lib ${ill})
                 get_all_targets(NAME ${gat_NAME}
                                 NAMESPACE ${gat_NAMESPACE}
                                 ITEMS ${lib})
+                list(APPEND _targets ${${gat_NAME}_list})
             endforeach()
         endif()
     endforeach()
+    set(${gat_NAME}_list ${_targets} PARENT_SCOPE)
 endfunction()
 
 
+# Return the intermediate setup-file input path for a package.
+#
+# Arguments:
+#   outvar  Output variable that receives the path.
+#   name    Third-party package name used in Setup<name>.cmake.in.
+function(get_lib_setup_cmake_input_file outvar name)
+    set(${outvar} ${VISIT_BINARY_DIR}/Setup${name}.cmake.in PARENT_SCOPE)
+endfunction()
+
+# Generate and install the final Setup<NAME>.cmake file.
+#
+# Arguments:
+#   NAME  Third-party package name whose Setup<NAME>.cmake.in should be
+#         processed with file(GENERATE) and installed.
+function(generate_lib_setup_cmake)
+    cmake_parse_arguments(glsc "" "NAME" "" ${ARGN})
+    if(NOT DEFINED glsc_NAME)
+        message(FATAL_ERROR "generate_lib_setup_cmake missing NAME arg")
+    endif()
+
+    get_lib_setup_cmake_input_file(fname ${glsc_NAME})
+    if(CMAKE_CONFIGURATION_TYPES)
+        set(generated_fname ${VISIT_BINARY_DIR}/$<CONFIG>/Setup${glsc_NAME}.cmake)
+    else()
+        set(generated_fname ${VISIT_BINARY_DIR}/Setup${glsc_NAME}.cmake)
+    endif()
+
+    file(READ ${fname} setup_content)
+    string(REPLACE "$<" "$<1:$><" setup_content "${setup_content}")
+    string(REGEX REPLACE "@VISIT_TP_GENEX_([^@]+)@" "$<\\1>" setup_content "${setup_content}")
+    string(REGEX REPLACE "@VISIT_TP_FRAMEWORK_DIR_NAME:([^@]+)@" "$<PATH:GET_FILENAME,$<TARGET_FILE_DIR:\\1>>" setup_content "${setup_content}")
+
+    file(GENERATE OUTPUT ${generated_fname}
+                  CONTENT "${setup_content}")
+
+    install(FILES ${generated_fname}
+            DESTINATION ${VISIT_INSTALLED_VERSION}/cmake
+            RENAME Setup${glsc_NAME}.cmake)
+endfunction()
+
+# Create or append to the intermediate Setup<NAME>.cmake.in file.
+#
+# This is the main entry point used by VisIt's Find modules for complex
+# third-party libraries whose imported targets cannot be exported with
+# visit_import_library(). It collects the requested targets and their
+# same-namespace target dependencies, then writes add_library()/add_executable()
+# and set_target_properties() commands into the intermediate setup file.
+#
+# Required arguments:
+#   NAME       Third-party package name used in Setup<NAME>.cmake.in.
+#   NAMESPACE  Target namespace to collect, such as VTK:: or Qt6::.
+#   ITEMS      Initial list of targets to write.
+#   INCBASE    Installed include directory base below include/.
+#
+# Optional arguments:
+#   SIMPLE_INCLUDE   If set, write include/${INCBASE} directly instead of
+#                    deriving include subdirectories from target properties.
+#   NESTED_INCLUDES  If set, preserve nested include paths below INCBASE.
+#   SKIP_HEADER      If set, append targets without rewriting the standard
+#                    header. Used by multi-namespace setup files such as Qt.
 function(create_lib_setup_cmake)
-    # this is the main function that should be called from one of VisIt's
-    # 'Find' modules. Used for complex Third party libraries for which
-    # 'blt_import_library' cannot be used with the EXPORTABLE flag on.
-    #
-    # required arguments:
-    #   NAME               Name of the ThirdParty library
-    #                         (will be used for the filename).
-    #   NAMESPACE         Namespace used by NAME.
-    #   ITEMS             Initial list of targets to be written.
-    #   INCBASE           Base of include directory
-    #
-    # optional arguments:
-    #   SIMPLE_INCLUDE    If true, don't get includes from targets.
-    #   NESTED_INCLUDES   If true, targets may have deeply nested includes.
-    #   SKIP_HEADER       Don't write the header. Useful for multi-namespace
-    #                     libraries that need to call this function twice
-    #                     (like Qt).
-    #
     cmake_parse_arguments(clsc "SIMPLE_INCLUDE;NESTED_INCLUDES;SKIP_HEADER" "NAME;NAMESPACE;INCBASE" "ITEMS" ${ARGN})
     if(NOT DEFINED clsc_NAME)
         message(FATAL_ERROR "create_lib_setup_make missing NAME arg")
@@ -309,7 +456,7 @@ function(create_lib_setup_cmake)
                     ITEMS     ${clsc_ITEMS})
     list(REMOVE_DUPLICATES ${clsc_NAME}_list)
 
-    set(fname ${VISIT_BINARY_DIR}/Setup${clsc_NAME}.cmake)
+    get_lib_setup_cmake_input_file(fname ${clsc_NAME})
     if(NOT ${clsc_SKIP_HEADER})
         file(WRITE ${fname} "")
         write_standard_header(${fname} ${clsc_NAME})
@@ -319,9 +466,6 @@ function(create_lib_setup_cmake)
     foreach(onetarget ${${clsc_NAME}_list})
         write_library_entry(${fname} ${onetarget} ${clsc_NAMESPACE} ${clsc_INCBASE} ${prefix} ${clsc_SIMPLE_INCLUDE} ${clsc_NESTED_INCLUDES})
     endforeach()
-
-    install(FILES ${fname}
-            DESTINATION  ${VISIT_INSTALLED_VERSION}/cmake)
 
     # cleanup
     unset(${clsc_NAME}_list CACHE)

--- a/src/resources/help/en_US/relnotes3.6.0.html
+++ b/src/resources/help/en_US/relnotes3.6.0.html
@@ -99,7 +99,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <p><b><font size="4">Other bugs fixed in version 3.6</font></b></p>
 <ul>
   <li>An issue partitioning nodal coordinates for parallel in Pixie files was fixed.</li>
-  <li>Bug Fix 2</li>
+  <li>Fixed bug with thirdparty Find mdoules when thirdparty library was not built in 'Release' mode.</li>
 </ul>
 
 <a name="Build_features"></a>


### PR DESCRIPTION
### Description

Resolves #21081

Avoid querying `IMPORTED_LOCATION_<CONFIG>` target properties for third party libraries imported from their cmake-export sets.  Use CMake generator expressions like:  `$<TARGET_FILE>` instead.  This avoids  having to test for all default CMake configuration types, and covers the case of custom configuration types.

Added new function for installing third party targets: `visit_install_thirdparty_target`.  Modified a few Find modules to use the new function.

One side-effect of this new install method:  in some cases, the non-versioned .so will not be installed with VisIt.
This happens if the cmake export set does not use the non-versioned .so for IMPORTED_LOCATION.
This is true for Silo and HDF5 (the way they are built using build_visit), both of which only set target properties using versioned .so's: IMPORTED_LOCATION_RELEASE and IMPORTED_SONAME_RELEASE.
VTK uses non-versioned .so naming for its IMPORTED_LOCATION_RELEASE.

Added logic to `WriteSetupThirdParty.cmake` to write first to a `SetupXXX.cmake.in` file using generator expressions, then have CMake resolve the expressions via `file(GENERATE ...)` command which writes the final `SetupXXX.cmake` files that get installed with VisIt.

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

Configure, build, install and successful run of regression tests on Windows and Linux.

Created a Debug build of HDF5 on Windows, changed config-site to use this version. New configure, build,
install and successful run of regressions.
Also tested with both Debug and Release versions of HDF5 in the same directory. The Release version was chosen for VIsIt built in release mode.

Created a RelWithDebInfo build of Silo on Linux, changed config-site to use this version. New configure, build, install and successful run of regressions.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

