### PR TITLE
Add patches to buid_visit modules allowing successful compilation with gcc 16,

### DIFF
--- a/src/resources/help/en_US/relnotes3.6.0.html
+++ b/src/resources/help/en_US/relnotes3.6.0.html
@@ -109,6 +109,7 @@ enhancements and bug-fixes that were added to this release.</p>
   <li>build_visit now has a `--cleanup` option. When turned on it triggers deletion of src and build dirs for each library if build and install are successful.</li>
   <li>MOAB was updated to version 5.6.0.</li>
   <li>The `--print-files` and `--print-files-html` options were fixed so that no libraries are missing from the printed lists.</li>
+  <li>Issues with running build_visit on Fedora44 with gcc16 were resolved with patches to some modules.</li>
 </ul>
 
 <a name="Dev_changes"></a>

--- a/src/tools/dev/scripts/bv_support/bv_adios.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios.sh
@@ -131,9 +131,331 @@ function bv_adios_ensure
 # ***************************************************************************
 
 
+function apply_adios_1131_bool_patch
+{
+    if [[ "$ADIOS_1131_BOOL_PATCH_APPLIED" == "yes" ]] ; then
+        return 0
+    fi
+
+    if [[ -f utils/bpls/bpls.h ]] && grep -q "#  include <stdbool.h>" utils/bpls/bpls.h ; then
+        ADIOS_1131_BOOL_PATCH_APPLIED="yes"
+        return 0
+    fi
+
+    info "Patching ADIOS 1.13.1 bool definitions"
+    patch -p0 << \EOF
+--- examples/staging/stage_write/utils.h	2018-01-22 14:57:53.000000000 -0800
++++ examples/staging/stage_write/utils.h	2026-07-28 13:53:11.985004000 -0700
+@@ -15,9 +15,15 @@
+ #define print(...) fprintf (stderr, __VA_ARGS__); 
+ #define print0(...) if (!rank) fprintf (stderr, __VA_ARGS__); 
+ 
+-#define bool int
+-#define false 0
+-#define true 1
++#if defined(__cplusplus)
++/* bool, true, and false are built in. */
++#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
++#  define bool int
++#  define false 0
++#  define true 1
++#endif
+ 
+ void ints_to_str (int n, int *values, char *s);
+ void int64s_to_str (int n, uint64_t *values, char *s);
+@@ -47,4 +53,3 @@
+ int createdir_recursive( char* path);
+ 
+ #endif
+-
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch1 failed."
+        return 1
+    fi
+
+    patch -p0 << \EOF
+--- examples/staging/stage_write_varyingsize/utils.h	2018-01-22 14:57:53.000000000 -0800
++++ examples/staging/stage_write_varyingsize/utils.h	2026-07-28 13:53:12.570246000 -0700
+@@ -15,9 +15,15 @@
+ #define print(...) fprintf (stderr, __VA_ARGS__); 
+ #define print0(...) if (!rank) fprintf (stderr, __VA_ARGS__); 
+ 
+-#define bool int
+-#define false 0
+-#define true 1
++#if defined(__cplusplus)
++/* bool, true, and false are built in. */
++#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
++#  define bool int
++#  define false 0
++#  define true 1
++#endif
+ 
+ void ints_to_str (int n, int *values, char *s);
+ void int64s_to_str (int n, uint64_t *values, char *s);
+@@ -47,4 +53,3 @@
+ int createdir_recursive( char* path);
+ 
+ #endif
+-
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch2 failed."
+        return 1
+    fi
+
+    patch -p0 << \EOF
+--- utils/bp2h5/bp2h5.c	2018-01-22 14:57:57.000000000 -0800
++++ utils/bp2h5/bp2h5.c	2026-07-28 13:53:10.417327000 -0700
+@@ -43,10 +43,18 @@
+ #include "dmalloc.h"
+ #endif
+ 
+-#ifndef bool
+-    typedef int bool;
+-#   define false 0
+-#   define true  1
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#   include <stdbool.h>
++#else
++#   ifndef bool
++typedef int bool;
++#   endif
++#   ifndef false
++#      define false 0
++#   endif
++#   ifndef true
++#      define true  1
++#   endif
+ #endif
+ 
+ bool noindex = false;              // do no print array indices with data
+@@ -641,4 +649,3 @@
+     }
+     return status;
+ }
+-
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch3 failed."
+        return 1
+    fi
+
+
+    patch -p0 << \EOF
+--- utils/bpdiff/utils.h	2018-01-22 14:57:57.000000000 -0800
++++ utils/bpdiff/utils.h	2026-07-28 13:53:11.482481000 -0700
+@@ -16,9 +16,15 @@
+ #define print(...) fprintf (stderr, __VA_ARGS__); 
+ #define print0(...) if (!rank) fprintf (stderr, __VA_ARGS__); 
+ 
+-#define bool int
+-#define false 0
+-#define true 1
++#if defined(__cplusplus)
++/* bool, true, and false are built in. */
++#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
++#  define bool int
++#  define false 0
++#  define true 1
++#endif
+ 
+ void ints_to_str (int n, int *values, char *s);
+ void int64s_to_str (int n, uint64_t *values, char *s);
+@@ -48,4 +54,3 @@
+ int createdir_recursive( char* path);
+ 
+ #endif
+-
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch4 failed."
+        return 1
+    fi
+
+
+    patch -p0 << \EOF
+--- utils/bpls/bpls.h	2018-01-22 14:57:57.000000000 -0800
++++ utils/bpls/bpls.h	2026-07-28 13:53:10.953449000 -0700
+@@ -17,9 +17,15 @@
+ #  define strndup(str,len) strdup(str)
+ #endif
+ 
++#if defined(__cplusplus)
++/* bool, true, and false are built in. */
++#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
+ typedef int bool;
+-#define false 0
+-#define true  1
++#  define false 0
++#  define true  1
++#endif
+ 
+ #define CUT_TO_BYTE(x) (x < 0 ? 0 : (x > 255 ? 255 : x))
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch5 failed."
+        return 1
+    fi
+
+ 
+    patch -p0 << \EOF
+--- utils/bpsplit/bpappend.c	2018-01-22 14:57:57.000000000 -0800
++++ utils/bpsplit/bpappend.c	2026-07-28 13:53:09.321559000 -0700
+@@ -50,11 +50,19 @@
+ 
+ #define DIVIDER "========================================================\n"
+ 
+-#ifndef bool
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
++#  ifndef bool
+ typedef int bool;
++#  endif
++#  ifndef true
++#    define true 1
++#  endif
++#  ifndef false
++#    define false 0
++#  endif
+ #endif
+-#define true 1
+-#define false 0
+ 
+ /** Prototypes */
+ int bpappend(char *filein, char *fileout);
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch6 failed."
+        return 1
+    fi
+
+
+    patch -p0 << \EOF
+--- utils/bpsplit/bpgettime.c	2018-01-22 14:57:57.000000000 -0800
++++ utils/bpsplit/bpgettime.c	2026-07-28 13:53:09.883540000 -0700
+@@ -44,11 +44,19 @@
+ 
+ #define DIVIDER "========================================================\n"
+ 
+-#ifndef bool
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
++#  ifndef bool
+ typedef int bool;
++#  endif
++#  ifndef true
++#    define true 1
++#  endif
++#  ifndef false
++#    define false 0
++#  endif
+ #endif
+-#define true 1
+-#define false 0
+ 
+ /** Prototypes */
+ int bpgettime(char *filein);
+@@ -203,4 +211,3 @@
+ 
+     return excode;
+ }
+-
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch7 failed."
+        return 1
+    fi
+
+
+    patch -p0 << \EOF
+--- utils/bpsplit/bpsplit.c	2018-01-22 14:57:57.000000000 -0800
++++ utils/bpsplit/bpsplit.c	2026-07-28 13:53:08.768578000 -0700
+@@ -50,11 +50,19 @@
+ 
+ #define DIVIDER "========================================================\n"
+ 
+-#ifndef bool
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#  include <stdbool.h>
++#else
++#  ifndef bool
+ typedef int bool;
++#  endif
++#  ifndef true
++#    define true 1
++#  endif
++#  ifndef false
++#    define false 0
++#  endif
+ #endif
+-#define true 1
+-#define false 0
+ 
+ /** Prototypes */
+ int bpsplit(char *filein, char *fileout, char *recordfile, int from_in, int to_in, bool skiplast);
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bool patch8 failed."
+        return 1
+    fi
+
+    ADIOS_1131_BOOL_PATCH_APPLIED="yes"
+    return 0
+}
+
+function apply_adios_1131_bpls_hidden_attrs_patch
+{
+    if [[ -f utils/bpls/bpls.c ]] && ! grep -q "bool hidden_attrs" utils/bpls/bpls.c ; then
+        return 0
+    fi
+
+    info "Patching ADIOS 1.13.1 bpls hidden_attrs option flag"
+    patch -p0 << \EOF
+--- utils/bpls/bpls.c	2018-01-22 14:57:57.000000000 -0800
++++ utils/bpls/bpls.c	2026-07-28 16:48:00.000000000 -0700
+@@ -67,7 +67,7 @@
+ bool noindex;              // do no print array indices with data
+ bool printByteAsChar;      // print 8 bit integer arrays as string
+ bool plot;                 // dump histogram related information
+-bool hidden_attrs;         // show hidden attrs in BP file
++int  hidden_attrs;         // show hidden attrs in BP file; getopt_long requires int flags
+ bool show_decomp;          // show decomposition of arrays
+ 
+ // other global variables
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS 1.13.1 bpls hidden_attrs patch failed."
+        return 1
+    fi
+
+    return 0
+}
+
 function apply_adios_patch
 {
-    info "No patches for adios"
+    if [[ "$ADIOS_VERSION" == "1.13.1" ]] ; then
+        apply_adios_1131_bool_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+        apply_adios_1131_bpls_hidden_attrs_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+    fi
+
     return 0
 }
 
@@ -150,6 +472,8 @@ function build_adios
         warn "Unable to prepare ADIOS Build Directory. Giving Up"
         return 1
     fi
+
+    cd $ADIOS_BUILD_DIR || error "Can't cd to ADIOS build dir."
 
     #
     # Apply patches
@@ -171,7 +495,6 @@ function build_adios
     # Apply configure
     #
     info "Configuring ADIOS . . ."
-    cd $ADIOS_BUILD_DIR || error "Can't cd to ADIOS build dir."
 
     info "Invoking command to configure ADIOS"
 
@@ -232,22 +555,6 @@ function build_adios
     if [[ $? != 0 ]] ; then
         warn "ADIOS configure failed.  Giving up"
         return 1
-    fi
-
-    #
-    # Apply patches
-    #
-    apply_adios_patch
-    if [[ $? != 0 ]] ; then
-        if [[ $untarred_adios == 1 ]] ; then
-            warn "Giving up on Adios build because the patch failed."
-            return 1
-        else
-            warn "Patch failed, but continuing.  I believe that this script\n" \
-                 "tried to apply a patch to an existing directory that had\n" \
-                 "already been patched ... that is, the patch is\n" \
-                 "failing harmlessly on a second application."
-        fi
     fi
 
     #

--- a/src/tools/dev/scripts/bv_support/bv_adios2.sh
+++ b/src/tools/dev/scripts/bv_support/bv_adios2.sh
@@ -115,6 +115,43 @@ function bv_adios2_ensure
     fi
 }
 
+function apply_adios2_2100rc1_yamlcpp_cstdint_patch
+{
+    patch -p0 << \EOF
+diff -u thirdparty/yaml-cpp/yaml-cpp/src/emitterutils.cpp.orig thirdparty/yaml-cpp/yaml-cpp/src/emitterutils.cpp
+--- thirdparty/yaml-cpp/yaml-cpp/src/emitterutils.cpp.orig
++++ thirdparty/yaml-cpp/yaml-cpp/src/emitterutils.cpp
+@@ -1,5 +1,6 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>
+ 
+ #include "emitterutils.h"
+EOF
+
+    if [[ $? != 0 ]] ; then
+        warn "ADIOS2 yaml-cpp cstdint patch failed."
+        return 1
+    fi
+
+    return 0
+}
+
+function apply_adios2_patch
+{
+    info "Patching ADIOS2 . . ."
+
+    if [[ "$ADIOS2_VERSION" == "2.10.0-rc1" ]] ; then
+        apply_adios2_2100rc1_yamlcpp_cstdint_patch
+        if [[ $? != 0 ]] ; then
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
 function build_adios2
 {
     #
@@ -137,6 +174,24 @@ function build_adios2
         warn "Unable to prepare ADIOS2 Build Directory. Giving Up"
         return 1
     fi
+
+    #
+    # Apply patches
+    #
+    cd $ADIOS2_BUILD_DIR || error "Can't cd to ADIOS2 build dir."
+    apply_adios2_patch
+    if [[ $? != 0 ]] ; then
+        if [[ $untarred_ADIOS2 == 1 ]] ; then
+            warn "Giving up on ADIOS2 build because the patch failed."
+            return 1
+        else
+            warn "Patch failed, but continuing.  I believe that this script\n" \
+                 "tried to apply a patch to an existing directory that had\n" \
+                 "already been patched ... that is, the patch is\n" \
+                 "failing harmlessly on a second application."
+        fi
+    fi
+    cd "$START_DIR"
 
     #### begin parallel
 

--- a/src/tools/dev/scripts/bv_support/bv_advio.sh
+++ b/src/tools/dev/scripts/bv_support/bv_advio.sh
@@ -237,11 +237,49 @@ EOF
     return 0 
 }
 
+function apply_advio_12_bool_patch
+{
+    patch -p0 << \EOF
+--- AdvIO-1.2/Base/AdvTypes.h	2006-02-14 04:09:33.000000000 -0800
++++ AdvIO-1.2/Base/AdvTypes.h.new	2026-07-29 09:58:52.000000000 -0700
+@@ -51,9 +51,13 @@
+ #else
+ /*---------- C ----------*/
+ 
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
++#include <stdbool.h>
++#else
+ typedef int bool;
+ #define false 0
+ #define true 1
++#endif
+ 
+ #endif /* __cplusplus */
+ 
+EOF
+    if [[ $? != 0 ]] ; then
+        echo "Failed applying AdvIO bool patch"
+        return 1
+    fi
+
+    return 0
+}
+
 function apply_advio_12_patch
 {
-    apply_advio_12_configure_patch
+    local patch_status=0
 
-    return $?
+    apply_advio_12_configure_patch
+    if [[ $? != 0 ]] ; then
+        patch_status=1
+    fi
+
+    apply_advio_12_bool_patch
+    if [[ $? != 0 ]] ; then
+        patch_status=1
+    fi
+
+    return $patch_status
 }
 
 function apply_advio_patch

--- a/src/tools/dev/scripts/bv_support/bv_gdal.sh
+++ b/src/tools/dev/scripts/bv_support/bv_gdal.sh
@@ -213,7 +213,10 @@ function build_gdal
         fi
     fi
     
-    C_OPT_FLAGS="-Wno-error=implicit-function-declaration"
+    # GCC 16 defaults to C23 semantics, where empty parameter lists mean
+    # "(void)". GDAL 2.2.4's bundled qhull relies on the older no-prototype
+    # meaning for declarations in alg/internal_qhull_headers.h.
+    C_OPT_FLAGS="-std=gnu99 -Wno-error=implicit-function-declaration"
     set -x
     ./configure CXX="$CXX_COMPILER" CC="$C_COMPILER" $EXTRA_FLAGS \
                 CFLAGS="$CFLAGS $C_OPT_FLAGS" \

--- a/src/tools/dev/scripts/bv_support/bv_mesagl.sh
+++ b/src/tools/dev/scripts/bv_support/bv_mesagl.sh
@@ -351,6 +351,55 @@ EOF
         return 1
     fi
 
+    #
+    # Patch so that building with newer glibc/gcc-16 will work. Newer
+    # glibc exposes once_flag, ONCE_FLAG_INIT, and call_once from stdlib.h.
+    #
+    patch -p0 << \EOF
+diff -u include/c11/threads_posix.h.orig include/c11/threads_posix.h
+--- include/c11/threads_posix.h.orig	2018-04-18 01:44:00.000000000 -0700
++++ include/c11/threads_posix.h	2026-07-28 12:00:00.000000000 -0700
+@@ -51,7 +51,10 @@
+ #include <pthread.h>
+ 
+ /*---------------------------- macros ----------------------------*/
++#ifndef ONCE_FLAG_INIT
+ #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++#define EMULATED_THREADS_USE_PTHREAD_ONCE
++#endif
+ #ifdef INIT_ONCE_STATIC_INIT
+ #define TSS_DTOR_ITERATIONS PTHREAD_DESTRUCTOR_ITERATIONS
+ #else
+@@ -66,7 +69,9 @@
+ typedef pthread_t       thrd_t;
+ typedef pthread_key_t   tss_t;
+ typedef pthread_mutex_t mtx_t;
++#ifdef EMULATED_THREADS_USE_PTHREAD_ONCE
+ typedef pthread_once_t  once_flag;
++#endif
+ 
+ 
+ /*
+@@ -91,11 +96,13 @@
+ 
+ /*--------------- 7.25.2 Initialization functions ---------------*/
+ // 7.25.2.1
++#ifdef EMULATED_THREADS_USE_PTHREAD_ONCE
+ static inline void
+ call_once(once_flag *flag, void (*func)(void))
+ {
+     pthread_once(flag, func);
+ }
++#endif
+ 
+ 
+ /*------------- 7.25.3 Condition variable functions -------------*/
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "MesaGL patch 9 failed."
+        return 1
+    fi
+
     return 0;
 }
 

--- a/src/tools/dev/scripts/bv_support/bv_osmesa.sh
+++ b/src/tools/dev/scripts/bv_support/bv_osmesa.sh
@@ -347,7 +347,56 @@ diff -c src/gallium/drivers/llvmpipe/lp_screen.c.orig src/gallium/drivers/llvmpi
      case PIPE_CAP_PREFER_BLIT_BASED_TEXTURE_TRANSFER:
 EOF
     if [[ $? != 0 ]] ; then
-        warn "OSMesa patch 6 failed."
+        warn "OSMesa patch 8 failed."
+        return 1
+    fi
+
+    #
+    # Patch so that building with newer glibc/gcc-16 will work. Newer
+    # glibc exposes once_flag, ONCE_FLAG_INIT, and call_once from stdlib.h.
+    #
+    patch -p0 << \EOF
+diff -u include/c11/threads_posix.h.orig include/c11/threads_posix.h
+--- include/c11/threads_posix.h.orig	2018-04-18 01:44:00.000000000 -0700
++++ include/c11/threads_posix.h	2026-07-28 12:00:00.000000000 -0700
+@@ -51,7 +51,10 @@
+ #include <pthread.h>
+ 
+ /*---------------------------- macros ----------------------------*/
++#ifndef ONCE_FLAG_INIT
+ #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++#define EMULATED_THREADS_USE_PTHREAD_ONCE
++#endif
+ #ifdef INIT_ONCE_STATIC_INIT
+ #define TSS_DTOR_ITERATIONS PTHREAD_DESTRUCTOR_ITERATIONS
+ #else
+@@ -66,7 +69,9 @@
+ typedef pthread_t       thrd_t;
+ typedef pthread_key_t   tss_t;
+ typedef pthread_mutex_t mtx_t;
++#ifdef EMULATED_THREADS_USE_PTHREAD_ONCE
+ typedef pthread_once_t  once_flag;
++#endif
+ 
+ 
+ /*
+@@ -91,11 +96,13 @@
+ 
+ /*--------------- 7.25.2 Initialization functions ---------------*/
+ // 7.25.2.1
++#ifdef EMULATED_THREADS_USE_PTHREAD_ONCE
+ static inline void
+ call_once(once_flag *flag, void (*func)(void))
+ {
+     pthread_once(flag, func);
+ }
++#endif
+ 
+ 
+ /*------------- 7.25.3 Condition variable functions -------------*/
+EOF
+    if [[ $? != 0 ]] ; then
+        warn "OSMesa patch 9 failed."
         return 1
     fi
 

--- a/src/tools/dev/scripts/bv_support/bv_silo.sh
+++ b/src/tools/dev/scripts/bv_support/bv_silo.sh
@@ -380,6 +380,38 @@ EOF
     fi
 }
 
+function apply_silo_4120_python_moduledef_patch
+{
+    info "Patching Silo 4.12.0 for Python module definition issue"
+    patch -p0 << \EOF
+--- Silo-4.12.0/tools/python/pysilo.h
++++ Silo-4.12.0/tools/python/pysilo.h
+@@ -82,8 +82,15 @@ void SiloErrorFunc(const char *errString);
+     #define PY_SILO_MOD_DEF(ob, name, methods)  \
+         static struct PyModuleDef moduledef = { \
+             PyModuleDef_HEAD_INIT,              \
+-            .m_name = name,                     \
+-            .m_methods = methods };             \
++            name,                               \
++            NULL,                               \
++            0,                                  \
++            methods,                            \
++            NULL,                               \
++            NULL,                               \
++            NULL,                               \
++            NULL                                \
++        };                                      \
+         ob = PyModule_Create(&moduledef);
+ #else
+     #define PY_SILO_MOD_DEF(ob, name, methods) \
+-- 
+2.50.1
+EOF
+    if [[ $? != 0 ]] ; then
+        return 1
+    fi
+}
+
 function apply_silo_patch
 {
     info "Patching silo . . ."
@@ -412,6 +444,11 @@ function apply_silo_patch
             return 1
         fi
         apply_silo_4120_extents_calc
+        if [[ $? != 0 ]] ; then
+            warn "Giving up on Silo build because the patch failed."
+            return 1
+        fi
+        apply_silo_4120_python_moduledef_patch
         if [[ $? != 0 ]] ; then
             warn "Giving up on Silo build because the patch failed."
             return 1

--- a/src/tools/dev/scripts/bv_support/bv_uintah.sh
+++ b/src/tools/dev/scripts/bv_support/bv_uintah.sh
@@ -138,6 +138,50 @@ index 9166e87..d80ae1d 100644
 EOF
 }
 
+function apply_uintah_cxx20_requires_patch
+{
+    info "Patching uintah C++ standard detection for C++20 requires keyword"
+    patch -p0 << \EOF
+--- Uintah-2.6.3/src/aclocal.m4	2018-06-20 14:50:32.000000000 -0700
++++ Uintah-2.6.3/src/aclocal.m4	2026-07-29 10:55:12.000000000 -0700
+@@ -1338,6 +1338,10 @@
+ 
+     auto d = a;
+     auto l = [](){};
++
++    struct cxx20_requires_check {
++      void requires();
++    };
+ ]])
+ 
+ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
+--- Uintah-2.6.3/src/configure	2018-06-20 14:50:35.000000000 -0700
++++ Uintah-2.6.3/src/configure	2026-07-29 10:55:12.000000000 -0700
+@@ -10398,6 +10398,10 @@
+ 
+     auto d = a;
+     auto l = [](){};
++
++    struct cxx20_requires_check {
++      void requires();
++    };
+ 
+ _ACEOF
+ if ac_fn_cxx_try_compile "$LINENO"; then :
+@@ -10445,6 +10449,10 @@
+ 
+     auto d = a;
+     auto l = [](){};
++
++    struct cxx20_requires_check {
++      void requires();
++    };
+ 
+ _ACEOF
+ if ac_fn_cxx_try_compile "$LINENO"; then :
+EOF
+}
+
 
 # **************************************************************************** #
 #                          Function 8.1, build_uintah                          #
@@ -261,6 +305,11 @@ function build_uintah
 
     # source patches
     apply_uintah_def_fix_patch
+    if [[ $? != 0 ]] ; then
+        warn "Failed to patch UINTAH"
+        return 1
+    fi
+    apply_uintah_cxx20_requires_patch
     if [[ $? != 0 ]] ; then
         warn "Failed to patch UINTAH"
         return 1


### PR DESCRIPTION
### Description

Resolves #20944

### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

In fedora44 docker container, ran build_visit (default gcc version 16), compiled visit against generated third party libraries, and ran a cli test with good image generated.

On rzwhippet, ran build_visit using gcc13 with success. Compile visit (develop) against the generated third party libraries, and successfully ran the full regression suite in serial and parallel.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
