### PR TITLE
Subset, Boundary, FilledBoundary don't change defaultAtts on ReInitializePlotAtts.

### DIFF
--- a/src/plots/Boundary/BoundaryAttributes.code
+++ b/src/plots/Boundary/BoundaryAttributes.code
@@ -117,7 +117,7 @@ Definition:
 //    Changed API.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    Send 'false' for 'setDefaultAtts' argument of PrivateSetPlotAtts so that
 //    defaultAtts won't be changed.
 //
 // ****************************************************************************
@@ -174,7 +174,7 @@ BoundaryViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 
 Target: xml2info
 Function: BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
-Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
+Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefaultAtts=true);
 Definition:
 // ****************************************************************************
 //  Method: BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
@@ -216,7 +216,7 @@ Definition:
 //    Remove Subset logic as this plot only supports Materials.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Add 'setDefault' argument, default to true. When false, no changes
+//    Add 'setDefaultAtts' argument, default to true. When false, no changes
 //    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
 //
 // ****************************************************************************
@@ -236,7 +236,7 @@ Definition:
 
 void
 BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot, const bool setDefault)
+    const avtPlotMetaData &plot, const bool setDefaultAtts)
 {
     BoundaryAttributes *boundaryAtts = (BoundaryAttributes *)atts;
 
@@ -344,7 +344,7 @@ BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    if(setDefault)
+    if(setDefaultAtts)
     {
         defaultAtts->SetBoundaryNames(sv);
         defaultAtts->SetMultiColor(cal);

--- a/src/plots/Boundary/BoundaryAttributes.code
+++ b/src/plots/Boundary/BoundaryAttributes.code
@@ -116,13 +116,17 @@ Definition:
 //    Brad Whitlock, Wed Feb 21 14:31:20 PST 2007
 //    Changed API.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    defaultAtts won't be changed.
+//
 // ****************************************************************************
 
 void
 BoundaryViewerEnginePluginInfo::ReInitializePlotAtts(AttributeSubject *atts,
     const avtPlotMetaData &plot)
 {
-    PrivateSetPlotAtts(atts, plot);
+    PrivateSetPlotAtts(atts, plot, false);
 }
 
 Target: xml2info
@@ -170,7 +174,7 @@ BoundaryViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 
 Target: xml2info
 Function: BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
-Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &);
+Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
 Definition:
 // ****************************************************************************
 //  Method: BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
@@ -211,6 +215,10 @@ Definition:
 //    Kathleen Biagas, Thu Dec 15 16:51:01 PST 2016
 //    Remove Subset logic as this plot only supports Materials.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Add 'setDefault' argument, default to true. When false, no changes
+//    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
+//
 // ****************************************************************************
 
 #include <stdio.h>
@@ -228,7 +236,7 @@ Definition:
 
 void
 BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot)
+    const avtPlotMetaData &plot, const bool setDefault)
 {
     BoundaryAttributes *boundaryAtts = (BoundaryAttributes *)atts;
 
@@ -336,7 +344,10 @@ BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    defaultAtts->SetBoundaryNames(sv);
-    defaultAtts->SetMultiColor(cal);
+    if(setDefault)
+    {
+        defaultAtts->SetBoundaryNames(sv);
+        defaultAtts->SetMultiColor(cal);
+    }
 }
 

--- a/src/plots/Boundary/BoundaryPluginInfo.h
+++ b/src/plots/Boundary/BoundaryPluginInfo.h
@@ -79,7 +79,7 @@ class BoundaryViewerEnginePluginInfo : public virtual ViewerEnginePlotPluginInfo
     static BoundaryAttributes *clientAtts;
     // User-defined functions
   private:
-    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
+    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefaultAtts=true);
 };
 
 class BoundaryViewerPluginInfo : public virtual ViewerPlotPluginInfo, public virtual BoundaryViewerEnginePluginInfo

--- a/src/plots/Boundary/BoundaryPluginInfo.h
+++ b/src/plots/Boundary/BoundaryPluginInfo.h
@@ -79,7 +79,7 @@ class BoundaryViewerEnginePluginInfo : public virtual ViewerEnginePlotPluginInfo
     static BoundaryAttributes *clientAtts;
     // User-defined functions
   private:
-    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &);
+    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
 };
 
 class BoundaryViewerPluginInfo : public virtual ViewerPlotPluginInfo, public virtual BoundaryViewerEnginePluginInfo

--- a/src/plots/Boundary/BoundaryViewerEnginePluginInfo.C
+++ b/src/plots/Boundary/BoundaryViewerEnginePluginInfo.C
@@ -194,13 +194,17 @@ BoundaryViewerEnginePluginInfo::InitializePlotAtts(AttributeSubject *atts,
 //    Brad Whitlock, Wed Feb 21 14:31:20 PST 2007
 //    Changed API.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    defaultAtts won't be changed.
+//
 // ****************************************************************************
 
 void
 BoundaryViewerEnginePluginInfo::ReInitializePlotAtts(AttributeSubject *atts,
     const avtPlotMetaData &plot)
 {
-    PrivateSetPlotAtts(atts, plot);
+    PrivateSetPlotAtts(atts, plot, false);
 }
 
 // ****************************************************************************
@@ -241,6 +245,7 @@ BoundaryViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 {
     PrivateSetPlotAtts(atts, plot);
 }
+
 
 // ****************************************************************************
 //  Method: BoundaryViewerEnginePluginInfo::GetMenuName
@@ -300,6 +305,10 @@ BoundaryViewerEnginePluginInfo::GetMenuName() const
 //    Kathleen Biagas, Thu Dec 15 16:51:01 PST 2016
 //    Remove Subset logic as this plot only supports Materials.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Add 'setDefault' argument, default to true. When false, no changes
+//    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
+//
 // ****************************************************************************
 
 #include <stdio.h>
@@ -317,7 +326,7 @@ BoundaryViewerEnginePluginInfo::GetMenuName() const
 
 void
 BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot)
+    const avtPlotMetaData &plot, const bool setDefault)
 {
     BoundaryAttributes *boundaryAtts = (BoundaryAttributes *)atts;
 
@@ -425,7 +434,10 @@ BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    defaultAtts->SetBoundaryNames(sv);
-    defaultAtts->SetMultiColor(cal);
+    if(setDefault)
+    {
+        defaultAtts->SetBoundaryNames(sv);
+        defaultAtts->SetMultiColor(cal);
+    }
 }
 

--- a/src/plots/Boundary/BoundaryViewerEnginePluginInfo.C
+++ b/src/plots/Boundary/BoundaryViewerEnginePluginInfo.C
@@ -195,7 +195,7 @@ BoundaryViewerEnginePluginInfo::InitializePlotAtts(AttributeSubject *atts,
 //    Changed API.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    Send 'false' for 'setDefaultAtts' argument of PrivateSetPlotAtts so that
 //    defaultAtts won't be changed.
 //
 // ****************************************************************************
@@ -306,7 +306,7 @@ BoundaryViewerEnginePluginInfo::GetMenuName() const
 //    Remove Subset logic as this plot only supports Materials.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Add 'setDefault' argument, default to true. When false, no changes
+//    Add 'setDefaultAtts' argument, default to true. When false, no changes
 //    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
 //
 // ****************************************************************************
@@ -326,7 +326,7 @@ BoundaryViewerEnginePluginInfo::GetMenuName() const
 
 void
 BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot, const bool setDefault)
+    const avtPlotMetaData &plot, const bool setDefaultAtts)
 {
     BoundaryAttributes *boundaryAtts = (BoundaryAttributes *)atts;
 
@@ -434,7 +434,7 @@ BoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    if(setDefault)
+    if(setDefaultAtts)
     {
         defaultAtts->SetBoundaryNames(sv);
         defaultAtts->SetMultiColor(cal);

--- a/src/plots/FilledBoundary/FilledBoundaryAttributes.code
+++ b/src/plots/FilledBoundary/FilledBoundaryAttributes.code
@@ -126,13 +126,17 @@ Definition:
 //   Brad Whitlock, Fri Mar 26 15:19:50 PST 2004
 //   I made it use passed in metadata.
 //
+//   Kathleen Biagas, Thu Sep 3, 2026
+//   Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//   defaultAtts won't be changed.
+//
 // ****************************************************************************
 
 void
 FilledBoundaryViewerEnginePluginInfo::ReInitializePlotAtts(AttributeSubject *atts,
     const avtPlotMetaData &plot)
 {
-    PrivateSetPlotAtts(atts, plot);
+    PrivateSetPlotAtts(atts, plot, false);
 }
 
 Target: xml2info
@@ -181,7 +185,7 @@ FilledBoundaryViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 
 Target: xml2info
 Function: FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
-Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &);
+Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
 Definition:
 // ****************************************************************************
 //  Method: FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
@@ -241,6 +245,10 @@ Definition:
 //    Removed Subset type logic as Material is the only subset this plot
 //    supports.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Add 'setDefault' argument, default to true. When false, no changes
+//    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
+//
 // ****************************************************************************
 
 #include <stdio.h>
@@ -257,7 +265,7 @@ Definition:
 
 void
 FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot)
+    const avtPlotMetaData &plot, const setDefault=true)
 {
     FilledBoundaryAttributes *boundaryAtts = (FilledBoundaryAttributes *)atts;
 
@@ -398,7 +406,10 @@ FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    defaultAtts->SetBoundaryNames(sv);
-    defaultAtts->SetMultiColor(cal);
+    if(setDefault)
+    {
+        defaultAtts->SetBoundaryNames(sv);
+        defaultAtts->SetMultiColor(cal);
+    }
 }
 

--- a/src/plots/FilledBoundary/FilledBoundaryAttributes.code
+++ b/src/plots/FilledBoundary/FilledBoundaryAttributes.code
@@ -127,7 +127,7 @@ Definition:
 //   I made it use passed in metadata.
 //
 //   Kathleen Biagas, Thu Sep 3, 2026
-//   Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//   Send 'false' for 'setDefaultAtts' argument of PrivateSetPlotAtts so that
 //   defaultAtts won't be changed.
 //
 // ****************************************************************************
@@ -185,7 +185,7 @@ FilledBoundaryViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 
 Target: xml2info
 Function: FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
-Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
+Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefaultAtts=true);
 Definition:
 // ****************************************************************************
 //  Method: FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts
@@ -246,7 +246,7 @@ Definition:
 //    supports.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Add 'setDefault' argument, default to true. When false, no changes
+//    Add 'setDefaultAtts' argument, default to true. When false, no changes
 //    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
 //
 // ****************************************************************************
@@ -265,7 +265,7 @@ Definition:
 
 void
 FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot, const setDefault=true)
+    const avtPlotMetaData &plot, const bool setDefaultAtts)
 {
     FilledBoundaryAttributes *boundaryAtts = (FilledBoundaryAttributes *)atts;
 
@@ -406,7 +406,7 @@ FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    if(setDefault)
+    if(setDefaultAtts)
     {
         defaultAtts->SetBoundaryNames(sv);
         defaultAtts->SetMultiColor(cal);

--- a/src/plots/FilledBoundary/FilledBoundaryPluginInfo.h
+++ b/src/plots/FilledBoundary/FilledBoundaryPluginInfo.h
@@ -79,7 +79,7 @@ class FilledBoundaryViewerEnginePluginInfo : public virtual ViewerEnginePlotPlug
     static FilledBoundaryAttributes *clientAtts;
     // User-defined functions
   private:
-    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &);
+    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
 };
 
 class FilledBoundaryViewerPluginInfo : public virtual ViewerPlotPluginInfo, public virtual FilledBoundaryViewerEnginePluginInfo

--- a/src/plots/FilledBoundary/FilledBoundaryPluginInfo.h
+++ b/src/plots/FilledBoundary/FilledBoundaryPluginInfo.h
@@ -79,7 +79,7 @@ class FilledBoundaryViewerEnginePluginInfo : public virtual ViewerEnginePlotPlug
     static FilledBoundaryAttributes *clientAtts;
     // User-defined functions
   private:
-    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
+    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefaultAtts=true);
 };
 
 class FilledBoundaryViewerPluginInfo : public virtual ViewerPlotPluginInfo, public virtual FilledBoundaryViewerEnginePluginInfo

--- a/src/plots/FilledBoundary/FilledBoundaryViewerEnginePluginInfo.C
+++ b/src/plots/FilledBoundary/FilledBoundaryViewerEnginePluginInfo.C
@@ -192,7 +192,7 @@ FilledBoundaryViewerEnginePluginInfo::InitializePlotAtts(AttributeSubject *atts,
 //   I made it use passed in metadata.
 //
 //   Kathleen Biagas, Thu Sep 3, 2026
-//   Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//   Send 'false' for 'setDefaultAtts' argument of PrivateSetPlotAtts so that
 //   defaultAtts won't be changed.
 //
 // ****************************************************************************
@@ -323,7 +323,7 @@ FilledBoundaryViewerEnginePluginInfo::GetMenuName() const
 //    supports.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Add 'setDefault' argument, default to true. When false, no changes
+//    Add 'setDefaultAtts' argument, default to true. When false, no changes
 //    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
 //
 // ****************************************************************************
@@ -342,7 +342,7 @@ FilledBoundaryViewerEnginePluginInfo::GetMenuName() const
 
 void
 FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot, const setDefault=true)
+    const avtPlotMetaData &plot, const bool setDefaultAtts)
 {
     FilledBoundaryAttributes *boundaryAtts = (FilledBoundaryAttributes *)atts;
 
@@ -483,7 +483,7 @@ FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    if(setDefault)
+    if(setDefaultAtts)
     {
         defaultAtts->SetBoundaryNames(sv);
         defaultAtts->SetMultiColor(cal);

--- a/src/plots/FilledBoundary/FilledBoundaryViewerEnginePluginInfo.C
+++ b/src/plots/FilledBoundary/FilledBoundaryViewerEnginePluginInfo.C
@@ -191,13 +191,17 @@ FilledBoundaryViewerEnginePluginInfo::InitializePlotAtts(AttributeSubject *atts,
 //   Brad Whitlock, Fri Mar 26 15:19:50 PST 2004
 //   I made it use passed in metadata.
 //
+//   Kathleen Biagas, Thu Sep 3, 2026
+//   Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//   defaultAtts won't be changed.
+//
 // ****************************************************************************
 
 void
 FilledBoundaryViewerEnginePluginInfo::ReInitializePlotAtts(AttributeSubject *atts,
     const avtPlotMetaData &plot)
 {
-    PrivateSetPlotAtts(atts, plot);
+    PrivateSetPlotAtts(atts, plot, false);
 }
 
 // ****************************************************************************
@@ -239,6 +243,7 @@ FilledBoundaryViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 {
     PrivateSetPlotAtts(atts, plot);
 }
+
 
 // ****************************************************************************
 //  Method: FilledBoundaryViewerEnginePluginInfo::GetMenuName
@@ -317,6 +322,10 @@ FilledBoundaryViewerEnginePluginInfo::GetMenuName() const
 //    Removed Subset type logic as Material is the only subset this plot
 //    supports.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Add 'setDefault' argument, default to true. When false, no changes
+//    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
+//
 // ****************************************************************************
 
 #include <stdio.h>
@@ -333,7 +342,7 @@ FilledBoundaryViewerEnginePluginInfo::GetMenuName() const
 
 void
 FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot)
+    const avtPlotMetaData &plot, const setDefault=true)
 {
     FilledBoundaryAttributes *boundaryAtts = (FilledBoundaryAttributes *)atts;
 
@@ -474,7 +483,10 @@ FilledBoundaryViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the boundary names and colors in the boundaryAtts.
     boundaryAtts->SetBoundaryNames(sv);
     boundaryAtts->SetMultiColor(cal);
-    defaultAtts->SetBoundaryNames(sv);
-    defaultAtts->SetMultiColor(cal);
+    if(setDefault)
+    {
+        defaultAtts->SetBoundaryNames(sv);
+        defaultAtts->SetMultiColor(cal);
+    }
 }
 

--- a/src/plots/Subset/SubsetAttributes.code
+++ b/src/plots/Subset/SubsetAttributes.code
@@ -177,13 +177,17 @@ Definition:
 //    Brad Whitlock, Wed Feb 21 14:31:20 PST 2007
 //    Changed API.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    defaultAtts won't be changed.
+//
 // ****************************************************************************
 
 void
 SubsetViewerEnginePluginInfo::ReInitializePlotAtts(AttributeSubject *atts,
     const avtPlotMetaData &plot)
 {
-    PrivateSetPlotAtts(atts, plot);
+    PrivateSetPlotAtts(atts, plot, false);
 }
 
 Target: xml2info
@@ -232,7 +236,7 @@ SubsetViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 
 Target: xml2info
 Function: SubsetViewerEnginePluginInfo::PrivateSetPlotAtts
-Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &);
+Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
 Definition:
 // ****************************************************************************
 //  Method: SubsetViewerEnginePluginInfo::PrivateSetPlotAtts
@@ -291,6 +295,10 @@ Definition:
 //    Kathleen Biagas, Thu Dec 15 16:13:57 PST 2016
 //    Removed Material as a subset option.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Add 'setDefault' argument, default to true. When false, no changes
+//    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
+//
 // ****************************************************************************
 #include <stdio.h>
 
@@ -306,7 +314,7 @@ Definition:
 
 void
 SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot)
+    const avtPlotMetaData &plot, const bool setDefault)
 {
     SubsetAttributes *subsetAtts = (SubsetAttributes *)atts;
 
@@ -346,7 +354,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
       case AVT_DOMAIN_SUBSET :
           debug5 << "Variable for subset plot is a domain Mesh." << endl;
           subsetAtts->SetSubsetType(SubsetAttributes::Domain);
-          defaultAtts->SetSubsetType(SubsetAttributes::Domain);
           if (mesh->blockNames.empty())
           {
               for (int i = 0; i < mesh->numBlocks; i++)
@@ -368,7 +375,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
       case AVT_GROUP_SUBSET :
           debug5 << "Variable for subset plot is a group Mesh." << endl;
           subsetAtts->SetSubsetType(SubsetAttributes::Group);
-          defaultAtts->SetSubsetType(SubsetAttributes::Group);
           if (!mesh->groupNames.empty())
           {
               for (size_t i = 0; i < mesh->groupNames.size(); ++i)
@@ -409,7 +415,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
       case AVT_ENUMSCALAR_SUBSET :
           debug5 << "Variable for subset plot is an enumerated Scalar."<<endl;
           subsetAtts->SetSubsetType(SubsetAttributes::EnumScalar);
-          defaultAtts->SetSubsetType(SubsetAttributes::EnumScalar);
           smd = md->GetScalar(vn);
           if (smd != NULL)
           {
@@ -426,7 +431,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
           {
               debug5 << "Variable for subset plot is a mesh."<<endl;
               subsetAtts->SetSubsetType(SubsetAttributes::Mesh);
-              defaultAtts->SetSubsetType(SubsetAttributes::Mesh);
               sprintf(temp, "Whole mesh (%s)", vn.c_str());
               sv.push_back(temp);
           }
@@ -497,7 +501,11 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the subset names and colors in the subsetAtts.
     subsetAtts->SetSubsetNames(sv);
     subsetAtts->SetMultiColor(cal);
-    defaultAtts->SetSubsetNames(sv);
-    defaultAtts->SetMultiColor(cal);
+    if(setDefault)
+    {
+        defaultAtts->SetSubsetType(subsetAtts->GetSubsetType());
+        defaultAtts->SetSubsetNames(sv);
+        defaultAtts->SetMultiColor(cal);
+    }
 }
 

--- a/src/plots/Subset/SubsetAttributes.code
+++ b/src/plots/Subset/SubsetAttributes.code
@@ -178,7 +178,7 @@ Definition:
 //    Changed API.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    Send 'false' for 'setDefaultAtts' argument of PrivateSetPlotAtts so that
 //    defaultAtts won't be changed.
 //
 // ****************************************************************************
@@ -236,7 +236,7 @@ SubsetViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 
 Target: xml2info
 Function: SubsetViewerEnginePluginInfo::PrivateSetPlotAtts
-Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
+Declaration: void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefaultAtts=true);
 Definition:
 // ****************************************************************************
 //  Method: SubsetViewerEnginePluginInfo::PrivateSetPlotAtts
@@ -296,7 +296,7 @@ Definition:
 //    Removed Material as a subset option.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Add 'setDefault' argument, default to true. When false, no changes
+//    Add 'setDefaultAtts' argument, default to true. When false, no changes
 //    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
 //
 // ****************************************************************************
@@ -314,7 +314,7 @@ Definition:
 
 void
 SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot, const bool setDefault)
+    const avtPlotMetaData &plot, const bool setDefaultAtts)
 {
     SubsetAttributes *subsetAtts = (SubsetAttributes *)atts;
 
@@ -501,7 +501,7 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the subset names and colors in the subsetAtts.
     subsetAtts->SetSubsetNames(sv);
     subsetAtts->SetMultiColor(cal);
-    if(setDefault)
+    if(setDefaultAtts)
     {
         defaultAtts->SetSubsetType(subsetAtts->GetSubsetType());
         defaultAtts->SetSubsetNames(sv);

--- a/src/plots/Subset/SubsetPluginInfo.h
+++ b/src/plots/Subset/SubsetPluginInfo.h
@@ -79,7 +79,7 @@ class SubsetViewerEnginePluginInfo : public virtual ViewerEnginePlotPluginInfo, 
     static SubsetAttributes *clientAtts;
     // User-defined functions
   private:
-    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &);
+    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
 };
 
 class SubsetViewerPluginInfo : public virtual ViewerPlotPluginInfo, public virtual SubsetViewerEnginePluginInfo

--- a/src/plots/Subset/SubsetPluginInfo.h
+++ b/src/plots/Subset/SubsetPluginInfo.h
@@ -79,7 +79,7 @@ class SubsetViewerEnginePluginInfo : public virtual ViewerEnginePlotPluginInfo, 
     static SubsetAttributes *clientAtts;
     // User-defined functions
   private:
-    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefault=true);
+    void   PrivateSetPlotAtts(AttributeSubject *atts, const avtPlotMetaData &, const bool setDefaultAtts=true);
 };
 
 class SubsetViewerPluginInfo : public virtual ViewerPlotPluginInfo, public virtual SubsetViewerEnginePluginInfo

--- a/src/plots/Subset/SubsetViewerEnginePluginInfo.C
+++ b/src/plots/Subset/SubsetViewerEnginePluginInfo.C
@@ -195,7 +195,7 @@ SubsetViewerEnginePluginInfo::InitializePlotAtts(AttributeSubject *atts,
 //    Changed API.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    Send 'false' for 'setDefaultAtts' argument of PrivateSetPlotAtts so that
 //    defaultAtts won't be changed.
 //
 // ****************************************************************************
@@ -325,7 +325,7 @@ SubsetViewerEnginePluginInfo::GetMenuName() const
 //    Removed Material as a subset option.
 //
 //    Kathleen Biagas, Thu Sep 3, 2026
-//    Add 'setDefault' argument, default to true. When false, no changes
+//    Add 'setDefaultAtts' argument, default to true. When false, no changes
 //    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
 //
 // ****************************************************************************
@@ -343,7 +343,7 @@ SubsetViewerEnginePluginInfo::GetMenuName() const
 
 void
 SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot, const bool setDefault)
+    const avtPlotMetaData &plot, const bool setDefaultAtts)
 {
     SubsetAttributes *subsetAtts = (SubsetAttributes *)atts;
 
@@ -530,7 +530,7 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the subset names and colors in the subsetAtts.
     subsetAtts->SetSubsetNames(sv);
     subsetAtts->SetMultiColor(cal);
-    if(setDefault)
+    if(setDefaultAtts)
     {
         defaultAtts->SetSubsetType(subsetAtts->GetSubsetType());
         defaultAtts->SetSubsetNames(sv);

--- a/src/plots/Subset/SubsetViewerEnginePluginInfo.C
+++ b/src/plots/Subset/SubsetViewerEnginePluginInfo.C
@@ -194,13 +194,17 @@ SubsetViewerEnginePluginInfo::InitializePlotAtts(AttributeSubject *atts,
 //    Brad Whitlock, Wed Feb 21 14:31:20 PST 2007
 //    Changed API.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Send 'false' for 'setDefault' argument of PrivateSetPlotAtts so that
+//    defaultAtts won't be changed.
+//
 // ****************************************************************************
 
 void
 SubsetViewerEnginePluginInfo::ReInitializePlotAtts(AttributeSubject *atts,
     const avtPlotMetaData &plot)
 {
-    PrivateSetPlotAtts(atts, plot);
+    PrivateSetPlotAtts(atts, plot, false);
 }
 
 // ****************************************************************************
@@ -242,6 +246,7 @@ SubsetViewerEnginePluginInfo::ResetPlotAtts(AttributeSubject *atts,
 {
     PrivateSetPlotAtts(atts, plot);
 }
+
 
 // ****************************************************************************
 //  Method: SubsetViewerEnginePluginInfo::GetMenuName
@@ -319,6 +324,10 @@ SubsetViewerEnginePluginInfo::GetMenuName() const
 //    Kathleen Biagas, Thu Dec 15 16:13:57 PST 2016
 //    Removed Material as a subset option.
 //
+//    Kathleen Biagas, Thu Sep 3, 2026
+//    Add 'setDefault' argument, default to true. When false, no changes
+//    are made to defaultAtts. ReInitializePlotAtts sets to 'false'.
+//
 // ****************************************************************************
 #include <stdio.h>
 
@@ -334,7 +343,7 @@ SubsetViewerEnginePluginInfo::GetMenuName() const
 
 void
 SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
-    const avtPlotMetaData &plot)
+    const avtPlotMetaData &plot, const bool setDefault)
 {
     SubsetAttributes *subsetAtts = (SubsetAttributes *)atts;
 
@@ -374,7 +383,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
       case AVT_DOMAIN_SUBSET :
           debug5 << "Variable for subset plot is a domain Mesh." << endl;
           subsetAtts->SetSubsetType(SubsetAttributes::Domain);
-          defaultAtts->SetSubsetType(SubsetAttributes::Domain);
           if (mesh->blockNames.empty())
           {
               for (int i = 0; i < mesh->numBlocks; i++)
@@ -396,7 +404,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
       case AVT_GROUP_SUBSET :
           debug5 << "Variable for subset plot is a group Mesh." << endl;
           subsetAtts->SetSubsetType(SubsetAttributes::Group);
-          defaultAtts->SetSubsetType(SubsetAttributes::Group);
           if (!mesh->groupNames.empty())
           {
               for (size_t i = 0; i < mesh->groupNames.size(); ++i)
@@ -437,7 +444,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
       case AVT_ENUMSCALAR_SUBSET :
           debug5 << "Variable for subset plot is an enumerated Scalar."<<endl;
           subsetAtts->SetSubsetType(SubsetAttributes::EnumScalar);
-          defaultAtts->SetSubsetType(SubsetAttributes::EnumScalar);
           smd = md->GetScalar(vn);
           if (smd != NULL)
           {
@@ -454,7 +460,6 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
           {
               debug5 << "Variable for subset plot is a mesh."<<endl;
               subsetAtts->SetSubsetType(SubsetAttributes::Mesh);
-              defaultAtts->SetSubsetType(SubsetAttributes::Mesh);
               sprintf(temp, "Whole mesh (%s)", vn.c_str());
               sv.push_back(temp);
           }
@@ -525,7 +530,11 @@ SubsetViewerEnginePluginInfo::PrivateSetPlotAtts(AttributeSubject *atts,
     // Set the subset names and colors in the subsetAtts.
     subsetAtts->SetSubsetNames(sv);
     subsetAtts->SetMultiColor(cal);
-    defaultAtts->SetSubsetNames(sv);
-    defaultAtts->SetMultiColor(cal);
+    if(setDefault)
+    {
+        defaultAtts->SetSubsetType(subsetAtts->GetSubsetType());
+        defaultAtts->SetSubsetNames(sv);
+        defaultAtts->SetMultiColor(cal);
+    }
 }
 

--- a/src/resources/help/en_US/relnotes3.6.0.html
+++ b/src/resources/help/en_US/relnotes3.6.0.html
@@ -103,7 +103,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>An issue partitioning nodal coordinates for parallel in Pixie files was fixed.</li>
   <li>Fixed bug with thirdparty Find mdoules when thirdparty library was not built in 'Release' mode.</li>
-  <li>Fixed a bug with Subset, Boundary, FilledBoundary plots for time and SIL varying databases where changes to color in the plot would affect a new plot.</li>
+  <li>Fixed a bug with Subset, Boundary, FilledBoundary plots for time and SIL varying databases where changes to color in the plot would affect new plots of same type.</li>
 </ul>
 
 <a name="Build_features"></a>

--- a/src/resources/help/en_US/relnotes3.6.0.html
+++ b/src/resources/help/en_US/relnotes3.6.0.html
@@ -103,6 +103,7 @@ enhancements and bug-fixes that were added to this release.</p>
 <ul>
   <li>An issue partitioning nodal coordinates for parallel in Pixie files was fixed.</li>
   <li>Fixed bug with thirdparty Find mdoules when thirdparty library was not built in 'Release' mode.</li>
+  <li>Fixed a bug with Subset, Boundary, FilledBoundary plots for time and SIL varying databases where changes to color in the plot would affect a new plot.</li>
 </ul>
 
 <a name="Build_features"></a>

--- a/src/test/tests/databases/geos.py
+++ b/src/test/tests/databases/geos.py
@@ -7,6 +7,10 @@
 #  Date:       January 7, 2025
 #
 #  Modifications:
+#    Kathleen Biagas, Thu Sep 3, 2026
+#    #20180 has been fixed, so remove workaround.
+#    Fix a test that is supposed to open the grouped .vtm files to actually
+#    do that.
 #
 # ----------------------------------------------------------------------------
 
@@ -42,10 +46,6 @@ def TestMPMdata():
 
     ChangeActivePlotsVar("blocks")
 
-    # needed due to bug #20180
-    defaultSubsetAtts = SubsetAttributes()
-    #
-
     s = SubsetAttributes()
     s.SetMultiColor(0,(255,0,0,68))
     s.SetMultiColor(1,(0,255,0,68))
@@ -67,22 +67,15 @@ def TestMPMdata():
 
     Test("geos_mpm_subset_blocks_02")
 
-    # reset Subset attributes to default so the next test isn't affected
-    #  by atts set here
-    # (needed until bug #20180 is fixed)
-    SetDefaultPlotOptions(defaultSubsetAtts)
-    #
-
     DeleteAllPlots()
     CloseDatabase(data_path("geos_test_data/mpm_moving_through_partition/vtkOutput.pvd"))
 
     # test opening the grouped *.vtm files
     # If it doesn't get opened as 'geos' flavor,
     # the number of scalars will be wrong
-    md = GetMetaData(data_path("geos_test_data/mpm_moving_through_partition/vtkOutput.pvd"))
+    md = GetMetaData(data_path("geos_test_data/mpm_moving_through_partition/vtkOutput/*.vtm database"))
     TestValueEQ("geos_mpm_grouped_vtm_num_scalars", md.GetNumScalars(), 18)
-    CloseDatabase(data_path("geos_test_data/mpm_moving_through_partition/vtkOutput.pvd"))
-
+    CloseDatabase(data_path("geos_test_data/mpm_moving_through_partition/vtkOutput/*.vtm database"))
 
 
 def TestTHMdata():


### PR DESCRIPTION
### Description

Resolves #20180
Subset, Boundary, and Filled Boundary plots all return `true` for `AttributesDependOnDatabaseMetaData()`.
For data that has time-varying-metadata, this sets up a call chain involving `ReInitializePlotAtts`.
This method in turn calls `PrivateSetPlotAtts`, which is a convenience method for setting up the atts which is called by several other methods. 

The bug involves the changing of defaultAtts in this call chain: when timestate changes, metadata is reread, and the plot atts need to be reinitialized.  It is not appropriate in this case for the defaultAtts to be changed, because, as evidenced in the bug ticket, that affects creation of new plots.

Modified `PrivateSetPlotAtts` to have a `setDefaultAtts` argument that is true by default.  When the new arg is false, it prevents changing the defaultAtts. 

`ReInitializePlotAtts` now passes `false` for its call to `PrivateSetPlotAtts`.


### Type of change

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~

### How Has This Been Tested?

Successful run of full regression tests on Linux.
Verified correct behavior using example in bug ticket.
Removed workaround for this bug from geos.py test and verified correct results.

### Checklist:

- [X] I have commented my code where applicable.
- [X] I have updated the release notes.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- ~~[ ] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.~~
