### PR TITLE
Fix LLDBDebugger.Executable() to gate macOS-only probe.

### DIFF
--- a/src/bin/internallauncher
+++ b/src/bin/internallauncher
@@ -1483,11 +1483,18 @@ class LLDBDebugger(Debugger):
         super(LLDBDebugger, self).__init__(launcher)
 
     def Executable(self):
-        native_arm64 = subprocess.check_output(["sysctl", "-n", "hw.optional.arm64"]).decode().strip()
-        if native_arm64 == "1":
-            return ["arch", "-arm64", "lldb"]
-        else:
-            return ["lldb"]
+        # "arch -arm64" is a macOS-only mechanism for selecting the native
+        # architecture out of a universal binary; it doesn't apply (and
+        # "sysctl -n hw.optional.arm64" doesn't exist) on other platforms.
+        if self.launcher.os == "darwin":
+            try:
+                native_arm64 = subprocess.check_output(
+                    ["sysctl", "-n", "hw.optional.arm64"]).decode().strip()
+                if native_arm64 == "1":
+                    return ["arch", "-arm64", "lldb"]
+            except (subprocess.CalledProcessError, OSError):
+                pass
+        return ["lldb"]
 
     def CreateCommand(self, args):
         #lldb_args = ["process","launch","--tty","--"]


### PR DESCRIPTION
### Description
Resolves #21141. Run the macOS-only sysctl hw.optional.arm64 check on darwin, and fall back to lldb gracefully if the sysctl call fails. 

### Type of change

<!-- Please check one of the boxes below -->

* [X] Bug fix
* ~~[ ] New feature~~
* ~~[ ] Documentation update~~
* ~~[ ] Other~~ <!-- please explain with a note below -->

### How Has This Been Tested?

1. Run lldb debugger on Linux (e.g., `visit -debug 5 -lldb viewer -xterm`)

### Reminders:

- Please follow the [style guidelines][1] of this project.
- Please perform a self-review of your code before submitting a PR and asking others to review it.
- Please assign reviewers (see [VisIt's PR procedures][2] for more information).

### Checklist:

<!-- For items in this checklist that do not apply, simply insert two tilde chars, `~~`, just ahead of the left bracket char, `[` at the beginning of a line. Each line ends with two tilde chars to make doing such ~~strikeouts~~ easy. -->

- [X] I have commented my code where applicable.
- ~~[ ] I have updated the release notes.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have added debugging support to my changes.~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [X] I have confirmed new and existing unit tests pass locally with my changes.
- ~~[ ] I have added new baselines for any new tests to the repo.~~
- [X] I have NOT made any changes to [*protocol* or *public interfaces*][3] in an RC branch.

[1]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/StyleGuide.html
[2]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/pr_create.html#reviewers
[3]: https://visit-sphinx-github-user-manual.readthedocs.io/en/develop/dev_manual/RCDevelopment.html#communication-protocols-and-public-apis
